### PR TITLE
Fix garbled chat output; guard MoE+hybrid; copy-paste-safe README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,87 +35,107 @@ The fastest way to download is with the [Hugging Face CLI](https://huggingface.c
 ```bash
 pip install huggingface_hub
 mkdir -p models
+```
 
+```bash
 # SmolLM2 1.7B — fast, low memory, great for testing (~1 GB)
-huggingface-cli download bartowski/SmolLM2-1.7B-Instruct-GGUF \
-  SmolLM2-1.7B-Instruct-Q4_K_M.gguf --local-dir models
+huggingface-cli download bartowski/SmolLM2-1.7B-Instruct-GGUF SmolLM2-1.7B-Instruct-Q4_K_M.gguf --local-dir models
+```
 
+```bash
 # Qwen3 8B — general purpose, fits in 6 GB VRAM (~5 GB)
-huggingface-cli download Qwen/Qwen3-8B-GGUF \
-  Qwen3-8B-Q4_K_M.gguf --local-dir models
+huggingface-cli download Qwen/Qwen3-8B-GGUF Qwen3-8B-Q4_K_M.gguf --local-dir models
+```
 
+```bash
 # Qwen3-Coder 30B-A3B — MoE coding model, ~20 t/s CPU (~17 GB)
-huggingface-cli download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
-  Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf --local-dir models
+huggingface-cli download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf --local-dir models
+```
 
+```bash
 # Llama 4 Scout 109B-16E — MoE, ~5 t/s CPU on DDR4-3200 (~61 GB, 2 shards)
-huggingface-cli download unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF \
-  --include "Q4_K_M/*" --local-dir models
+huggingface-cli download unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF --include "Q4_K_M/*" --local-dir models
 ```
 
 ### Image generation models (Z-Image-Turbo)
 
 ```bash
-# DiT model (choose one quant)
-huggingface-cli download jayn7/Z-Image-Turbo-GGUF \
-  z_image_turbo-Q5_K_M.gguf --local-dir models        # 5.5 GB, best quality
-  # z_image_turbo-Q4_K_M.gguf --local-dir models      # 4.5 GB, slightly faster
+# DiT model — Q5_K_M (5.5 GB, best quality); use z_image_turbo-Q4_K_M.gguf for ~4.5 GB
+huggingface-cli download jayn7/Z-Image-Turbo-GGUF z_image_turbo-Q5_K_M.gguf --local-dir models
+```
 
+```bash
 # VAE + tokenizer (from the original Tongyi-MAI repo)
-huggingface-cli download Tongyi-MAI/Z-Image-Turbo \
-  --include "vae/*" "tokenizer/*" --local-dir models/z-image-turbo
+huggingface-cli download Tongyi-MAI/Z-Image-Turbo --include "vae/*" "tokenizer/*" --local-dir models/z-image-turbo
+```
 
+```bash
 # Text encoder — uncensored Qwen3-4B fine-tune (~2.9 GB)
-huggingface-cli download BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1 \
-  Z-Image-AbliteratedV1.Q5_K_M.gguf --local-dir models
+huggingface-cli download BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1 Z-Image-AbliteratedV1.Q5_K_M.gguf --local-dir models
 ```
 
 ### Image generation models (FLUX.1)
 
 ```bash
 # FLUX.1-schnell GGUF (~7–9 GB depending on quant)
-huggingface-cli download city96/FLUX.1-schnell-gguf \
-  flux1-schnell-Q4_K_S.gguf --local-dir models
+huggingface-cli download city96/FLUX.1-schnell-gguf flux1-schnell-Q4_K_S.gguf --local-dir models
+```
 
+```bash
 # VAE + CLIP-L + T5-XXL encoders
-huggingface-cli download comfyanonymous/flux_text_encoders \
-  ae.safetensors clip_l.safetensors t5xxl_fp16.safetensors --local-dir models/flux
+huggingface-cli download comfyanonymous/flux_text_encoders ae.safetensors clip_l.safetensors t5xxl_fp16.safetensors --local-dir models/flux
 ```
 
 ## Quick Start
 
+Build first:
+
 ```bash
-# Build in release mode
 dotnet build -c Release
+```
 
-# Single-turn inference (CPU)
-dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
-  -p "What is 2+2?" --temp 0
+Each command below is on a single line so you can copy-paste straight into your terminal.
 
-# Single-turn inference (GPU — all layers in VRAM)
-dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
-  -p "What is 2+2?" --temp 0 -g -1
+**SmolLM2 1.7B — single-turn, CPU:**
 
-# Interactive chat session
-dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf -p "What is 2+2?" --temp 0
+```
 
-# MoE coding model (~20 t/s CPU)
-dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf \
-  -p "Implement a binary search tree in C#" --temp 0
+**SmolLM2 1.7B — single-turn, all-GPU:**
 
-# Speculative decoding (draft + target model, ~2× faster at temp 0)
-dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/Qwen3-8B-Q4_K_M.gguf \
-  --draft-model models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
-  -p "Write a quicksort in Python" --temp 0
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf -p "What is 2+2?" --temp 0 -g -1
+```
 
-# Start API server
-SHARPI_MODEL=models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
-  dotnet run --project src/SharpInference.Server -c Release
+**SmolLM2 1.7B — interactive chat:**
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf
+```
+
+**Qwen3-Coder 30B-A3B (MoE) — CPU + KV-cache compression:**
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf --tq -p "Implement a binary search tree in C#" --temp 0
+```
+
+**Speculative decoding (draft + target, ~2× faster at temp 0):**
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/Qwen3-8B-Q4_K_M.gguf --draft-model models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf -p "Write a quicksort in Python" --temp 0
+```
+
+**Start API server (CPU):**
+
+```bash
+SHARPI_MODEL=models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf dotnet run --project src/SharpInference.Server -c Release
+```
+
+PowerShell equivalent for the server line:
+
+```powershell
+$env:SHARPI_MODEL='models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf'; dotnet run --project src/SharpInference.Server -c Release
 ```
 
 ## CLI Reference
@@ -159,27 +179,13 @@ Supports two native pipelines: **Z-Image-Turbo** (auto-detected from model filen
 #### Z-Image-Turbo example
 
 ```bash
-dotnet run --project src/SharpInference.Cli -c Release -- image \
-  -m models/z_image_turbo-Q5_K_M.gguf \
-  --vae models/z-image-turbo/vae \
-  --qwen-encoder models/Z-Image-AbliteratedV1.Q5_K_M.gguf \
-  --qwen-tokenizer models/z-image-turbo/tokenizer/tokenizer.json \
-  -p "a serene mountain lake at sunrise" \
-  -W 1024 -H 1024 --steps 4 -o landscape.png -v
+dotnet run --project src/SharpInference.Cli -c Release -- image -m models/z_image_turbo-Q5_K_M.gguf --vae models/z-image-turbo/vae --qwen-encoder models/Z-Image-AbliteratedV1.Q5_K_M.gguf --qwen-tokenizer models/z-image-turbo/tokenizer/tokenizer.json -p "a serene mountain lake at sunrise" -W 1024 -H 1024 --steps 4 -o landscape.png -v
 ```
 
 #### FLUX.1-schnell example
 
 ```bash
-dotnet run --project src/SharpInference.Cli -c Release -- image \
-  -m models/flux1-schnell-Q4_K_S.gguf \
-  --vae models/flux/ae.safetensors \
-  --clip-l models/flux/clip_l.safetensors \
-  --clip-tokenizer models/flux/tokenizer_clip.json \
-  --t5xxl models/flux/t5xxl_fp16.safetensors \
-  --t5-tokenizer models/flux/tokenizer_t5.json \
-  -p "a cinematic photograph of a mountain lake" \
-  -W 512 -H 512 --steps 4 -o out.png
+dotnet run --project src/SharpInference.Cli -c Release -- image -m models/flux1-schnell-Q4_K_S.gguf --vae models/flux/ae.safetensors --clip-l models/flux/clip_l.safetensors --clip-tokenizer models/flux/tokenizer_clip.json --t5xxl models/flux/t5xxl_fp16.safetensors --t5-tokenizer models/flux/tokenizer_t5.json -p "a cinematic photograph of a mountain lake" -W 512 -H 512 --steps 4 -o out.png
 ```
 
 #### All image options
@@ -222,8 +228,7 @@ Benchmarked on AMD Zen 4 + RTX 4070 Ti:
 ### `list-metadata` — inspect a GGUF file
 
 ```bash
-dotnet run --project src/SharpInference.Cli -c Release -- \
-  list-metadata -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf
+dotnet run --project src/SharpInference.Cli -c Release -- list-metadata -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf
 ```
 
 Prints all GGUF metadata key/value pairs in a table (architecture, context length, rope settings, tokenizer vocab, etc.).
@@ -236,33 +241,51 @@ Prints all GGUF metadata key/value pairs in a table (architecture, context lengt
 
 Starts an HTTP server compatible with OpenAI and Anthropic clients. Defaults to `http://localhost:5000`.
 
+Start the server (CPU):
+
 ```bash
-# Start (CPU)
-SHARPI_MODEL=models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
-  dotnet run --project src/SharpInference.Server -c Release
+SHARPI_MODEL=models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf dotnet run --project src/SharpInference.Server -c Release
+```
 
-# OpenAI chat completions (streaming)
-curl http://localhost:5000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"smollm2","messages":[{"role":"user","content":"Hello"}],"stream":true}'
+PowerShell:
 
-# Anthropic messages (non-streaming)
-curl http://localhost:5000/v1/messages \
-  -H "Content-Type: application/json" \
-  -d '{"model":"smollm2","messages":[{"role":"user","content":"Hello"}],"max_tokens":256}'
+```powershell
+$env:SHARPI_MODEL='models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf'; dotnet run --project src/SharpInference.Server -c Release
+```
 
-# OpenAI Responses API
-curl http://localhost:5000/v1/responses \
-  -H "Content-Type: application/json" \
-  -d '{"model":"smollm2","input":"Hello"}'
+OpenAI chat completions (streaming):
 
-# List loaded model
+```bash
+curl http://localhost:5000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"smollm2","messages":[{"role":"user","content":"Hello"}],"stream":true}'
+```
+
+Anthropic messages (non-streaming):
+
+```bash
+curl http://localhost:5000/v1/messages -H "Content-Type: application/json" -d '{"model":"smollm2","messages":[{"role":"user","content":"Hello"}],"max_tokens":256}'
+```
+
+OpenAI Responses API:
+
+```bash
+curl http://localhost:5000/v1/responses -H "Content-Type: application/json" -d '{"model":"smollm2","input":"Hello"}'
+```
+
+List loaded model:
+
+```bash
 curl http://localhost:5000/v1/models
+```
 
-# Health check
+Health check:
+
+```bash
 curl http://localhost:5000/health
+```
 
-# Prometheus metrics
+Prometheus metrics:
+
+```bash
 curl http://localhost:5000/metrics
 ```
 
@@ -294,6 +317,71 @@ Any GGUF model with architecture `llama`, `llama4`, `qwen3`, or `qwen3moe` shoul
 | Z-Image-Turbo DiT | [jayn7/Z-Image-Turbo-GGUF](https://huggingface.co/jayn7/Z-Image-Turbo-GGUF) | Q5_K_M | 5.5 GB | Best quality; also Q4_K_M (4.5 GB) |
 | Z-Image-Turbo text encoder | [BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1](https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1) | Q5_K_M | 2.9 GB | Uncensored fine-tune of Qwen3-4B |
 | FLUX.1-schnell | [city96/FLUX.1-schnell-gguf](https://huggingface.co/city96/FLUX.1-schnell-gguf) | Q4_K_S | ~7 GB | 4-step distilled; VAE+encoders from comfyanonymous/flux_text_encoders |
+
+### What works today
+
+Verified on AMD Zen 4 (12c/24t, DDR4-3200) + RTX 4070 Ti (12 GB VRAM):
+
+#### SmolLM2 1.7B Instruct (`llama`, headDim 64)
+
+| Backend | `--tq` | Status | Decode (t/s) |
+|---------|--------|--------|--------------|
+| CPU (default) | — | ✓ works | ~51 |
+| CPU | `--tq` | ✗ refused — `headDim 64 != 128/256` (clear error) | — |
+| GPU (`-g -1`) | — | ✓ works | ~159 |
+| GPU (`-g -1`) | `--tq` | ✗ refused — same headDim guard | — |
+| Hybrid (`-g N`, 1 ≤ N < layers) | — | ✓ works | ~61 (`-g 8`) |
+| Hybrid | `--tq` | ✗ refused — same headDim guard | — |
+
+Copy-paste:
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf -p "Hello" --temp 0
+```
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf -p "Hello" --temp 0 -g -1
+```
+
+#### Qwen3-Coder 30B-A3B Instruct (`qwen3moe`, headDim 128, MoE 128/8)
+
+| Backend | `--tq` | Status | Decode (t/s) |
+|---------|--------|--------|--------------|
+| CPU (default) | — | ✓ works | ~21 |
+| CPU | `--tq` | ✓ works | ~21 |
+| GPU (`-g -1`) | any | ⚠ auto-fallback to CPU with a warning (issue [#2](https://github.com/pekkah/SharpInference/issues/2)) | — |
+| Hybrid (`-g N`) | any | ✗ refused with error pointing to issue [#2](https://github.com/pekkah/SharpInference/issues/2) | — |
+
+Copy-paste (recommended config for this machine):
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- -m models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf --tq -p "Write a Python quicksort." --temp 0
+```
+
+#### Meta-Llama-3.1-70B-Instruct-Q4_K_M.gguf
+
+The local file (`models/Meta-Llama-3.1-70B-Instruct-Q4_K_M.gguf`, 269 MB) is incomplete — a real 70B Q4_K_M is ~40 GB across multiple GGUF shards. Loading it crashes with `AccessViolationException` in `PrefaultWeights`. Re-download as a multi-shard set, e.g.:
+
+```bash
+huggingface-cli download bartowski/Meta-Llama-3.1-70B-Instruct-GGUF --include "Meta-Llama-3.1-70B-Instruct-Q4_K_M*.gguf" --local-dir models
+```
+
+#### Z-Image-Turbo (image generation)
+
+Models on disk: `models/z_image_turbo-Q5_K_M.gguf`, `models/Z-Image-AbliteratedV1.Q5_K_M.gguf`, `models/z-image-turbo/{vae,tokenizer}/`. The optional `RealESRGAN_x4plus.safetensors` is not present — upscaling falls back to bicubic unless you fetch it (`scripts/download-model.ps1 -Model realesrgan-x4`).
+
+Image generation has not been re-tested in this round; the existing example below should still work end-to-end:
+
+```bash
+dotnet run --project src/SharpInference.Cli -c Release -- image -m models/z_image_turbo-Q5_K_M.gguf --vae models/z-image-turbo/vae --qwen-encoder models/Z-Image-AbliteratedV1.Q5_K_M.gguf --qwen-tokenizer models/z-image-turbo/tokenizer/tokenizer.json -p "a serene mountain lake at sunrise" -W 1024 -H 1024 --steps 4 -o landscape.png -v
+```
+
+### Known limitations
+
+- **MoE on GPU**: any `qwen3moe`/`llama4` model with `-g N` (N > 0) is rejected with an explicit error. `-g -1` (auto) silently falls back to CPU. Tracking: [#2](https://github.com/pekkah/SharpInference/issues/2).
+- **GPU embedding lookup in `HybridForwardPass`**: works around a shader bug by always doing the per-token embedding row dequant on CPU. Cost is one row of dequant per token (negligible). Tracking: [#3](https://github.com/pekkah/SharpInference/issues/3).
+- **`--backend` flag**: does not exist — backend is selected via `-g`. Vulkan only; CUDA is wired into `image` only. Tracking: [#4](https://github.com/pekkah/SharpInference/issues/4).
+- **`--tq`** (TurboQuant): requires the model to have `headDim == 128` (most Qwen3 / Llama 3) or `256` (Llama 70B). SmolLM2's `headDim 64` is rejected with a clear error.
 
 ## Performance
 

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -589,12 +589,14 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         // Use the model's own Jinja2 chat template when available (read from GGUF metadata).
         if (s_jinja != null)
         {
-            // Qwen3 instruction-tuned models behave poorly without a system message —
-            // they end the turn after a few tokens for short prompts. The hardcoded
-            // fallback path (below) injects this same default; mirror it here so both
-            // paths produce comparable output.
+            // Qwen3 (dense) chat models behave poorly without a system message — they
+            // end the turn after a few tokens for short prompts. The hardcoded fallback
+            // path (below) injects this default; mirror it here for the same arch.
+            // Note: qwen3moe is intentionally excluded — Qwen3-Coder appears to be
+            // tuned to operate without a system prompt and gets HIGH-confidence on
+            // <|endoftext|> when one is forced (logit ~29 vs ~14 with no system).
             string? effectiveSystemPrompt = systemPrompt
-                ?? (s_arch is "qwen3moe" or "qwen3" ? "You are a helpful assistant." : null);
+                ?? (s_arch is "qwen3" ? "You are a helpful assistant." : null);
             var messages = JinjaChatTemplate.BuildMessages(userMessage, systemContent: effectiveSystemPrompt);
             return s_jinja.Render(new Dictionary<string, object?>
             {

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -166,6 +166,23 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         }
 
         int nGpuLayers = settings.NGpuLayers;
+
+        // MoE models are not yet supported on the hybrid GPU+CPU path. The GpuMoeFfn path
+        // produces NaN/degenerate output (see https://github.com/pekkah/SharpInference/issues/2).
+        // Fall back to CPU automatically when -g is -1 (auto), refuse explicit -g N for MoE.
+        if (hp.IsMoE && nGpuLayers != 0)
+        {
+            if (nGpuLayers > 0)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] MoE models (this one is [yellow]{s_arch}[/]) are not yet supported on the hybrid GPU+CPU path; output is degenerate. Tracking issue: https://github.com/pekkah/SharpInference/issues/2");
+                AnsiConsole.MarkupLine("Re-run without [yellow]-g[/] (or [yellow]-g 0[/]) to use the working CPU path. [yellow]--tq[/] is supported on CPU.");
+                return 1;
+            }
+            // -g -1 (auto) → silently fall back to CPU
+            AnsiConsole.MarkupLine("[yellow]Note:[/] [yellow]-g -1[/] requested, but MoE models run only on CPU until issue #2 is fixed. Falling back to CPU.");
+            nGpuLayers = 0;
+        }
+
         if (nGpuLayers == 0)
         {
             // CPU only

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -589,7 +589,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         // Use the model's own Jinja2 chat template when available (read from GGUF metadata).
         if (s_jinja != null)
         {
-            var messages = JinjaChatTemplate.BuildMessages(userMessage, systemContent: systemPrompt);
+            // Qwen3 instruction-tuned models behave poorly without a system message —
+            // they end the turn after a few tokens for short prompts. The hardcoded
+            // fallback path (below) injects this same default; mirror it here so both
+            // paths produce comparable output.
+            string? effectiveSystemPrompt = systemPrompt
+                ?? (s_arch is "qwen3moe" or "qwen3" ? "You are a helpful assistant." : null);
+            var messages = JinjaChatTemplate.BuildMessages(userMessage, systemContent: effectiveSystemPrompt);
             return s_jinja.Render(new Dictionary<string, object?>
             {
                 ["messages"]             = messages,

--- a/src/SharpInference.Core/JinjaChatTemplate.cs
+++ b/src/SharpInference.Core/JinjaChatTemplate.cs
@@ -207,9 +207,21 @@ public sealed class JinjaChatTemplate
                     {
                         return nodes; // caller handles
                     }
+                    else if (tag.StartsWith("macro ", StringComparison.Ordinal)
+                          || tag.StartsWith("block ", StringComparison.Ordinal)
+                          || tag == "raw")
+                    {
+                        // Consume the body up to {% endmacro %} / {% endblock %} / {% endraw %} and discard.
+                        // Macros are only invoked from inside branches we don't enter (e.g. tool-call rendering
+                        // when tools is empty); calls to undefined macros emit "" via CallFunction's null fallback.
+                        pos++;
+                        ParseNodes(tokens, ref pos);
+                        if (pos < tokens.Count && tokens[pos].Kind == TokenKind.Block
+                            && IsEndTag(tokens[pos].Content)) pos++;
+                    }
                     else
                     {
-                        pos++; // skip unknown (raw, block, macro, …)
+                        pos++; // skip unknown single-line tag
                     }
                     break;
             }

--- a/src/SharpInference.Core/JinjaChatTemplate.cs
+++ b/src/SharpInference.Core/JinjaChatTemplate.cs
@@ -129,17 +129,43 @@ public sealed class JinjaChatTemplate
 
     private static void ApplyStripping(List<Token> tokens)
     {
+        // Match HuggingFace transformers' chat-template renderer defaults:
+        //   trim_blocks=True   — strip a single \n immediately after {% ... %} or {# ... #}
+        //   lstrip_blocks=True — strip leading horizontal whitespace before {% %} on a line
+        // Plus the explicit Jinja whitespace controls: {%- / -%}, {{- / -}}, {#- / -#}.
         for (int i = 0; i < tokens.Count; i++)
         {
             var tok = tokens[i];
             if (tok.Kind is TokenKind.Text) continue;
 
+            // Left strip — explicit `{%-` strips ALL prior trailing whitespace incl. newlines.
+            // Implicit lstrip_blocks for {% %} / {# #} strips only horizontal whitespace
+            // (spaces, tabs) at the start of the line up to the tag.
             if (tok.StripL && i > 0 && tokens[i - 1].Kind == TokenKind.Text)
             {
                 var prev = tokens[i - 1];
                 tokens[i - 1] = prev with { Content = prev.Content.TrimEnd() };
             }
+            else if (tok.Kind is TokenKind.Block or TokenKind.Comment
+                     && i > 0 && tokens[i - 1].Kind == TokenKind.Text)
+            {
+                var prev = tokens[i - 1];
+                string c = prev.Content;
+                int n = c.Length;
+                while (n > 0 && (c[n - 1] == ' ' || c[n - 1] == '\t')) n--;
+                if (n < c.Length && (n == 0 || c[n - 1] == '\n'))
+                    tokens[i - 1] = prev with { Content = c[..n] };
+            }
+
+            // Right strip — explicit `-%}` strips ALL leading whitespace (incl. newlines).
+            // Implicit trim_blocks for {% %} / {# #} strips a single trailing \r? \n.
             if (tok.StripR && i + 1 < tokens.Count && tokens[i + 1].Kind == TokenKind.Text)
+            {
+                var nxt = tokens[i + 1];
+                tokens[i + 1] = nxt with { Content = nxt.Content.TrimStart() };
+            }
+            else if (tok.Kind is TokenKind.Block or TokenKind.Comment
+                     && i + 1 < tokens.Count && tokens[i + 1].Kind == TokenKind.Text)
             {
                 var nxt = tokens[i + 1];
                 string c = nxt.Content;

--- a/src/SharpInference.Engine/HybridForwardPass.cs
+++ b/src/SharpInference.Engine/HybridForwardPass.cs
@@ -470,7 +470,7 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             CpuEmbedToken(token, pinned);
             _gpu.UnmapPinned(_pinnedHidden);
             CopyGpuBuffer(_gpuHidden, _pinnedHidden);
-            _gpu.RecordTransferBarrier();
+            _gpu.RecordBarrier();
         }
 
         for (int i = 0; i < _nGpuLayers; i++)
@@ -490,9 +490,9 @@ public sealed unsafe class HybridForwardPass : IForwardPass
 
         if (_nCpuLayers > 0)
         {
-            // Download hidden state to pinned buffer
+            // Download hidden state to pinned buffer.
             CopyGpuBuffer(_pinnedHidden, _gpuHidden);
-            _gpu.RecordTransferBarrier();
+            _gpu.RecordBarrier();
         }
 
         _gpu.EndRecordAndSubmit();
@@ -526,7 +526,7 @@ public sealed unsafe class HybridForwardPass : IForwardPass
                 // Upload pinned → GPU hidden, then final norm + output
                 _gpu.BeginRecord();
                 CopyGpuBuffer(_gpuHidden, _pinnedHidden);
-                _gpu.RecordTransferBarrier();
+                _gpu.RecordBarrier();
             }
             else
             {
@@ -540,7 +540,7 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             if (_gpuOutputWeight is null)
             {
                 CopyGpuBuffer(_pinnedHidden, _gpuHidden);
-                _gpu.RecordTransferBarrier();
+                _gpu.RecordBarrier();
                 _gpu.EndRecordAndSubmit();
 
                 float* pinned = _gpu.MapPinned(_pinnedHidden);
@@ -598,7 +598,7 @@ public sealed unsafe class HybridForwardPass : IForwardPass
     private void GpuLayer(int i, int position)
     {
         CopyGpuBuffer(_gpuResidual, _gpuHidden);
-        _gpu.RecordTransferBarrier();
+        _gpu.RecordBarrier();
 
         _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuAttnNorm[i], _hp.RmsNormEps);
         _gpu.RecordBarrier();
@@ -653,7 +653,7 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             {
                 CopyGpuBufferRegion(_gpuEvictK!, 0, _gpuKCache[i], (long)_gpuFp32WriteIdx * rowBytes, rowBytes);
                 CopyGpuBufferRegion(_gpuEvictV!, 0, _gpuVCache[i], (long)_gpuFp32WriteIdx * rowBytes, rowBytes);
-                _gpu.RecordTransferBarrier();
+                _gpu.RecordBarrier();
 
                 _gpu.TqKvAppend(_gpuEvictK!, _gpuEvictV!, _gpuTqKCache![i], _gpuTqVCache![i],
                     _gpuSignPatterns![i], _gpuCodebook!, _gpuBoundaries!,
@@ -696,9 +696,10 @@ public sealed unsafe class HybridForwardPass : IForwardPass
         }
         _gpu.RecordBarrier();
         _gpu.AddInPlace(_gpuHidden, _gpuResidual);
+        _gpu.RecordBarrier();
 
         CopyGpuBuffer(_gpuResidual, _gpuHidden);
-        _gpu.RecordTransferBarrier();
+        _gpu.RecordBarrier();
 
         _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuFfnNorm[i], _hp.RmsNormEps);
         _gpu.RecordBarrier();
@@ -710,6 +711,7 @@ public sealed unsafe class HybridForwardPass : IForwardPass
         _gpu.RecordBarrier();
 
         _gpu.AddInPlace(_gpuHidden, _gpuResidual);
+        _gpu.RecordBarrier();
     }
 
     // ================================================================
@@ -1146,12 +1148,12 @@ public sealed unsafe class HybridForwardPass : IForwardPass
 
     private static bool ShouldKeepFixedWeightsOnCpu(GgufTensorInfo embedding, GgufTensorInfo? output)
     {
-        const long maxStorageBufferBytes = 2L * 1024 * 1024 * 1024 - 1;
-        if (EstimateGpuTensorBytes(embedding) > maxStorageBufferBytes)
-            return true;
-        if (output is not null && EstimateGpuTensorBytes(output.Value) > maxStorageBufferBytes)
-            return true;
-        return false;
+        // Always keep embedding+output on CPU for the hybrid path. The GPU embedding-lookup
+        // shader produces garbage when invoked inside HybridForwardPass (root cause unclear —
+        // identical shader works in GpuForwardPass), and the embedding is one-row-per-token
+        // which is negligible vs. the layer compute, so the perf cost is near zero.
+        // TODO: investigate why EmbedLookupQ4K writes wrong values in hybrid context.
+        return true;
     }
 
     private static long EstimateGpuTensorBytes(GgufTensorInfo tensor)
@@ -1218,8 +1220,8 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             _gpu.Softmax(_gpuRouterLogits!);
         // Copy norm buf to pinned memory while still recording so the CPU can
         // read it after submit via MapPinned — avoids a second CopyBuffer call.
+        _gpu.RecordBarrier();
         CopyGpuBuffer(_gpuPinnedNorm!, _gpuNormBuf);
-        _gpu.RecordTransferBarrier();
         _gpu.EndRecordAndSubmit();
         _gpu.Download(_gpuRouterLogits!, _gpuRouterBuf!);
 
@@ -1472,25 +1474,16 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             _gpuWeightDTypes.TryGetValue(weights.Handle, out var dt) ? dt : DType.Float32);
     }
 
-    private void CopyGpuBuffer(Tensor dst, Tensor src)
-    {
-        var srcBuf = _gpu.GetBuffer(src);
-        var dstBuf = _gpu.GetBuffer(dst);
-        Vortice.Vulkan.VkBufferCopy region = new() { size = srcBuf.Size };
-        _gpu.Vkd.vkCmdCopyBuffer(_gpu.TransferCmd, srcBuf.Buffer, dstBuf.Buffer, 1, &region);
-    }
+    // Compute-shader-based buffer copies. Critical: `vkCmdCopyBuffer` runs in the Transfer
+    // pipeline stage, which is NOT synchronized with the rest of this forward pass — every
+    // RecordBarrier() in this file is a Compute→Compute memory barrier and does nothing for
+    // transfer-stage writes. Using a compute copy keeps everything in the compute stage so
+    // those barriers are correct.
+    private void CopyGpuBuffer(Tensor dst, Tensor src) => _gpu.RecordComputeCopy(dst, src);
 
     private void CopyGpuBufferRegion(Tensor dst, long dstOffsetBytes, Tensor src, long srcOffsetBytes, long sizeBytes)
     {
-        var srcBuf = _gpu.GetBuffer(src);
-        var dstBuf = _gpu.GetBuffer(dst);
-        Vortice.Vulkan.VkBufferCopy region = new()
-        {
-            srcOffset = (ulong)srcOffsetBytes,
-            dstOffset = (ulong)dstOffsetBytes,
-            size = (ulong)sizeBytes,
-        };
-        _gpu.Vkd.vkCmdCopyBuffer(_gpu.TransferCmd, srcBuf.Buffer, dstBuf.Buffer, 1, &region);
+        _gpu.RecordComputeCopyRegion(dst, dstOffsetBytes, src, srcOffsetBytes, sizeBytes);
     }
 
     private static void PerHeadRmsNorm(float* data, float* weight, int numHeads, int headDim, float eps)


### PR DESCRIPTION
## Summary

- **Jinja chat template**: handle `{% macro %}` / `{% block %}` / `{% raw %}`. Without this, any template that opens with a macro definition (the Unsloth Qwen3-Coder template) collapsed to `"\n\n"`, the model received no prompt, and produced garbled output.
- **HybridForwardPass barriers**: switch inter-layer copies from `vkCmdCopyBuffer` (transfer stage) to `RecordComputeCopy` (compute stage), and add the missing `RecordBarrier()` at the end of `GpuLayer`. With these, SmolLM2 hybrid produces coherent output at every `-g N`.
- **HybridForwardPass embedding**: force CPU embedding+output as a workaround for a separate shader bug (issue #3).
- **CLI guards**: refuse explicit `-g N` on MoE models with an error linking to issue #2; `-g -1` falls back to CPU with a warning.
- **README**: every command is single-line so it survives copy-paste, plus a "What works today" matrix per locally-tested model.

## Verified

| Model | Path | Decode |
|---|---|---|
| SmolLM2 1.7B | CPU | ~51 t/s |
| SmolLM2 1.7B | `-g -1` (all GPU) | ~159 t/s |
| SmolLM2 1.7B | `-g 8` (hybrid) | ~61 t/s |
| Qwen3-Coder 30B-A3B | CPU + `--tq` | ~21 t/s |
| Qwen3-Coder 30B-A3B | `-g 1` | refused with helpful error |
| Qwen3-Coder 30B-A3B | `-g -1` | warns, runs on CPU at ~21 t/s |
| SmolLM2 + `--tq` | any | refused (head dim 64 != 128/256) |

## Tracking issues opened

- #2 MoE on hybrid GPU+CPU produces NaN / degenerate output
- #3 GPU embedding lookup writes garbage in HybridForwardPass (worked around here)
- #4 CLI: `--backend cuda` silently ignored; clarify backend selection

## Test plan

- [x] `dotnet test tests/SharpInference.Tests.Core` — 26/26 pass
- [x] SmolLM2 CPU (`def add_two_numbers(a, b): return a + b`)
- [x] SmolLM2 `-g -1` and `-g 4/8/16/23`
- [x] Qwen3-Coder CPU + `--tq`
- [x] Qwen3-Coder `-g 1` rejection message
- [x] Qwen3-Coder `-g -1` auto-fallback to CPU
- [ ] Image generation pipelines not re-tested (separate path; unchanged)
- [ ] API server not re-tested (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)