### PR TITLE
Fix multi-byte UTF-8 streaming output (closes #13)

### DIFF
--- a/src/SharpInference.Cli/Program.cs
+++ b/src/SharpInference.Cli/Program.cs
@@ -1,5 +1,12 @@
+using System.Text;
 using Spectre.Console.Cli;
 using SharpInference.Cli;
+
+// Force UTF-8 for stdin/stdout. On Windows the console defaults to the OEM
+// code page, which mangles multi-byte UTF-8 output (CJK, emoji, smart quotes)
+// into '?' or replacement glyphs.
+Console.OutputEncoding = Encoding.UTF8;
+Console.InputEncoding = Encoding.UTF8;
 
 var app = new CommandApp<RunCommand>();
 app.Configure(config =>

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -378,11 +378,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
         sw.Restart();
         int generated = 0;
+        var streamDec = new Utf8StreamDecoder();
         spec.Decode(sp.MaxNewTokens, sp.StopTokenIds ?? [], token =>
         {
-            Console.Write(tok.Decode([token]));
+            Console.Write(streamDec.Append(tok.DecodeBytes(token)));
             generated++;
         });
+        Console.Write(streamDec.Flush());
         var decodeMs = sw.Elapsed.TotalMilliseconds;
 
         Console.WriteLine();
@@ -425,11 +427,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
             sw.Restart();
             int generated = 0;
+            var streamDec = new Utf8StreamDecoder();
             spec.Decode(sp.MaxNewTokens, sp.StopTokenIds ?? [], token =>
             {
-                Console.Write(tok.Decode([token]));
+                Console.Write(streamDec.Append(tok.DecodeBytes(token)));
                 generated++;
             });
+            Console.Write(streamDec.Flush());
             var decodeMs = sw.Elapsed.TotalMilliseconds;
 
             Console.WriteLine();
@@ -466,6 +470,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         int generated = 0;
         bool inThinking = false; // set to true when model generates <think> token
         var recentTokens = new List<int>(64);
+        var streamDec = new Utf8StreamDecoder();
         for (int i = 0; i < sp.MaxNewTokens; i++)
         {
             var spWithHistory = sp.RepetitionPenalty != 1.0f && recentTokens.Count > 0
@@ -492,13 +497,14 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             }
             else if (!inThinking)
             {
-                Console.Write(tok.Decode([next]));
+                Console.Write(streamDec.Append(tok.DecodeBytes(next)));
                 generated++;
             }
             recentTokens.Add(next);
             if (recentTokens.Count > 64) recentTokens.RemoveAt(0);
             logits = forward(next, tokens.Count + i);
         }
+        Console.Write(streamDec.Flush());
         if (inThinking) Console.Write("\x1b[0m"); // reset if thinking was never closed
         var decodeMs = sw.Elapsed.TotalMilliseconds;
 
@@ -534,6 +540,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             int generated = 0;
             bool inThinking = false; // set to true when model generates <think> token
             var recentTokens = new List<int>(64);
+            var streamDec = new Utf8StreamDecoder();
             for (int i = 0; i < sp.MaxNewTokens; i++)
             {
                 var spWithHistory = sp.RepetitionPenalty != 1.0f && recentTokens.Count > 0
@@ -553,13 +560,14 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 }
                 else if (!inThinking)
                 {
-                    Console.Write(tok.Decode([next]));
+                    Console.Write(streamDec.Append(tok.DecodeBytes(next)));
                     generated++;
                 }
                 recentTokens.Add(next);
                 if (recentTokens.Count > 64) recentTokens.RemoveAt(0);
                 logits = forward(next, tokens.Count + i);
             }
+            Console.Write(streamDec.Flush());
             if (inThinking) Console.Write("\x1b[0m"); // reset if thinking was never closed
             var decodeMs = sw.Elapsed.TotalMilliseconds;
 

--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -14,6 +14,10 @@ public sealed class GgufTokenizer : ITokenizer
     private readonly Dictionary<string, int> _specialTokens;
     private readonly Dictionary<int, string> _specialTokensById;
     private readonly Dictionary<string, int> _vocab;
+    // Vocab strings indexed by token ID — for byte-level BPE these are the raw
+    // GPT-2 byte-level encoded forms, used by DecodeBytes to recover exact bytes
+    // without the inner tokenizer's lossy U+FFFD substitution on partial sequences.
+    private readonly string[] _idToToken;
     private readonly bool _needsByteEncoding;
 
     public int VocabSize { get; }
@@ -40,6 +44,7 @@ public sealed class GgufTokenizer : ITokenizer
         Dictionary<string, int> specialTokens,
         Dictionary<int, string> specialTokensById,
         Dictionary<string, int> vocab,
+        string[] idToToken,
         int vocabSize,
         int bosTokenId,
         int eosTokenId,
@@ -52,6 +57,7 @@ public sealed class GgufTokenizer : ITokenizer
         _specialTokens = specialTokens;
         _specialTokensById = specialTokensById;
         _vocab = vocab;
+        _idToToken = idToToken;
         _needsByteEncoding = needsByteEncoding;
         VocabSize = vocabSize;
         BosTokenId = bosTokenId;
@@ -169,11 +175,16 @@ public sealed class GgufTokenizer : ITokenizer
             needsByteEncoding = true;
         }
 
+        var idToToken = new string[tokensArray.Length];
+        for (int i = 0; i < tokensArray.Length; i++)
+            idToToken[i] = (string)tokensArray[i];
+
         var tokenizer = new GgufTokenizer(
             inner,
             specialTokens,
             specialTokens.ToDictionary(kv => kv.Value, kv => kv.Key),
             BuildVocabLookup(tokensArray),
+            idToToken,
             tokensArray.Length,
             bosTokenId,
             eosTokenId,
@@ -307,42 +318,61 @@ public sealed class GgufTokenizer : ITokenizer
         // Ġ (U+0120) = space, Ċ (U+010A) = newline, etc.
         // Convert them back to actual bytes if present.
         if (text.Contains('\u0120') || text.Contains('\u010A'))
-            text = DecodeGpt2Bytes(text);
+            text = Encoding.UTF8.GetString(Gpt2CharsToBytes(text));
 
         return text;
     }
 
-    /// <summary>
-    /// Convert GPT-2 byte-level BPE Unicode characters back to actual bytes.
-    /// GPT-2 maps bytes 0x00-0xFF to Unicode chars starting at various offsets.
-    /// The most common: Ġ (U+0120) = space (0x20), Ċ (U+010A) = newline (0x0A).
-    /// </summary>
-    private static string DecodeGpt2Bytes(string text)
+    /// <inheritdoc/>
+    public byte[] DecodeBytes(int token)
     {
+        // Special tokens (control / user-defined) decode to their literal UTF-8 bytes.
+        if (_specialTokensById.TryGetValue(token, out var specialStr))
+            return Encoding.UTF8.GetBytes(specialStr);
+
+        // Look up the raw vocab string by ID rather than going through _inner.Decode,
+        // which silently substitutes U+FFFD for incomplete UTF-8 sequences and so
+        // loses the exact bytes a single token contributes to the stream.
+        if ((uint)token >= (uint)_idToToken.Length)
+            return [];
+
+        return Gpt2CharsToBytes(_idToToken[token]);
+    }
+
+    /// <summary>
+    /// Convert GPT-2 byte-level BPE Unicode characters back to raw bytes.
+    /// Bytes 0x21-0x7E and 0xA1-0xFF stay as-is; 0x00-0x20 and 0x7F-0xA0 are
+    /// remapped to U+0100-U+0142 to keep them printable.
+    ///
+    /// Returns the raw byte sequence — caller is responsible for UTF-8 decoding,
+    /// which may need to span multiple tokens to assemble multi-byte characters.
+    /// </summary>
+    private static byte[] Gpt2CharsToBytes(string text)
+    {
+        // Inverse of EncodeByteToGpt2 — must match exactly:
+        //   0x21-0x7E       → identity
+        //   0xA1-0xFF       → identity
+        //   U+0100-U+0120   → 0x00-0x20  (subtract 0x100)
+        //   U+0121-U+0142   → 0x7F-0xA0  (subtract 0xA2 = 0x121 - 0x7F)
         var bytes = new List<byte>(text.Length);
         foreach (char c in text)
         {
-            if (c < 256)
-            {
+            if (c is >= '!' and <= '~')
                 bytes.Add((byte)c);
-            }
+            else if (c is >= '¡' and <= 'ÿ')
+                bytes.Add((byte)c);
+            else if (c is >= 'Ā' and <= 'Ġ')
+                bytes.Add((byte)(c - 0x100));
+            else if (c is >= 'ġ' and <= 'ł')
+                bytes.Add((byte)(c - 0xA2));
             else
             {
-                // GPT-2 byte mapping: chars 0x100-0x1FF map to bytes via lookup
-                // The mapping: printable ASCII stays as-is, non-printable gets offset
-                // Simplified: U+0100+n maps to byte n for n < 256
-                int mapped = c - 0x100;
-                if (mapped >= 0 && mapped < 256)
-                    bytes.Add((byte)mapped);
-                else
-                {
-                    // Not a byte token — encode as UTF-8
-                    foreach (byte b in System.Text.Encoding.UTF8.GetBytes(new[] { c }))
-                        bytes.Add(b);
-                }
+                // Not a byte token — encode as UTF-8 (rare fallback)
+                foreach (byte b in Encoding.UTF8.GetBytes(new[] { c }))
+                    bytes.Add(b);
             }
         }
-        return System.Text.Encoding.UTF8.GetString(bytes.ToArray());
+        return bytes.ToArray();
     }
 
     private static int GetMetadataInt(GgufModel model, string key, int defaultValue)

--- a/src/SharpInference.Core/ITokenizer.cs
+++ b/src/SharpInference.Core/ITokenizer.cs
@@ -11,6 +11,15 @@ public interface ITokenizer
     /// <summary>Decode token IDs back to text.</summary>
     string Decode(IEnumerable<int> tokens);
 
+    /// <summary>
+    /// Decode a single token to its raw UTF-8 bytes. For byte-level BPE tokenizers
+    /// the bytes are exactly the token's contribution to the output stream — they
+    /// may form an incomplete UTF-8 sequence on their own. Stream-decode through
+    /// <see cref="Utf8StreamDecoder"/> to reassemble multi-byte characters
+    /// split across tokens.
+    /// </summary>
+    byte[] DecodeBytes(int token);
+
     int VocabSize { get; }
     int BosTokenId { get; }
     int EosTokenId { get; }

--- a/src/SharpInference.Core/Utf8StreamDecoder.cs
+++ b/src/SharpInference.Core/Utf8StreamDecoder.cs
@@ -1,0 +1,47 @@
+using System.Text;
+
+namespace SharpInference.Core;
+
+/// <summary>
+/// Stateful UTF-8 decoder for streaming token output.
+///
+/// Byte-level BPE models split a single multi-byte UTF-8 character (CJK, emoji,
+/// curly quotes, em-dash, etc.) across several tokens. Decoding each token's
+/// bytes independently with <c>Encoding.UTF8.GetString</c> yields U+FFFD
+/// replacement characters because each call sees an incomplete sequence.
+///
+/// This helper wraps <see cref="System.Text.Decoder"/>, which retains incomplete
+/// trailing bytes between calls so partial sequences are reassembled across
+/// token boundaries.
+/// </summary>
+public sealed class Utf8StreamDecoder
+{
+    private readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+
+    /// <summary>
+    /// Feed token bytes to the decoder and return any complete codepoints
+    /// produced so far. Trailing partial bytes are buffered for the next call.
+    /// </summary>
+    public string Append(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty) return string.Empty;
+        // GetCharCount mutates decoder state, so skip it and size the output
+        // buffer using the worst-case bound: each input byte plus an optional
+        // surrogate trailing char from completing a buffered 4-byte sequence.
+        int maxChars = bytes.Length + 4;
+        Span<char> buf = maxChars <= 256 ? stackalloc char[256] : new char[maxChars];
+        int written = _decoder.GetChars(bytes, buf, flush: false);
+        return written == 0 ? string.Empty : new string(buf[..written]);
+    }
+
+    /// <summary>
+    /// End of stream — surface any final partial bytes. Truly incomplete
+    /// sequences are emitted as a single U+FFFD replacement character.
+    /// </summary>
+    public string Flush()
+    {
+        Span<char> buf = stackalloc char[8];
+        int written = _decoder.GetChars(ReadOnlySpan<byte>.Empty, buf, flush: true);
+        return written == 0 ? string.Empty : new string(buf[..written]);
+    }
+}

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -50,6 +50,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         public required Random Rng;
         public required CancellationToken Ct;
         public int TokenCount;
+        // Per-sequence stateful UTF-8 decoder: reassembles multi-byte characters
+        // split across tokens (CJK, emoji, smart quotes).
+        public Utf8StreamDecoder StreamDec = new();
     }
 
     public ContinuousBatchingEngine(
@@ -155,6 +158,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
 
                 if (done)
                 {
+                    var tail = seq.StreamDec.Flush();
+                    if (tail.Length > 0)
+                        seq.Output.Writer.TryWrite(tail);
                     seq.Output.Writer.TryComplete();
                     seq.Cache.Dispose();
                     active.RemoveAt(i);
@@ -162,7 +168,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 }
                 else
                 {
-                    seq.Output.Writer.TryWrite(_tokenizer.Decode([next]));
+                    var chunk = seq.StreamDec.Append(_tokenizer.DecodeBytes(next));
+                    if (chunk.Length > 0)
+                        seq.Output.Writer.TryWrite(chunk);
                     seq.CurrentToken = next;
                     seq.Position++;
                     seq.TokenCount++;
@@ -173,6 +181,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         // Drain: complete any remaining active sequences
         foreach (var seq in active)
         {
+            var tail = seq.StreamDec.Flush();
+            if (tail.Length > 0)
+                seq.Output.Writer.TryWrite(tail);
             seq.Output.Writer.TryComplete();
             seq.Cache.Dispose();
             Interlocked.Decrement(ref _activeCount);
@@ -212,9 +223,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             return;
         }
 
-        req.Output.Writer.TryWrite(_tokenizer.Decode([firstToken]));
-
-        active.Add(new ActiveSeq
+        var seq = new ActiveSeq
         {
             CurrentToken = firstToken,
             Position = tokens.Length,
@@ -225,7 +234,12 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             Rng = rng,
             Ct = req.Ct,
             TokenCount = 1,
-        });
+        };
+        var firstChunk = seq.StreamDec.Append(_tokenizer.DecodeBytes(firstToken));
+        if (firstChunk.Length > 0)
+            req.Output.Writer.TryWrite(firstChunk);
+
+        active.Add(seq);
         Interlocked.Increment(ref _activeCount);
     }
 

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -119,7 +119,10 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
 
                     _prevTokens = tokens;
 
-                    // Decode loop
+                    // Decode loop. Stream UTF-8 through a stateful decoder so multi-byte
+                    // characters split across tokens (CJK, emoji, smart quotes) are
+                    // reassembled instead of producing U+FFFD per partial sequence.
+                    var streamDec = new Utf8StreamDecoder();
                     for (int i = 0; i < sp.MaxNewTokens; i++)
                     {
                         ct.ThrowIfCancellationRequested();
@@ -130,9 +133,14 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
 
                         if (stopIds.Contains(next)) break;
 
-                        channel.Writer.TryWrite(_tokenizer.Decode([next]));
+                        var chunk = streamDec.Append(_tokenizer.DecodeBytes(next));
+                        if (chunk.Length > 0)
+                            channel.Writer.TryWrite(chunk);
                         logits = _fwd.Forward(next, tokens.Length + i);
                     }
+                    var tail = streamDec.Flush();
+                    if (tail.Length > 0)
+                        channel.Writer.TryWrite(tail);
 
                     channel.Writer.TryComplete();
                 }

--- a/tests/SharpInference.Tests.Core/GgufTokenizerTests.cs
+++ b/tests/SharpInference.Tests.Core/GgufTokenizerTests.cs
@@ -122,4 +122,57 @@ public sealed class GgufTokenizerTests
 
         Assert.Equal(text, decoded);
     }
+
+    [Fact]
+    public void DecodeBytes_PerTokenStream_ReassemblesMultiByteUnicode()
+    {
+        var tokenizer = CreateTokenizer();
+        if (tokenizer is null) return;
+
+        // Multi-byte UTF-8 (3-byte CJK and curly quotes, em-dash) is the regression
+        // case for issue #13: a single character is split across token boundaries.
+        var text = "你好，世界 — “hello”";
+        var ids = tokenizer.Encode(text);
+
+        // Concat all per-token DecodeBytes output and verify it equals UTF-8 of original.
+        var bytes = new System.Collections.Generic.List<byte>();
+        foreach (var id in ids)
+            bytes.AddRange(tokenizer.DecodeBytes(id));
+
+        Assert.Equal(System.Text.Encoding.UTF8.GetBytes(text), bytes.ToArray());
+    }
+
+    [Fact]
+    public void DecodeBytes_StreamedThroughUtf8Decoder_ProducesNoReplacementChars()
+    {
+        var tokenizer = CreateTokenizer();
+        if (tokenizer is null) return;
+
+        var text = "你好世界";
+        var ids = tokenizer.Encode(text);
+
+        var dec = new Utf8StreamDecoder();
+        var sb = new System.Text.StringBuilder();
+        foreach (var id in ids)
+            sb.Append(dec.Append(tokenizer.DecodeBytes(id)));
+        sb.Append(dec.Flush());
+
+        var output = sb.ToString();
+        Assert.Equal(text, output);
+        Assert.DoesNotContain('�', output);
+    }
+
+    [Fact]
+    public void DecodeBytes_AsciiToken_RoundTripsThroughUtf8()
+    {
+        var tokenizer = CreateTokenizer();
+        if (tokenizer is null) return;
+
+        var ids = tokenizer.Encode("Hello, world!");
+        var bytes = new System.Collections.Generic.List<byte>();
+        foreach (var id in ids)
+            bytes.AddRange(tokenizer.DecodeBytes(id));
+
+        Assert.Equal("Hello, world!", System.Text.Encoding.UTF8.GetString(bytes.ToArray()));
+    }
 }

--- a/tests/SharpInference.Tests.Core/Utf8StreamDecoderTests.cs
+++ b/tests/SharpInference.Tests.Core/Utf8StreamDecoderTests.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using SharpInference.Core;
+
+namespace SharpInference.Tests.Core;
+
+public sealed class Utf8StreamDecoderTests
+{
+    [Fact]
+    public void Append_EmptyInput_ReturnsEmpty()
+    {
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("", dec.Append(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void Append_AsciiBytes_ReturnsSameText()
+    {
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("Hello", dec.Append("Hello"u8));
+    }
+
+    [Fact]
+    public void Append_CompleteMultiByteChar_ReturnsChar()
+    {
+        // 中 is 0xE4 0xB8 0xAD in UTF-8.
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("中", dec.Append([0xE4, 0xB8, 0xAD]));
+    }
+
+    [Fact]
+    public void Append_SplitMultiByteChar_BuffersUntilComplete()
+    {
+        // 中 = 0xE4 0xB8 0xAD split across three calls.
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("", dec.Append([0xE4]));
+        Assert.Equal("", dec.Append([0xB8]));
+        Assert.Equal("中", dec.Append([0xAD]));
+    }
+
+    [Fact]
+    public void Append_SplitFourByteEmoji_BuffersUntilComplete()
+    {
+        // 😀 = U+1F600 = F0 9F 98 80 in UTF-8.
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("", dec.Append([0xF0, 0x9F]));
+        Assert.Equal("", dec.Append([0x98]));
+        Assert.Equal("😀", dec.Append([0x80]));
+    }
+
+    [Fact]
+    public void Append_AsciiAfterIncompleteCharBoundary_ReassemblesCorrectly()
+    {
+        // "a中b" = 0x61, 0xE4 0xB8 0xAD, 0x62. Split between bytes 2 and 3 of 中.
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("a", dec.Append([0x61, 0xE4, 0xB8]));
+        Assert.Equal("中b", dec.Append([0xAD, 0x62]));
+    }
+
+    [Fact]
+    public void Flush_AfterCompleteInput_ReturnsEmpty()
+    {
+        var dec = new Utf8StreamDecoder();
+        dec.Append("Hello"u8);
+        Assert.Equal("", dec.Flush());
+    }
+
+    [Fact]
+    public void Flush_AfterTrulyIncompleteBytes_EmitsReplacementChar()
+    {
+        // 0xE4 0xB8 starts a 3-byte sequence; if the third byte never arrives,
+        // flush should surface a single U+FFFD.
+        var dec = new Utf8StreamDecoder();
+        Assert.Equal("", dec.Append([0xE4, 0xB8]));
+        Assert.Equal("�", dec.Flush());
+    }
+
+    [Fact]
+    public void Streaming_ConcatenatedAppends_MatchesGetString()
+    {
+        // Stream a Chinese sentence one byte at a time and verify the output
+        // matches Encoding.UTF8.GetString of all bytes.
+        var text = "你好，世界！😀";
+        var bytes = Encoding.UTF8.GetBytes(text);
+
+        var dec = new Utf8StreamDecoder();
+        var sb = new StringBuilder();
+        foreach (var b in bytes)
+            sb.Append(dec.Append([b]));
+        sb.Append(dec.Flush());
+
+        Assert.Equal(text, sb.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ITokenizer.DecodeBytes(int)` returning raw bytes per token, plus a stateful `Utf8StreamDecoder` that buffers partial UTF-8 sequences across token boundaries — fixes emoji / CJK / smart quotes rendering as `�`.
- Set `Console.OutputEncoding`/`InputEncoding` to UTF-8 in `Program.cs` so Windows OEM code page no longer mangles valid UTF-8 on its way to the terminal.
- Thread the streaming decoder through all 7 per-token output sites (`RunCommand` x4, `InferenceEngine`, `ContinuousBatchingEngine` decode + admit + drain).
- Drive-by fix: GPT-2 byte-level inverse mapping for the 0x7F-0xA0 range (was decoding 0xA0 as 0x42).

## Root cause
For byte-level BPE, a single 3- or 4-byte UTF-8 character is almost always split across two or more tokens. Both the inner Microsoft.ML.Tokenizers decoder and the existing `GgufTokenizer.Decode([id])` path call `UTF8.GetString` on each token's bytes in isolation, so partial sequences become U+FFFD. `DecodeBytes` exposes the raw bytes; `Utf8StreamDecoder` reassembles them across calls using `Encoding.UTF8.GetDecoder()`.

## Test plan
- [x] 9 new unit tests in `Tests.Core` (Utf8StreamDecoder behavior + per-token round-trip on SmolLM2 vocab)
- [x] Full test suite: 218/220 (the 2 pre-existing TurboQuant shard-loading failures on master are unrelated to this change)
- [x] End-to-end CLI smoke test on SmolLM2-1.7B: `你好世界` (3-byte CJK) and `😀` (4-byte emoji) render correctly
- [ ] Manual verification on Qwen3-Coder / Llama 3.x with longer Chinese paragraphs
- [ ] Manual verification of API server `/v1/chat/completions` streaming with multi-byte content

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)