### PR TITLE
Refresh README performance table with measured t/s

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,11 @@ Verified on AMD Zen 4 (12c/24t, DDR4-3200) + RTX 4070 Ti (12 GB VRAM):
 
 | Backend | `--tq` | Status | Decode (t/s) |
 |---------|--------|--------|--------------|
-| CPU (default) | — | ✓ works | ~51 |
+| CPU (default) | — | ✓ works | ~49 |
 | CPU | `--tq` | ✗ refused — `headDim 64 != 128/256` (clear error) | — |
-| GPU (`-g -1`) | — | ✓ works | ~159 |
+| GPU (`-g -1`) | — | ✓ works | ~163 |
 | GPU (`-g -1`) | `--tq` | ✗ refused — same headDim guard | — |
-| Hybrid (`-g N`, 1 ≤ N < layers) | — | ✓ works | ~61 (`-g 8`) |
+| Hybrid (`-g N`, 1 ≤ N < layers) | — | ✓ works | ~53 (`-g 8`) |
 | Hybrid | `--tq` | ✗ refused — same headDim guard | — |
 
 Copy-paste:
@@ -348,7 +348,7 @@ dotnet run --project src/SharpInference.Cli -c Release -- -m models/SmolLM2-1.7B
 | Backend | `--tq` | Status | Decode (t/s) |
 |---------|--------|--------|--------------|
 | CPU (default) | — | ✓ works | ~21 |
-| CPU | `--tq` | ✓ works | ~21 |
+| CPU | `--tq` | ✓ works | ~20 |
 | GPU (`-g -1`) | any | ⚠ auto-fallback to CPU with a warning (issue [#2](https://github.com/pekkah/SharpInference/issues/2)) | — |
 | Hybrid (`-g N`) | any | ✗ refused with error pointing to issue [#2](https://github.com/pekkah/SharpInference/issues/2) | — |
 | Hybrid (`-g 1..9`, debug only) | any | ✓ works with `SHARPI_ALLOW_BROKEN_MOE_HYBRID=1` after the [#2](https://github.com/pekkah/SharpInference/issues/2) host-barrier fix | ~15 (`-g 1 --tq`) |
@@ -386,17 +386,19 @@ dotnet run --project src/SharpInference.Cli -c Release -- image -m models/z_imag
 
 ## Performance
 
-Benchmarked on AMD Zen 4 (12c/24t, DDR4-3200) + RTX 4070 Ti:
+Benchmarked on AMD Zen 4 (12c/24t, DDR4-3200) + RTX 4070 Ti.
+Each row is the median of 3 runs at `--temp 0`, `-n 256`, decoded from a short prompt. Output was verified coherent in every run.
 
 | Model | Backend | Decode (t/s) | Notes |
 |-------|---------|-------------|-------|
-| SmolLM2 1.7B Q4_K_M | GPU (Vulkan) | 131.3 | Multi-row compute shaders + subgroupAdd |
-| SmolLM2 1.7B Q4_K_M | CPU (AVX2) | 48.6 | Fused dequant-matvec, multi-threaded |
-| Qwen3 8B Q4_K_M | GPU (Vulkan) | 43.5 | Full VRAM fit |
-| Qwen3 8B Q4_K_M | CPU | 13.5 | 1.23× llama.cpp |
-| Llama 4 Scout Q4_K_M | CPU | 5.3 | Bandwidth-limited on 65 GB DDR4 |
-| Qwen3-Coder 30B-A3B Q4_K_M | CPU | 20.8 | MoE: only 8/128 experts active per token |
-| llama.cpp SmolLM2 1.7B | CPU (reference) | 45.1 | Same hardware |
+| SmolLM2 1.7B Q4_K_M | GPU (Vulkan, `-g -1`) | 162.6 | Multi-row compute shaders + subgroupAdd |
+| SmolLM2 1.7B Q4_K_M | Hybrid (`-g 8`, 8/24 layers) | 53.2 | Mixed CPU/GPU forward pass |
+| SmolLM2 1.7B Q4_K_M | CPU (AVX2) | 48.9 | Fused dequant-matvec, multi-threaded |
+| Qwen3-Coder 30B-A3B Q4_K_M | CPU | 21.3 | MoE: only 8/128 experts active per token |
+| Qwen3-Coder 30B-A3B Q4_K_M | CPU `--tq` | 20.3 | TurboQuant 3-bit KV cache (~5× less RAM for KV) |
+| Llama 4 Scout 17B-16E Q4_K_M | CPU | 4.9 | MoE 17B/109B, 16 experts. 60.9 GB on disk; mmap'd from SSD (model > RAM). |
+
+Earlier rounds also measured Qwen3 8B (~43 t/s GPU, ~13 t/s CPU) — that model is not currently on disk so the numbers were not refreshed.
 
 ## Build & Test
 

--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -21,7 +21,8 @@
 param(
     [ValidateSet("smollm2", "qwen3-8b", "llama31-70b", "qwen3-coder-30b-a3b", "llama4-scout",
                  "z-image-turbo", "z-image-turbo-q8", "realesrgan-x4")]
-    [string]$Model
+    [string]$Model,
+    [string]$DestDir
 )
 
 $Models = @{
@@ -119,7 +120,7 @@ $Models = @{
     }
 }
 
-$ModelDir= Join-Path $PSScriptRoot "..\models"
+$ModelDir = if ($DestDir) { $DestDir } else { Join-Path $PSScriptRoot "..\models" }
 if (-not (Test-Path $ModelDir)) {
     New-Item -ItemType Directory -Path $ModelDir -Force | Out-Null
 }


### PR DESCRIPTION
## Summary

- Re-ran the decode benchmark (median of 3 at `--temp 0`, `-n 256`, with output verified coherent) for every text model currently on disk on AMD Zen 4 + RTX 4070 Ti.
- Replaced the consolidated **Performance** table with fresh numbers and updated the per-backend tables under "What works today" so the two views stay consistent.
- Added a new Llama 4 Scout 17B-16E row at 4.9 t/s CPU. The model is 60.9 GB and didn't fit on the primary SSD, so the downloader script now accepts an optional `-DestDir` flag to target any drive.

## Measured numbers

| Config | Decode (t/s) |
|---|---|
| SmolLM2 1.7B Q4_K_M, GPU (`-g -1`) | 162.6 |
| SmolLM2 1.7B Q4_K_M, Hybrid (`-g 8`) | 53.2 |
| SmolLM2 1.7B Q4_K_M, CPU | 48.9 |
| Qwen3-Coder 30B-A3B Q4_K_M, CPU | 21.3 |
| Qwen3-Coder 30B-A3B Q4_K_M, CPU `--tq` | 20.3 |
| Llama 4 Scout 17B-16E Q4_K_M, CPU | 4.9 |

Notable shifts vs the old table: SmolLM2 GPU went from 131.3 → 162.6 t/s (+24%, presumably from prior multi-row shader work that's already merged). SmolLM2 Hybrid `-g 8` dropped from ~61 → ~53 t/s — could be variance, may warrant a separate look.

## Test plan

- [x] Reproduced each row 3× and used the median; outputs verified coherent (correct binary search code, sensible essays).
- [x] All runs strictly sequential — single-process bench load on the same hardware.
- [ ] Reviewer can repro any row with the unchanged copy-paste commands in the README. Scout uses the first shard:
  ```
  dotnet run --project src/SharpInference.Cli -c Release -- -m "E:/models/Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf" -p "Write a Python implementation of binary search with comments." --temp 0 -n 256 --single-turn --no-display-prompt
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)