### PR TITLE
GDN snapshot/restore unlocks prefix-cache reuse on Qwen3.6 hybrid (#21)

### DIFF
--- a/src/SharpInference.Core/IForwardPass.cs
+++ b/src/SharpInference.Core/IForwardPass.cs
@@ -53,4 +53,23 @@ public interface IForwardPass : IDisposable
     /// throw on partial rewind.
     /// </summary>
     bool SupportsPartialRewind => false;
+
+    /// <summary>
+    /// Length (in tokens) of the most recently captured end-of-decode snapshot, or
+    /// <c>-1</c> when no snapshot is held. Used by <see cref="InferenceEngine"/> to
+    /// reuse cached state across chat-continuation turns on forward passes that don't
+    /// support arbitrary partial rewind (specifically GDN hybrids — issue #21).
+    /// The default <c>-1</c> means "no snapshot facility"; rewindable transformer
+    /// passes ignore this and the engine instead consults <see cref="SupportsPartialRewind"/>.
+    /// </summary>
+    int SnapshotLength => -1;
+
+    /// <summary>
+    /// Capture a snapshot of the current cache state so a subsequent
+    /// <see cref="TruncateTo"/> at <see cref="SnapshotLength"/> can restore it.
+    /// Called once at end-of-decode by the inference engine; no-op by default.
+    /// Implementations that support snapshots must update <see cref="SnapshotLength"/>
+    /// to the cache's current token length when this returns.
+    /// </summary>
+    void CaptureSnapshot() { }
 }

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -633,9 +633,41 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             ResetCache();
             return;
         }
+        if (length == _snapshotLength && _snapshotLength >= 0)
+        {
+            // Issue #21: restore from the end-of-decode snapshot.
+            // 1. Pull the host-side cache from the snapshot buffer.
+            _gdnStateCache.RestoreFrom(_snapshotBuf, _snapshotCap);
+            // 2. On the GPU GDN path, upload each per-layer host buffer back to
+            //    the device tensors. CPU GDN path has nothing extra to do — state
+            //    already lives in _gdnStateCache.
+            if (!_cpuGdn)
+            {
+                int scanFloats = _gdnStateCache.ScanStateFloatsPerLayer;
+                int convFloats = _gdnStateCache.ConvStateFloatsPerLayer;
+                for (int layer = 0; layer < _hp.NumLayers; layer++)
+                {
+                    int g = _gdnStateCache.GdnLayerOf(layer);
+                    if (g < 0) continue;
+                    if (_gpuGdnScanState[layer] is { } scanT && scanFloats > 0)
+                    {
+                        float* hostScan = _gdnStateCache.ScanStateAt(g);
+                        _gpu.UploadInto(scanT, new ReadOnlySpan<float>(hostScan, scanFloats));
+                    }
+                    if (_gpuGdnConvState[layer] is { } convT && convFloats > 0)
+                    {
+                        float* hostConv = _gdnStateCache.ConvStateAt(g);
+                        _gpu.UploadInto(convT, new ReadOnlySpan<float>(hostConv, convFloats));
+                    }
+                }
+            }
+            _kvCache.TruncateTo(length);
+            return;
+        }
         throw new NotSupportedException(
             $"CudaHybridGdnForwardPass.TruncateTo({length}): GDN state is destructively " +
-            $"updated and cannot be partially rewound; only length == 0 or current ({_gdnStateCache.Length}) is supported. " +
+            $"updated and cannot be partially rewound; only length == 0, current ({_gdnStateCache.Length}), " +
+            $"or SnapshotLength ({_snapshotLength}) is supported. " +
             "SupportsPartialRewind == false on this pass — callers should check it before invoking " +
             "TruncateTo with an intermediate length.");
     }
@@ -644,6 +676,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     {
         _kvCache.Reset();
         _gdnStateCache.Reset();
+        ClearSnapshot();
         if (!_cpuGdn)
         {
             // Zero GPU-resident scan + conv state for every GDN layer.
@@ -657,6 +690,64 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     /// <inheritdoc />
     public bool SupportsPartialRewind => false;
+
+    // ── Snapshot / restore (issue #21) ─────────────────────────────────
+    // Same Phase-1 design as HybridGdnForwardPass: one snapshot per forward-pass
+    // instance, captured at end-of-decode by InferenceEngine. The GPU path
+    // downloads device state into the host-side _gdnStateCache before writing
+    // it into _snapshotBuf, then uploads back on restore.
+    private byte* _snapshotBuf;
+    private long _snapshotCap;
+    private int _snapshotLength = -1;
+
+    /// <inheritdoc />
+    public int SnapshotLength => _snapshotLength;
+
+    /// <inheritdoc />
+    public void CaptureSnapshot()
+    {
+        EnsureSnapshotBuf();
+        if (!_cpuGdn)
+        {
+            // GPU GDN path: device tensors hold the live state; the host-side
+            // _gdnStateCache scan/conv buffers are stale. Download per-layer
+            // before snapshotting. _gpu.Download self-syncs the stream so all
+            // recurrence kernels for this token have committed before the copy.
+            int scanFloats = _gdnStateCache.ScanStateFloatsPerLayer;
+            int convFloats = _gdnStateCache.ConvStateFloatsPerLayer;
+            for (int layer = 0; layer < _hp.NumLayers; layer++)
+            {
+                int g = _gdnStateCache.GdnLayerOf(layer);
+                if (g < 0) continue;
+                if (_gpuGdnScanState[layer] is { } scanT && scanFloats > 0)
+                {
+                    float* hostScan = _gdnStateCache.ScanStateAt(g);
+                    _gpu.Download(scanT, new Span<float>(hostScan, scanFloats));
+                }
+                if (_gpuGdnConvState[layer] is { } convT && convFloats > 0)
+                {
+                    float* hostConv = _gdnStateCache.ConvStateAt(g);
+                    _gpu.Download(convT, new Span<float>(hostConv, convFloats));
+                }
+            }
+        }
+        _gdnStateCache.SnapshotInto(_snapshotBuf, _snapshotCap);
+        _snapshotLength = _gdnStateCache.Length;
+    }
+
+    /// <summary>Drop the currently held snapshot (if any).</summary>
+    public void ClearSnapshot() => _snapshotLength = -1;
+
+    private void EnsureSnapshotBuf()
+    {
+        long needed = _gdnStateCache.SnapshotBytes;
+        if (_snapshotBuf != null && _snapshotCap >= needed)
+            return;
+        if (_snapshotBuf != null)
+            NativeMemory.Free(_snapshotBuf);
+        _snapshotBuf = (byte*)NativeMemory.Alloc((nuint)needed);
+        _snapshotCap = needed;
+    }
 
     /// <summary>Forward one token through the hybrid CUDA + CPU stack.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)
@@ -1679,6 +1770,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
             _expertSlotManager.Dispose();
         }
+        if (_snapshotBuf != null)
+        {
+            NativeMemory.Free(_snapshotBuf);
+            _snapshotBuf = null;
+        }
+
         _kvCache.Dispose();
         _gdnStateCache.Dispose();
     }

--- a/src/SharpInference.Engine/GdnStateCache.cs
+++ b/src/SharpInference.Engine/GdnStateCache.cs
@@ -213,6 +213,106 @@ public sealed unsafe class GdnStateCache : IDisposable
     public void IncrementPosition() => _length++;
 
     /// <summary>
+    /// Total native byte footprint of a snapshot of this cache: a 4-byte length, a
+    /// 4-byte pad (so the float payload is 8-byte aligned), then per-layer conv state
+    /// followed by per-layer scan state, all in dense (GDN-layer-index) order.
+    /// </summary>
+    /// <remarks>
+    /// Layout, byte offsets:
+    /// <list type="bullet">
+    ///   <item><c>0..4</c>:           <c>_length</c> as int32.</item>
+    ///   <item><c>4..8</c>:           padding (zero).</item>
+    ///   <item><c>8..C0</c>:          <c>NumGdnLayers</c> contiguous conv blocks,
+    ///                                each <see cref="ConvStateFloatsPerLayer"/> floats.</item>
+    ///   <item><c>C0..end</c>:        <c>NumGdnLayers</c> contiguous scan blocks,
+    ///                                each <see cref="ScanStateFloatsPerLayer"/> floats.</item>
+    /// </list>
+    /// Per-layer pointers that are <c>null</c> (degenerate <c>ConvKernel == 1</c>)
+    /// contribute zero bytes — they're skipped in both directions.
+    /// </remarks>
+    public long SnapshotBytes =>
+        sizeof(int) + sizeof(int) /* pad */ +
+        (long)NumGdnLayers * ((long)_convStateBytesPerLayer + (long)_scanStateBytesPerLayer);
+
+    /// <summary>
+    /// Write the contents of this cache (including <see cref="Length"/>) into
+    /// <paramref name="dst"/>. The destination must be at least
+    /// <see cref="SnapshotBytes"/> bytes long.
+    /// </summary>
+    /// <exception cref="ArgumentException">When <paramref name="dstBytes"/> is too small.</exception>
+    public void SnapshotInto(byte* dst, long dstBytes)
+    {
+        long needed = SnapshotBytes;
+        if (dst == null)
+            throw new ArgumentNullException(nameof(dst));
+        if (dstBytes < needed)
+            throw new ArgumentException(
+                $"GdnStateCache.SnapshotInto: dstBytes={dstBytes} < SnapshotBytes={needed}.",
+                nameof(dstBytes));
+
+        // Header: length + 4-byte zero pad for alignment.
+        *(int*)dst = _length;
+        *(int*)(dst + sizeof(int)) = 0;
+
+        byte* cursor = dst + 2 * sizeof(int);
+        // Conv blocks first, scan blocks second — matches SnapshotBytes layout.
+        for (int g = 0; g < NumGdnLayers; g++)
+        {
+            if (_convState[g] != null && _convStateBytesPerLayer > 0)
+            {
+                NativeMemory.Copy(_convState[g], cursor, _convStateBytesPerLayer);
+                cursor += (long)_convStateBytesPerLayer;
+            }
+        }
+        for (int g = 0; g < NumGdnLayers; g++)
+        {
+            if (_scanState[g] != null && _scanStateBytesPerLayer > 0)
+            {
+                NativeMemory.Copy(_scanState[g], cursor, _scanStateBytesPerLayer);
+                cursor += (long)_scanStateBytesPerLayer;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Restore the cache contents (and <see cref="Length"/>) from a snapshot previously
+    /// produced by <see cref="SnapshotInto"/>. The source must be at least
+    /// <see cref="SnapshotBytes"/> bytes long.
+    /// </summary>
+    /// <exception cref="ArgumentException">When <paramref name="srcBytes"/> is too small.</exception>
+    public void RestoreFrom(byte* src, long srcBytes)
+    {
+        long needed = SnapshotBytes;
+        if (src == null)
+            throw new ArgumentNullException(nameof(src));
+        if (srcBytes < needed)
+            throw new ArgumentException(
+                $"GdnStateCache.RestoreFrom: srcBytes={srcBytes} < SnapshotBytes={needed}.",
+                nameof(srcBytes));
+
+        _length = *(int*)src;
+        // Padding byte ignored.
+
+        byte* cursor = src + 2 * sizeof(int);
+        for (int g = 0; g < NumGdnLayers; g++)
+        {
+            if (_convState[g] != null && _convStateBytesPerLayer > 0)
+            {
+                NativeMemory.Copy(cursor, _convState[g], _convStateBytesPerLayer);
+                cursor += (long)_convStateBytesPerLayer;
+            }
+        }
+        for (int g = 0; g < NumGdnLayers; g++)
+        {
+            if (_scanState[g] != null && _scanStateBytesPerLayer > 0)
+            {
+                NativeMemory.Copy(cursor, _scanState[g], _scanStateBytesPerLayer);
+                cursor += (long)_scanStateBytesPerLayer;
+            }
+        }
+    }
+
+    /// <summary>
     /// Free all native state buffers. Safe to call twice — subsequent calls are no-ops.
     /// </summary>
     public void Dispose()

--- a/src/SharpInference.Engine/HybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/HybridGdnForwardPass.cs
@@ -338,9 +338,16 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
     }
 
     /// <summary>
-    /// Truncate caches to <paramref name="length"/>. For hybrid GDN models this is
-    /// only valid at the no-op boundary (length == current) or full reset (length == 0);
-    /// the GDN recurrent state is destructively updated and cannot be partially rewound.
+    /// Truncate caches to <paramref name="length"/>. For hybrid GDN models the GDN
+    /// recurrent state is destructively updated, so this method only accepts:
+    /// <list type="bullet">
+    ///   <item><c>length == 0</c> (full reset).</item>
+    ///   <item><c>length == Length</c> (no-op).</item>
+    ///   <item><c>length == <see cref="SnapshotLength"/></c> when a snapshot was
+    ///         captured by <see cref="CaptureSnapshot"/> at end of the previous
+    ///         decode (issue #21 — restores GDN state from the held snapshot).</item>
+    /// </list>
+    /// Any other length still throws <see cref="NotSupportedException"/>.
     /// </summary>
     public void TruncateTo(int length)
     {
@@ -354,21 +361,64 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
             ResetCache();
             return;
         }
+        if (length == _snapshotLength && _snapshotLength >= 0)
+        {
+            // Issue #21: restore GDN state from the end-of-decode snapshot, then
+            // soft-truncate the KV cache to the matching position.
+            _gdnStateCache.RestoreFrom(_snapshotBuf, _snapshotCap);
+            _kvCache.TruncateTo(length);
+            return;
+        }
         throw new NotSupportedException(
             $"HybridGdnForwardPass.TruncateTo({length}): Gated DeltaNet state is destructively " +
-            $"updated and cannot be partially rewound; only length == 0 (Reset) or length == {_gdnStateCache.Length} " +
-            "(current) is supported. SupportsPartialRewind == false on this pass — callers should " +
-            "check it before invoking TruncateTo with an intermediate length.");
+            $"updated and cannot be partially rewound; only length == 0 (Reset), length == {_gdnStateCache.Length} " +
+            $"(current), or length == SnapshotLength ({_snapshotLength}) is supported. " +
+            "SupportsPartialRewind == false on this pass — callers should check it before invoking " +
+            "TruncateTo with an intermediate length.");
     }
 
     public void ResetCache()
     {
         _kvCache.Reset();
         _gdnStateCache.Reset();
+        ClearSnapshot();
     }
 
     /// <inheritdoc />
     public bool SupportsPartialRewind => false;
+
+    // ── Snapshot / restore (issue #21) ─────────────────────────────────
+    // One snapshot is held per forward-pass instance. The buffer is lazily
+    // allocated on first capture and reused thereafter — sizes are constant
+    // for the lifetime of the pass (model dims don't change).
+    private byte* _snapshotBuf;       // pinned native, lazy-allocated to _gdnStateCache.SnapshotBytes
+    private long _snapshotCap;        // allocated capacity in bytes
+    private int _snapshotLength = -1; // -1 ⇒ no snapshot held
+
+    /// <inheritdoc />
+    public int SnapshotLength => _snapshotLength;
+
+    /// <inheritdoc />
+    public void CaptureSnapshot()
+    {
+        EnsureSnapshotBuf();
+        _gdnStateCache.SnapshotInto(_snapshotBuf, _snapshotCap);
+        _snapshotLength = _gdnStateCache.Length;
+    }
+
+    /// <summary>Drop the currently held snapshot (if any).</summary>
+    public void ClearSnapshot() => _snapshotLength = -1;
+
+    private void EnsureSnapshotBuf()
+    {
+        long needed = _gdnStateCache.SnapshotBytes;
+        if (_snapshotBuf != null && _snapshotCap >= needed)
+            return;
+        if (_snapshotBuf != null)
+            NativeMemory.Free(_snapshotBuf);
+        _snapshotBuf = (byte*)NativeMemory.Alloc((nuint)needed);
+        _snapshotCap = needed;
+    }
 
     /// <summary>Run one token through the hybrid transformer.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)
@@ -1073,6 +1123,12 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         foreach (var p in _normCache.Values)
             NativeMemory.Free((float*)p);
         _normCache.Clear();
+
+        if (_snapshotBuf != null)
+        {
+            NativeMemory.Free(_snapshotBuf);
+            _snapshotBuf = null;
+        }
 
         _kvCache.Dispose();
         _gdnStateCache.Dispose();

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -165,19 +165,54 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                     var rng = new Random();
                     var stopIds = sp.StopTokenIds ?? [_tokenizer.EosTokenId];
 
-                    // Prefix cache check: reuse K/V for matching prefix, skip its prefill.
-                    // Skipped entirely when the forward pass can't partially rewind (Gated
-                    // DeltaNet hybrid models) — issue #20.
-                    int prefixLen = _fwd.SupportsPartialRewind ? FindCacheablePrefix(tokens) : 0;
-                    if (prefixLen > 0)
+                    // Track the full generated sequence (prompt + decoded tokens) so the
+                    // next turn's prefix match has the right baseline — issue #21. Sized
+                    // up front: prompt + MaxNewTokens is a safe upper bound. List<int> is
+                    // cheap (vs. native alloc) and just shadows the tokens we'd lose to
+                    // the channel writer.
+                    var fullSeq = new List<int>(tokens.Length + Math.Max(1, sp.MaxNewTokens));
+                    fullSeq.AddRange(tokens);
+
+                    // Prefix cache decision: two branches.
+                    //   (a) Rewindable attention pass — existing FindCacheablePrefix path,
+                    //       page-aligned KV reuse.
+                    //   (b) Non-rewindable GDN hybrid with a snapshot — issue #21: try
+                    //       exact-match against the most-recent snapshot length so the
+                    //       held GDN recurrent state can be restored.
+                    // If neither branch hits, fall back to a full ResetCache + Prefill.
+                    int prefixLen = 0;
+                    if (_fwd.SupportsPartialRewind)
                     {
-                        // Soft-truncate: discard positions >= prefixLen, keep prefix K/V.
-                        _fwd.TruncateTo(prefixLen);
-                        Interlocked.Add(ref _prefillTokensReused, prefixLen);
+                        int candidate = FindCacheablePrefix(tokens);
+                        if (candidate > 0)
+                        {
+                            _fwd.TruncateTo(candidate);
+                            prefixLen = candidate;
+                        }
+                    }
+                    else if (_fwd.SnapshotLength > 0 && _prevTokens != null)
+                    {
+                        int snapLen = _fwd.SnapshotLength;
+                        // snapLen must be a strict prefix of the new prompt (need at least
+                        // one suffix token to drive the decoder) AND a prefix of the
+                        // previously decoded sequence (so the snapshot matches the state
+                        // at that token position).
+                        if (snapLen <= tokens.Length - 1 && snapLen <= _prevTokens.Length
+                            && tokens.AsSpan(0, snapLen).SequenceEqual(_prevTokens.AsSpan(0, snapLen)))
+                        {
+                            _fwd.TruncateTo(snapLen);
+                            prefixLen = snapLen;
+                        }
+                    }
+                    if (prefixLen == 0)
+                    {
+                        _fwd.ResetCache();
                     }
                     else
                     {
-                        _fwd.ResetCache();
+                        // Issue #22 observability: account reused tokens regardless of
+                        // mechanism (attention partial-rewind or GDN snapshot).
+                        Interlocked.Add(ref _prefillTokensReused, prefixLen);
                     }
 
                     // Prefill: process all prompt tokens (or just the suffix after the cached prefix).
@@ -187,11 +222,6 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                         logits = _fwd.Prefill(suffixTokens, prefixLen);
                     else
                         logits = _fwd.Forward(tokens[^1], tokens.Length - 1);
-
-                    // Only track tokens for FindCacheablePrefix when the pass can actually
-                    // use them — on incompatible passes the array would be dead weight.
-                    if (_fwd.SupportsPartialRewind)
-                        _prevTokens = tokens;
 
                     // Decode loop. Separate stateful UTF-8 decoders for the answer stream and
                     // the thinking stream so multi-byte characters in either stream reassemble
@@ -221,6 +251,12 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                                 ? Sampler.Greedy(logits)
                                 : Sampler.Sample(logits, sp, rng);
                         }
+
+                        // Record every emitted/consumed token (stop tokens included) so the
+                        // post-decode snapshot of _prevTokens reflects the full transcript.
+                        // Issue #21: chat-continuation prompts for turn N+1 typically extend
+                        // turn N's full transcript, not just turn N's prompt.
+                        fullSeq.Add(next);
 
                         if (stopIds.Contains(next)) break;
 
@@ -280,6 +316,18 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable
                     var thinkFlush = thinkDec.Flush();
                     if (thinkFlush.Length > 0)
                         channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkFlush));
+
+                    // Capture end-of-decode snapshot (issue #21) for the GDN-hybrid passes
+                    // and record the full sequence for prefix matching on the next turn.
+                    // ct.ThrowIfCancellationRequested above ensures we don't reach here on
+                    // a cancelled token — skip capture in that case to avoid stale state.
+                    if (!ct.IsCancellationRequested)
+                    {
+                        _fwd.CaptureSnapshot();
+                        // Write _prevTokens AFTER capturing the snapshot so a subsequent
+                        // turn's prefix check sees the matching state.
+                        _prevTokens = fullSeq.ToArray();
+                    }
 
                     channel.Writer.TryComplete();
                 }

--- a/tests/SharpInference.Tests.ForwardPass/GdnStateCacheSnapshotTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/GdnStateCacheSnapshotTests.cs
@@ -1,0 +1,200 @@
+using System.Runtime.InteropServices;
+
+using SharpInference.Core;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #21 coverage for <see cref="GdnStateCache.SnapshotInto"/> /
+/// <see cref="GdnStateCache.RestoreFrom"/>. The hybrid GDN forward passes capture
+/// one of these at end-of-decode so the inference engine can reuse the recurrent
+/// state across chat-continuation turns (which would otherwise be impossible — the
+/// recurrence is destructively updated and <c>SupportsPartialRewind</c> stays
+/// <c>false</c>).
+/// </summary>
+public sealed unsafe class GdnStateCacheSnapshotTests
+{
+    // Tiny shape so the snapshot byte count is small but every code path
+    // (multiple GDN layers, both conv and scan blocks, length tracking) exercises.
+    private static LayerType[] TinyLayerTypes() =>
+    [
+        LayerType.GatedDeltaNet,
+        LayerType.Attention,
+        LayerType.GatedDeltaNet,
+        LayerType.GatedDeltaNet,
+    ];
+
+    private static GdnConfig TinyGdn() => new(
+        NumKHeads: 1,
+        NumVHeads: 2,
+        HeadDim: 4,
+        InnerSize: 8,
+        ConvKernel: 3,
+        FullAttentionInterval: 2);
+
+    [Fact]
+    public void Snapshot_RoundTrip_PreservesLengthAndPerLayerBuffers()
+    {
+        using var cache = new GdnStateCache(TinyLayerTypes(), TinyGdn());
+
+        Assert.Equal(3, cache.NumGdnLayers);
+        Assert.True(cache.ConvStateFloatsPerLayer > 0);
+        Assert.True(cache.ScanStateFloatsPerLayer > 0);
+
+        // Mutate the cache: write distinctive sentinel patterns into both buffers
+        // of every GDN layer, advance _length a few times.
+        int convLen = cache.ConvStateFloatsPerLayer;
+        int scanLen = cache.ScanStateFloatsPerLayer;
+        for (int g = 0; g < cache.NumGdnLayers; g++)
+        {
+            float* cp = cache.ConvStateAt(g);
+            float* sp = cache.ScanStateAt(g);
+            for (int i = 0; i < convLen; i++)
+                cp[i] = (g + 1) * 100f + i * 0.5f;
+            for (int i = 0; i < scanLen; i++)
+                sp[i] = (g + 1) * -100f - i * 0.25f;
+        }
+        cache.IncrementPosition();
+        cache.IncrementPosition();
+        cache.IncrementPosition();
+        Assert.Equal(3, cache.Length);
+
+        // Snapshot into a managed byte array so we can also poke the header.
+        long snapshotBytes = cache.SnapshotBytes;
+        Assert.True(snapshotBytes > 0);
+        var buf = new byte[snapshotBytes];
+        fixed (byte* bp = buf)
+        {
+            cache.SnapshotInto(bp, buf.Length);
+
+            // Header sanity: first int is _length, second int is padding (zero).
+            Assert.Equal(3, *(int*)bp);
+            Assert.Equal(0, *(int*)(bp + sizeof(int)));
+        }
+
+        // Wipe the cache. After this, every byte and the length are back to zero.
+        cache.Reset();
+        Assert.Equal(0, cache.Length);
+        for (int g = 0; g < cache.NumGdnLayers; g++)
+        {
+            Assert.Equal(0f, cache.ConvStateAt(g)[0]);
+            Assert.Equal(0f, cache.ScanStateAt(g)[scanLen - 1]);
+        }
+
+        // Restore from the snapshot and verify byte-identical recovery.
+        fixed (byte* bp = buf)
+            cache.RestoreFrom(bp, buf.Length);
+        Assert.Equal(3, cache.Length);
+        for (int g = 0; g < cache.NumGdnLayers; g++)
+        {
+            float* cp = cache.ConvStateAt(g);
+            float* sp = cache.ScanStateAt(g);
+            for (int i = 0; i < convLen; i++)
+                Assert.Equal((g + 1) * 100f + i * 0.5f, cp[i]);
+            for (int i = 0; i < scanLen; i++)
+                Assert.Equal((g + 1) * -100f - i * 0.25f, sp[i]);
+        }
+    }
+
+    [Fact]
+    public void SnapshotBytes_MatchesDocumentedFormula()
+    {
+        using var cache = new GdnStateCache(TinyLayerTypes(), TinyGdn());
+
+        long expected =
+            sizeof(int) /* length */
+          + sizeof(int) /* pad */
+          + (long)cache.NumGdnLayers * (
+                (long)cache.ConvStateFloatsPerLayer * sizeof(float)
+              + (long)cache.ScanStateFloatsPerLayer * sizeof(float));
+        Assert.Equal(expected, cache.SnapshotBytes);
+    }
+
+    [Fact]
+    public void SnapshotInto_TooSmallDst_Throws()
+    {
+        using var cache = new GdnStateCache(TinyLayerTypes(), TinyGdn());
+
+        // 1 byte below the required size triggers the size guard.
+        long needed = cache.SnapshotBytes;
+        var buf = new byte[needed];
+        fixed (byte* bp = buf)
+        {
+            byte* p = bp;
+            Assert.Throws<ArgumentException>(() => cache.SnapshotInto(p, needed - 1));
+        }
+    }
+
+    [Fact]
+    public void RestoreFrom_TooSmallSrc_Throws()
+    {
+        using var cache = new GdnStateCache(TinyLayerTypes(), TinyGdn());
+
+        long needed = cache.SnapshotBytes;
+        var buf = new byte[needed];
+        fixed (byte* bp = buf)
+        {
+            byte* p = bp;
+            Assert.Throws<ArgumentException>(() => cache.RestoreFrom(p, needed - 1));
+        }
+    }
+
+    [Fact]
+    public void SnapshotInto_NullDst_Throws()
+    {
+        using var cache = new GdnStateCache(TinyLayerTypes(), TinyGdn());
+        Assert.Throws<ArgumentNullException>(() => cache.SnapshotInto(null, cache.SnapshotBytes));
+    }
+
+    [Fact]
+    public void RestoreFrom_NullSrc_Throws()
+    {
+        using var cache = new GdnStateCache(TinyLayerTypes(), TinyGdn());
+        Assert.Throws<ArgumentNullException>(() => cache.RestoreFrom(null, cache.SnapshotBytes));
+    }
+
+    [Fact]
+    public void ConvKernel1_DegenerateLayout_SnapshotsScanOnly()
+    {
+        // ConvKernel == 1 ⇒ ConvStateFloatsPerLayer == 0; per-layer conv pointers
+        // are null. SnapshotInto / RestoreFrom must skip those blocks cleanly.
+        var gdn = new GdnConfig(
+            NumKHeads: 1,
+            NumVHeads: 1,
+            HeadDim: 2,
+            InnerSize: 2,
+            ConvKernel: 1,
+            FullAttentionInterval: 4);
+        using var cache = new GdnStateCache([LayerType.GatedDeltaNet], gdn);
+
+        Assert.Equal(0, cache.ConvStateFloatsPerLayer);
+        Assert.True(cache.ConvStateAt(0) == null);
+
+        // Write into the scan buffer only.
+        float* sp = cache.ScanStateAt(0);
+        for (int i = 0; i < cache.ScanStateFloatsPerLayer; i++)
+            sp[i] = i + 1f;
+        cache.IncrementPosition();
+
+        long snapshotBytes = cache.SnapshotBytes;
+        // Header (8) + scan only.
+        Assert.Equal(
+            sizeof(int) + sizeof(int) +
+            (long)cache.ScanStateFloatsPerLayer * sizeof(float),
+            snapshotBytes);
+
+        var buf = new byte[snapshotBytes];
+        fixed (byte* bp = buf)
+            cache.SnapshotInto(bp, buf.Length);
+
+        cache.Reset();
+        Assert.Equal(0, cache.Length);
+
+        fixed (byte* bp = buf)
+            cache.RestoreFrom(bp, buf.Length);
+        Assert.Equal(1, cache.Length);
+        for (int i = 0; i < cache.ScanStateFloatsPerLayer; i++)
+            Assert.Equal(i + 1f, sp[i]);
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
@@ -6,15 +6,22 @@ namespace SharpInference.Tests.ForwardPass;
 
 /// <summary>
 /// Regression coverage for <see cref="InferenceEngine"/>'s prefix-cache reuse path
-/// (issue #20). Two scenarios:
+/// (issues #20 and #21). Three scenarios:
 ///
 /// <list type="number">
-///   <item>A forward pass that does NOT support partial rewind (Qwen3.6-style
-///         GDN hybrid) must not be asked to <see cref="IForwardPass.TruncateTo"/>
-///         to an intermediate length; the engine must fall back to a full reset.</item>
+///   <item>A forward pass that does NOT support partial rewind AND has no snapshot
+///         facility (e.g. unknown future backend) must not be asked to
+///         <see cref="IForwardPass.TruncateTo"/> to an intermediate length; the
+///         engine must fall back to a full reset (issue #20).</item>
 ///   <item>A forward pass that DOES support partial rewind keeps the existing
-///         prefix-cache fast path — guards against accidentally disabling it for
-///         every backend.</item>
+///         page-aligned prefix-cache fast path — guards against accidentally
+///         disabling it for every backend.</item>
+///   <item>A forward pass that does NOT support partial rewind but DOES expose
+///         <see cref="IForwardPass.CaptureSnapshot"/> /
+///         <see cref="IForwardPass.SnapshotLength"/> (GDN hybrid; issue #21)
+///         can reuse state across chat turns when the new prompt extends the
+///         previous full sequence — the engine calls <c>TruncateTo(snapLen)</c>
+///         instead of resetting.</item>
 /// </list>
 /// </summary>
 public sealed class InferenceEnginePrefixCacheTests
@@ -121,6 +128,47 @@ public sealed class InferenceEnginePrefixCacheTests
         Assert.Equal(32, engine.PrefillTokensReused);
     }
 
+    /// <summary>
+    /// Issue #21: a non-rewindable pass with a snapshot facility (GDN hybrid)
+    /// should still reuse cached state across chat-continuation turns by way
+    /// of <see cref="IForwardPass.CaptureSnapshot"/> at end-of-decode and
+    /// <see cref="IForwardPass.TruncateTo"/> on the snapshot length next turn.
+    ///
+    /// Turn 1: 32 prompt tokens; after the loop (1 generated token + EOS),
+    /// the stub captures a snapshot at the full-sequence length.
+    /// Turn 2: 33 prompt tokens whose first 33 tokens are exactly the turn-1
+    /// full sequence (32 prompt + 1 generated). The engine must call
+    /// TruncateTo(snapLen) — not propagate any throw, not call ResetCache.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_OnSnapshotCapablePass_RestoresSnapshotOnContinuation()
+    {
+        var tokenizer = new SnapshotMultiTurnTokenizer();
+        var fwd = new SnapshotCapableForwardPass();
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+
+        await Drain(engine.GenerateAsync("turn1", sp));
+
+        // After turn 1, _prevTokens is the 32-token prompt + the 1 generated token.
+        // The stub generated token (id 50) is not in stopIds, so it's appended; the
+        // loop then iterates once more and hits MaxNewTokens, exiting cleanly.
+        // CaptureSnapshot records the GdnStateCache.Length-equivalent (mock).
+        Assert.Equal(33, fwd.LastCapturedSnapshotLength);
+
+        await Drain(engine.GenerateAsync("turn2", sp));
+
+        // Engine should have asked the snapshot-capable pass to restore at length 33.
+        Assert.Equal(33, fwd.LastTruncateLength);
+        Assert.False(
+            fwd.ResetCalledAfter,
+            "ResetCache must not run on turn 2 — the snapshot branch already prepared the cache.");
+        // Suffix prefill covers only the tokens after the snapshot length.
+        Assert.True(fwd.LastPrefillLength > 0);
+        Assert.Equal(33, fwd.LastPrefillStartPos);
+    }
+
     private static async Task Drain(IAsyncEnumerable<string> stream)
     {
         await foreach (var _ in stream) { }
@@ -209,6 +257,127 @@ public sealed class InferenceEnginePrefixCacheTests
         {
             Array.Clear(_logits);
             _logits[Eos] = 1.0f;
+            return _logits;
+        }
+    }
+
+    /// <summary>
+    /// Tokenizer paired with <see cref="SnapshotCapableForwardPass"/>. Generates
+    /// a 32-token prefix; for "turn2" extends by 1 sampled-token-slot + 1 fresh
+    /// token so the snapshot length (33) is a strict prefix of the new prompt
+    /// and at least one suffix token remains.
+    /// </summary>
+    private sealed class SnapshotMultiTurnTokenizer : ITokenizer
+    {
+        public const int SampledTokenId = 50;
+
+        public int VocabSize => 200;
+        public int BosTokenId => 0;
+        public int EosTokenId => Eos;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => Eos;
+        public bool AddBosToken => false;
+
+        public IReadOnlyList<int> Encode(string text)
+        {
+            // turn1: 32-token prefix (matches the GDN-hybrid 'apply chat template' result).
+            var prefix = Enumerable.Range(0, 32).ToArray();
+            if (text == "turn2")
+            {
+                // turn2 = [prefix(32) , SampledTokenId , fresh-token(110)]
+                // The engine's full-sequence for turn1 is [prefix(32) , SampledTokenId],
+                // length 33. turn2's first 33 tokens must equal that; the 34th token is
+                // the fresh user-message extension that drives a non-empty prefill.
+                return prefix.Concat([SampledTokenId, 110]).ToArray();
+            }
+            return prefix;
+        }
+
+        public string Decode(IEnumerable<int> tokens) => string.Empty;
+        public byte[] DecodeBytes(int token) => [];
+    }
+
+    /// <summary>
+    /// Models a GDN-hybrid contract: <see cref="SupportsPartialRewind"/> is false
+    /// (recurrent state is destructively updated), but the pass exposes
+    /// <see cref="CaptureSnapshot"/> / <see cref="SnapshotLength"/> so the engine
+    /// can reuse state across chat turns whose prompt extends the prior transcript.
+    /// </summary>
+    private sealed class SnapshotCapableForwardPass : IForwardPass
+    {
+        private readonly float[] _logits = new float[200];
+        private int _length;
+
+        public int LastCapturedSnapshotLength { get; private set; } = -1;
+        public int LastTruncateLength { get; private set; } = -1;
+        public int LastPrefillLength { get; private set; } = -1;
+        public int LastPrefillStartPos { get; private set; } = -1;
+        public bool ResetCalledAfter { get; private set; }
+
+        public bool SupportsPartialRewind => false;
+        public int VocabSize => 200;
+        public int MaxSeqLen => 4096;
+
+        public int SnapshotLength { get; private set; } = -1;
+
+        public ReadOnlySpan<float> Forward(int token, int position)
+        {
+            _length = position + 1;
+            return SampledLogits();
+        }
+
+        public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0)
+        {
+            LastPrefillLength = tokens.Count;
+            LastPrefillStartPos = startPos;
+            _length = startPos + tokens.Count;
+            return SampledLogits();
+        }
+
+        public void TruncateTo(int length)
+        {
+            // Mirror GDN semantics: accept 0, current, and SnapshotLength.
+            // Record every call so the test can verify the engine took the
+            // snapshot branch even when current == SnapshotLength (the trivial
+            // no-op overlap that the real GDN pass would also accept).
+            LastTruncateLength = length;
+            if (length == 0) { _length = 0; SnapshotLength = -1; return; }
+            if (length == _length) return;
+            if (length == SnapshotLength && SnapshotLength >= 0)
+            {
+                _length = length;
+                return;
+            }
+            throw new NotSupportedException(
+                $"SnapshotCapableForwardPass.TruncateTo({length}): only 0, current ({_length}), or SnapshotLength ({SnapshotLength}) supported.");
+        }
+
+        public void ResetCache()
+        {
+            // After a successful TruncateTo(snapLen), the engine must NOT call ResetCache.
+            // Record only when reset happens after the snapshot was captured — that's
+            // the actual regression we're guarding against.
+            if (SnapshotLength >= 0)
+                ResetCalledAfter = true;
+            _length = 0;
+            SnapshotLength = -1;
+        }
+
+        public void CaptureSnapshot()
+        {
+            LastCapturedSnapshotLength = _length;
+            SnapshotLength = _length;
+        }
+
+        public void Dispose() { }
+
+        private ReadOnlySpan<float> SampledLogits()
+        {
+            // Force a non-stop token so the decode loop runs once and the snapshot
+            // is captured at "prompt + 1 generated token" length, mirroring real
+            // generation. EOS is the only default stop id.
+            Array.Clear(_logits);
+            _logits[SnapshotMultiTurnTokenizer.SampledTokenId] = 1.0f;
             return _logits;
         }
     }


### PR DESCRIPTION
## Summary
- Adds an end-of-decode snapshot/restore path for the GDN recurrent state in \`GdnStateCache\` so \`InferenceEngine\`'s prefix-cache reuse path actually works on \`HybridGdnForwardPass\` and \`CudaHybridGdnForwardPass\` (Qwen3.6) — turning multi-turn chat from full re-prefill into the same fast path attention models already get.
- Phase 1 only: one snapshot per request, restored only on exact-match prefix. \`SupportsPartialRewind\` stays \`false\` on the GDN passes so \`SpeculativeDecoder\`'s issue-#20 construction guard still rejects them; per-step snapshots for spec-decode are Phase 2.
- \`IForwardPass\` picks up two defaulted no-op members (\`SnapshotLength\`, \`CaptureSnapshot()\`); attention passes inherit the defaults and behave identically.

## Test plan
- [x] \`dotnet build -c Release\` — 0 warnings, 0 errors under \`TreatWarningsAsErrors\`.
- [x] \`dotnet test\` — 368/368 across 5 projects (+8 new tests).
- [x] Targeted: \`FullyQualifiedName~Gdn|FullyQualifiedName~PrefixCache|FullyQualifiedName~SpeculativeDecoder\` — 49/49.
- [x] GPU↔host transfer ordering verified — \`_gpu.Download\` self-syncs, \`UploadInto\` is synchronous, no race against the next \`Forward\`.
- [x] Cancellation safety — snapshot + \`_prevTokens\` writes gated on \`!ct.IsCancellationRequested\`; cancelled mid-decode leaves the prior matched (snapshot, prev-tokens) pair intact so the next turn's restore corrects any in-flight contamination.
- [ ] Smoke: two-turn chat against Qwen3.6 on the CUDA hybrid path, confirm the second turn skips re-prefill of the shared prefix.

Closes #21. Follow-ups for Phase 2 are listed in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)