### PR TITLE
InferenceEngine: surface prefix-cache status (#22)

### DIFF
--- a/src/SharpInference.Core/IForwardPass.cs
+++ b/src/SharpInference.Core/IForwardPass.cs
@@ -22,8 +22,15 @@ public interface IForwardPass : IDisposable
     ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0);
 
     /// <summary>
-    /// Truncate the KV cache to the given length, discarding positions >= length.
+    /// Truncate the KV cache to the given length, discarding positions &gt;= length.
     /// Used by speculative decoding to rewind rejected draft tokens.
+    /// <para>
+    /// Implementations that return <c>false</c> from <see cref="SupportsPartialRewind"/>
+    /// accept only <c>length == 0</c> (full reset) or <c>length == currentCacheLength</c>
+    /// (no-op); any other value must throw <see cref="NotSupportedException"/>. Callers that
+    /// need to rewind to an intermediate position must check <see cref="SupportsPartialRewind"/>
+    /// first.
+    /// </para>
     /// </summary>
     void TruncateTo(int length);
 
@@ -35,4 +42,15 @@ public interface IForwardPass : IDisposable
 
     /// <summary>Reset the KV cache to empty (start of a new conversation).</summary>
     void ResetCache();
+
+    /// <summary>
+    /// Whether <see cref="TruncateTo"/> accepts arbitrary intermediate lengths (i.e. values
+    /// other than 0 or the current cache length). Defaults to <c>false</c> so new
+    /// implementations are safe by default; rewindable transformer passes must opt in by
+    /// overriding this to <c>true</c>. Models whose state is destructively updated per
+    /// token (e.g. Gated DeltaNet hybrid) leave this at the default. Consumed by the
+    /// inference engine and speculative decoder to skip code paths that would otherwise
+    /// throw on partial rewind.
+    /// </summary>
+    bool SupportsPartialRewind => false;
 }

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -105,6 +105,16 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     public int ActiveRequests => _activeCount;
 
     /// <summary>
+    /// Continuous batching does not (yet) share KV state across requests — each admitted
+    /// sequence allocates its own <see cref="PagedKvCache"/> — so prefix caching is always
+    /// off here.
+    /// </summary>
+    public bool PrefixCacheEnabled => false;
+
+    /// <inheritdoc/>
+    public long PrefillTokensReused => 0;
+
+    /// <summary>
     /// Back-compat string-stream view of <see cref="GenerateChunksAsync"/>: yields only
     /// user-facing answer text, suppressing reasoning chunks. Equivalent to the default
     /// interface-method implementation on <see cref="IInferenceEngine"/> but callable

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -750,6 +750,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         _kvCache.TruncateTo(length);
     }
 
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => true;
+
     /// <inheritdoc/>
     public void ResetCache()
     {

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -128,6 +128,9 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             _cpuKvCache.TruncateTo(length);
     }
 
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => true;
+
     public CudaHybridForwardPass(GgufModel model, CudaBackend gpu, ModelHyperparams hp,
         LayerPlacement placement, bool enableTq = false, int tqFp32Window = 256, int tqBits = 3,
         int expertSlotCapacity = -1)

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -635,7 +635,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         }
         throw new NotSupportedException(
             $"CudaHybridGdnForwardPass.TruncateTo({length}): GDN state is destructively " +
-            $"updated and cannot be partially rewound; only length == 0 or current ({_gdnStateCache.Length}) is supported.");
+            $"updated and cannot be partially rewound; only length == 0 or current ({_gdnStateCache.Length}) is supported. " +
+            "SupportsPartialRewind == false on this pass — callers should check it before invoking " +
+            "TruncateTo with an intermediate length.");
     }
 
     public void ResetCache()
@@ -652,6 +654,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             }
         }
     }
+
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => false;
 
     /// <summary>Forward one token through the hybrid CUDA + CPU stack.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)

--- a/src/SharpInference.Engine/ForwardPass.cs
+++ b/src/SharpInference.Engine/ForwardPass.cs
@@ -293,6 +293,9 @@ public sealed unsafe class ForwardPass : IForwardPass
             _kvCache.TruncateTo(length);
     }
 
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => true;
+
     public void ResetCache()
     {
         if (_tqKvCache != null)

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -84,6 +84,9 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         _kvCache.TruncateTo(length);
     }
 
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => true;
+
     // CPU KV cache kept for fallback (not used when GPU attention works)
     private readonly Engine.KvCache _kvCache;
 

--- a/src/SharpInference.Engine/HybridForwardPass.cs
+++ b/src/SharpInference.Engine/HybridForwardPass.cs
@@ -123,6 +123,9 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             _cpuKvCache.TruncateTo(length);
     }
 
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => true;
+
     public HybridForwardPass(GgufModel model, VulkanBackend gpu, ModelHyperparams hp,
         LayerPlacement placement, bool enableTq = false, int tqFp32Window = 256, int tqBits = 3,
         int expertSlotCapacity = -1)

--- a/src/SharpInference.Engine/HybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/HybridGdnForwardPass.cs
@@ -357,7 +357,8 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         throw new NotSupportedException(
             $"HybridGdnForwardPass.TruncateTo({length}): Gated DeltaNet state is destructively " +
             $"updated and cannot be partially rewound; only length == 0 (Reset) or length == {_gdnStateCache.Length} " +
-            "(current) is supported. Speculative decoding is disabled for hybrid GDN models in v1.");
+            "(current) is supported. SupportsPartialRewind == false on this pass — callers should " +
+            "check it before invoking TruncateTo with an intermediate length.");
     }
 
     public void ResetCache()
@@ -365,6 +366,9 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         _kvCache.Reset();
         _gdnStateCache.Reset();
     }
+
+    /// <inheritdoc />
+    public bool SupportsPartialRewind => false;
 
     /// <summary>Run one token through the hybrid transformer.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)

--- a/src/SharpInference.Engine/IInferenceEngine.cs
+++ b/src/SharpInference.Engine/IInferenceEngine.cs
@@ -18,6 +18,22 @@ public interface IInferenceEngine
     int ActiveRequests { get; }
 
     /// <summary>
+    /// Whether this engine is *capable* of prefix-cache reuse — not whether a reuse just
+    /// happened. Returns <c>false</c> when the underlying forward pass cannot partially
+    /// rewind its KV cache (e.g. Gated DeltaNet hybrid models like Qwen3.6); in that case
+    /// every request re-prefills the full prompt. To observe whether prefix reuse is
+    /// actually saving work, scrape <see cref="PrefillTokensReused"/>.
+    /// </summary>
+    bool PrefixCacheEnabled { get; }
+
+    /// <summary>
+    /// Running count of prompt tokens skipped via the prefix-cache fast path across the
+    /// lifetime of this engine instance. <c>long</c> because the value can grow unbounded
+    /// on a long-running server.
+    /// </summary>
+    long PrefillTokensReused { get; }
+
+    /// <summary>
     /// Generate typed chunks from a pre-formatted prompt string. Each chunk is tagged as
     /// either user-facing <see cref="GenerateChunkKind.Text"/> or internal
     /// <see cref="GenerateChunkKind.Thinking"/> reasoning. The boundary tokens

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -153,7 +153,9 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                     var stopIds = sp.StopTokenIds ?? [_tokenizer.EosTokenId];
 
                     // Prefix cache check: reuse K/V for matching prefix, skip its prefill.
-                    int prefixLen = FindCacheablePrefix(tokens);
+                    // Skipped entirely when the forward pass can't partially rewind (Gated
+                    // DeltaNet hybrid models) — issue #20.
+                    int prefixLen = _fwd.SupportsPartialRewind ? FindCacheablePrefix(tokens) : 0;
                     if (prefixLen > 0)
                     {
                         // Soft-truncate: discard positions >= prefixLen, keep prefix K/V.
@@ -172,7 +174,10 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                     else
                         logits = _fwd.Forward(tokens[^1], tokens.Length - 1);
 
-                    _prevTokens = tokens;
+                    // Only track tokens for FindCacheablePrefix when the pass can actually
+                    // use them — on incompatible passes the array would be dead weight.
+                    if (_fwd.SupportsPartialRewind)
+                        _prevTokens = tokens;
 
                     // Decode loop. Separate stateful UTF-8 decoders for the answer stream and
                     // the thinking stream so multi-byte characters in either stream reassemble

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -33,6 +33,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
     // Observability counters (updated via Interlocked).
     private int _pendingCount;
     private int _activeCount;
+    private long _prefillTokensReused;
 
     private bool _disposed;
 
@@ -43,6 +44,12 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
 
     /// <summary>1 while a generation is in progress, 0 otherwise.</summary>
     public int ActiveRequests => _activeCount;
+
+    /// <inheritdoc/>
+    public bool PrefixCacheEnabled => _fwd.SupportsPartialRewind;
+
+    /// <inheritdoc/>
+    public long PrefillTokensReused => Interlocked.Read(ref _prefillTokensReused);
 
     /// <param name="fwd">Forward pass implementation (CPU / GPU / Hybrid). Owned by this engine.</param>
     /// <param name="tokenizer">Tokenizer matching the model vocabulary.</param>
@@ -70,6 +77,12 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
         _thinkTokenId = thinkTokenId;
         _endThinkTokenId = endThinkTokenId;
         _owned = owned;
+
+        if (!fwd.SupportsPartialRewind)
+        {
+            Console.Error.WriteLine(
+                $"[InferenceEngine] prefix cache disabled — {fwd.GetType().Name} reports SupportsPartialRewind == false. Multi-turn requests will re-prefill the full prompt.");
+        }
     }
 
     /// <summary>
@@ -160,6 +173,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                     {
                         // Soft-truncate: discard positions >= prefixLen, keep prefix K/V.
                         _fwd.TruncateTo(prefixLen);
+                        Interlocked.Add(ref _prefillTokensReused, prefixLen);
                     }
                     else
                     {

--- a/src/SharpInference.Engine/SpeculativeDecoder.cs
+++ b/src/SharpInference.Engine/SpeculativeDecoder.cs
@@ -36,6 +36,22 @@ public sealed class SpeculativeDecoder
             throw new ArgumentException(
                 $"Target and draft vocab sizes differ ({target.VocabSize} vs {draft.VocabSize}). " +
                 "Both models must share the same tokenizer.");
+        // Spec-decoding rewinds rejected draft tokens via TruncateTo(P + accepted) on
+        // both passes. Models whose state is destructively updated per token (Gated
+        // DeltaNet hybrid) can't honor that, so fail fast at construction rather than
+        // mid-decode. See issue #20.
+        if (!target.SupportsPartialRewind)
+            throw new ArgumentException(
+                $"Speculative decoding requires the target forward pass to support partial rewind; " +
+                $"{target.GetType().Name} does not. Disable speculative decoding for this model or " +
+                "use a non-GDN target pass.",
+                nameof(target));
+        if (!draft.SupportsPartialRewind)
+            throw new ArgumentException(
+                $"Speculative decoding requires the draft forward pass to support partial rewind; " +
+                $"{draft.GetType().Name} does not. Disable speculative decoding for this model or " +
+                "use a non-GDN draft pass.",
+                nameof(draft));
         _target = target;
         _draft = draft;
         _lookahead = Math.Max(1, lookahead);

--- a/src/SharpInference.Server/Endpoints/HealthEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/HealthEndpoints.cs
@@ -49,7 +49,13 @@ public static class HealthEndpoints
             $"sharpi_queue_depth {engine.QueueDepth}\n" +
             $"# HELP sharpi_active_requests Number of requests currently generating tokens\n" +
             $"# TYPE sharpi_active_requests gauge\n" +
-            $"sharpi_active_requests {engine.ActiveRequests}\n",
+            $"sharpi_active_requests {engine.ActiveRequests}\n" +
+            $"# HELP sharpi_prefix_cache_enabled 1 if the engine's prefix-cache reuse path is active, 0 if disabled (e.g. GDN hybrid models)\n" +
+            $"# TYPE sharpi_prefix_cache_enabled gauge\n" +
+            $"sharpi_prefix_cache_enabled {(engine.PrefixCacheEnabled ? 1 : 0)}\n" +
+            $"# HELP sharpi_prefill_tokens_reused_total Total prompt tokens skipped via the prefix-cache fast path\n" +
+            $"# TYPE sharpi_prefill_tokens_reused_total counter\n" +
+            $"sharpi_prefill_tokens_reused_total {engine.PrefillTokensReused}\n",
             ctx.RequestAborted);
     }
 }

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
@@ -259,6 +259,7 @@ public sealed class InferenceEngineChunkTests
         public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0) => EmitNext();
         public void TruncateTo(int length) { }
         public void ResetCache() { _step = 0; }
+        public bool SupportsPartialRewind => true;
         public void Dispose() { }
     }
 }

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
@@ -1,0 +1,209 @@
+using System.Text;
+using SharpInference.Core;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Regression coverage for <see cref="InferenceEngine"/>'s prefix-cache reuse path
+/// (issue #20). Two scenarios:
+///
+/// <list type="number">
+///   <item>A forward pass that does NOT support partial rewind (Qwen3.6-style
+///         GDN hybrid) must not be asked to <see cref="IForwardPass.TruncateTo"/>
+///         to an intermediate length; the engine must fall back to a full reset.</item>
+///   <item>A forward pass that DOES support partial rewind keeps the existing
+///         prefix-cache fast path — guards against accidentally disabling it for
+///         every backend.</item>
+/// </list>
+/// </summary>
+public sealed class InferenceEnginePrefixCacheTests
+{
+    private const int Eos = 99;
+
+    /// <summary>
+    /// Drives two sequential <c>GenerateAsync</c> calls with prompts that share a
+    /// 32-token page-aligned prefix (2 × <see cref="PagedKvCache.PageSize"/>). On a
+    /// rewind-incompatible pass the engine must not propagate the
+    /// <see cref="NotSupportedException"/> from <see cref="IForwardPass.TruncateTo"/>.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_OnRewindIncompatiblePass_DoesNotPropagateTruncateThrow()
+    {
+        var tokenizer = new MultiTurnTokenizer();
+        var fwd = new RewindIncompatibleForwardPass();
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+
+        // Turn 1: 32 prompt tokens. After this _prevTokens has 32 entries.
+        await Drain(engine.GenerateAsync("turn1", sp));
+
+        // Turn 2: 48 prompt tokens, first 32 shared with turn 1. FindCacheablePrefix
+        // returns 32; without the fix the engine calls TruncateTo(32) which throws.
+        await Drain(engine.GenerateAsync("turn2", sp));
+
+        Assert.False(
+            fwd.PartialTruncateAttempted,
+            "InferenceEngine called TruncateTo with a partial length on a rewind-incompatible pass.");
+        // ResetCache is the cold-start branch the engine takes whenever prefixLen == 0. On a
+        // rewind-incompatible pass the gate forces prefixLen to 0 even when prefixes match,
+        // so observing ResetCache here confirms the gate fired (no partial TruncateTo was tried).
+        Assert.True(fwd.ResetCacheCalled, "Engine should reach the ResetCache branch when the prefix gate forces prefixLen to 0.");
+    }
+
+    /// <summary>
+    /// Same two-turn pattern on a rewind-capable pass — the engine should call
+    /// <see cref="IForwardPass.TruncateTo"/> with the matched prefix length and
+    /// only re-prefill the new suffix.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_OnRewindCapablePass_ReusesPrefixOnSecondCall()
+    {
+        var tokenizer = new MultiTurnTokenizer();
+        var fwd = new RewindCapableForwardPass();
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+
+        await Drain(engine.GenerateAsync("turn1", sp));
+        await Drain(engine.GenerateAsync("turn2", sp));
+
+        Assert.Equal(32, fwd.LastTruncateLength);
+        // Second prefill should cover only the 16-token suffix, not all 48 tokens.
+        Assert.Equal(16, fwd.LastPrefillLength);
+        Assert.Equal(32, fwd.LastPrefillStartPos);
+    }
+
+    private static async Task Drain(IAsyncEnumerable<string> stream)
+    {
+        await foreach (var _ in stream) { }
+    }
+
+    // ── Mocks ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Hand-rolled tokenizer that returns two distinct token sequences sharing a
+    /// 32-token (two-page) prefix:
+    ///   "turn1" → [0..32)
+    ///   "turn2" → [0..32) followed by [100..116)
+    /// </summary>
+    private sealed class MultiTurnTokenizer : ITokenizer
+    {
+        public int VocabSize => 200;
+        public int BosTokenId => 0;
+        public int EosTokenId => Eos;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => Eos;
+        public bool AddBosToken => false;
+
+        public IReadOnlyList<int> Encode(string text)
+        {
+            // 32-token shared prefix for any prompt; "turn2" appends 16 fresh tokens.
+            var prefix = Enumerable.Range(0, 32).ToArray();
+            if (text == "turn2")
+                return prefix.Concat(Enumerable.Range(100, 16)).ToArray();
+            return prefix;
+        }
+
+        public string Decode(IEnumerable<int> tokens) => string.Empty;
+        public byte[] DecodeBytes(int token) => [];
+    }
+
+    /// <summary>
+    /// Models the Qwen3.6 GDN hybrid contract: <see cref="TruncateTo"/> only accepts
+    /// length 0 or the current length. Any other call records the attempt and throws.
+    /// </summary>
+    private sealed class RewindIncompatibleForwardPass : IForwardPass
+    {
+        private readonly float[] _logits = new float[200];
+        private int _length;
+
+        public bool PartialTruncateAttempted { get; private set; }
+        public bool ResetCacheCalled { get; private set; }
+
+        public bool SupportsPartialRewind => false;
+
+        public int VocabSize => 200;
+        public int MaxSeqLen => 4096;
+
+        public ReadOnlySpan<float> Forward(int token, int position)
+        {
+            _length = position + 1;
+            return EosLogits();
+        }
+
+        public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0)
+        {
+            _length = startPos + tokens.Count;
+            return EosLogits();
+        }
+
+        public void TruncateTo(int length)
+        {
+            if (length == _length || length == 0)
+            {
+                if (length == 0) _length = 0;
+                return;
+            }
+            PartialTruncateAttempted = true;
+            throw new NotSupportedException(
+                $"RewindIncompatibleForwardPass.TruncateTo({length}): only length == 0 or current ({_length}) is supported.");
+        }
+
+        public void ResetCache()
+        {
+            ResetCacheCalled = true;
+            _length = 0;
+        }
+
+        public void Dispose() { }
+
+        private ReadOnlySpan<float> EosLogits()
+        {
+            Array.Clear(_logits);
+            _logits[Eos] = 1.0f;
+            return _logits;
+        }
+    }
+
+    /// <summary>
+    /// Rewind-capable forward pass that records the arguments to the last
+    /// <see cref="TruncateTo"/> and <see cref="Prefill"/> calls so the test can
+    /// confirm the prefix path was taken.
+    /// </summary>
+    private sealed class RewindCapableForwardPass : IForwardPass
+    {
+        private readonly float[] _logits = new float[200];
+
+        // Sentinel -1 means "never called" — distinguishes a missing call from a TruncateTo(0).
+        public int LastTruncateLength { get; private set; } = -1;
+        public int LastPrefillLength { get; private set; } = -1;
+        public int LastPrefillStartPos { get; private set; } = -1;
+
+        public bool SupportsPartialRewind => true;
+
+        public int VocabSize => 200;
+        public int MaxSeqLen => 4096;
+
+        public ReadOnlySpan<float> Forward(int token, int position) => EosLogits();
+
+        public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0)
+        {
+            LastPrefillLength = tokens.Count;
+            LastPrefillStartPos = startPos;
+            return EosLogits();
+        }
+
+        public void TruncateTo(int length) => LastTruncateLength = length;
+        public void ResetCache() { }
+        public void Dispose() { }
+
+        private ReadOnlySpan<float> EosLogits()
+        {
+            Array.Clear(_logits);
+            _logits[Eos] = 1.0f;
+            return _logits;
+        }
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
@@ -75,6 +75,52 @@ public sealed class InferenceEnginePrefixCacheTests
         Assert.Equal(32, fwd.LastPrefillStartPos);
     }
 
+    /// <summary>
+    /// Issue #22: rewind-incompatible passes must surface <see cref="IInferenceEngine.PrefixCacheEnabled"/>
+    /// as <c>false</c>, and <see cref="IInferenceEngine.PrefillTokensReused"/> must remain at zero across
+    /// turns because the engine is forced down the full-reset branch.
+    /// </summary>
+    [Fact]
+    public async Task PrefixCacheState_OnRewindIncompatiblePass_ReportsDisabledAndZeroReused()
+    {
+        var tokenizer = new MultiTurnTokenizer();
+        var fwd = new RewindIncompatibleForwardPass();
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        Assert.False(engine.PrefixCacheEnabled);
+        Assert.Equal(0, engine.PrefillTokensReused);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+        await Drain(engine.GenerateAsync("turn1", sp));
+        await Drain(engine.GenerateAsync("turn2", sp));
+
+        Assert.Equal(0, engine.PrefillTokensReused);
+    }
+
+    /// <summary>
+    /// Issue #22: rewind-capable passes report <see cref="IInferenceEngine.PrefixCacheEnabled"/> true
+    /// and accumulate the matched-prefix length into <see cref="IInferenceEngine.PrefillTokensReused"/>
+    /// after a cache hit. The fixture's two-turn prompt shares a 32-token prefix.
+    /// </summary>
+    [Fact]
+    public async Task PrefixCacheState_OnRewindCapablePass_ReportsEnabledAndAccumulatesReused()
+    {
+        var tokenizer = new MultiTurnTokenizer();
+        var fwd = new RewindCapableForwardPass();
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        Assert.True(engine.PrefixCacheEnabled);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+        await Drain(engine.GenerateAsync("turn1", sp));
+        // First turn is a cold start — no prefix to reuse.
+        Assert.Equal(0, engine.PrefillTokensReused);
+
+        await Drain(engine.GenerateAsync("turn2", sp));
+        // Second turn shares a 32-token prefix with turn 1.
+        Assert.Equal(32, engine.PrefillTokensReused);
+    }
+
     private static async Task Drain(IAsyncEnumerable<string> stream)
     {
         await foreach (var _ in stream) { }

--- a/tests/SharpInference.Tests.ForwardPass/SpeculativeDecoderTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SpeculativeDecoderTests.cs
@@ -1,0 +1,76 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Construction-time contract for <see cref="SpeculativeDecoder"/>. Speculative decoding
+/// rewinds rejected draft tokens via <see cref="IForwardPass.TruncateTo"/>; any forward
+/// pass whose state is destructively updated per token (Gated DeltaNet hybrid models,
+/// <see cref="IForwardPass.SupportsPartialRewind"/> == false) is rejected up front so the
+/// failure surfaces at construction rather than mid-decode. See issue #20.
+/// </summary>
+public sealed class SpeculativeDecoderTests
+{
+    [Fact]
+    public void Ctor_RewindIncompatibleTarget_ThrowsWithParamNameTarget()
+    {
+        var target = new MockForwardPass(vocabSize: 16, supportsPartialRewind: false);
+        var draft = new MockForwardPass(vocabSize: 16, supportsPartialRewind: true);
+
+        var ex = Assert.Throws<ArgumentException>(() => new SpeculativeDecoder(target, draft));
+        Assert.Equal("target", ex.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_RewindIncompatibleDraft_ThrowsWithParamNameDraft()
+    {
+        var target = new MockForwardPass(vocabSize: 16, supportsPartialRewind: true);
+        var draft = new MockForwardPass(vocabSize: 16, supportsPartialRewind: false);
+
+        var ex = Assert.Throws<ArgumentException>(() => new SpeculativeDecoder(target, draft));
+        Assert.Equal("draft", ex.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_BothRewindCapable_ConstructsSuccessfully()
+    {
+        var target = new MockForwardPass(vocabSize: 16, supportsPartialRewind: true);
+        var draft = new MockForwardPass(vocabSize: 16, supportsPartialRewind: true);
+
+        // No throw expected. Lookahead defaults to 4 (clamped below in the ctor for ≤ 0).
+        var decoder = new SpeculativeDecoder(target, draft);
+        Assert.Equal(4, decoder.Lookahead);
+    }
+
+    [Fact]
+    public void Ctor_VocabSizeMismatch_ThrowsArgumentExceptionRegardlessOfRewindSupport()
+    {
+        // Regression guard: the vocab-size check (pre-existing) and the partial-rewind check
+        // (new in #20) coexist. The vocab-size check runs first.
+        var target = new MockForwardPass(vocabSize: 16, supportsPartialRewind: false);
+        var draft = new MockForwardPass(vocabSize: 32, supportsPartialRewind: false);
+
+        var ex = Assert.Throws<ArgumentException>(() => new SpeculativeDecoder(target, draft));
+        Assert.Contains("vocab", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class MockForwardPass : IForwardPass
+    {
+        public MockForwardPass(int vocabSize, bool supportsPartialRewind)
+        {
+            VocabSize = vocabSize;
+            SupportsPartialRewind = supportsPartialRewind;
+        }
+
+        public int VocabSize { get; }
+        public int MaxSeqLen => 4096;
+        public bool SupportsPartialRewind { get; }
+
+        public ReadOnlySpan<float> Forward(int token, int position) => new float[VocabSize];
+        public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0) => new float[VocabSize];
+        public void TruncateTo(int length) { }
+        public void ResetCache() { }
+        public void Dispose() { }
+    }
+}

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -1014,6 +1014,8 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
     public string ModelId { get; }
     public int QueueDepth => 0;
     public int ActiveRequests => 0;
+    public bool PrefixCacheEnabled => true;
+    public long PrefillTokensReused => 0;
 
     /// <summary>
     /// Captures the <see cref="SamplingParams"/> handed to the most recent


### PR DESCRIPTION
## Summary
- Adds `PrefixCacheEnabled` (capability flag) and `PrefillTokensReused` (counter) to `IInferenceEngine`; exposes both via `/metrics`.
- One-shot `Console.Error` log at engine construction when the underlying forward pass reports `SupportsPartialRewind == false` — operators hosting Qwen3.6 hybrid now get a clear signal that prefix reuse is disabled.
- No behavior change on the cache-miss path; capability flag mirrors `IForwardPass.SupportsPartialRewind`, counter increments by `prefixLen` on hits via `Interlocked.Add`.

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors (under `TreatWarningsAsErrors`).
- [x] `dotnet test` — 354/354 across 5 projects.
- [x] New regression cases in `InferenceEnginePrefixCacheTests`: incompatible pass keeps counter at 0; capable pass accumulates 32 (= one page-aligned shared prefix) after turn 2.
- [ ] Smoke `/metrics` on a running server, confirm both new lines surface.

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)