### PR TITLE
Fix compute->host visibility in HybridForwardPass MoE path (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B
 | CPU | `--tq` | ✓ works | ~21 |
 | GPU (`-g -1`) | any | ⚠ auto-fallback to CPU with a warning (issue [#2](https://github.com/pekkah/SharpInference/issues/2)) | — |
 | Hybrid (`-g N`) | any | ✗ refused with error pointing to issue [#2](https://github.com/pekkah/SharpInference/issues/2) | — |
+| Hybrid (`-g 1..9`, debug only) | any | ✓ works with `SHARPI_ALLOW_BROKEN_MOE_HYBRID=1` after the [#2](https://github.com/pekkah/SharpInference/issues/2) host-barrier fix | ~15 (`-g 1 --tq`) |
 
 Copy-paste (recommended config for this machine):
 
@@ -378,7 +379,7 @@ dotnet run --project src/SharpInference.Cli -c Release -- image -m models/z_imag
 
 ### Known limitations
 
-- **MoE on GPU**: any `qwen3moe`/`llama4` model with `-g N` (N > 0) is rejected with an explicit error. `-g -1` (auto) silently falls back to CPU. Tracking: [#2](https://github.com/pekkah/SharpInference/issues/2).
+- **MoE on GPU**: any `qwen3moe`/`llama4` model with `-g N` (N > 0) is rejected with an explicit error. `-g -1` (auto) silently falls back to CPU. Tracking: [#2](https://github.com/pekkah/SharpInference/issues/2). The compute→host visibility bug (Bug 1 in #2) that produced NaN at low `-g N` is fixed; the residual prefetcher-path corruption past `~-g 9` keeps the guard in place. Set `SHARPI_ALLOW_BROKEN_MOE_HYBRID=1` to bypass the guard for debugging.
 - **GPU embedding lookup in `HybridForwardPass`**: works around a shader bug by always doing the per-token embedding row dequant on CPU. Cost is one row of dequant per token (negligible). Tracking: [#3](https://github.com/pekkah/SharpInference/issues/3).
 - **`--backend` flag**: does not exist — backend is selected via `-g`. Vulkan only; CUDA is wired into `image` only. Tracking: [#4](https://github.com/pekkah/SharpInference/issues/4).
 - **`--tq`** (TurboQuant): requires the model to have `headDim == 128` (most Qwen3 / Llama 3) or `256` (Llama 70B). SmolLM2's `headDim 64` is rejected with a clear error.

--- a/docs/SharpInference-Design.md
+++ b/docs/SharpInference-Design.md
@@ -1692,6 +1692,28 @@ layers remain on CPU. More GPU layers or a VRAM-sufficient config would flip thi
 
 **Target model:** Llama 4 Scout 109B/16E Q2_K (~37 GB)
 
+**Compute→Host barrier for `_gpuPinnedNorm` (issue #2, partial fix):**
+`GpuMoeFfn` populates a host-coherent BAR buffer (`_gpuPinnedNorm`) with the post-RmsNorm
+hidden state via `RecordComputeCopy`, then submits and waits on a fence so the CPU can
+`MapPinned` and read it for the expert CPU fallback path. On RTX 4070 Ti, fence completion
+alone did **not** make the compute-shader writes visible to host reads — `MapPinned`
+returned stale data, the CPU fallback consumed bogus `normPtr` values, and the resulting
+`_cpuFallbackBuf` was wildly out of range (e.g. magnitudes ~1062 vs the expected O(1)),
+which propagated through residuals as garbled tokens (issue #2). Fixed by recording an
+explicit `compute→host` pipeline barrier (`SHADER_WRITE → HOST_READ`,
+`COMPUTE_SHADER → HOST` stages) immediately before `EndRecordAndSubmit`. The new helper
+is `VulkanBackend.RecordComputeToHostBarrier`. With this fix, the CPU-fallback expert
+path produces correct output for any `-g N`.
+
+**Residual issue (still tracked under #2):** Beyond `~-g 9` GPU layers on Qwen3-Coder
+30B-A3B, the *prefetcher-cached* GPU expert path still produces wrong output. Disabling
+the prefetcher entirely (forcing all experts through the CPU fallback) restores
+correctness across the full `-g` range, indicating the residual bug is in the
+GPU-expert MatMul reading prefetched weights — most likely descriptor-set reuse across
+multiple recorded dispatches in `ComputePipeline._reusableDs`. The CLI guard in
+`RunCommand.cs` therefore still refuses MoE on the hybrid path by default; set
+`SHARPI_ALLOW_BROKEN_MOE_HYBRID=1` to bypass for further investigation.
+
 ### Phase 5b: Scout Q4_K CPU Micro-optimization ✅
 
 **Goal:** Push Llama 4 Scout Q4_K_M CPU decode above the usable threshold on DDR4 hardware.

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -170,7 +170,9 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         // MoE models are not yet supported on the hybrid GPU+CPU path. The GpuMoeFfn path
         // produces NaN/degenerate output (see https://github.com/pekkah/SharpInference/issues/2).
         // Fall back to CPU automatically when -g is -1 (auto), refuse explicit -g N for MoE.
-        if (hp.IsMoE && nGpuLayers != 0)
+        // SHARPI_ALLOW_BROKEN_MOE_HYBRID=1 bypasses the guard for debugging issue #2.
+        bool allowBrokenMoeHybrid = Environment.GetEnvironmentVariable("SHARPI_ALLOW_BROKEN_MOE_HYBRID") == "1";
+        if (hp.IsMoE && nGpuLayers != 0 && !allowBrokenMoeHybrid)
         {
             if (nGpuLayers > 0)
             {
@@ -181,6 +183,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             // -g -1 (auto) → silently fall back to CPU
             AnsiConsole.MarkupLine("[yellow]Note:[/] [yellow]-g -1[/] requested, but MoE models run only on CPU until issue #2 is fixed. Falling back to CPU.");
             nGpuLayers = 0;
+        }
+        if (hp.IsMoE && nGpuLayers != 0 && allowBrokenMoeHybrid)
+        {
+            AnsiConsole.MarkupLine("[red]Warning:[/] SHARPI_ALLOW_BROKEN_MOE_HYBRID=1 set; running MoE on hybrid path despite known NaN/garbled output (issue #2 debug mode).");
         }
 
         if (nGpuLayers == 0)

--- a/src/SharpInference.Engine/HybridForwardPass.cs
+++ b/src/SharpInference.Engine/HybridForwardPass.cs
@@ -1231,6 +1231,11 @@ public sealed unsafe class HybridForwardPass : IForwardPass
         // read it after submit via MapPinned — avoids a second CopyBuffer call.
         _gpu.RecordBarrier();
         CopyGpuBuffer(_gpuPinnedNorm!, _gpuNormBuf);
+        // Compute→Host barrier: fence-wait alone does NOT make compute-shader writes
+        // to host-coherent memory visible to host reads on all drivers (observed stale
+        // _gpuPinnedNorm reads on RTX 4070 Ti, manifesting as garbled MoE output past
+        // ~10 GPU layers — issue #2). Explicit HOST_READ barrier flushes the writes.
+        _gpu.RecordComputeToHostBarrier();
         _gpu.EndRecordAndSubmit();
         _gpu.Download(_gpuRouterLogits!, _gpuRouterBuf!);
 
@@ -1259,7 +1264,8 @@ public sealed unsafe class HybridForwardPass : IForwardPass
         if (hasCpuFallback)
         {
             // _gpuPinnedNorm was populated by the GPU session above — map it directly,
-            // no extra Download / CopyBuffer call needed.
+            // no extra Download / CopyBuffer call needed. The compute→host barrier above
+            // ensures the shader writes are visible to host reads after fence completion.
             unsafe
             {
                 float* normPtr = _gpu.MapPinned(_gpuPinnedNorm!);

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -92,6 +92,23 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     }
 
     /// <summary>
+    /// Insert a compute→host barrier so subsequent host reads of host-visible (pinned/BAR)
+    /// memory observe the latest compute-shader writes after the next submit completes.
+    /// Fence wait alone is insufficient on some drivers; an explicit Host-stage barrier is required.
+    /// </summary>
+    public void RecordComputeToHostBarrier()
+    {
+        VkMemoryBarrier barrier = new()
+        {
+            srcAccessMask = VkAccessFlags.ShaderWrite,
+            dstAccessMask = VkAccessFlags.HostRead,
+        };
+        _vkd.vkCmdPipelineBarrier(_transferCmd,
+            VkPipelineStageFlags.ComputeShader, VkPipelineStageFlags.Host,
+            0, 1, &barrier, 0, null, 0, null);
+    }
+
+    /// <summary>
     /// Record a GPU→staging copy into the current command buffer.
     /// Call before <see cref="EndRecordAndSubmit"/>, then <see cref="ReadFromStaging"/>
     /// after the fence fires — eliminates a second command-buffer submission for logits download.


### PR DESCRIPTION
## Summary

Partial fix for issue #2 (Hybrid GPU+CPU MoE path producing NaN/garbled output). The
documented repro (`-g 1 --tq` on Qwen3-Coder 30B-A3B) now decodes coherent text at
~14.7 t/s instead of 0 NaN tokens.

## Root cause (Bug 1, fixed)

`HybridForwardPass.GpuMoeFfn` writes the post-RmsNorm hidden state to a host-coherent
BAR buffer (`_gpuPinnedNorm`) via `RecordComputeCopy`, then submits and waits on a
fence so the CPU expert-fallback path can read it via `MapPinned`. On RTX 4070 Ti,
fence completion alone did not make the compute-shader writes visible to host reads
— `MapPinned` returned stale data, the CPU fallback consumed bogus `normPtr` values,
the resulting `_cpuFallbackBuf` was ~1000x out of range, and the residual carried the
corruption through every later layer as the garbled tokens reported in the issue.

Adding an explicit `compute -> host` pipeline barrier (`SHADER_WRITE -> HOST_READ` on
`COMPUTE_SHADER -> HOST` stages) immediately before `EndRecordAndSubmit` fixes it. The
new helper is `VulkanBackend.RecordComputeToHostBarrier()`.

## Residual issue (Bug 2, still open under #2)

Beyond `~-g 9` GPU layers on Qwen3-Coder 30B-A3B, the *prefetcher-cached* GPU expert
path still produces wrong output even with the host barrier. Disabling the prefetcher
entirely (forcing all experts through CPU fallback) restores correctness across the
full `-g 1..-1` range, which points at the GPU-expert MatMul reading prefetched
weights — most likely descriptor-set reuse across multiple recorded dispatches in
`ComputePipeline._reusableDs`. That fix is a deeper rework and intentionally out of
scope here.

The CLI guard from PR #5 therefore stays in place by default. Set
`SHARPI_ALLOW_BROKEN_MOE_HYBRID=1` to bypass the guard for further work on Bug 2.

## Test plan

- [x] Original issue repro: `SHARPI_ALLOW_BROKEN_MOE_HYBRID=1 ... -g 1 --tq -p \"Hello\"`
      produces coherent decode (was: 0 NaN tokens)
- [x] Sweep `-g 1..9` with prefetcher-on: all produce coherent output
- [x] Sweep `-g 1..-1` with prefetcher disabled (debug only): all produce coherent output
- [x] Default behavior unchanged: guard still refuses MoE on hybrid path with the
      issue #2 message
- [x] Full test suite green (excluding 2 pre-existing Vulkan failures unrelated to MoE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)