### PR TITLE
Fix RoPE convention for Qwen3-MoE and other NEOX-family architectures

### DIFF
--- a/docs/SharpInference-Design.md
+++ b/docs/SharpInference-Design.md
@@ -189,7 +189,8 @@ public interface IComputeBackend : IDisposable
     void MatVecMulDequant(TensorRef output, TensorRef quantMatrix, TensorRef vector,
                           QuantFormat format);
     void RmsNorm(TensorRef output, TensorRef input, TensorRef weight, float epsilon);
-    void RoPE(TensorRef qk, int position, int headDim, float ropeTheta);
+    // neox=false: LLaMA interleaved pairs (2i, 2i+1); neox=true: NEOX/half pairs (i, i+headDim/2)
+    void RoPE(TensorRef qk, int position, int headDim, float ropeTheta, bool neox = false);
     void Softmax(TensorRef output, TensorRef input);
     void SiLU(TensorRef output, TensorRef input);
     void ElementwiseMul(TensorRef output, TensorRef a, TensorRef b);
@@ -1986,6 +1987,7 @@ curl http://localhost:5000/v1/messages \
   if (_hasQkNorm) { NormedQ = RmsNorm(Q); NormedK = RmsNorm(K); }
   ApplyRoPE(NormedQ, NormedK, position);
   ```
+- `ModelGraph.cs` / `SimdKernels.cs` / `ForwardPass.cs` — **NEOX-style RoPE** for Qwen3 family: rotates dim pairs `(i, i + headDim/2)` instead of consecutive pairs `(2i, 2i+1)` used by LLaMA. New `IsNeoxRope` hyperparameter set per architecture (qwen, qwen2/2moe, qwen3/3moe, phi2/3, phimoe, gemma/2/3, falcon, stablelm, olmo2, olmoe, starcoder2, gptneox, openelm, exaone, nemotron). Mirrors `llama_model_rope_type()` in llama.cpp. New `ApplyRoPECachedNeox` SIMD kernel; `ForwardPass.ApplyRope()` helper dispatches based on `_hp.IsNeoxRope`.
 - `ForwardPass.cs` — removed double-normalization bug in `MoeFfn`: `SelectTopK` already normalizes weights for k>1; the additional renorm was a no-op for k>1 but incorrectly set weight=1.0 for k=1 (broke Llama-4 softmax test)
 - `GgufTokenizer.cs` — added `_specialTokensById` reverse lookup; `Decode(int[])` for single special tokens (type 3/4) now returns the correct string via this map instead of an empty string from the BPE inner tokenizer
 - `RunCommand.cs` — ChatML prompt formatting for qwen3/qwen3moe; default system prompt injection (model generates `<\|endoftext\|>` without it); `<\|endoftext\|>` added to stop tokens (was causing infinite repetition); `<think>` / `</think>` token IDs looked up at startup and their tokens displayed with dim ANSI formatting in the decode loop
@@ -1998,7 +2000,7 @@ Qwen3 supports chain-of-thought via `/think` in the user message. Two approaches
 
 **Final approach:** No automatic thinking mode injection. The model works well without it for coding tasks. Users can append `/think` to their message manually when desired.
 
-**Q4_K_M quirk:** Certain imperative phrasings ("Write a C# method...") trigger `<\|endoftext\|>` as the first token with logit ~28–35, while semantically equivalent "Implement X in C#" or "Can you write a C# method?" work correctly. This is a quantization artifact — the 4-bit precision loss in specific weight regions affecting these token sequences. Not fixable at the inference engine level.
+**RoPE convention bug (Issue #6, fixed):** Earlier versions of this engine applied LLaMA-style interleaved RoPE to all architectures. Qwen2/Qwen3 (and Phi/Gemma/Falcon/etc.) require NEOX-style rotation — pairs offset by `headDim/2`. The mismatch produced subtly-wrong attention output that compounded layer-by-layer; cumulative direction error eventually pushed the residual into a degenerate region where the LM head predicted `<\|endoftext\|>` or `<\|im_end\|>` with high confidence on many short prompts (originally misattributed as a Q4_K_M quantization artifact). Fixed by adding `IsNeoxRope` to `ModelHyperparams` and dispatching to `ApplyRoPECachedNeox` for NEOX-family architectures.
 
 **Benchmark results (Qwen3-Coder-30B-A3B-Instruct-Q4_K_M, Ryzen 9 7900X, CPU only):**
 

--- a/src/SharpInference.Core/IComputeBackend.cs
+++ b/src/SharpInference.Core/IComputeBackend.cs
@@ -85,8 +85,12 @@ public interface IComputeBackend : IDisposable
     /// <summary>Apply SiLU (x * sigmoid(x)) activation in-place.</summary>
     void SiLU(Tensor x);
 
-    /// <summary>Apply rotary positional embedding in-place.</summary>
-    void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f);
+    /// <summary>
+    /// Apply rotary positional embedding in-place.
+    /// <paramref name="neox"/> selects rotation convention: false = LLaMA interleaved (pairs (2i, 2i+1)),
+    /// true = NEOX/half (pairs (i, i + headDim/2)) used by Qwen, Phi, Gemma, Falcon, etc.
+    /// </summary>
+    void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f, bool neox = false);
 
     /// <summary>
     /// General matrix multiply: C[M,N] = A[M,K] × B[N,K]^T

--- a/src/SharpInference.Core/ModelGraph.cs
+++ b/src/SharpInference.Core/ModelGraph.cs
@@ -82,6 +82,14 @@ public sealed record ModelHyperparams
     public bool UseL2QkNorm { get; init; }
 
     /// <summary>
+    /// True for NEOX-style RoPE (rotates dim pairs (i, i + headDim/2)).
+    /// False for LLaMA-style "normal" RoPE (rotates consecutive pairs (2i, 2i+1)).
+    /// Qwen2/Qwen3, Phi, Gemma, Falcon, and most non-LLaMA architectures use NEOX.
+    /// LLaMA, Mistral, SmolLM, Granite, and DeepSeek use the interleaved convention.
+    /// </summary>
+    public bool IsNeoxRope { get; init; }
+
+    /// <summary>
     /// Extract hyperparameters from GGUF metadata using the model's architecture prefix.
     /// Supports llama-family models (llama, mistral, qwen, smollm, etc.) and MoE variants.
     /// </summary>
@@ -116,6 +124,33 @@ public sealed record ModelHyperparams
         bool useL2QkNorm = isLlama4;
         if (isLlama4) hasQkNorm = true;
 
+        // RoPE convention: NEOX (pairs offset by headDim/2) vs NORM/interleaved (consecutive pairs).
+        // Mirrors llama.cpp's llama_model_rope_type() in src/llama-model.cpp (NEOX block).
+        // Architectures NOT listed here default to NORM (LLaMA-style interleaved).
+        // Special rope types (MROPE for QWEN2VL/PADDLEOCR, IMROPE for QWEN3VL family, conditional
+        // for GLM4/GLM4_MOE) are not currently supported and would need their own dispatch.
+        bool isNeoxRope = arch switch
+        {
+            "falcon" or "falcon-h1" or "grok" or "dbrx" or
+            "bert" or "jina-bert-v3" or "modern-bert" or "nomic-bert" or "nomic-bert-moe" or "eurobert" or
+            "stablelm" or "bitnet" or
+            "qwen" or "qwen2" or "dream" or "qwen2moe" or "qwen3" or "qwen3moe" or
+            "llada-moe" or "rnd1" or
+            "olmo2" or "olmoe" or
+            "phi2" or "phi3" or "phimoe" or
+            "plamo" or "plamo2" or "plamo3" or
+            "gemma" or "gemma2" or "gemma3" or "gemma3n" or "gemma4" or "gemma-embedding" or
+            "starcoder2" or "openelm" or "gptneox" or "codeshell" or "orion" or
+            "nemotron" or "exaone" or "exaone4" or "exaone-moe" or
+            "minicpm3" or "bailingmoe2" or "dots1" or
+            "hunyuan-moe" or "hunyuan-dense" or
+            "jais2" or "gpt-oss" or
+            "lfm2" or "lfm2moe" or "smallthinker" or "seed_oss" or "grovemoe" or
+            "apertus" or "minimax-m2" or "cogvlm" or "pangu-embedded" or "afmoe" or
+            "qwen3next" or "mimo2" or "step35" => true,
+            _ => false,
+        };
+
         int embDim = GetInt(metadata, $"{arch}.embedding_length");
         int numHeads = GetInt(metadata, $"{arch}.attention.head_count");
         // Some models (e.g. Qwen3-MoE) use a head dim that differs from embDim/numHeads.
@@ -147,6 +182,7 @@ public sealed record ModelHyperparams
             NoRopeLayerStep = noRopeStep,
             UseSigmoidGating = useSigmoidGating,
             UseL2QkNorm = useL2QkNorm,
+            IsNeoxRope = isNeoxRope,
         };
     }
 

--- a/src/SharpInference.Cpu/CpuBackend.cs
+++ b/src/SharpInference.Cpu/CpuBackend.cs
@@ -196,16 +196,16 @@ public sealed unsafe class CpuBackend : IComputeBackend
 
     /// <summary>
     /// Rotary positional embedding (RoPE) in-place.
-    /// Applies rotation to pairs of elements: (x[2i], x[2i+1]) rotated by position * freq_i.
+    /// neox=true: rotates pairs (x[i], x[i+halfDim]) — Qwen, Phi, Gemma, Falcon, etc.
+    /// neox=false: rotates pairs (x[2i], x[2i+1]) — LLaMA, Mistral, SmolLM, etc.
     /// freq_i = 1 / (theta ^ (2i / headDim))
     /// </summary>
-    public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f)
+    public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f, bool neox = false)
     {
         var count = (int)x.ElementCount;
         var px = (float*)x.Handle;
         int halfDim = headDim / 2;
 
-        // Process each head in the tensor
         int numHeads = count / headDim;
         for (int h = 0; h < numHeads; h++)
         {
@@ -217,10 +217,12 @@ public sealed unsafe class CpuBackend : IComputeBackend
                 float cos = MathF.Cos(angle);
                 float sin = MathF.Sin(angle);
 
-                float x0 = head[i];
-                float x1 = head[i + halfDim];
-                head[i] = x0 * cos - x1 * sin;
-                head[i + halfDim] = x0 * sin + x1 * cos;
+                int a = neox ? i : 2 * i;
+                int b = neox ? i + halfDim : 2 * i + 1;
+                float x0 = head[a];
+                float x1 = head[b];
+                head[a] = x0 * cos - x1 * sin;
+                head[b] = x0 * sin + x1 * cos;
             }
         }
     }

--- a/src/SharpInference.Cpu/SimdKernels.cs
+++ b/src/SharpInference.Cpu/SimdKernels.cs
@@ -1741,6 +1741,40 @@ public static unsafe class SimdKernels
         }
     }
 
+    /// <summary>
+    /// NEOX-style RoPE (used by Qwen, Phi, Gemma, Falcon, etc.):
+    /// rotates dim pair (i, i + headDim/2) instead of consecutive (2i, 2i+1).
+    /// </summary>
+    public static void ApplyRoPECachedNeox(float* x, float* cosTab, float* sinTab, int numHeads, int headDim)
+    {
+        int halfDim = headDim / 2;
+        for (int h = 0; h < numHeads; h++)
+        {
+            float* head = x + h * headDim;
+            int i = 0;
+            if (Avx.IsSupported)
+            {
+                for (; i + 8 <= halfDim; i += 8)
+                {
+                    var x0 = Avx.LoadVector256(head + i);
+                    var x1 = Avx.LoadVector256(head + i + halfDim);
+                    var c = Avx.LoadVector256(cosTab + i);
+                    var s = Avx.LoadVector256(sinTab + i);
+                    var r0 = Fma.MultiplySubtract(x0, c, Avx.Multiply(x1, s));
+                    var r1 = Fma.MultiplyAdd(x0, s, Avx.Multiply(x1, c));
+                    Avx.Store(head + i, r0);
+                    Avx.Store(head + i + halfDim, r1);
+                }
+            }
+            for (; i < halfDim; i++)
+            {
+                float x0 = head[i], x1 = head[i + halfDim];
+                head[i] = x0 * cosTab[i] - x1 * sinTab[i];
+                head[i + halfDim] = x0 * sinTab[i] + x1 * cosTab[i];
+            }
+        }
+    }
+
     public static void ApplyRoPE(float* x, int position, int numHeads, int headDim, float theta)
     {
         int halfDim = headDim / 2;

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -480,7 +480,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     public void SiLU(Tensor x) =>
         throw new NotSupportedException("CudaBackend is DiT-only");
 
-    public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f) =>
+    public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f, bool neox = false) =>
         throw new NotSupportedException("CudaBackend is DiT-only");
 
     public void FullSeqAttention(Tensor output, Tensor q, Tensor k, Tensor v,

--- a/src/SharpInference.Engine/ForwardPass.cs
+++ b/src/SharpInference.Engine/ForwardPass.cs
@@ -73,6 +73,25 @@ public sealed unsafe class ForwardPass : IForwardPass
     private float* _rotatedQuery;  // scratch for WHT-rotated query [headDim]
     private float* _decompBuf;     // scratch for decompressed TQ value [headDim]
 
+    // Diagnostic: per-layer residual L2-norm trace (env: SHARPI_TRACE_NORMS=1).
+    private static readonly bool _traceNorms =
+        Environment.GetEnvironmentVariable("SHARPI_TRACE_NORMS") == "1";
+    private float[]? _normTraceAttn;   // [numLayers] post-attn-residual L2 norm
+    private float[]? _normTraceFfn;    // [numLayers] post-ffn-residual L2 norm
+    // Optional MoE router probe (env: SHARPI_TRACE_ROUTERS=1 dumps top-k experts for every
+    // MoE layer). To restrict to a single position (large MoE models), set SHARPI_TRACE_POS=<n>.
+    private static readonly bool _traceRouters =
+        Environment.GetEnvironmentVariable("SHARPI_TRACE_ROUTERS") == "1";
+    private static readonly int _traceRouterPos = ParseInt("SHARPI_TRACE_POS", -1);
+    private static int ParseInt(string env, int def)
+    {
+        var s = Environment.GetEnvironmentVariable(env);
+        return int.TryParse(s, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : def;
+    }
+    // Tracks the position of the in-flight forward pass so MoeFfn can decide whether to log.
+    private int _currentPos;
+
     // Precomputed RoPE cos/sin tables [maxSeqLen * halfDim]
     private readonly float* _ropeCosTable;
     private readonly float* _ropeSinTable;
@@ -109,6 +128,12 @@ public sealed unsafe class ForwardPass : IForwardPass
         _ffnUp = Alloc(_intermDim);
         _logits = Alloc(hp.VocabSize);
         _attnScores = Alloc(_numHeads * ctxLen);
+
+        if (_traceNorms)
+        {
+            _normTraceAttn = new float[hp.NumLayers];
+            _normTraceFfn = new float[hp.NumLayers];
+        }
 
         // Precompute RoPE cos/sin tables for all positions [0, ctxLen)
         _ropeHalfDim = _headDim / 2;
@@ -398,8 +423,8 @@ public sealed unsafe class ForwardPass : IForwardPass
 
                         if (useRoPE)
                         {
-                            SimdKernels.ApplyRoPECached(qn, _ropeCosTable + (long)(startPos + n) * _ropeHalfDim, _ropeSinTable + (long)(startPos + n) * _ropeHalfDim, _numHeads, _headDim);
-                            SimdKernels.ApplyRoPECached(kn, _ropeCosTable + (long)(startPos + n) * _ropeHalfDim, _ropeSinTable + (long)(startPos + n) * _ropeHalfDim, _numKvHeads, _headDim);
+                            ApplyRope(qn, startPos + n, _numHeads);
+                            ApplyRope(kn, startPos + n, _numKvHeads);
                         }
 
                         // L2 QK-norm (Llama-4): norm AFTER RoPE, only on RoPE layers
@@ -603,8 +628,8 @@ public sealed unsafe class ForwardPass : IForwardPass
 
                         if (useRoPE)
                         {
-                            SimdKernels.ApplyRoPECached(qn, _ropeCosTable + (long)pos * _ropeHalfDim, _ropeSinTable + (long)pos * _ropeHalfDim, _numHeads, _headDim);
-                            SimdKernels.ApplyRoPECached(kn, _ropeCosTable + (long)pos * _ropeHalfDim, _ropeSinTable + (long)pos * _ropeHalfDim, _numKvHeads, _headDim);
+                            ApplyRope(qn, pos, _numHeads);
+                            ApplyRope(kn, pos, _numKvHeads);
                         }
 
                         // L2 QK-norm (Llama-4): norm AFTER RoPE, only on RoPE layers
@@ -711,8 +736,12 @@ public sealed unsafe class ForwardPass : IForwardPass
     /// </summary>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
+        _currentPos = position;
+
         // 1. Embedding lookup (single-row dequant, no full table materialization)
         EmbedToken(token);
+
+        float embNorm = _traceNorms ? L2Norm(_hidden, _embDim) : 0f;
 
         // 2. Transformer layers
         for (int layer = 0; layer < _hp.NumLayers; layer++)
@@ -750,8 +779,8 @@ public sealed unsafe class ForwardPass : IForwardPass
 
             if (useRoPE)
             {
-                SimdKernels.ApplyRoPECached(_q, _ropeCosTable + (long)position * _ropeHalfDim, _ropeSinTable + (long)position * _ropeHalfDim, _numHeads, _headDim);
-                SimdKernels.ApplyRoPECached(_k, _ropeCosTable + (long)position * _ropeHalfDim, _ropeSinTable + (long)position * _ropeHalfDim, _numKvHeads, _headDim);
+                ApplyRope(_q, position, _numHeads);
+                ApplyRope(_k, position, _numKvHeads);
             }
 
             // L2 QK-norm (Llama-4): only on RoPE layers, applied after RoPE
@@ -789,6 +818,8 @@ public sealed unsafe class ForwardPass : IForwardPass
             // Residual
             SimdKernels.AddInPlace(_hidden, _residual, _embDim);
 
+            if (_traceNorms) _normTraceAttn![layer] = L2Norm(_hidden, _embDim);
+
             // Save residual for FFN
             Copy(_residual, _hidden, _embDim);
 
@@ -803,6 +834,8 @@ public sealed unsafe class ForwardPass : IForwardPass
 
             // Residual
             SimdKernels.AddInPlace(_hidden, _residual, _embDim);
+
+            if (_traceNorms) _normTraceFfn![layer] = L2Norm(_hidden, _embDim);
         }
 
         // Increment KV cache position
@@ -811,14 +844,64 @@ public sealed unsafe class ForwardPass : IForwardPass
         else
             _kvCache.IncrementPosition();
 
+        float preFinalNorm = _traceNorms ? L2Norm(_hidden, _embDim) : 0f;
+
         // 3. Final RMS norm
         var outNormW = GetNormWeight(_outputNorm);
         SimdKernels.RmsNorm(_hidden, _hidden, outNormW, _embDim, _hp.RmsNormEps);
 
+        float postFinalNorm = _traceNorms ? L2Norm(_hidden, _embDim) : 0f;
+
         // 4. Output projection → logits (fused, no 400MB intermediate buffer)
         FusedMatVec(_logits, _outputWeight, _hidden, _hp.VocabSize, _embDim);
 
+        if (_traceNorms)
+            EmitNormTrace(token, position, embNorm, preFinalNorm, postFinalNorm);
+
         return new ReadOnlySpan<float>(_logits, _hp.VocabSize);
+    }
+
+    private void ApplyRope(float* x, int pos, int heads)
+    {
+        var cos = _ropeCosTable + (long)pos * _ropeHalfDim;
+        var sin = _ropeSinTable + (long)pos * _ropeHalfDim;
+        if (_hp.IsNeoxRope)
+            SimdKernels.ApplyRoPECachedNeox(x, cos, sin, heads, _headDim);
+        else
+            SimdKernels.ApplyRoPECached(x, cos, sin, heads, _headDim);
+    }
+
+    private static float L2Norm(float* x, int n)
+    {
+        double s = 0;
+        for (int i = 0; i < n; i++) { double v = x[i]; s += v * v; }
+        return (float)Math.Sqrt(s);
+    }
+
+    private void EmitNormTrace(int token, int position,
+        float embNorm, float preFinalNorm, float postFinalNorm)
+    {
+        // Top-1 logit + index
+        int topIdx = 0; float topVal = float.MinValue;
+        for (int i = 0; i < _hp.VocabSize; i++)
+            if (_logits[i] > topVal) { topVal = _logits[i]; topIdx = i; }
+
+        var sb = new System.Text.StringBuilder(2048);
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        sb.Append("[norms pos=").Append(position)
+          .Append(" tok=").Append(token)
+          .Append(" emb=").Append(embNorm.ToString("F2", inv));
+        for (int i = 0; i < _hp.NumLayers; i++)
+        {
+            sb.Append(" L").Append(i).Append(":a=")
+              .Append(_normTraceAttn![i].ToString("F1", inv))
+              .Append("/f=").Append(_normTraceFfn![i].ToString("F1", inv));
+        }
+        sb.Append(" preFN=").Append(preFinalNorm.ToString("F2", inv))
+          .Append(" postFN=").Append(postFinalNorm.ToString("F2", inv))
+          .Append(" top=").Append(topIdx)
+          .Append('@').Append(topVal.ToString("F2", inv));
+        Console.Error.WriteLine(sb.ToString());
     }
 
     // ================================================================
@@ -999,6 +1082,22 @@ public sealed unsafe class ForwardPass : IForwardPass
         Span<int> selectedExperts = stackalloc int[numActive];
         Span<float> expertWeights = stackalloc float[numActive];
         SelectTopK(_routerLogits, numExperts, numActive, selectedExperts, expertWeights);
+
+        if (_traceRouters && (_traceRouterPos < 0 || _traceRouterPos == _currentPos))
+        {
+            var inv = System.Globalization.CultureInfo.InvariantCulture;
+            var sb = new System.Text.StringBuilder(512);
+            sb.Append("[router pos=").Append(_currentPos).Append(" L").Append(layer).Append(']');
+            float wsum = 0;
+            for (int i = 0; i < numActive; i++)
+            {
+                sb.Append(' ').Append(selectedExperts[i]).Append('=')
+                  .Append(expertWeights[i].ToString("F4", inv));
+                wsum += expertWeights[i];
+            }
+            sb.Append(" sum=").Append(wsum.ToString("F4", inv));
+            Console.Error.WriteLine(sb.ToString());
+        }
 
         // Step 2: Shared expert (runs on every token if present)
         // Shared expert uses the same dim as routed experts (ExpertIntermediateDim)
@@ -1267,8 +1366,8 @@ public sealed unsafe class ForwardPass : IForwardPass
                 }
                 if (useRoPE)
                 {
-                    SimdKernels.ApplyRoPECached(_q, _ropeCosTable + (long)pos * _ropeHalfDim, _ropeSinTable + (long)pos * _ropeHalfDim, _numHeads, _headDim);
-                    SimdKernels.ApplyRoPECached(_k, _ropeCosTable + (long)pos * _ropeHalfDim, _ropeSinTable + (long)pos * _ropeHalfDim, _numKvHeads, _headDim);
+                    ApplyRope(_q, pos, _numHeads);
+                    ApplyRope(_k, pos, _numKvHeads);
                 }
                 if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
                 {
@@ -1396,8 +1495,8 @@ public sealed unsafe class ForwardPass : IForwardPass
                         caches[n].TruncateTo(pos);
                         if (useRoPE)
                         {
-                            SimdKernels.ApplyRoPECached(qn, _ropeCosTable + (long)pos * _ropeHalfDim, _ropeSinTable + (long)pos * _ropeHalfDim, _numHeads, _headDim);
-                            SimdKernels.ApplyRoPECached(kn, _ropeCosTable + (long)pos * _ropeHalfDim, _ropeSinTable + (long)pos * _ropeHalfDim, _numKvHeads, _headDim);
+                            ApplyRope(qn, pos, _numHeads);
+                            ApplyRope(kn, pos, _numKvHeads);
                         }
                         if (_hasQkNorm)
                         {

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -386,8 +386,8 @@ public sealed unsafe class GpuForwardPass : IForwardPass
                 if (useRoPE)
                 {
                     // RoPE on Q and K
-                    _gpu.RoPE(_q, position, _headDim, _hp.RopeTheta);
-                    _gpu.RoPE(_k, position, _headDim, _hp.RopeTheta);
+                    _gpu.RoPE(_q, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                    _gpu.RoPE(_k, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
                     _gpu.RecordBarrier();
                 }
 

--- a/src/SharpInference.Engine/HybridForwardPass.cs
+++ b/src/SharpInference.Engine/HybridForwardPass.cs
@@ -622,8 +622,8 @@ public sealed unsafe class HybridForwardPass : IForwardPass
                 || (i + 1) % _hp.NoRopeLayerStep != 0;
             if (useRoPE)
             {
-                _gpu.RoPE(_gpuQ, position, _headDim, _hp.RopeTheta);
-                _gpu.RoPE(_gpuK, position, _headDim, _hp.RopeTheta);
+                _gpu.RoPE(_gpuQ, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                _gpu.RoPE(_gpuK, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
                 _gpu.RecordBarrier();
             }
 
@@ -746,9 +746,18 @@ public sealed unsafe class HybridForwardPass : IForwardPass
 
         if (useRoPE)
         {
-            // RoPE
-            SimdKernels.ApplyRoPECached(_cpuQ, _ropeCosTable + (long)position * _ropeHalfDim, _ropeSinTable + (long)position * _ropeHalfDim, _numHeads, _headDim);
-            SimdKernels.ApplyRoPECached(_cpuK, _ropeCosTable + (long)position * _ropeHalfDim, _ropeSinTable + (long)position * _ropeHalfDim, _numKvHeads, _headDim);
+            var cos = _ropeCosTable + (long)position * _ropeHalfDim;
+            var sin = _ropeSinTable + (long)position * _ropeHalfDim;
+            if (_hp.IsNeoxRope)
+            {
+                SimdKernels.ApplyRoPECachedNeox(_cpuQ, cos, sin, _numHeads, _headDim);
+                SimdKernels.ApplyRoPECachedNeox(_cpuK, cos, sin, _numKvHeads, _headDim);
+            }
+            else
+            {
+                SimdKernels.ApplyRoPECached(_cpuQ, cos, sin, _numHeads, _headDim);
+                SimdKernels.ApplyRoPECached(_cpuK, cos, sin, _numKvHeads, _headDim);
+            }
         }
 
         // QK-norm: for L2 (Llama-4), only on RoPE layers per llama.cpp

--- a/src/SharpInference.Vulkan/Shaders.cs
+++ b/src/SharpInference.Vulkan/Shaders.cs
@@ -326,7 +326,7 @@ internal static class Shaders
         """;
 
     /// <summary>
-    /// RoPE: interleaved pair rotation.
+    /// RoPE: interleaved pair rotation. Used by LLaMA, Mistral, SmolLM, etc.
     /// Push constants: { uint num_heads, uint head_dim, int position, float theta }.
     /// Bindings: 0=x (in/out).
     /// Each thread handles one pair (2 elements).
@@ -363,6 +363,46 @@ internal static class Shaders
             float x1 = x_data[base_idx + 1];
             x_data[base_idx]     = x0 * cos_a - x1 * sin_a;
             x_data[base_idx + 1] = x0 * sin_a + x1 * cos_a;
+        }
+        """;
+
+    /// <summary>
+    /// RoPE: NEOX/half rotation (pairs offset by head_dim/2). Used by Qwen, Phi, Gemma, Falcon, etc.
+    /// </summary>
+    internal const string RoPENeox = """
+        #version 450
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) buffer X { float x_data[]; };
+
+        layout(push_constant) uniform Params {
+            uint num_heads;
+            uint head_dim;
+            int position;
+            float theta;
+        };
+
+        void main() {
+            uint pair_idx = gl_GlobalInvocationID.x;
+            uint half_dim = head_dim / 2;
+            uint total_pairs = num_heads * half_dim;
+            if (pair_idx >= total_pairs) return;
+
+            uint h = pair_idx / half_dim;
+            uint i = pair_idx % half_dim;
+
+            float freq = 1.0 / pow(theta, 2.0 * float(i) / float(head_dim));
+            float angle = float(position) * freq;
+            float cos_a = cos(angle);
+            float sin_a = sin(angle);
+
+            uint head_base = h * head_dim;
+            uint a_idx = head_base + i;
+            uint b_idx = head_base + i + half_dim;
+            float x0 = x_data[a_idx];
+            float x1 = x_data[b_idx];
+            x_data[a_idx] = x0 * cos_a - x1 * sin_a;
+            x_data[b_idx] = x0 * sin_a + x1 * cos_a;
         }
         """;
 

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -924,6 +924,7 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     private ComputePipeline? _clearPipeline;
     private ComputePipeline? _elementwiseMulPipeline;
     private ComputePipeline? _ropePipeline;
+    private ComputePipeline? _ropeNeoxPipeline;
     private ComputePipeline? _softmaxPipeline;
     private ComputePipeline? _sigmoidPipeline;
     private ComputePipeline? _matVecQ4KPipeline;
@@ -1082,13 +1083,23 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         DispatchOrRecord(_elementwiseMulPipeline, [GetBuffer(a), GetBuffer(b), GetBuffer(output)], ((uint)a.ElementCount + 255) / 256, &p);
     }
 
-    public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f)
+    public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f, bool neox = false)
     {
-        _ropePipeline ??= new ComputePipeline(this, Shaders.RoPE, 1, pushConstantSize: sizeof(RoPEParams));
+        ComputePipeline pipeline;
+        if (neox)
+        {
+            _ropeNeoxPipeline ??= new ComputePipeline(this, Shaders.RoPENeox, 1, pushConstantSize: sizeof(RoPEParams));
+            pipeline = _ropeNeoxPipeline;
+        }
+        else
+        {
+            _ropePipeline ??= new ComputePipeline(this, Shaders.RoPE, 1, pushConstantSize: sizeof(RoPEParams));
+            pipeline = _ropePipeline;
+        }
         uint numHeads = (uint)(x.ElementCount / headDim);
         uint totalPairs = numHeads * (uint)(headDim / 2);
         var p = new RoPEParams { numHeads = numHeads, headDim = (uint)headDim, position = position, theta = ropeTheta };
-        DispatchOrRecord(_ropePipeline, [GetBuffer(x)], (totalPairs + 255) / 256, &p);
+        DispatchOrRecord(pipeline, [GetBuffer(x)], (totalPairs + 255) / 256, &p);
     }
 
     public void Softmax(Tensor x)
@@ -1520,6 +1531,7 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _clearPipeline?.Dispose();
         _elementwiseMulPipeline?.Dispose();
         _ropePipeline?.Dispose();
+        _ropeNeoxPipeline?.Dispose();
         _softmaxPipeline?.Dispose();
         _sigmoidPipeline?.Dispose();
         _matVecQ4KPipeline?.Dispose();

--- a/tests/SharpInference.Tests.ForwardPass/CpuBackendTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CpuBackendTests.cs
@@ -301,20 +301,36 @@ public sealed class CpuBackendTests : IDisposable
     [Fact]
     public void RoPE_PreservesNorm()
     {
-        // Rotation should preserve the norm of each pair
-        float[] data = [3f, 4f, 1f, 0f]; // headDim=4: pairs are (3,1) and (4,0)
+        // Default (interleaved/LLaMA): pairs are (data[0], data[1]) and (data[2], data[3])
+        float[] data = [3f, 4f, 1f, 0f];
         var t = Upload(data, TensorShape.D1(4));
 
-        // Compute original norms for the rotated pairs
-        // Pair (data[0], data[2]) = (3, 1): norm = sqrt(9+1) = sqrt(10)
-        // Pair (data[1], data[3]) = (4, 0): norm = sqrt(16+0) = 4
-        float norm0Before = MathF.Sqrt(3f * 3f + 1f * 1f);
-        float norm1Before = MathF.Sqrt(4f * 4f + 0f * 0f);
+        float norm0Before = MathF.Sqrt(3f * 3f + 4f * 4f);  // pair (3,4)
+        float norm1Before = MathF.Sqrt(1f * 1f + 0f * 0f);  // pair (1,0)
 
         _backend.RoPE(t, position: 5, headDim: 4);
         var result = Download(t);
 
-        // After rotation: pair (result[0], result[2]) should have same norm
+        float norm0After = MathF.Sqrt(result[0] * result[0] + result[1] * result[1]);
+        float norm1After = MathF.Sqrt(result[2] * result[2] + result[3] * result[3]);
+
+        Assert.InRange(norm0After, norm0Before - 0.01f, norm0Before + 0.01f);
+        Assert.InRange(norm1After, norm1Before - 0.01f, norm1Before + 0.01f);
+    }
+
+    [Fact]
+    public void RoPE_Neox_PreservesNorm()
+    {
+        // NEOX convention: pairs are (data[0], data[halfDim]) and (data[1], data[halfDim+1])
+        float[] data = [3f, 4f, 1f, 0f];
+        var t = Upload(data, TensorShape.D1(4));
+
+        float norm0Before = MathF.Sqrt(3f * 3f + 1f * 1f);  // pair (data[0], data[2])
+        float norm1Before = MathF.Sqrt(4f * 4f + 0f * 0f);  // pair (data[1], data[3])
+
+        _backend.RoPE(t, position: 5, headDim: 4, ropeTheta: 10000f, neox: true);
+        var result = Download(t);
+
         float norm0After = MathF.Sqrt(result[0] * result[0] + result[2] * result[2]);
         float norm1After = MathF.Sqrt(result[1] * result[1] + result[3] * result[3]);
 


### PR DESCRIPTION
## Summary

Fixes Issue #6 — Qwen3-Coder-30B-A3B (and any other Qwen/Phi/Gemma/Falcon model) generated `<|endoftext|>` or `<|im_end|>` as the first token on many short prompts. Originally suspected as a Q4_K_M quantization artifact, the actual cause was a **RoPE convention mismatch**.

SharpInference was applying LLaMA-style **interleaved** RoPE (pairs `(2i, 2i+1)`) to all architectures. Qwen2/Qwen3 (and Phi, Gemma, Falcon, etc.) require **NEOX-style** rotation (pairs offset by `headDim/2`). The wrong rotation produced subtly-incorrect attention output that compounded layer-by-layer until the residual landed in a degenerate region where the LM head predicted EOT with high confidence.

## Changes

- **`ModelHyperparams.IsNeoxRope`** — dispatched per architecture string from `general.architecture` GGUF metadata. NEOX list mirrors `llama.cpp/src/llama-model.cpp:llama_model_rope_type()` (full enumeration: 60+ archs).
- **`SimdKernels.ApplyRoPECachedNeox`** — new SIMD (AVX/FMA) kernel for NEOX rotation.
- **`Shaders.RoPENeox`** — new Vulkan compute shader for NEOX rotation.
- **`IComputeBackend.RoPE`** — added optional `bool neox = false` parameter; `CpuBackend`, `VulkanBackend`, `CudaBackend` updated.
- **`ForwardPass.ApplyRope()`** helper — dispatches between interleaved and NEOX based on `_hp.IsNeoxRope`. All RoPE call sites updated. Same dispatch added to `GpuForwardPass` and `HybridForwardPass` (both GPU and CPU layers).
- **Tests** — split `CpuBackendTests.RoPE_PreservesNorm` into two tests (interleaved and NEOX). The existing test was silently validating NEOX semantics because `CpuBackend.RoPE` was NEOX-only while the engine used interleaved everywhere — that inconsistency is now resolved.
- **Diagnostic instrumentation** — added `SHARPI_TRACE_NORMS` and `SHARPI_TRACE_ROUTERS` env-var-gated logging used to localize this bug. Kept for future debugging; zero overhead when disabled.
- **Design doc** — replaced the incorrect "Q4_K_M quirk" attribution in Phase 11 with the actual root cause and fix description.

## Why is the convention picked automatically?

GGUF has no dedicated rope-type metadata key. `general.architecture` is the only signal, and `llama.cpp` itself hardcodes the convention per architecture. We mirror their full mapping. Special rope variants (MROPE for Qwen2VL, IMROPE for Qwen3VL family, conditional GLM4) are explicitly noted as not yet supported and would need their own dispatch + kernels.

## Test plan

- [x] Qwen3-Coder-30B-A3B previously-failing WGSL/PBR shader prompt — produces clean output
- [x] Qwen3-Coder-30B-A3B Python fibonacci (V18 from bisection) — produces clean output
- [x] Qwen3-Coder-30B-A3B + TurboQuant (`--tq`) — produces clean output
- [x] SmolLM2 (LLaMA arch, interleaved RoPE — control) — unchanged on CPU, GPU at 164 t/s decode
- [x] Full test suite: 206/208 pass; 2 failures are pre-existing partial-Llama-3.1-70B file issues unrelated to RoPE
- [x] New `RoPE_Neox_PreservesNorm` test added; existing `RoPE_PreservesNorm` reframed for the default interleaved convention
- [ ] **Not yet covered**: GPU/Vulkan path on a NEOX-family model (Qwen3 8B etc.) — MoE GPU is gated by issue #2, and no Qwen3 8B dense file is checked in locally. The new `RoPENeox` Vulkan shader compiles and dispatches correctly but has not been end-to-end exercised against a reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)