### PR TITLE
feat: SnapKV port to CudaForwardPass (#59 dense CUDA half)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -132,8 +132,26 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     // Dtype dispatch for MatMul (mirrors GpuForwardPass._weightDTypes).
     private readonly Dictionary<nint, DType> _weightDTypes = new();
 
+    // SnapKV (#59) — prefill-time eviction by attention-weight scoring.
+    // Mirrors the CudaHybridGdnForwardPass layout, minus the GDN per-layer-type
+    // indirection: every layer in CudaForwardPass is an attention layer.
+    private readonly SnapKvConfig _snapKvCfg;
+    private readonly int _snapKvEffectiveBudget;
+    private Tensor? _snapKvQCapture;     // [numLayers × W × qDim] f32, captured during Prefill
+    private int _snapKvQCaptureW;        // cached W the buffer was sized for
+    private Tensor? _snapKvScoreAccum;   // [maxSeqLen] f32, per-position importance accumulator
+    private Tensor? _snapKvScoreScratch; // [numHeads × maxSeqLen] f32, lazy scratch for the score kernel
+    private bool _snapKvScoreScratchOwned; // false if aliased to _attnScoresScratch
+    private int _snapKvCaptureSlot = -1; // 0..W-1 for tokens in the capture window; -1 otherwise
+
     public int VocabSize => _hp.VocabSize;
     public int MaxSeqLen => _maxSeqLen;
+
+    /// <summary>
+    /// Test-only accessor for the post-prefill KV slot count. After a SnapKV-active
+    /// prefill this is the keep-set size (≤ budget); otherwise it's the prompt length.
+    /// </summary>
+    internal int KvLength => _kvLength;
 
     public CudaForwardPass(GgufModel model, CudaBackend gpu, ModelHyperparams hp,
         int maxContextLength = 0,
@@ -177,6 +195,41 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         }
 
         _kvCache = new KvCache(hp.NumLayers, _maxSeqLen, hp.NumKvHeads, hp.HeadDim);
+
+        // SnapKV (issue #59) — gated by SHARPI_SNAPKV_BUDGET. Buffers are lazily
+        // allocated on the first active prefill in Prefill(). Composition with
+        // TurboQuant requires per-block ring bookkeeping that doesn't yet exist
+        // (issue #60); explicit opt-in + TQ is rejected up front, and the auto
+        // path stays disabled when TQ is on.
+        _snapKvCfg = SnapKvConfig.FromEnvironment();
+        if (_tqEnabled && _snapKvCfg.IsBudgetExplicit && _snapKvCfg.Budget > 0)
+            throw new NotSupportedException(
+                "SnapKV + TurboQuant composition is not yet implemented (issue #60). " +
+                "Set SHARPI_SNAPKV_BUDGET=0 to disable or disable --tq.");
+        if (_snapKvCfg.IsBudgetExplicit)
+        {
+            _snapKvEffectiveBudget = _snapKvCfg.Budget;
+        }
+        else if (_tqEnabled)
+        {
+            // SnapKV stacking on the TQ ring buffer needs separate design — see #60.
+            // Defer auto-enable.
+            _snapKvEffectiveBudget = 0;
+        }
+        else
+        {
+            long fullCacheBytes = (long)_hp.NumLayers * _maxSeqLen
+                                * _numKvHeads * _headDim * 2 * sizeof(float); // K + V, fp32
+            _snapKvEffectiveBudget = SnapKvConfig.ComputeAutoBudget(_maxSeqLen, fullCacheBytes);
+            if (_snapKvEffectiveBudget > 0)
+            {
+                Console.Error.WriteLine(
+                    $"[CudaForwardPass] SnapKV auto-enabled: budget={_snapKvEffectiveBudget}, " +
+                    $"window={_snapKvCfg.Window}, recency={_snapKvCfg.Recency} " +
+                    $"(full cache ~{fullCacheBytes / (1024.0 * 1024.0):F0} MiB; " +
+                    "set SHARPI_SNAPKV_BUDGET=0 to disable).");
+            }
+        }
 
         Console.Error.WriteLine($"[CudaForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength}){(_tqEnabled ? " [TQ3]" : "")}");
 
@@ -519,6 +572,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass
                 }
             }
 
+            // SnapKV (issue #59): capture the post-RoPE / post-Q-norm query for
+            // this (layer, token) into the scoring ring. Gated by the Prefill
+            // wrapper — outside that path _snapKvCaptureSlot stays -1 and we skip.
+            // Every layer here is an attention layer, so no per-layer-type filter.
+            if (_snapKvCaptureSlot >= 0 && _snapKvQCapture is { } capBuf)
+            {
+                int qDim = _numHeads * _headDim;
+                long dstOffsetElems = ((long)layer * _snapKvQCaptureW + _snapKvCaptureSlot) * qDim;
+                _gpu.CopyDeviceRegion(capBuf, dstOffsetElems * sizeof(float),
+                                      _q, 0, (long)qDim * sizeof(float));
+            }
+
             int kvDim = _numKvHeads * _headDim;
 
             if (_tqEnabled)
@@ -679,6 +744,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             _gpu.Synchronize();
             AccPhase(PH_ROPE_QKN, sw, ref t0);
 
+            // SnapKV (issue #59) capture — same as Forward, mirrored into the profiled path.
+            if (_snapKvCaptureSlot >= 0 && _snapKvQCapture is { } capBuf)
+            {
+                int qDimCap = _numHeads * _headDim;
+                long dstOffsetElems = ((long)layer * _snapKvQCaptureW + _snapKvCaptureSlot) * qDimCap;
+                _gpu.CopyDeviceRegion(capBuf, dstOffsetElems * sizeof(float),
+                                      _q, 0, (long)qDimCap * sizeof(float));
+            }
+
             int kvDim = _numKvHeads * _headDim;
             _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer], kvDim, position, _maxSeqLen);
             _gpu.Attention(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
@@ -743,10 +817,157 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     /// <inheritdoc/>
     public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0)
     {
+        if (tokens is null || tokens.Count == 0)
+            throw new ArgumentException("Token list is empty", nameof(tokens));
+
+        int N = tokens.Count;
+
+        // SnapKV (issue #59) gating: only run eviction when this is a fresh
+        // prefill (startPos==0), the effective budget is positive (env-set or
+        // VRAM-scaled auto), the prompt is long enough that eviction would drop
+        // something, and TQ is off (composition with the TQ ring is #60).
+        bool snapKvActive = _snapKvEffectiveBudget > 0
+                         && startPos == 0
+                         && !_tqEnabled
+                         && N > _snapKvEffectiveBudget
+                         && N > _snapKvCfg.Window;
+        int W = 0, wStart = 0;
+        if (snapKvActive)
+        {
+            W = Math.Min(_snapKvCfg.Window, N);
+            wStart = N - W;
+            EnsureSnapKvCaptureBuffer(W);
+        }
+
         ReadOnlySpan<float> logits = default;
-        for (int i = 0; i < tokens.Count; i++)
+        for (int i = 0; i < N; i++)
+        {
+            // Drive Q-capture for the last W tokens — Forward reads
+            // _snapKvCaptureSlot and writes _q into _snapKvQCapture.
+            _snapKvCaptureSlot = (snapKvActive && i >= wStart) ? (i - wStart) : -1;
             logits = Forward(tokens[i], startPos + i);
+        }
+        _snapKvCaptureSlot = -1;
+
+        if (snapKvActive)
+            ApplySnapKvEviction(N, W, wStart);
+
         return logits;
+    }
+
+    /// <summary>
+    /// SnapKV (issue #59): score the captured trailing-W queries against the
+    /// VRAM K cache for every layer (atomicAdd-pooled into a single per-position
+    /// accumulator), download the accumulator, pick a keep set, then compact the
+    /// GPU K/V rings + the host-side <see cref="_kvCache"/> length bookkeeping.
+    /// Called once at the end of a SnapKV-active prefill.
+    /// </summary>
+    private void ApplySnapKvEviction(int N, int W, int wStart)
+    {
+        EnsureSnapKvScoreBuffers();
+        // Zero only the prompt-prefix slice; the rest of the [maxSeqLen] buffer
+        // doesn't participate in scoring and will not be downloaded.
+        _gpu.ClearRegion(_snapKvScoreAccum!, 0, N);
+
+        int qDim = _numHeads * _headDim;
+        for (int layer = 0; layer < _hp.NumLayers; layer++)
+        {
+            for (int w = 0; w < W; w++)
+            {
+                // Stage the captured Q into _q so the scoring kernel can read a
+                // contiguous [numHeads × headDim] vector at the same device
+                // pointer it does during Forward.
+                long srcOffsetElems = ((long)layer * _snapKvQCaptureW + w) * qDim;
+                _gpu.CopyDeviceRegion(_q, 0,
+                    _snapKvQCapture!, srcOffsetElems * sizeof(float),
+                    (long)qDim * sizeof(float));
+
+                int qAbsPos = wStart + w;
+                _gpu.SnapKvScore(_q, _gpuKCache[layer],
+                    _snapKvScoreAccum!, _snapKvScoreScratch!,
+                    _numHeads, _numKvHeads, _headDim,
+                    N, qAbsPos, _maxSeqLen);
+            }
+        }
+
+        // Download the prompt-length prefix of the accumulator and pick the keep set.
+        var hostScores = new float[N];
+        _gpu.Download(_snapKvScoreAccum!, hostScores);
+
+        var selector = new SnapKvSelector(_numHeads, _numKvHeads, _headDim);
+        selector.LoadScores(hostScores, N);
+        int[] keep = selector.SelectKeepSet(N, _snapKvEffectiveBudget, _snapKvCfg.Recency);
+        int K = keep.Length;
+        if (K >= N)
+        {
+            // No actual eviction — leave the GPU ring + bookkeeping alone.
+            return;
+        }
+
+        // Upload the keep list to device (int32) for the gather kernels.
+        ReadOnlySpan<byte> keepBytes = MemoryMarshal.AsBytes(keep.AsSpan());
+        var keepDev = _gpu.UploadRaw(keepBytes, TensorShape.D1(K), DType.Int32);
+        int kvDim = _numKvHeads * _headDim;
+        var stage = _gpu.Allocate(TensorShape.D1((long)K * kvDim));
+        try
+        {
+            long sliceBytes = (long)K * kvDim * sizeof(float);
+            for (int layer = 0; layer < _hp.NumLayers; layer++)
+            {
+                // K: gather kept positions into stage, then copy stage back over
+                // the cache's [0, K * kvDim) prefix. Same for V. Two-phase to
+                // avoid src==dst race (kernel block ordering is undefined).
+                _gpu.KvCompact(_gpuKCache[layer], stage, keepDev, K, kvDim);
+                _gpu.CopyDeviceRegion(_gpuKCache[layer], 0, stage, 0, sliceBytes);
+                _gpu.KvCompact(_gpuVCache[layer], stage, keepDev, K, kvDim);
+                _gpu.CopyDeviceRegion(_gpuVCache[layer], 0, stage, 0, sliceBytes);
+            }
+        }
+        finally
+        {
+            _gpu.Free(stage);
+            _gpu.Free(keepDev);
+        }
+
+        // Update host-side length bookkeeping. _kvCache is bookkeeping-only on
+        // CudaForwardPass — actual data lives in _gpuKCache/_gpuVCache.
+        _kvLength = K;
+        _kvCache.TruncateTo(K);
+    }
+
+    private void EnsureSnapKvCaptureBuffer(int W)
+    {
+        if (_snapKvQCapture is not null && _snapKvQCaptureW >= W) return;
+        if (_snapKvQCapture is { } old) _gpu.Free(old);
+        int qDim = _numHeads * _headDim;
+        long elems = (long)_hp.NumLayers * W * qDim;
+        _snapKvQCapture = _gpu.Allocate(TensorShape.D1(elems));
+        _snapKvQCaptureW = W;
+    }
+
+    private void EnsureSnapKvScoreBuffers()
+    {
+        if (_snapKvScoreAccum is null)
+            _snapKvScoreAccum = _gpu.Allocate(TensorShape.D1(_maxSeqLen));
+
+        // The SnapKvScore kernel only reads/writes scratch when prompt_len > 4096
+        // (the shared-memory fast-path cap), but it always *indexes* into it.
+        // Reuse the attention scratch when it's already allocated; otherwise
+        // make a dedicated allocation sized [numHeads × maxSeqLen]. Track
+        // ownership so Dispose doesn't double-free the aliased case.
+        if (_snapKvScoreScratch is null)
+        {
+            if (_attnScoresScratch is { } existing)
+            {
+                _snapKvScoreScratch = existing;
+                _snapKvScoreScratchOwned = false;
+            }
+            else
+            {
+                _snapKvScoreScratch = _gpu.Allocate(TensorShape.D1((long)_numHeads * _maxSeqLen));
+                _snapKvScoreScratchOwned = true;
+            }
+        }
     }
 
     /// <inheritdoc/>
@@ -1139,8 +1360,17 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             _gpu.Free(_rotatedQ!);
             _gpu.Free(_evictK!);
             _gpu.Free(_evictV!);
-            if (_attnScoresScratch is { } scratch) _gpu.Free(scratch);
         }
+
+        // _attnScoresScratch is shared with SnapKV's score scratch when both are
+        // allocated; the SnapKV side flags ownership so we free it exactly once
+        // here regardless of which path allocated it.
+        if (_attnScoresScratch is { } attnScratch) _gpu.Free(attnScratch);
+
+        // SnapKV (issue #59) scratch (only allocated when active during a prefill).
+        if (_snapKvQCapture is { } qc) _gpu.Free(qc);
+        if (_snapKvScoreAccum is { } sa) _gpu.Free(sa);
+        if (_snapKvScoreScratchOwned && _snapKvScoreScratch is { } ss) _gpu.Free(ss);
 
         _kvCache.Dispose();
     }

--- a/src/SharpInference.Engine/SharpInference.Engine.csproj
+++ b/src/SharpInference.Engine/SharpInference.Engine.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\SharpInference.Pipeline\SharpInference.Pipeline.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpInference.Tests.ForwardPass" />
+  </ItemGroup>
+
 </Project>

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassSnapKvTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassSnapKvTests.cs
@@ -1,0 +1,228 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// SnapKV (issue #59) CudaForwardPass coverage — the dense full-GPU path that
+/// owns Qwen3-8B Q4_K_M at 12 GB. Mirrors <see cref="CudaHybridGdnSnapKvTests"/>
+/// for the non-hybrid (every layer is attention) case. Asserts:
+/// <list type="bullet">
+///   <item>KvLength shrinks to the configured budget after a long-prompt prefill,</item>
+///   <item>decode produces finite, non-degenerate logits and ≥2 distinct argmaxes,</item>
+///   <item>with the env var unset on a tiny context, the cache is untouched
+///         (auto-budget gated off below the cache-size threshold),</item>
+///   <item>a short prompt (under window size) skips eviction even with the env
+///         var set — the SnapKV gate excludes it.</item>
+/// </list>
+///
+/// Skipped silently when CUDA is unavailable or the Qwen3-8B GGUF isn't on disk.
+/// </summary>
+public sealed class CudaForwardPassSnapKvTests
+{
+    private const string ModelFile = "Qwen3-8B-Q4_K_M.gguf";
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); } catch { return null; }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absoluteCandidates =
+        {
+            $@"C:\p\sharpi\models\{ModelFile}",
+            $@"E:\models\{ModelFile}",
+        };
+        foreach (var p in absoluteCandidates)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Repeat a few sentences until the tokenizer encodes at least
+    /// <paramref name="approxTokenCount"/> tokens. Picks varied content so the
+    /// SnapKV scoring kernel sees a non-degenerate attention pattern.
+    /// </summary>
+    private static int[] LongPrompt(GgufTokenizer tokenizer, int approxTokenCount)
+    {
+        const string seed =
+            "The quick brown fox jumps over the lazy dog. " +
+            "Sphinx of black quartz, judge my vow. " +
+            "Pack my box with five dozen liquor jugs. ";
+        var sb = new System.Text.StringBuilder();
+        while (true)
+        {
+            sb.Append(seed);
+            var attempt = tokenizer.Encode(sb.ToString());
+            if (attempt.Count >= approxTokenCount) return attempt.ToArray();
+            if (sb.Length > 100_000)
+                throw new InvalidOperationException("Tokenizer not packing enough — unexpected for Qwen3.");
+        }
+    }
+
+    [Fact]
+    public void CudaForwardPassSnapKv_LongPrompt_CacheShrinksToBudget_DecodeStaysWellFormed()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+        const int promptTargetLen = 768;
+
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", budget.ToString());
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+            // Keep ctx tight so the prefill (and the matching budget gate) stays
+            // small — we're testing the eviction logic, not the throughput path.
+            int ctx = Math.Min(hp.ContextLength, 2048);
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: ctx);
+
+            var tokens = LongPrompt(tokenizer, promptTargetLen);
+            Assert.True(tokens.Length >= budget + SnapKvSelector.DefaultWindow,
+                $"Prompt too short ({tokens.Length}) — SnapKV gate requires it to exceed budget + window.");
+
+            var logits = fwd.Prefill(tokens).ToArray();
+
+            Assert.Equal(budget, fwd.KvLength);
+
+            float min = float.MaxValue, max = float.MinValue;
+            for (int i = 0; i < logits.Length; i++)
+            {
+                Assert.True(float.IsFinite(logits[i]),
+                    $"Non-finite logit at vocab idx {i}: {logits[i]} — likely a kernel " +
+                    "bug in llm_snapkv_score / llm_kv_compact or a slot-vs-position " +
+                    "mismatch in the post-eviction Attention seqLen.");
+                if (logits[i] < min) min = logits[i];
+                if (logits[i] > max) max = logits[i];
+            }
+            Assert.True(max - min > 0.5f,
+                $"Post-SnapKV logit range collapsed to {min:F3}..{max:F3}; GPU eviction is " +
+                "producing degenerate output.");
+
+            var produced = new List<int>(4);
+            for (int i = 0; i < 4; i++)
+            {
+                int next = Sampler.Greedy(logits);
+                produced.Add(next);
+                logits = fwd.Forward(next, tokens.Length + i).ToArray();
+                for (int k = 0; k < logits.Length; k++)
+                    Assert.True(float.IsFinite(logits[k]),
+                        $"Non-finite logit at decode step {i}, vocab idx {k}: {logits[k]}");
+            }
+
+            int distinct = produced.Distinct().Count();
+            Assert.True(distinct >= 2,
+                $"Greedy decode under SnapKV produced only {distinct} distinct token(s): " +
+                $"[{string.Join(",", produced)}]. Likely a kvPosition vs LogicalLength " +
+                "mismatch — Forward's position arg should track tokens.Length + i regardless " +
+                "of the compacted slot count.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev);
+        }
+    }
+
+    /// <summary>
+    /// With <c>SHARPI_SNAPKV_BUDGET</c> unset and a small configured context,
+    /// the full-cache byte size sits below
+    /// <see cref="SnapKvConfig.AutoEnableMinCacheBytes"/> and the auto-budget
+    /// stays disabled. Verifies the threshold keeps small-context smoke runs
+    /// lossless even though SnapKV is otherwise auto-enabled on CudaForwardPass.
+    /// </summary>
+    [Fact]
+    public void CudaForwardPassSnapKv_EnvUnset_SmallCtx_CacheUntouched()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        var path = FindModelPath();
+        if (path is null) return;
+
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", null);
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+            // ctx=1024 on Qwen3-8B (8 KV heads × 128 = 1024 kv_dim, 32 layers, fp32)
+            // → ~256 MiB cache, right at the auto-enable threshold. Use ctx=512 to
+            // stay safely below it.
+            int ctx = Math.Min(hp.ContextLength, 512);
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: ctx);
+
+            var tokens = LongPrompt(tokenizer, 384);
+            _ = fwd.Prefill(tokens);
+
+            Assert.Equal(tokens.Length, fwd.KvLength);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev);
+        }
+    }
+
+    /// <summary>
+    /// A short prompt (≤ budget or ≤ window) skips eviction even with the budget
+    /// explicitly set. Covers the upper guards in the Prefill SnapKV gate.
+    /// </summary>
+    [Fact]
+    public void CudaForwardPassSnapKv_ShortPrompt_BudgetNotTriggered_CacheUntouched()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", budget.ToString());
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+            int ctx = Math.Min(hp.ContextLength, 2048);
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: ctx);
+
+            // Prompt is short enough that N <= budget — gate excludes it.
+            var tokens = tokenizer.Encode("Hello world, this is a tiny prompt.").ToArray();
+            Assert.True(tokens.Length <= budget,
+                $"Test pre-condition: prompt is {tokens.Length} tokens, should be ≤ {budget}.");
+
+            _ = fwd.Prefill(tokens);
+
+            Assert.Equal(tokens.Length, fwd.KvLength);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Plumbs SnapKV prefill-time KV eviction into `CudaForwardPass` (full-GPU dense path). Mirrors the `CudaHybridGdnForwardPass` reference from #58 — per-token Q capture during `Prefill`'s `Forward` loop, post-prefill `SnapKvScore` over each layer's K cache, per-position keep-set via `SnapKvSelector`, `KvCompact` two-phase compaction of GPU K/V rings, `_kvLength` bookkeeping update.

Reuses the existing CUDA kernels (`SnapKvScore`, `KvCompact`) — no new shader code. Auto-budget via `SnapKvConfig.ComputeAutoBudget(maxSeqLen, fullCacheBytes)`. TQ + SnapKV throws `NotSupportedException` referencing #60 (composition design TBD).

This PR addresses the **dense CUDA half** of #59 (`CudaForwardPass`). The Vulkan half (`GpuForwardPass`) and `CudaHybridForwardPass` (CPU+GPU split, needs new `KvCache.Compact` infra) are deferred to follow-ups so #59 closes in stages.

## Bonus fix

`_attnScoresScratch` was previously freed only on the TQ branch of `Dispose`; the alloc path runs whenever `_maxSeqLen > 4096` so this leaked on long-context non-TQ runs. Moved out of the TQ-only block.

## Test plan

- [x] `dotnet build -c Release` clean under `TreatWarningsAsErrors=true`.
- [x] `dotnet test -c Release` — 406/406 pass (3 new `CudaForwardPassSnapKvTests` actually run on this CUDA box, not silently skipped).
- [x] Sanity-run on RTX 4070 Ti (12 GB) with `SHARPI_SNAPKV_BUDGET=64 SHARPI_SNAPKV_WINDOW=32 SHARPI_SNAPKV_RECENCY=32` on Qwen3-8B Q4_K_M, 118-token prompt: coherent decode, 64.1 t/s (no regression vs 65.2 t/s pre-PR baseline; expected: SnapKV-active prefill is one-time post-prefill cost).
- [x] `SHARPI_SNAPKV_BUDGET=0` baseline: 65.1 t/s, identical output to master.

## Out of scope (follow-up issues)

- Vulkan port (`GpuForwardPass`) — new GLSL `snapkv_score.comp` + `kv_compact.comp` shaders needed.
- `CudaHybridForwardPass` — needs new `KvCache.Compact(int[] keep)` for the CPU K/V layers + mixed CPU+GPU score accumulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)