### PR TITLE
perf(engine,cuda,cpu): GEMM-batch the GDN-hybrid prefill trunk + dequant-once MoE dots (#111, #112)

### DIFF
--- a/src/SharpInference.Cpu/SimdKernels.cs
+++ b/src/SharpInference.Cpu/SimdKernels.cs
@@ -2541,6 +2541,145 @@ public static unsafe class SimdKernels
     }
 
     // ================================================================
+    //  Q3_K · Q8_KS Dot Product — two-input dequant-once (issue #112)
+    // ================================================================
+    // Decodes the Q3_K weight row ONCE (the 3-bit unpack + 6-bit scale decode is
+    // the expensive part) and dots it against two Q8_KS-prepacked inputs. Each
+    // input's accumulation is byte-for-byte identical to <see cref="DotQ3K_Q8KS"/>
+    // — same sub-block order, same int MAdd / offset-correction / FP FMA chain —
+    // so it is bit-identical to two single dots. Used by the batched routed-MoE
+    // path to amortize the unpack across token pairs routing to the same expert.
+    public static void DotQ3K_Q8KS_2In(byte* row, byte* scratch1, byte* scratch2, int cols,
+                                       out float sum1, out float sum2)
+    {
+        int numBlocks = cols / 256;
+        if (Avx2.IsSupported && Fma.IsSupported)
+        {
+            DotQ3K_Q8KS_2In_Avx2(row, scratch1, scratch2, numBlocks, out sum1, out sum2);
+            return;
+        }
+        sum1 = DotQ3K_Q8KS_Scalar(row, scratch1, numBlocks);
+        sum2 = DotQ3K_Q8KS_Scalar(row, scratch2, numBlocks);
+    }
+
+    private static void DotQ3K_Q8KS_2In_Avx2(byte* row, byte* scratch1, byte* scratch2,
+                                             int numBlocks, out float sum1, out float sum2)
+    {
+        const uint kmask1 = 0x03030303;
+        const uint kmask2 = 0x0f0f0f0f;
+        float* dArr1 = (float*)scratch1;
+        sbyte* qsArr1 = (sbyte*)(scratch1 + numBlocks * 32);
+        short* bsumsArr1 = (short*)(scratch1 + numBlocks * 32 + numBlocks * 256);
+        float* dArr2 = (float*)scratch2;
+        sbyte* qsArr2 = (sbyte*)(scratch2 + numBlocks * 32);
+        short* bsumsArr2 = (short*)(scratch2 + numBlocks * 32 + numBlocks * 256);
+
+        var m3 = Vector256.Create((byte)0x03);
+        var m1 = Vector256.Create((byte)0x01);
+        var acc1 = Vector256<float>.Zero;
+        var acc2 = Vector256<float>.Zero;
+        Span<uint> aux = stackalloc uint[4];
+        Span<sbyte> scales = stackalloc sbyte[16];
+
+        for (int b = 0; b < numBlocks; b++)
+        {
+            byte* x = row + b * 110;
+            float dAll = HalfToFloat(x[108], x[109]);
+            float* dSub1 = dArr1 + b * 8;
+            float* dSub2 = dArr2 + b * 8;
+
+            // Scales decode (shared between both inputs).
+            aux[0] = *(uint*)(x + 96);
+            aux[1] = *(uint*)(x + 100);
+            uint tmp = *(uint*)(x + 104);
+            aux[2] = ((aux[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+            aux[3] = ((aux[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+            aux[0] = (aux[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+            aux[1] = (aux[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+            for (int i = 0; i < 4; i++)
+            {
+                scales[i * 4 + 0] = (sbyte)((byte)(aux[i] >> 0) - 32);
+                scales[i * 4 + 1] = (sbyte)((byte)(aux[i] >> 8) - 32);
+                scales[i * 4 + 2] = (sbyte)((byte)(aux[i] >> 16) - 32);
+                scales[i * 4 + 3] = (sbyte)((byte)(aux[i] >> 24) - 32);
+            }
+
+            short* bsums1 = bsumsArr1 + b * 16;
+            short* bsums2 = bsumsArr2 + b * 16;
+            var hm_v = Vector256.LoadUnsafe(ref *(x + 0));
+            sbyte* q8a = qsArr1 + b * 256;
+            sbyte* q8b = qsArr2 + b * 256;
+            byte* qs = x + 32;
+
+            for (int half = 0; half < 2; half++)
+            {
+                var qs_v = Vector256.LoadUnsafe(ref *(qs + half * 32));
+
+                for (int j = 0; j < 4; j++)
+                {
+                    int sub = half * 4 + j;
+
+                    var qloShifted = j switch
+                    {
+                        0 => qs_v,
+                        1 => Avx2.ShiftRightLogical(qs_v.AsInt16(), 2).AsByte(),
+                        2 => Avx2.ShiftRightLogical(qs_v.AsInt16(), 4).AsByte(),
+                        _ => Avx2.ShiftRightLogical(qs_v.AsInt16(), 6).AsByte(),
+                    };
+                    var qlo = Avx2.And(qloShifted, m3);
+
+                    var hmShifted = (half, j) switch
+                    {
+                        (0, 0) => hm_v,
+                        (0, 1) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 1).AsByte(),
+                        (0, 2) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 2).AsByte(),
+                        (0, 3) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 3).AsByte(),
+                        (1, 0) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 4).AsByte(),
+                        (1, 1) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 5).AsByte(),
+                        (1, 2) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 6).AsByte(),
+                        _      => Avx2.ShiftRightLogical(hm_v.AsInt16(), 7).AsByte(),
+                    };
+                    var hbit = Avx2.ShiftLeftLogical(
+                        Avx2.And(hmShifted, m1).AsInt16(), 2).AsByte();
+                    var q3u = Avx2.Or(qlo, hbit);   // shared weight quants
+
+                    int isc = half * 8 + 2 * j;
+                    sbyte scA = scales[isc + 0];
+                    sbyte scB = scales[isc + 1];
+                    var sc16 = Vector256.Create(
+                        Vector128.Create((short)scA),
+                        Vector128.Create((short)scB));
+
+                    // Input 1 — same accumulation as the single-input kernel.
+                    {
+                        var q8_v = Vector256.LoadUnsafe(ref *(q8a + half * 128 + j * 32)).AsSByte();
+                        var p16 = Avx2.MultiplyAddAdjacent(q3u, q8_v);
+                        var sub_i32 = Avx2.MultiplyAddAdjacent(sc16, p16);
+                        int subCorr = ((int)scA * bsums1[isc] + (int)scB * bsums1[isc + 1]) << 2;
+                        sub_i32 = sub_i32.WithElement(0, sub_i32.GetElement(0) - subCorr);
+                        var sub_fp = Avx.ConvertToVector256Single(sub_i32);
+                        float scaleSub = dAll * dSub1[sub];
+                        acc1 = Fma.MultiplyAdd(Vector256.Create(scaleSub), sub_fp, acc1);
+                    }
+                    // Input 2 — reuses decoded q3u / sc16.
+                    {
+                        var q8_v = Vector256.LoadUnsafe(ref *(q8b + half * 128 + j * 32)).AsSByte();
+                        var p16 = Avx2.MultiplyAddAdjacent(q3u, q8_v);
+                        var sub_i32 = Avx2.MultiplyAddAdjacent(sc16, p16);
+                        int subCorr = ((int)scA * bsums2[isc] + (int)scB * bsums2[isc + 1]) << 2;
+                        sub_i32 = sub_i32.WithElement(0, sub_i32.GetElement(0) - subCorr);
+                        var sub_fp = Avx.ConvertToVector256Single(sub_i32);
+                        float scaleSub = dAll * dSub2[sub];
+                        acc2 = Fma.MultiplyAdd(Vector256.Create(scaleSub), sub_fp, acc2);
+                    }
+                }
+            }
+        }
+        sum1 = HSum256(acc1);
+        sum2 = HSum256(acc2);
+    }
+
+    // ================================================================
     //  Q8_0 · Q8_KS Dot Product  (one row, per-32 prequantized input)
     // ================================================================
     // Q8_0 block (32 elements / 34 bytes) naturally pairs 1:1 with one

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -31,6 +31,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private readonly int _smVersion;
     private readonly nint _stream;
     private readonly ConcurrentDictionary<nint, (nint devPtr, nuint byteSize)> _devPtrs = new();
+    // Issue #111: handles registered by View() — non-owning slices into another
+    // tensor's allocation. Free() drops the registration without freeing memory.
+    private readonly ConcurrentDictionary<nint, byte> _viewHandles = new();
     private long _nextHandle = 1;
 
     // Pinned host staging buffer for DMA-capable async H2D/D2H transfers.
@@ -137,6 +140,19 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _matvecQ4KN2Kernel;
     private nint   _matvecQ5KN2Kernel;
     private nint   _matvecQ6KN2Kernel;
+    // Issue #111: batched GEMM-N variants — one weight matrix, N input vectors,
+    // N output rows in a single launch. Each (row, token) runs the identical
+    // per-row reduction as the GEMV so results are bit-identical to N sequential
+    // matvecs. Collapses the per-token trunk launches that dominate GDN-hybrid
+    // prefill into one launch per projection.
+    private nint   _matvecF32GemmNKernel;
+    private nint   _matvecQ4KGemmNKernel;
+    private nint   _matvecQ6KGemmNKernel;
+    // Issue #111: batched trunk elementwise/norm kernels (one launch over N tokens).
+    private nint   _rmsNormBatchedKernel;
+    private nint   _headNormBatchedKernel;
+    private nint   _splitQgBatchedKernel;
+    private nint   _ropeNeoxPartialBatchedKernel;
     private nint   _attentionKernel;
     // Gemma 4 (Phase 7): sliding-window attention, tanh-GELU FFN, final-logit
     // softcap. Kernel work only — forward-pass wiring lands in Phase 8.
@@ -168,6 +184,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // dispatches the Q4_K path (sequential MatMul callers never touch it).
     private nint   _q81BufB;
     private nuint  _q81BufBSize;
+    // Issue #111: Q8_1 scratch for MatMulBatched's N input vectors (laid out as
+    // N contiguous q81 rows). Grow-only, same policy as _q81Buf.
+    private nint   _q81BatchBuf;
+    private nuint  _q81BatchBufSize;
 
     // Tracks dtype per tensor handle so MatMul can dispatch to the right matvec variant
     // (Q4_K / Q5_K / Q6_K / F32). Norm/bias weights upload as F32; quantized weight bytes
@@ -396,8 +416,45 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         return new Tensor(shape, dtype, handle);
     }
 
+    /// <summary>
+    /// Registers a non-owning view into <paramref name="parent"/> starting at
+    /// <paramref name="elemOffset"/> elements, spanning <paramref name="elemCount"/>
+    /// elements (issue #111). The returned <see cref="Tensor"/> shares the parent's
+    /// device memory; <see cref="Free"/> on it only drops the handle registration and
+    /// never frees the underlying allocation. Used by batched prefill to pass a
+    /// per-token slice of a <c>[N×dim]</c> batched buffer to the per-position
+    /// recurrence / KV-append / attention kernels without an extra device copy.
+    /// Element size is taken from the parent dtype (Float32 for activation buffers).
+    /// </summary>
+    public Tensor View(Tensor parent, long elemOffset, long elemCount, DType dtype = DType.Float32)
+    {
+        if (!_devPtrs.TryGetValue(parent.Handle, out var pe))
+            throw new InvalidOperationException($"View: parent handle {parent.Handle} not registered.");
+        if (elemOffset < 0 || elemCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(elemOffset),
+                $"View: elemOffset ({elemOffset}) and elemCount ({elemCount}) must be non-negative.");
+        int elemBytes = DTypeInfo.BytesPerElement(dtype);
+        long byteOffset = elemOffset * elemBytes;
+        long byteCount = elemCount * elemBytes;
+        if (byteOffset < 0 || byteOffset + byteCount > (long)pe.byteSize)
+            throw new ArgumentOutOfRangeException(nameof(elemOffset),
+                $"View [{elemOffset}, {elemOffset + elemCount}) (×{elemBytes}B) out of parent bounds ({pe.byteSize}B).");
+        var handle = (nint)Interlocked.Increment(ref _nextHandle);
+        _devPtrs[handle] = (pe.devPtr + (nint)byteOffset, (nuint)byteCount);
+        _viewHandles[handle] = 0;
+        return new Tensor(TensorShape.D1(elemCount), dtype, handle);
+    }
+
     public void Free(Tensor tensor)
     {
+        if (_viewHandles.TryRemove(tensor.Handle, out _))
+        {
+            // Non-owning view: drop the handle registration only; the parent owns
+            // the device memory and frees it on its own Free().
+            _tensorDTypes.TryRemove(tensor.Handle, out _);
+            _devPtrs.TryRemove(tensor.Handle, out _);
+            return;
+        }
         _tensorDTypes.TryRemove(tensor.Handle, out _);
         if (_pinnedAllocs.Remove(tensor.Handle, out var pinned))
         {
@@ -1287,6 +1344,148 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     }
 
     /// <summary>
+    /// Batched matrix-vector multiply (GEMM-N, issue #111): one <paramref name="matrix"/>
+    /// applied to <paramref name="nTok"/> input vectors, producing <paramref name="nTok"/>
+    /// output rows — in a single kernel launch. Layout is token-major:
+    /// <paramref name="inputAll"/> is <c>[nTok × cols]</c> and <paramref name="outputAll"/>
+    /// is <c>[nTok × rows]</c> (token <c>t</c>'s slice starts at <c>t × rows</c>).
+    ///
+    /// <para><b>Bit-exact:</b> each (row, token) pair runs the identical per-row reduction
+    /// as the single-token <see cref="MatMul(Tensor,Tensor,Tensor,DType)"/> — same weight
+    /// decode, same dp4a/FMA chain, same warp + shared reduce — so the result is
+    /// bit-identical to <paramref name="nTok"/> sequential <see cref="MatMul"/> calls. This
+    /// is the property the GDN/MTP byte-parity oracles depend on; do not reorder the
+    /// reduction. Only the launch count collapses (N → 1), killing the host launch
+    /// overhead that dominates GDN-hybrid prefill.</para>
+    ///
+    /// Supports Q4_K (via per-token Q8_1 quantize + the GEMM-N dp4a kernel) and Float32.
+    /// Other dtypes throw — the GDN-hybrid trunk projections are all Q4_K.
+    /// </summary>
+    public void MatMulBatched(Tensor outputAll, Tensor matrix, Tensor inputAll,
+                              int nTok, DType weightDType)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available on this system.");
+        if (nTok <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nTok), nTok, "nTok must be > 0.");
+        if (outputAll.ElementCount % nTok != 0 || inputAll.ElementCount % nTok != 0)
+            throw new ArgumentException(
+                $"MatMulBatched: outputAll ({outputAll.ElementCount}) and inputAll ({inputAll.ElementCount}) " +
+                $"element counts must be divisible by nTok ({nTok}).");
+
+        int rows = (int)(outputAll.ElementCount / nTok);
+        int cols = (int)(inputAll.ElementCount / nTok);
+        nint wPtr = GetDevPtr(matrix);
+        nint xPtr = GetDevPtr(inputAll);
+        nint yPtr = GetDevPtr(outputAll);
+
+        if (weightDType == DType.Q4_K)
+        {
+            DispatchMatVecQ4KBatched(wPtr, xPtr, yPtr, rows, cols, nTok);
+            return;
+        }
+        if (weightDType == DType.Float32 || weightDType == DType.Q6_K)
+        {
+            // Both take F32 input; the Q6_K kernel decodes the weight per element.
+            nint kernel = weightDType == DType.Q6_K ? _matvecQ6KGemmNKernel : _matvecF32GemmNKernel;
+            int pRows = rows, pCols = cols, pN = nTok;
+            nint* args = stackalloc nint[6]
+            {
+                (nint)(&wPtr), (nint)(&xPtr), (nint)(&yPtr),
+                (nint)(&pRows), (nint)(&pCols), (nint)(&pN)
+            };
+            uint gridX = (uint)((rows + 7) / 8);
+            int r = NvrtcInterop.LaunchKernel(kernel, gridX, (uint)nTok, 1,
+                                              256, 1, 1, 0, _stream, args, null);
+            if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(matvec_gemm_n) failed: {r}");
+            return;
+        }
+        throw new NotSupportedException(
+            $"CUDA MatMulBatched: weight dtype {weightDType} not supported (expected Q4_K, Q6_K, or Float32).");
+    }
+
+    /// <summary>
+    /// Convenience overload: looks up the weight dtype from the
+    /// <see cref="UploadRaw"/> tag dictionary.
+    /// </summary>
+    public void MatMulBatched(Tensor outputAll, Tensor matrix, Tensor inputAll, int nTok)
+    {
+        var dtype = _tensorDTypes.GetValueOrDefault(matrix.Handle, matrix.DType);
+        MatMulBatched(outputAll, matrix, inputAll, nTok, dtype);
+    }
+
+    /// <summary>
+    /// Q4_K batched GEMM-N: quantizes all <paramref name="nTok"/> input vectors into a
+    /// single contiguous Q8_1 scratch (one launch over <c>nTok × subBlocks</c> blocks —
+    /// the per-token quantize is independent so this is bit-identical to per-token
+    /// quantization), then dispatches <c>llm_matvec_q4k_gemm_n</c> over a (rows, nTok)
+    /// grid.
+    /// </summary>
+    private void DispatchMatVecQ4KBatched(nint wPtr, nint xPtr, nint yPtr,
+                                          int rows, int cols, int nTok)
+    {
+        if ((cols & 0xff) != 0)
+            throw new InvalidOperationException(
+                $"CUDA matvec_q4k_gemm_n requires cols % 256 == 0 (got {cols}).");
+
+        int subBlocks = cols / 32;                          // per token
+        long totalSub = (long)subBlocks * nTok;
+        nuint q81Bytes = (nuint)(totalSub * 36L);
+        EnsureQ81BatchBuf(q81Bytes);
+
+        // Quantize all nTok inputs → contiguous Q8_1. The single-token kernel's
+        // index math (elem_idx = block_id*32 + lane, out += block_id*36) already
+        // covers a contiguous [nTok × cols] batch: block_id runs [0, nTok*subBlocks).
+        {
+            nint qInPtr  = xPtr;
+            nint qOutPtr = _q81BatchBuf;
+            int  qN      = (int)((long)cols * nTok);
+            if ((long)cols * nTok > int.MaxValue)
+                throw new InvalidOperationException(
+                    $"MatMulBatched: cols*nTok ({(long)cols * nTok}) exceeds int range.");
+            nint* args = stackalloc nint[3]
+            {
+                (nint)(&qInPtr), (nint)(&qOutPtr), (nint)(&qN)
+            };
+            int rq = NvrtcInterop.LaunchKernel(
+                _quantizeQ81Kernel, (uint)totalSub, 1, 1,
+                32, 1, 1, 0, _stream, args, null);
+            if (rq != 0) throw new InvalidOperationException($"cuLaunchKernel(quantize_q8_1 batched) failed: {rq}");
+        }
+
+        {
+            nint q81Ptr = _q81BatchBuf;
+            int  pRows  = rows, pCols = cols, pN = nTok;
+            nint* args = stackalloc nint[6]
+            {
+                (nint)(&wPtr), (nint)(&q81Ptr), (nint)(&yPtr),
+                (nint)(&pRows), (nint)(&pCols), (nint)(&pN)
+            };
+            // grid = (rows, nTok); block = 32 × MATVEC_Q4K_NWARPS(8) = 256 threads.
+            int rm = NvrtcInterop.LaunchKernel(
+                _matvecQ4KGemmNKernel, (uint)rows, (uint)nTok, 1,
+                32, 8, 1, 0, _stream, args, null);
+            if (rm != 0) throw new InvalidOperationException($"cuLaunchKernel(matvec_q4k_gemm_n) failed: {rm}");
+        }
+    }
+
+    private void EnsureQ81BatchBuf(nuint required)
+    {
+        if (_q81BatchBuf != nint.Zero && _q81BatchBufSize >= required) return;
+        if (_q81BatchBuf != nint.Zero)
+        {
+            CuBlasInterop.CudaFree(_q81BatchBuf);
+            _q81BatchBuf = nint.Zero;
+            _q81BatchBufSize = 0;
+        }
+        nuint newSize = (required + 0xffffu) & ~(nuint)0xffffu;
+        int r = CuBlasInterop.CudaMalloc(out _q81BatchBuf, newSize);
+        if (r != 0) throw new InvalidOperationException($"cudaMalloc(q8_1 batch scratch, {newSize} B) failed: {r}");
+        _q81BatchBufSize = newSize;
+    }
+
+    /// <summary>
     /// Q4_K N=2 matvec: quantizes both input vectors into independent Q8_1
     /// scratches (<c>_q81Buf</c> for A, <c>_q81BufB</c> for B), then dispatches
     /// the cooperative <c>llm_matvec_q4k_n2</c> kernel that reads each weight
@@ -1484,6 +1683,32 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rmsnorm) failed: {r}");
     }
 
+    /// <summary>
+    /// Batched RmsNorm over <paramref name="nTok"/> rows (issue #111). <paramref name="x"/>
+    /// and <paramref name="output"/> are <c>[nTok × dim]</c> contiguous; <paramref name="weight"/>
+    /// is shared across rows. One block per token runs the identical reduction as
+    /// <see cref="RmsNorm"/>, so output is bit-identical to nTok sequential calls.
+    /// </summary>
+    public void RmsNormBatched(Tensor output, Tensor x, Tensor weight, int nTok, int dim, float eps = 1e-5f)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        nint xPtr = GetDevPtr(x);
+        nint wPtr = GetDevPtr(weight);
+        nint yPtr = GetDevPtr(output);
+        int   pN = dim, pNT = nTok;
+        float pE = eps;
+        nint* args = stackalloc nint[6]
+        {
+            (nint)(&xPtr), (nint)(&wPtr), (nint)(&yPtr),
+            (nint)(&pN), (nint)(&pE), (nint)(&pNT)
+        };
+        int r = NvrtcInterop.LaunchKernel(_rmsNormBatchedKernel, (uint)nTok, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rmsnorm_batched) failed: {r}");
+    }
+
     /// <summary>Per-head RMS norm with learned weights (Qwen3 / OLMoE QK norm).
     /// <paramref name="perChannelWeight"/> false → weight is shared <c>[headDim]</c> vector
     /// applied identically to every head (Qwen3); true → weight is
@@ -1507,6 +1732,31 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         };
         int r = NvrtcInterop.LaunchKernel(_headNormKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(head_norm) failed: {r}");
+    }
+
+    /// <summary>
+    /// Batched per-head RmsNorm over <paramref name="nTok"/> rows (issue #111).
+    /// <paramref name="data"/> is <c>[nTok × numHeads × headDim]</c>; grid = (numHeads, nTok).
+    /// Bit-identical to nTok sequential <see cref="HeadNorm"/> calls.
+    /// </summary>
+    public void HeadNormBatched(Tensor data, Tensor weight, int numHeads, int headDim,
+        int nTok, float eps = 1e-6f, bool perChannelWeight = false)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        nint dPtr = GetDevPtr(data);
+        nint wPtr = GetDevPtr(weight);
+        int  pHD = headDim, pNH = numHeads, pWS = perChannelWeight ? headDim : 0, pNT = nTok;
+        float pE = eps;
+        nint* args = stackalloc nint[7]
+        {
+            (nint)(&dPtr), (nint)(&wPtr),
+            (nint)(&pHD), (nint)(&pNH), (nint)(&pE), (nint)(&pWS), (nint)(&pNT)
+        };
+        int r = NvrtcInterop.LaunchKernel(_headNormBatchedKernel, (uint)numHeads, (uint)nTok, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(head_norm_batched) failed: {r}");
     }
 
     /// <summary>Per-head L2 normalize (no learned weights). Llama-4 style.</summary>
@@ -1674,6 +1924,39 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     }
 
     /// <summary>
+    /// Batched partial NEOX RoPE over <paramref name="nTok"/> rows (issue #111). Token t
+    /// rotates at position <paramref name="basePosition"/> + t (prefill assigns contiguous
+    /// positions). <paramref name="x"/> is <c>[nTok × numHeads × headDim]</c>. Bit-identical
+    /// to nTok sequential <see cref="RoPEPartial"/> calls at the matching positions.
+    /// </summary>
+    public void RoPEPartialBatched(Tensor x, int basePosition, int headDim, int ropeDim,
+        float ropeTheta, int numHeads, int nTok, bool neox)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (!neox)
+            throw new ArgumentException("RoPEPartialBatched currently supports only neox=true.", nameof(neox));
+        if (ropeDim <= 0 || (ropeDim & 1) != 0)
+            throw new ArgumentException("ropeDim must be a positive even number.", nameof(ropeDim));
+        if (ropeDim > headDim)
+            throw new ArgumentException("ropeDim must be <= headDim.", nameof(ropeDim));
+
+        int totalPairs = numHeads * (ropeDim / 2);
+        nint xPtr = GetDevPtr(x);
+        int  pNH = numHeads, pHD = headDim, pRD = ropeDim, pPos = basePosition, pNT = nTok;
+        float pT = ropeTheta;
+        nint* args = stackalloc nint[7]
+        {
+            (nint)(&xPtr),
+            (nint)(&pNH), (nint)(&pHD), (nint)(&pRD), (nint)(&pPos), (nint)(&pT), (nint)(&pNT)
+        };
+        uint grid = (uint)((totalPairs + 255) / 256);
+        int r = NvrtcInterop.LaunchKernel(_ropeNeoxPartialBatchedKernel, grid, (uint)nTok, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rope_neox_partial_batched) failed: {r}");
+    }
+
+    /// <summary>
     /// NEOX RoPE with per-half-dim frequency factors (Gemma 4 global layers /
     /// Gemma-3n). <paramref name="freqFactors"/> is a <c>head_dim/2</c> F32 device
     /// vector that divides each pair's frequency; mirrors llama.cpp
@@ -1771,6 +2054,33 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         uint grid = (uint)((total + 255) / 256);
         int r = NvrtcInterop.LaunchKernel(_splitQgKernel, grid, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(split_qg) failed: {r}");
+    }
+
+    /// <summary>
+    /// Batched <see cref="SplitQG"/> over <paramref name="nTok"/> rows (issue #111).
+    /// <paramref name="qg"/> is <c>[nTok × numHeads × headDim × 2]</c>; <paramref name="q"/>
+    /// and <paramref name="g"/> are <c>[nTok × numHeads × headDim]</c>. Bit-identical to
+    /// nTok sequential <see cref="SplitQG"/> calls.
+    /// </summary>
+    public void SplitQGBatched(Tensor q, Tensor g, Tensor qg, int numHeads, int headDim, int nTok)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        nint qgPtr = GetDevPtr(qg);
+        nint qPtr  = GetDevPtr(q);
+        nint gPtr  = GetDevPtr(g);
+        int  pNH = numHeads, pHD = headDim, pNT = nTok;
+        nint* args = stackalloc nint[6]
+        {
+            (nint)(&qgPtr), (nint)(&qPtr), (nint)(&gPtr),
+            (nint)(&pNH), (nint)(&pHD), (nint)(&pNT)
+        };
+        int total = numHeads * headDim;
+        uint grid = (uint)((total + 255) / 256);
+        int r = NvrtcInterop.LaunchKernel(_splitQgBatchedKernel, grid, (uint)nTok, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(split_qg_batched) failed: {r}");
     }
 
     /// <summary>Write fresh K and V vectors for one token into the layer KV cache at <paramref name="position"/>.</summary>
@@ -2744,6 +3054,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _matvecF32Kernel, _matvecQ4KKernel, _matvecQ5KKernel, _matvecQ6KKernel,
             _matvecQ80Kernel,
             _matvecF32N2Kernel, _matvecQ4KN2Kernel, _matvecQ5KN2Kernel, _matvecQ6KN2Kernel,
+            _matvecF32GemmNKernel, _matvecQ4KGemmNKernel, _matvecQ6KGemmNKernel,
+            _rmsNormBatchedKernel, _headNormBatchedKernel,
+            _splitQgBatchedKernel, _ropeNeoxPartialBatchedKernel,
             _attentionKernel, _attentionBf16Kernel, _attentionSwaKernel,
             _geluTanhMulKernel, _softcapKernel,
             _clearF32Kernel, _quantizeQ81Kernel,
@@ -2804,6 +3117,13 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _matvecQ4KN2Kernel     = GetKernelFunc("llm_matvec_q4k_n2");
         _matvecQ5KN2Kernel     = GetKernelFunc("llm_matvec_q5k_n2");
         _matvecQ6KN2Kernel     = GetKernelFunc("llm_matvec_q6k_n2");
+        _matvecF32GemmNKernel  = GetKernelFunc("llm_matvec_f32_gemm_n");
+        _matvecQ4KGemmNKernel  = GetKernelFunc("llm_matvec_q4k_gemm_n");
+        _matvecQ6KGemmNKernel  = GetKernelFunc("llm_matvec_q6k_gemm_n");
+        _rmsNormBatchedKernel  = GetKernelFunc("llm_rmsnorm_batched");
+        _headNormBatchedKernel = GetKernelFunc("llm_head_norm_batched");
+        _splitQgBatchedKernel  = GetKernelFunc("llm_split_qg_batched");
+        _ropeNeoxPartialBatchedKernel = GetKernelFunc("llm_rope_neox_partial_batched");
         _attentionKernel       = GetKernelFunc("llm_attention");
         _attentionBf16Kernel   = GetKernelFunc("llm_attention_bf16");
         _attentionSwaKernel    = GetKernelFunc("llm_attention_swa");
@@ -3166,6 +3486,12 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             CuBlasInterop.CudaFree(_q81BufB);
             _q81BufB = nint.Zero;
             _q81BufBSize = 0;
+        }
+        if (_q81BatchBuf != nint.Zero)
+        {
+            CuBlasInterop.CudaFree(_q81BatchBuf);
+            _q81BatchBuf = nint.Zero;
+            _q81BatchBufSize = 0;
         }
 
         CuBlasInterop.Destroy(_handle);

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -1466,6 +1466,340 @@ extern ""C"" __global__ void llm_matvec_q5k_n2(
     }
 }
 
+// ── MatVec F32 — batched GEMM-N variant (issue #111) ──────────────────────
+// One weight matrix, N input vectors, N output rows. grid = (ceil(rows/8), N);
+// block = 256 threads (8 rows × 32 lanes). Block (rx, t) computes 8 output rows
+// for token t. Each (row, token) runs the IDENTICAL per-row reduction as
+// llm_matvec_f32, so output_all is bit-identical to N sequential llm_matvec_f32
+// launches — only the input/output base pointers shift by token. Collapses the
+// N per-token launches into one, killing the host launch overhead that dominates
+// GDN-hybrid prefill (#111).
+extern ""C"" __global__ void llm_matvec_f32_gemm_n(
+    const float* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols] contiguous
+    float* __restrict__ output_all,        // [n_tok][rows] contiguous
+    int rows, int cols, int n_tok)
+{
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    int token = (int)blockIdx.y;
+    if (row >= rows || token >= n_tok) return;
+
+    const float* input = input_all + (long)token * (long)cols;
+
+    float acc = 0.f;
+    long base = (long)row * (long)cols;
+    for (int i = lane; i < cols; i += THREADS_PER_ROW)
+        acc += weights[base + i] * input[i];
+
+    float result = sharpi_warp_reduce_sum(acc);
+    if (lane == 0) output_all[(long)token * (long)rows + row] = result;
+}
+
+// ── MatVec Q4_K — batched GEMM-N variant (issue #111) ─────────────────────
+// One weight matrix, N input vectors (pre-quantized to Q8_1 as N contiguous
+// q81 rows), N output rows. grid = (rows, N); block = (32, NWARPS). Block
+// (row, token) runs the IDENTICAL per-row reduction as llm_matvec_q4k — same
+// weight decode, same dp4a chain, same warp + shared reduce — so output_all is
+// bit-identical to N sequential llm_matvec_q4k launches. Weight is reread per
+// token (the trunk bottleneck is launch latency, not weight bandwidth — #111).
+extern ""C"" __global__ void llm_matvec_q4k_gemm_n(
+    const unsigned int* __restrict__ weights,
+    const unsigned char* __restrict__ y_q81_all,  // [n_tok][num_blocks*8*36] bytes
+    float* __restrict__ output_all,               // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    int row     = (int)blockIdx.x;
+    int token   = (int)blockIdx.y;
+    int warp_id = (int)threadIdx.y;
+    int lane    = (int)threadIdx.x;
+    if (row >= rows || token >= n_tok) return;
+
+    int num_blocks = cols >> 8;
+    long word_row_base = (long)row * (long)num_blocks * 36L;
+    // q81 row stride = (cols/32) sub-blocks × 36 bytes = num_blocks*8*36.
+    const unsigned char* y_q81 = y_q81_all + (long)token * (long)num_blocks * 8L * 36L;
+
+    int chunk    = lane >> 3;
+    int byte_off = (lane & 7) * 4;
+    int q4_offset = 4 + chunk * 8 + (lane & 7);
+
+    float acc = 0.f;
+
+    for (int block = warp_id; block < num_blocks; block += MATVEC_Q4K_NWARPS) {
+        long word_base = word_row_base + (long)block * 36L;
+
+        unsigned int w0  = __ldg(&weights[word_base]);
+        unsigned int sm0 = __ldg(&weights[word_base + 1]);
+        unsigned int sm1 = __ldg(&weights[word_base + 2]);
+        unsigned int sm2 = __ldg(&weights[word_base + 3]);
+        float super_d    = sharpi_fp16_to_fp32(w0 & 0xffffu);
+        float super_dmin = sharpi_fp16_to_fp32(w0 >> 16);
+
+        unsigned int sc_lo, mn_lo, sc_hi, mn_hi;
+        switch (chunk) {
+            case 0:
+                sc_lo = (sm0)       & 63u; mn_lo = (sm1)       & 63u;
+                sc_hi = (sm0 >>  8) & 63u; mn_hi = (sm1 >>  8) & 63u;
+                break;
+            case 1:
+                sc_lo = (sm0 >> 16) & 63u; mn_lo = (sm1 >> 16) & 63u;
+                sc_hi = (sm0 >> 24) & 63u; mn_hi = (sm1 >> 24) & 63u;
+                break;
+            case 2:
+                sc_lo = (sm2        & 0xFu) | (((sm0 >>  6) & 3u) << 4);
+                mn_lo = ((sm2 >>  4) & 0xFu) | (((sm1 >>  6) & 3u) << 4);
+                sc_hi = ((sm2 >>  8) & 0xFu) | (((sm0 >> 14) & 3u) << 4);
+                mn_hi = ((sm2 >> 12) & 0xFu) | (((sm1 >> 14) & 3u) << 4);
+                break;
+            default:
+                sc_lo = ((sm2 >> 16) & 0xFu) | (((sm0 >> 22) & 3u) << 4);
+                mn_lo = ((sm2 >> 20) & 0xFu) | (((sm1 >> 22) & 3u) << 4);
+                sc_hi = ((sm2 >> 24) & 0xFu) | (((sm0 >> 30) & 3u) << 4);
+                mn_hi = ((sm2 >> 28) & 0xFu) | (((sm1 >> 30) & 3u) << 4);
+                break;
+        }
+
+        unsigned int wq    = __ldg(&weights[word_base + q4_offset]);
+        unsigned int wq_lo = wq & 0x0F0F0F0Fu;
+        unsigned int wq_hi = (wq >> 4) & 0x0F0F0F0Fu;
+
+        long q81_base_lo = (long)(block * 8 + chunk * 2)     * 36L;
+        long q81_base_hi = (long)(block * 8 + chunk * 2 + 1) * 36L;
+
+        unsigned int d_bits_lo = __ldg(reinterpret_cast<const unsigned int*>(y_q81 + q81_base_lo)) & 0xffffu;
+        unsigned int d_bits_hi = __ldg(reinterpret_cast<const unsigned int*>(y_q81 + q81_base_hi)) & 0xffffu;
+        float d8_lo = sharpi_fp16_to_fp32(d_bits_lo);
+        float d8_hi = sharpi_fp16_to_fp32(d_bits_hi);
+
+        int act_lo = *reinterpret_cast<const int*>(y_q81 + q81_base_lo + 4 + byte_off);
+        int act_hi = *reinterpret_cast<const int*>(y_q81 + q81_base_hi + 4 + byte_off);
+
+        int dot_lo   = __dp4a((int)wq_lo, act_lo, 0);
+        int dot_hi   = __dp4a((int)wq_hi, act_hi, 0);
+        int sum_lo   = __dp4a((int)0x01010101, act_lo, 0);
+        int sum_hi   = __dp4a((int)0x01010101, act_hi, 0);
+
+        float coef_d_lo = super_d    * (float)sc_lo * d8_lo;
+        float coef_m_lo = super_dmin * (float)mn_lo * d8_lo;
+        float coef_d_hi = super_d    * (float)sc_hi * d8_hi;
+        float coef_m_hi = super_dmin * (float)mn_hi * d8_hi;
+        acc += coef_d_lo * (float)dot_lo - coef_m_lo * (float)sum_lo;
+        acc += coef_d_hi * (float)dot_hi - coef_m_hi * (float)sum_hi;
+    }
+
+    acc = sharpi_warp_reduce_sum(acc);
+
+    __shared__ float warp_acc[MATVEC_Q4K_NWARPS];
+    if (lane == 0) warp_acc[warp_id] = acc;
+    __syncthreads();
+
+    if (warp_id == 0 && lane == 0) {
+        float s = 0.f;
+        #pragma unroll
+        for (int w = 0; w < MATVEC_Q4K_NWARPS; w++) s += warp_acc[w];
+        output_all[(long)token * (long)rows + row] = s;
+    }
+}
+
+// ── MatVec Q6_K — batched GEMM-N variant (issue #111) ─────────────────────
+// One weight matrix, N F32 input vectors, N output rows. grid = (ceil(rows/8), N);
+// block = 256 (8 rows × 32 lanes). Block (rx, token) computes 8 output rows for
+// token. Identical per-row reduction to llm_matvec_q6k; only input/output base
+// pointers shift by token. Used for the shared-expert down projection (Q6_K).
+extern ""C"" __global__ void llm_matvec_q6k_gemm_n(
+    const unsigned int* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols]
+    float* __restrict__ output_all,        // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    int token = (int)blockIdx.y;
+    if (row >= rows || token >= n_tok) return;
+
+    const float* input = input_all + (long)token * (long)cols;
+    int num_blocks = cols >> 8;
+    long row_base_bytes = (long)row * (long)num_blocks * 210L;
+
+    float acc = 0.f;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long b0 = row_base_bytes + (long)block * 210L;
+
+        unsigned int dlo = (weights[(b0 + 208) >> 2] >> (((b0 + 208) & 3) * 8)) & 0xFFu;
+        unsigned int dhi = (weights[(b0 + 209) >> 2] >> (((b0 + 209) & 3) * 8)) & 0xFFu;
+        float d = sharpi_fp16_to_fp32(dlo | (dhi << 8));
+
+        long isc = (long)(lane >> 4);
+
+        float sc0 = d * (float)sharpi_int8_at(weights, b0 + 192 + isc);
+        float sc1 = d * (float)sharpi_int8_at(weights, b0 + 194 + isc);
+        float sc2 = d * (float)sharpi_int8_at(weights, b0 + 196 + isc);
+        float sc3 = d * (float)sharpi_int8_at(weights, b0 + 198 + isc);
+        float sc4 = d * (float)sharpi_int8_at(weights, b0 + 200 + isc);
+        float sc5 = d * (float)sharpi_int8_at(weights, b0 + 202 + isc);
+        float sc6 = d * (float)sharpi_int8_at(weights, b0 + 204 + isc);
+        float sc7 = d * (float)sharpi_int8_at(weights, b0 + 206 + isc);
+
+        unsigned int ql0 = sharpi_byte_at(weights, b0 +   0 + lane);
+        unsigned int ql1 = sharpi_byte_at(weights, b0 +  32 + lane);
+        unsigned int ql2 = sharpi_byte_at(weights, b0 +  64 + lane);
+        unsigned int ql3 = sharpi_byte_at(weights, b0 +  96 + lane);
+        unsigned int qh0 = sharpi_byte_at(weights, b0 + 128 + lane);
+        unsigned int qh1 = sharpi_byte_at(weights, b0 + 160 + lane);
+
+        int base_elem = block * 256;
+
+        acc += sc0 * (float)((int)((ql0 & 0xFu)        | (((qh0 >> 0) & 3u) << 4)) - 32) * input[base_elem +       lane];
+        acc += sc1 * (float)((int)((ql1 & 0xFu)        | (((qh0 >> 2) & 3u) << 4)) - 32) * input[base_elem +  32 + lane];
+        acc += sc2 * (float)((int)(((ql0 >> 4) & 0xFu) | (((qh0 >> 4) & 3u) << 4)) - 32) * input[base_elem +  64 + lane];
+        acc += sc3 * (float)((int)(((ql1 >> 4) & 0xFu) | (((qh0 >> 6) & 3u) << 4)) - 32) * input[base_elem +  96 + lane];
+        acc += sc4 * (float)((int)((ql2 & 0xFu)        | (((qh1 >> 0) & 3u) << 4)) - 32) * input[base_elem + 128 + lane];
+        acc += sc5 * (float)((int)((ql3 & 0xFu)        | (((qh1 >> 2) & 3u) << 4)) - 32) * input[base_elem + 160 + lane];
+        acc += sc6 * (float)((int)(((ql2 >> 4) & 0xFu) | (((qh1 >> 4) & 3u) << 4)) - 32) * input[base_elem + 192 + lane];
+        acc += sc7 * (float)((int)(((ql3 >> 4) & 0xFu) | (((qh1 >> 6) & 3u) << 4)) - 32) * input[base_elem + 224 + lane];
+    }
+
+    float result = sharpi_warp_reduce_sum(acc);
+    if (lane == 0) output_all[(long)token * (long)rows + row] = result;
+}
+
+// ── Batched trunk elementwise/norm kernels (issue #111) ───────────────────
+// Each adds a token dimension (grid.y or a token-major offset) over the
+// single-token kernel above; the per-token math is byte-for-byte identical, so
+// batched output matches N sequential single-token launches exactly. Used by
+// CudaHybridGdnForwardPass batched prefill to collapse the per-token trunk
+// launches into one launch per op.
+
+// RmsNorm over N rows: one block per (token), 256 threads. Identical reduction
+// to llm_rmsnorm; input/output offset by token*n; weight shared across tokens.
+extern ""C"" __global__ void llm_rmsnorm_batched(
+    const float* __restrict__ input,
+    const float* __restrict__ weight,
+    float* __restrict__ output,
+    int n, float eps, int n_tok)
+{
+    __shared__ float sdata[256];
+    unsigned int tid = threadIdx.x;
+    int token = (int)blockIdx.x;
+    if (token >= n_tok) return;
+
+    const float* in = input + (long)token * (long)n;
+    float* out = output + (long)token * (long)n;
+
+    float sum = 0.f;
+    for (int i = (int)tid; i < n; i += 256) {
+        float v = in[i];
+        sum += v * v;
+    }
+    sdata[tid] = sum;
+    __syncthreads();
+
+    for (unsigned int s = 128; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+
+    float scale = rsqrtf(sdata[0] / (float)n + eps);
+    for (int i = (int)tid; i < n; i += 256)
+        out[i] = in[i] * scale * weight[i];
+}
+
+// HeadNorm over N rows: grid = (num_heads, n_tok); block 256. data offset by
+// token*(num_heads*head_dim). Identical reduction to llm_head_norm.
+extern ""C"" __global__ void llm_head_norm_batched(
+    float* __restrict__ data,
+    const float* __restrict__ weight,
+    int head_dim, int num_heads, float eps, int weight_stride, int n_tok)
+{
+    __shared__ float sdata[256];
+    unsigned int tid = threadIdx.x;
+    unsigned int head = blockIdx.x;
+    int token = (int)blockIdx.y;
+    if ((int)head >= num_heads || token >= n_tok) return;
+
+    long token_off = (long)token * (long)num_heads * (long)head_dim;
+    long base_off = token_off + (long)head * head_dim;
+    int  w_off    = (int)head * weight_stride;
+
+    float sum = 0.f;
+    for (int i = (int)tid; i < head_dim; i += 256) {
+        float v = data[base_off + i];
+        sum += v * v;
+    }
+    sdata[tid] = sum;
+    __syncthreads();
+
+    for (unsigned int s = 128; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+
+    float scale = rsqrtf(sdata[0] / (float)head_dim + eps);
+    for (int i = (int)tid; i < head_dim; i += 256)
+        data[base_off + i] = data[base_off + i] * scale * weight[w_off + i];
+}
+
+// Strided de-interleave [Q‖G] → Q, G over N tokens. qg row stride =
+// num_heads*head_dim*2; q/g row stride = num_heads*head_dim.
+extern ""C"" __global__ void llm_split_qg_batched(
+    const float* __restrict__ qg,
+    float* __restrict__ q,
+    float* __restrict__ g,
+    int num_heads, int head_dim, int n_tok)
+{
+    int total = num_heads * head_dim;
+    int idx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int token = (int)blockIdx.y;
+    if (idx >= total || token >= n_tok) return;
+
+    int h = idx / head_dim;
+    int j = idx % head_dim;
+    long qg_base = (long)token * (long)num_heads * (long)head_dim * 2L + (long)h * head_dim * 2;
+    long out_base = (long)token * (long)total + (long)h * head_dim;
+    q[out_base + j] = qg[qg_base + j];
+    g[out_base + j] = qg[qg_base + head_dim + j];
+}
+
+// Partial NEOX RoPE over N tokens. Position for token t is base_position + t
+// (prompt prefill assigns contiguous positions). x row stride = num_heads*head_dim.
+extern ""C"" __global__ void llm_rope_neox_partial_batched(
+    float* __restrict__ x,
+    int num_heads, int head_dim, int rope_dim, int base_position, float theta, int n_tok)
+{
+    int pair_idx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int rope_half_dim = rope_dim / 2;
+    int total_pairs = num_heads * rope_half_dim;
+    int token = (int)blockIdx.y;
+    if (pair_idx >= total_pairs || token >= n_tok) return;
+
+    int h = pair_idx / rope_half_dim;
+    int i = pair_idx % rope_half_dim;
+    int position = base_position + token;
+
+    float freq = 1.0f / powf(theta, 2.0f * (float)i / (float)rope_dim);
+    float angle = (float)position * freq;
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    long head_base = (long)token * (long)num_heads * (long)head_dim + (long)h * head_dim;
+    long a = head_base + i;
+    long b = head_base + i + rope_half_dim;
+    float x0 = x[a];
+    float x1 = x[b];
+    x[a] = x0 * c - x1 * s;
+    x[b] = x0 * s + x1 * c;
+}
+
 // ── TurboQuant rotate_query ────────────────────────────────────────────────
 // Applies the Walsh-Hadamard transform + per-layer sign flip to each query
 // head. One block per query head, head_dim threads per block.

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -423,6 +423,25 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     private bool _disposed;
 
+    // Issue #110/#111: batched prefill is non-transactional — it mutates the GDN
+    // scan/conv recurrent state and writes KV pages as it goes, deferring the
+    // length-counter bookkeeping to the end. A throw mid-chunk (CUDA stream fault,
+    // OOM) therefore leaves the recurrent state partially advanced while the length
+    // counters still read startPos. Retrying any forward call would run on poisoned
+    // state and silently produce wrong output. We latch this fault and refuse all
+    // subsequent forward entries so the caller must discard the pass / reload the
+    // model rather than getting garbage tokens.
+    private bool _faulted;
+
+    private void ThrowIfFaulted()
+    {
+        if (_faulted)
+            throw new InvalidOperationException(
+                "CudaHybridGdnForwardPass: a prior batched prefill faulted mid-chunk, leaving the " +
+                "GDN recurrent state corrupted. This instance can no longer produce correct output — " +
+                "discard it and reload the model.");
+    }
+
     // Prefill profiling (SHARPI_PREFILL_PROFILE=1): accumulate synchronous CPU-MoE
     // wall time vs total Forward wall time to size the batching opportunity.
     private static readonly bool _prefillProfile =
@@ -467,6 +486,36 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private int*   _bExpTokI;          // [bCap × numActive] — token index, grouped by expert
     private int*   _bExpTokK;          // [bCap × numActive] — slot (top-k rank), grouped by expert
     private int*   _bUsedExperts;      // [numExperts] — compact list of experts with ≥1 token this layer
+
+    // ── Batched trunk (issue #111) ────────────────────────────────────────
+    // Device-side per-token activation buffers for the GEMM-batched trunk. The
+    // projection matvecs (GDN qkv/z/alpha/beta/ssm_out, attn q/k/v/o, shared
+    // gate/up/down) run as single GEMM-N launches over all N tokens; the conv1d /
+    // delta-net recurrence and KV-append / SDPA stay per-position, reading per-token
+    // slices via CudaBackend.View. Token-major layout ([N × dim]) matches MatMulBatched.
+    // Allocated grow-only by EnsureBatchedTrunkScratch; null when _cpuGdn (the CPU-GDN
+    // debug path keeps the sequential per-token trunk). Disabled with
+    // SHARPI_BATCHED_TRUNK=0 (falls back to the per-token trunk loop).
+    internal static bool BatchedTrunkEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_BATCHED_TRUNK") != "0";
+    private int _btCap;
+    private Tensor? _gpuBtNorm;      // [N × embDim] attn-norm output (block input)
+    private Tensor? _gpuBtBlockOut;  // [N × embDim] block output → postBlock (resid)
+    private Tensor? _gpuBtMoeNorm;   // [N × embDim] post-attn-norm (MoE input)
+    private Tensor? _gpuBtShared;    // [N × embDim] shared-expert output (unscaled)
+    private Tensor? _gpuBtQkv;       // [N × convChannels] GDN joint QKV
+    private Tensor? _gpuBtZ;         // [N × valueDim] GDN z-gate
+    private Tensor? _gpuBtAlpha;     // [N × numVHeads] GDN alpha
+    private Tensor? _gpuBtBeta;      // [N × numVHeads] GDN beta
+    private Tensor? _gpuBtGdnOut;    // [N × valueDim] GDN recurrence output
+    private Tensor? _gpuBtQGate;     // [N × qDim*2] attn Q‖gate
+    private Tensor? _gpuBtQ;         // [N × qDim] attn Q
+    private Tensor? _gpuBtGate;      // [N × qDim] attn GLU gate
+    private Tensor? _gpuBtK;         // [N × kvDim] attn K
+    private Tensor? _gpuBtV;         // [N × kvDim] attn V
+    private Tensor? _gpuBtAttnOut;   // [N × qDim] attn output (pre-O)
+    private Tensor? _gpuBtSGate;     // [N × expertDim] shared-expert gate
+    private Tensor? _gpuBtSUp;       // [N × expertDim] shared-expert up
 
     public int VocabSize => _hp.VocabSize;
     public int MaxSeqLen => _maxSeqLen;
@@ -1156,6 +1205,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0)
     {
+        ThrowIfFaulted();
         if (tokens is null || tokens.Count == 0)
             throw new ArgumentException("Token list is empty", nameof(tokens));
 
@@ -1329,6 +1379,271 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     {
         if (_gpuStreamAll is { } s) { _gpu.Free(s); _gpuStreamAll = null; }
         FreeBatchedHostScratch();
+        FreeBatchedTrunkScratch();
+    }
+
+    /// <summary>
+    /// Grow-only (exact-size) allocation of the device batched-trunk activation
+    /// buffers (issue #111). Sized to exactly <paramref name="N"/> tokens — the GEMM-N
+    /// kernels derive <c>rows = output.ElementCount / nTok</c>, so over-allocation would
+    /// misshape the launch. Reallocated when N changes (at most twice per prompt: a full
+    /// chunk then a remainder). Only used on the GPU-GDN path (<c>!_cpuGdn</c>).
+    /// </summary>
+    private void EnsureBatchedTrunkScratch(int N)
+    {
+        if (_btCap == N) return;
+        FreeBatchedTrunkScratch();
+
+        int embDim = _embDim;
+        int qDim = _numHeads * _headDim;
+        int kvDim = _numKvHeads * _headDim;
+
+        Tensor A(long elems) => _gpu.Allocate(TensorShape.D1(elems));
+
+        _gpuBtNorm     = A((long)N * embDim);
+        _gpuBtBlockOut = A((long)N * embDim);
+        _gpuBtMoeNorm  = A((long)N * embDim);
+        _gpuBtShared   = A((long)N * embDim);
+        _gpuBtQkv      = A((long)N * _gdnConvChannels);
+        _gpuBtZ        = A((long)N * _gdnValueDim);
+        _gpuBtAlpha    = A((long)N * _gdnNumVHeads);
+        _gpuBtBeta     = A((long)N * _gdnNumVHeads);
+        _gpuBtGdnOut   = A((long)N * _gdnValueDim);
+        _gpuBtQGate    = A((long)N * qDim * 2);
+        _gpuBtQ        = A((long)N * qDim);
+        _gpuBtGate     = A((long)N * qDim);
+        _gpuBtK        = A((long)N * kvDim);
+        _gpuBtV        = A((long)N * kvDim);
+        _gpuBtAttnOut  = A((long)N * qDim);
+        _gpuBtSGate    = A((long)N * _expertDim);
+        _gpuBtSUp      = A((long)N * _expertDim);
+        _btCap = N;
+    }
+
+    private void FreeBatchedTrunkScratch()
+    {
+        void F(ref Tensor? t) { if (t is { } v) { _gpu.Free(v); t = null; } }
+        F(ref _gpuBtNorm); F(ref _gpuBtBlockOut); F(ref _gpuBtMoeNorm); F(ref _gpuBtShared);
+        F(ref _gpuBtQkv); F(ref _gpuBtZ); F(ref _gpuBtAlpha); F(ref _gpuBtBeta); F(ref _gpuBtGdnOut);
+        F(ref _gpuBtQGate); F(ref _gpuBtQ); F(ref _gpuBtGate); F(ref _gpuBtK); F(ref _gpuBtV); F(ref _gpuBtAttnOut);
+        F(ref _gpuBtSGate); F(ref _gpuBtSUp);
+        _btCap = 0;
+    }
+
+    /// <summary>
+    /// Sequential per-token trunk for one layer (the pre-#111 path). Used on the
+    /// CPU-GDN debug path and when SHARPI_BATCHED_TRUNK=0. Produces the host
+    /// <see cref="_bResidAll"/> / <see cref="_bNormAll"/> / <see cref="_bSharedAll"/>
+    /// buffers and self-syncs the stream, exactly as the batched variant.
+    /// </summary>
+    private void TrunkLayerSequential(int layer, int N, int startPos, bool isAttn,
+                                      bool snapKvActive, int wStart)
+    {
+        int embDim = _embDim;
+        for (int i = 0; i < N; i++)
+        {
+            _gpu.CopyDeviceRegion(_gpuHidden, 0, _gpuStreamAll!,
+                                  (long)i * embDim * sizeof(float), (long)embDim * sizeof(float));
+            _gpu.CopyDevice(_gpuResidual, _gpuHidden);
+            _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuAttnNorm[layer], _hp.RmsNormEps);
+
+            _snapKvCaptureSlot = (snapKvActive && i >= wStart) ? (i - wStart) : -1;
+
+            if (isAttn)
+                GpuAttnBlockAt(layer, position: startPos + i, kvPosition: startPos + i,
+                               normIn: _gpuNormBuf, hiddenOut: _gpuHidden);
+            else if (_cpuGdn)
+                CpuGdnBlockAt(layer, position: startPos + i, normInGpu: _gpuNormBuf,
+                              hiddenOutGpu: _gpuHidden, cpuNormScratch: _cpuNormBuf,
+                              cpuHiddenScratch: _cpuHiddenOut);
+            else
+                GpuGdnBlockAt(layer, position: startPos + i, normIn: _gpuNormBuf, hiddenOut: _gpuHidden);
+
+            _gpu.AddInPlace(_gpuHidden, _gpuResidual);           // postBlock (MoE residual)
+            _gpu.DownloadAsync(_gpuHidden, (nint)(_bResidAll + (long)i * embDim), embDim);
+
+            _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuPostAttnNorm[layer], _hp.RmsNormEps);
+            _gpu.DownloadAsync(_gpuNormBuf, (nint)(_bNormAll + (long)i * embDim), embDim);
+
+            GpuMatMul(_gpuFfnGate, _gpuWGateShexp[layer], _gpuNormBuf);
+            GpuMatMul(_gpuFfnUp, _gpuWUpShexp[layer], _gpuNormBuf);
+            _gpu.SiLuMul(_gpuFfnGate, _gpuFfnUp);
+            GpuMatMul(_gpuSharedOut, _gpuWDownShexp[layer], _gpuFfnGate);
+            _gpu.DownloadAsync(_gpuSharedOut, (nint)(_bSharedAll + (long)i * embDim), embDim);
+        }
+        _snapKvCaptureSlot = -1;
+        _gpu.Synchronize();   // drain all queued D2H: resid/norm/shared now host-valid
+    }
+
+    /// <summary>
+    /// GEMM-batched trunk for one layer (issue #111). The projection matvecs —
+    /// GDN qkv/z/alpha/beta/ssm_out, attention q/k/v/o, shared-expert gate/up/down —
+    /// plus the attn-norm / post-attn-norm RmsNorms, per-head Q/K RMSNorm, RoPE,
+    /// Q‖gate split and GLU gate run as single batched launches over all N tokens.
+    /// The conv1d / delta-net recurrence and KV-append / scaled-dot-product attention
+    /// stay per-position (they are positional), reading per-token slices via
+    /// <see cref="CudaBackend.View"/>. Output is bit-identical to
+    /// <see cref="TrunkLayerSequential"/>: every batched kernel runs the same per-row /
+    /// per-element computation as its single-token counterpart, only collapsing the
+    /// N per-token launches into one each — which is what removes the host launch
+    /// overhead that dominates GDN-hybrid prefill.
+    /// </summary>
+    private void TrunkLayerBatched(int layer, int N, int startPos, bool isAttn,
+                                   bool snapKvActive, int wStart)
+    {
+        int embDim = _embDim;
+        EnsureBatchedTrunkScratch(N);
+        var stream   = _gpuStreamAll!;
+        var norm     = _gpuBtNorm!;
+        var blockOut = _gpuBtBlockOut!;
+        var moeNorm  = _gpuBtMoeNorm!;
+        var shared   = _gpuBtShared!;
+
+        // attn-norm (block input) over all tokens.
+        _gpu.RmsNormBatched(norm, stream, _gpuAttnNorm[layer], N, embDim, _hp.RmsNormEps);
+
+        if (isAttn)
+            AttnBlockBatched(layer, N, startPos, snapKvActive, wStart, norm, blockOut);
+        else
+            GdnBlockBatched(layer, N, norm, blockOut);
+
+        // postBlock = blockOut + stream (the pre-block residual). blockOut now holds
+        // the MoE residual — download it to the host combine buffer.
+        _gpu.AddInPlace(blockOut, stream);
+        _gpu.DownloadAsync(blockOut, (nint)_bResidAll, (int)((long)N * embDim));
+
+        // post-attention norm (MoE input).
+        _gpu.RmsNormBatched(moeNorm, blockOut, _gpuPostAttnNorm[layer], N, embDim, _hp.RmsNormEps);
+        _gpu.DownloadAsync(moeNorm, (nint)_bNormAll, (int)((long)N * embDim));
+
+        // Shared expert (unscaled) — gate/up/down batched over all tokens; scale
+        // folded into the host combine, matching the sequential path's operand order.
+        GpuMatMulBatched(_gpuBtSGate!, _gpuWGateShexp[layer], moeNorm, N);
+        GpuMatMulBatched(_gpuBtSUp!,   _gpuWUpShexp[layer],   moeNorm, N);
+        _gpu.SiLuMul(_gpuBtSGate!, _gpuBtSUp!);   // pointwise over N×expertDim
+        GpuMatMulBatched(shared, _gpuWDownShexp[layer], _gpuBtSGate!, N);
+        _gpu.DownloadAsync(shared, (nint)_bSharedAll, (int)((long)N * embDim));
+
+        _gpu.Synchronize();   // drain all queued D2H: resid/norm/shared now host-valid
+    }
+
+    /// <summary>Batched GDN block: projections over N tokens, per-position recurrence.</summary>
+    private void GdnBlockBatched(int layer, int N, Tensor norm, Tensor blockOut)
+    {
+        int convCh = _gdnConvChannels, valDim = _gdnValueDim, nVH = _gdnNumVHeads;
+        int kDim = _gdnKeyDim, hd = _gdnHeadDim;
+        var qkvAll = _gpuBtQkv!; var zAll = _gpuBtZ!;
+        var alphaAll = _gpuBtAlpha!; var betaAll = _gpuBtBeta!; var gdnOutAll = _gpuBtGdnOut!;
+
+        // Batched projections (one launch each over all tokens).
+        GpuMatMulBatched(qkvAll,   _gpuWAttnQkv[layer],  norm, N);
+        GpuMatMulBatched(zAll,     _gpuWAttnGate[layer], norm, N);
+        GpuMatMulBatched(alphaAll, _gpuWSsmAlpha[layer], norm, N);
+        GpuMatMulBatched(betaAll,  _gpuWSsmBeta[layer],  norm, N);
+
+        var scanState = _gpuGdnScanState[layer]!;
+        var convState = _gpuGdnConvState[layer]!;
+
+        // Per-token conv1d + delta-net recurrence (positional → sequential). The
+        // conv/L2/tile scratch (_gpuGdnQkvConv / _gpuGdnQHead / _gpuGdnKHead /
+        // _gpuGdnVHead) is reused per token; only the batched-buffer inputs/output
+        // need per-token views.
+        for (int i = 0; i < N; i++)
+        {
+            var qkvIn = _gpu.View(qkvAll, (long)i * convCh, convCh);
+            var zIn   = _gpu.View(zAll,   (long)i * valDim, valDim);
+            var aIn   = _gpu.View(alphaAll, (long)i * nVH, nVH);
+            var bIn   = _gpu.View(betaAll,  (long)i * nVH, nVH);
+            var outV  = _gpu.View(gdnOutAll, (long)i * valDim, valDim);
+            try
+            {
+                _gpu.GdnConv1dDecode(qkvIn, convState, _gpuSsmConv1d[layer], _gpuGdnQkvConv,
+                    convCh, _gdnConvKernel);
+                _gpu.SiLUInPlace(_gpuGdnQkvConv);
+                _gpu.GdnL2NormPerHead(_gpuGdnQkvConv, 0,    _gdnNumKHeads, hd, eps: 1e-6f);
+                _gpu.GdnL2NormPerHead(_gpuGdnQkvConv, kDim, _gdnNumKHeads, hd, eps: 1e-6f);
+                _gpu.GdnTileHeads(_gpuGdnQkvConv, 0,    _gpuGdnQHead, 0, _gdnNumKHeads, _gdnKvRepeat, hd);
+                _gpu.GdnTileHeads(_gpuGdnQkvConv, kDim, _gpuGdnKHead, 0, _gdnNumKHeads, _gdnKvRepeat, hd);
+                _gpu.CopyDeviceRegion(_gpuGdnVHead, 0,
+                    _gpuGdnQkvConv, 2L * kDim * sizeof(float), (long)valDim * sizeof(float));
+                _gpu.GdnRecurrenceDecode(
+                    scanState, _gpuGdnQHead, _gpuGdnKHead, _gpuGdnVHead, aIn, bIn,
+                    _gpuSsmA[layer], _gpuSsmDtBias[layer], _gpuSsmNormW[layer], zIn, outV,
+                    nVH, hd, normEps: 1e-6f);
+            }
+            finally
+            {
+                _gpu.Free(qkvIn); _gpu.Free(zIn); _gpu.Free(aIn); _gpu.Free(bIn); _gpu.Free(outV);
+            }
+        }
+
+        // Batched ssm_out projection: blockOut = WSsmOut @ gdnOutAll.
+        GpuMatMulBatched(blockOut, _gpuWSsmOut[layer], gdnOutAll, N);
+    }
+
+    /// <summary>Batched attention block: projections + Q/K norm + RoPE over N tokens,
+    /// per-position KV-append + SDPA.</summary>
+    private void AttnBlockBatched(int layer, int N, int startPos, bool snapKvActive, int wStart,
+                                  Tensor norm, Tensor blockOut)
+    {
+        int qDim = _numHeads * _headDim, kvDim = _numKvHeads * _headDim;
+        var qGateAll = _gpuBtQGate!; var qAll = _gpuBtQ!; var gateAll = _gpuBtGate!;
+        var kAll = _gpuBtK!; var vAll = _gpuBtV!; var attnOutAll = _gpuBtAttnOut!;
+
+        // Batched projections + de-interleave + per-head norm + RoPE over all tokens.
+        GpuMatMulBatched(qGateAll, _gpuWQGate[layer], norm, N);
+        GpuMatMulBatched(kAll,     _gpuWK[layer],     norm, N);
+        GpuMatMulBatched(vAll,     _gpuWV[layer],     norm, N);
+
+        _gpu.SplitQGBatched(qAll, gateAll, qGateAll, _numHeads, _headDim, N);
+        _gpu.HeadNormBatched(qAll, _gpuQNorm[layer], _numHeads,   _headDim, N, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+        _gpu.HeadNormBatched(kAll, _gpuKNorm[layer], _numKvHeads, _headDim, N, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+        _gpu.RoPEPartialBatched(qAll, startPos, _headDim, _ropeDim, _hp.RopeTheta, _numHeads,   N, neox: true);
+        _gpu.RoPEPartialBatched(kAll, startPos, _headDim, _ropeDim, _hp.RopeTheta, _numKvHeads, N, neox: true);
+
+        // Per-position KV-append + scaled-dot-product attention (positional →
+        // sequential), plus SnapKV Q-capture for the trailing window.
+        for (int i = 0; i < N; i++)
+        {
+            int pos = startPos + i;
+            var qV = _gpu.View(qAll, (long)i * qDim, qDim);
+            var kV = _gpu.View(kAll, (long)i * kvDim, kvDim);
+            var vV = _gpu.View(vAll, (long)i * kvDim, kvDim);
+            var oV = _gpu.View(attnOutAll, (long)i * qDim, qDim);
+            try
+            {
+                if (snapKvActive && i >= wStart && _snapKvQCapture is { } capBuf)
+                {
+                    int attnIdx = _attnLayerIndexOf[layer];
+                    if (attnIdx >= 0)
+                    {
+                        long dstOff = ((long)attnIdx * _snapKvQCaptureW + (i - wStart)) * qDim;
+                        _gpu.CopyDeviceRegion(capBuf, dstOff * sizeof(float),
+                                              qV, 0, (long)qDim * sizeof(float));
+                    }
+                }
+                if (_kvDType == DType.BFloat16)
+                {
+                    _gpu.KvAppendBf16(kV, vV, _gpuKCache[layer]!, _gpuVCache[layer]!, kvDim, pos, _maxSeqLen);
+                    _gpu.AttentionBf16(qV, _gpuKCache[layer]!, _gpuVCache[layer]!, oV, _gpuAttnScratch,
+                        _numHeads, _numKvHeads, _headDim, pos + 1, _maxSeqLen);
+                }
+                else
+                {
+                    _gpu.KvAppend(kV, vV, _gpuKCache[layer]!, _gpuVCache[layer]!, kvDim, pos, _maxSeqLen);
+                    _gpu.Attention(qV, _gpuKCache[layer]!, _gpuVCache[layer]!, oV, _gpuAttnScratch,
+                        _numHeads, _numKvHeads, _headDim, pos + 1, _maxSeqLen);
+                }
+            }
+            finally
+            {
+                _gpu.Free(qV); _gpu.Free(kV); _gpu.Free(vV); _gpu.Free(oV);
+            }
+        }
+
+        // GLU gate (pointwise over N×qDim) then batched O projection.
+        _gpu.SigmoidMulInPlace(attnOutAll, gateAll);
+        GpuMatMulBatched(blockOut, _gpuWO[layer], attnOutAll, N);
     }
 
     private void FreeBatchedHostScratch()
@@ -1386,6 +1701,13 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         long t0 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         long trunkTicks = 0, routerTicks = 0, routedTicks = 0, combineTicks = 0;
 
+        // Pessimistic fault latch: the GDN recurrent-state mutation + deferred
+        // length-counter bookkeeping below is non-transactional, so mark the pass
+        // poisoned for the whole region and clear it only once the counters have
+        // been advanced consistently (step 3). A throw anywhere in between leaves
+        // _faulted set, and ThrowIfFaulted() blocks any retry on corrupt state.
+        _faulted = true;
+
         // 1. Embed every token into the residual-stream buffer + reserve KV blocks.
         for (int i = 0; i < N; i++)
         {
@@ -1401,44 +1723,19 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             bool isAttn = _hp.LayerTypes![layer] == LayerType.Attention;
             long lt0 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
-            // ── Trunk: sequential per token (GPU), queue D2H of resid/norm/shared.
-            for (int i = 0; i < N; i++)
+            // ── Trunk: GEMM-batched over N tokens (issue #111) on the GPU-GDN path;
+            //    sequential per token on the CPU-GDN debug path / when disabled.
+            //    Both produce host _bResidAll / _bNormAll / _bSharedAll, then the
+            //    batched MoE below runs identically. The batched trunk is bit-identical
+            //    to the sequential one (same kernels, same per-row FP reduction).
+            if (BatchedTrunkEnabled && !_cpuGdn)
             {
-                _gpu.CopyDeviceRegion(_gpuHidden, 0, _gpuStreamAll!,
-                                      (long)i * embDim * sizeof(float), (long)embDim * sizeof(float));
-                _gpu.CopyDevice(_gpuResidual, _gpuHidden);
-                _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuAttnNorm[layer], _hp.RmsNormEps);
-
-                _snapKvCaptureSlot = (snapKvActive && i >= wStart) ? (i - wStart) : -1;
-
-                if (isAttn)
-                    GpuAttnBlockAt(layer, position: startPos + i, kvPosition: startPos + i,
-                                   normIn: _gpuNormBuf, hiddenOut: _gpuHidden);
-                else if (_cpuGdn)
-                    CpuGdnBlockAt(layer, position: startPos + i, normInGpu: _gpuNormBuf,
-                                  hiddenOutGpu: _gpuHidden, cpuNormScratch: _cpuNormBuf,
-                                  cpuHiddenScratch: _cpuHiddenOut);
-                else
-                    GpuGdnBlockAt(layer, position: startPos + i, normIn: _gpuNormBuf, hiddenOut: _gpuHidden);
-
-                _gpu.AddInPlace(_gpuHidden, _gpuResidual);           // postBlock (MoE residual)
-                _gpu.DownloadAsync(_gpuHidden, (nint)(_bResidAll + (long)i * embDim), embDim);
-
-                _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuPostAttnNorm[layer], _hp.RmsNormEps);
-                _gpu.DownloadAsync(_gpuNormBuf, (nint)(_bNormAll + (long)i * embDim), embDim);
-
-                // Shared expert (unscaled) — scale folded into the host combine.
-                // Kept in the trunk loop: the GPU compute is tiny and overlapping
-                // it with the routed-CPU work only shifts host launch overhead
-                // (issuing the launches), which is the real cost — no net win.
-                GpuMatMul(_gpuFfnGate, _gpuWGateShexp[layer], _gpuNormBuf);
-                GpuMatMul(_gpuFfnUp, _gpuWUpShexp[layer], _gpuNormBuf);
-                _gpu.SiLuMul(_gpuFfnGate, _gpuFfnUp);
-                GpuMatMul(_gpuSharedOut, _gpuWDownShexp[layer], _gpuFfnGate);
-                _gpu.DownloadAsync(_gpuSharedOut, (nint)(_bSharedAll + (long)i * embDim), embDim);
+                TrunkLayerBatched(layer, N, startPos, isAttn, snapKvActive, wStart);
             }
-            _snapKvCaptureSlot = -1;
-            _gpu.Synchronize();   // drain all queued D2H: resid/norm/shared now host-valid
+            else
+            {
+                TrunkLayerSequential(layer, N, startPos, isAttn, snapKvActive, wStart);
+            }
             long lt1 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
             // ── Router + shared-expert gate per token (host).
@@ -1497,6 +1794,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             _kvCache.IncrementPosition();
             _gdnStateCache.IncrementPosition();
         }
+        // Recurrent state + length counters are now consistent — clear the fault latch.
+        _faulted = false;
 
         // 4. MTP hidden history: _bHiddenAll holds the pre-output-norm hidden for
         //    every token after the final layer — mirror into the absolute-position
@@ -1607,18 +1906,43 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             int e = used[u];
             byte* gateRow = gateP + (long)e * expertDimL * bprG + (long)r * bprG;
             byte* upRow   = upP   + (long)e * expertDimL * bprU + (long)r * bprU;
-            for (int p = expStart[e]; p < expStart[e + 1]; p++)
+            int pStart = expStart[e], pEnd = expStart[e + 1];
+            // Issue #112: dot each gate/up row against the expert's tokens in PAIRS,
+            // decoding the (Q4_K/Q5_K/Q3_K) weight row once per pair. Bit-identical to
+            // the per-token dots (the 2In kernels mirror the single accumulation order).
+            int p = pStart;
+            for (; p + 1 < pEnd; p += 2)
+            {
+                int i0 = expTokI[p],     k0 = expTokK[p];
+                int i1 = expTokI[p + 1], k1 = expTokK[p + 1];
+                long o0 = ((long)i0 * naL + k0) * expertDimL + r;
+                long o1 = ((long)i1 * naL + k1) * expertDimL + r;
+                float a0, a1;
+                if (useQ8KGate)
+                    DispatchDotQ8K2In(gateRow, normAllQ8K + (long)i0 * q8kEmbStride,
+                        normAllQ8K + (long)i1 * q8kEmbStride, embDimL, gateDt, out a0, out a1);
+                else
+                    DispatchDot2In(gateRow, normAll + (long)i0 * embDimL,
+                        normAll + (long)i1 * embDimL, embDimL, gateDt, out a0, out a1);
+                gateAll[o0] = a0; gateAll[o1] = a1;
+                if (useQ8KUp)
+                    DispatchDotQ8K2In(upRow, normAllQ8K + (long)i0 * q8kEmbStride,
+                        normAllQ8K + (long)i1 * q8kEmbStride, embDimL, upDt, out a0, out a1);
+                else
+                    DispatchDot2In(upRow, normAll + (long)i0 * embDimL,
+                        normAll + (long)i1 * embDimL, embDimL, upDt, out a0, out a1);
+                upAll[o0] = a0; upAll[o1] = a1;
+            }
+            if (p < pEnd) // odd remainder
             {
                 int i = expTokI[p], k = expTokK[p];
                 long outIdx = ((long)i * naL + k) * expertDimL + r;
-                if (useQ8KGate)
-                    gateAll[outIdx] = DispatchDotQ8K(gateRow, normAllQ8K + (long)i * q8kEmbStride, embDimL, gateDt);
-                else
-                    gateAll[outIdx] = DispatchDot(gateRow, normAll + (long)i * embDimL, embDimL, gateDt);
-                if (useQ8KUp)
-                    upAll[outIdx] = DispatchDotQ8K(upRow, normAllQ8K + (long)i * q8kEmbStride, embDimL, upDt);
-                else
-                    upAll[outIdx] = DispatchDot(upRow, normAll + (long)i * embDimL, embDimL, upDt);
+                gateAll[outIdx] = useQ8KGate
+                    ? DispatchDotQ8K(gateRow, normAllQ8K + (long)i * q8kEmbStride, embDimL, gateDt)
+                    : DispatchDot(gateRow, normAll + (long)i * embDimL, embDimL, gateDt);
+                upAll[outIdx] = useQ8KUp
+                    ? DispatchDotQ8K(upRow, normAllQ8K + (long)i * q8kEmbStride, embDimL, upDt)
+                    : DispatchDot(upRow, normAll + (long)i * embDimL, embDimL, upDt);
             }
         });
 
@@ -1639,10 +1963,27 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             int r = idx % embDimL;
             int e = used[u];
             byte* downRow = downP + (long)e * embDimL * bprD + (long)r * bprD;
-            for (int p = expStart[e]; p < expStart[e + 1]; p++)
+            int pStart = expStart[e], pEnd = expStart[e + 1];
+            // Issue #112: down row dotted against the expert's silu'd-gate slices in
+            // PAIRS, decoding the weight row once per pair (bit-identical to per-token).
+            int p = pStart;
+            for (; p + 1 < pEnd; p += 2)
             {
-                int i = expTokI[p], k = expTokK[p];
-                long slot = (long)i * naL + k;
+                long s0 = (long)expTokI[p]     * naL + expTokK[p];
+                long s1 = (long)expTokI[p + 1] * naL + expTokK[p + 1];
+                float d0, d1;
+                if (useQ8KDown)
+                    DispatchDotQ8K2In(downRow, gateAllQ8K + s0 * q8kExpStride,
+                        gateAllQ8K + s1 * q8kExpStride, expertDimL, downDt, out d0, out d1);
+                else
+                    DispatchDot2In(downRow, gateAll + s0 * expertDimL,
+                        gateAll + s1 * expertDimL, expertDimL, downDt, out d0, out d1);
+                downPartial[s0 * embDimL + r] = d0;
+                downPartial[s1 * embDimL + r] = d1;
+            }
+            if (p < pEnd) // odd remainder
+            {
+                long slot = (long)expTokI[p] * naL + expTokK[p];
                 downPartial[slot * embDimL + r] = useQ8KDown
                     ? DispatchDotQ8K(downRow, gateAllQ8K + slot * q8kExpStride, expertDimL, downDt)
                     : DispatchDot(downRow, gateAll + slot * expertDimL, expertDimL, downDt);
@@ -1992,6 +2333,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// <summary>Forward one token through the hybrid CUDA + CPU stack.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
+        ThrowIfFaulted();
         long fwdT0 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         // 1. Embedding → _gpuHidden
         EmbedToken(_gpuHidden, token);
@@ -2153,6 +2495,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     public void BatchForward2(int t1, int t2, int startPos,
         out ReadOnlySpan<float> logits1, out ReadOnlySpan<float> logits2)
     {
+        ThrowIfFaulted();
         if (!SupportsBatchVerify)
             throw new InvalidOperationException(
                 "BatchForward2 is only supported on dense-FFN MTP passes. " +
@@ -2477,6 +2820,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// <inheritdoc />
     public ReadOnlySpan<float> MtpForward(int token, int position, ReadOnlySpan<float> prevHidden)
     {
+        ThrowIfFaulted();
         if (!_hasMtp)
             throw new InvalidOperationException(
                 "MtpForward called on a CudaHybridGdnForwardPass that did not load an MTP head. " +
@@ -2664,6 +3008,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// </remarks>
     public void PrefillMtp(IReadOnlyList<int> tokens, int startPos = 0)
     {
+        ThrowIfFaulted();
         if (!_hasMtp) return;
         if (tokens is null || tokens.Count == 0) return;
 
@@ -3313,6 +3658,46 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             _ => throw new NotSupportedException($"Routed expert dtype {dtype} not supported in batched path"),
         };
 
+    // Issue #112: dequant-once two-input dispatch. Decodes the quantized weight row
+    // ONCE and dots it against two token inputs, amortizing the (Q4_K/Q5_K nibble)
+    // unpack across the pair. Bit-identical to two <see cref="DispatchDot"/> calls —
+    // the 2In kernels mirror the single-input accumulator structure exactly (proven
+    // by the MTP batched-verify path) — so the routed-MoE byte-parity oracle still
+    // holds. Dtypes without a 2In kernel fall back to two single dots (no win, still
+    // correct).
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDot2In(byte* row, float* in1, float* in2, int cols, DType dtype,
+        out float v1, out float v2)
+    {
+        switch (dtype)
+        {
+            case DType.Q4_K: SimdKernels.DotQ4K_2In(row, in1, in2, cols, out v1, out v2); break;
+            case DType.Q5_K: SimdKernels.DotQ5K_2In(row, in1, in2, cols, out v1, out v2); break;
+            default:
+                v1 = DispatchDot(row, in1, cols, dtype);
+                v2 = DispatchDot(row, in2, cols, dtype);
+                break;
+        }
+    }
+
+    // Issue #112: dequant-once two-input dispatch for the Q8_KS-prepacked path.
+    // Decodes the Q3_K weight row once and dots against two prepacked token inputs.
+    // Bit-identical to two <see cref="DispatchDotQ8K"/> calls. Q8_0 has no expensive
+    // unpack, so it falls back to two single dots.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDotQ8K2In(byte* row, byte* scr1, byte* scr2, int cols, DType dtype,
+        out float v1, out float v2)
+    {
+        switch (dtype)
+        {
+            case DType.Q3_K: SimdKernels.DotQ3K_Q8KS_2In(row, scr1, scr2, cols, out v1, out v2); break;
+            default:
+                v1 = DispatchDotQ8K(row, scr1, cols, dtype);
+                v2 = DispatchDotQ8K(row, scr2, cols, dtype);
+                break;
+        }
+    }
+
     // Same idea as DispatchDot but the input is already prepacked to Q8_KS
     // (per-32-element scales — issue #107) once per CpuMoeFfnCore call (Phase A:
     // cpuNormIn; Phase C: each gateAll slice), so individual rows hit the
@@ -3389,6 +3774,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private void GpuMatMul(Tensor output, Tensor matrix, Tensor vector)
     {
         _gpu.MatMul(output, matrix, vector,
+            _gpuWeightDTypes.TryGetValue(matrix.Handle, out var dt) ? dt : DType.Float32);
+    }
+
+    /// Issue #111: batched (GEMM-N) MatMul dispatch — one weight read applied to N
+    /// token columns in a single launch, bit-identical to N sequential GpuMatMul calls.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void GpuMatMulBatched(Tensor outputAll, Tensor matrix, Tensor inputAll, int nTok)
+    {
+        _gpu.MatMulBatched(outputAll, matrix, inputAll, nTok,
             _gpuWeightDTypes.TryGetValue(matrix.Handle, out var dt) ? dt : DType.Float32);
     }
 

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
@@ -142,6 +142,70 @@ public sealed class CudaHybridGdnBatchedPrefillTests
         fwd.LastHidden.ToArray();
 
     /// <summary>
+    /// Issue #111: the GEMM-batched trunk (<c>TrunkLayerBatched</c>, default) must be
+    /// bit-identical to the per-token <c>TrunkLayerSequential</c> fallback
+    /// (<c>SHARPI_BATCHED_TRUNK=0</c>). Both run under batched prefill; only the trunk
+    /// strategy differs. This is the equivalence users rely on when bisecting with the
+    /// env var — otherwise asserted only by prose.
+    /// </summary>
+    [Fact]
+    public void BatchedTrunk_BitwiseMatchesSequentialTrunk_Carnice()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCarnicePath();
+        if (path is null) return;
+
+        var prevCpuMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+        Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+        bool prevBatchedPrefill = CudaHybridGdnForwardPass.BatchedPrefillEnabled;
+        bool prevBatchedTrunk = CudaHybridGdnForwardPass.BatchedTrunkEnabled;
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            if (!hp.IsMoE) return;
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            var placement = new LayerPlacement(
+                GpuLayers: hp.NumLayers, CpuLayers: 0, GpuWeightBytes: 0, GpuKvBytes: 0,
+                RecommendedCtxSize: Math.Min(hp.ContextLength, 4096));
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts!");
+            Assert.True(tokens.Count >= 8);
+
+            CudaHybridGdnForwardPass.BatchedPrefillEnabled = true;
+
+            float[] RunWithTrunk(bool batchedTrunk)
+            {
+                CudaHybridGdnForwardPass.BatchedTrunkEnabled = batchedTrunk;
+                using var fwd = new CudaHybridGdnForwardPass(model, gpu, hp, placement);
+                return fwd.Prefill(tokens).ToArray();
+            }
+
+            float[] seqTrunk = RunWithTrunk(false);
+            float[] batTrunk = RunWithTrunk(true);
+
+            Assert.Equal(seqTrunk.Length, batTrunk.Length);
+            int firstDiff = -1;
+            for (int i = 0; i < seqTrunk.Length; i++)
+                if (BitConverter.SingleToInt32Bits(seqTrunk[i]) != BitConverter.SingleToInt32Bits(batTrunk[i]))
+                { firstDiff = i; break; }
+            Assert.True(firstDiff < 0,
+                $"Batched trunk diverges from sequential trunk at index {firstDiff}. " +
+                "TrunkLayerBatched must be bit-identical to TrunkLayerSequential (SHARPI_BATCHED_TRUNK=0).");
+            Assert.Equal(Sampler.Greedy(seqTrunk), Sampler.Greedy(batTrunk));
+        }
+        finally
+        {
+            CudaHybridGdnForwardPass.BatchedPrefillEnabled = prevBatchedPrefill;
+            CudaHybridGdnForwardPass.BatchedTrunkEnabled = prevBatchedTrunk;
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
+        }
+    }
+
+    /// <summary>
     /// Multi-chunk parity: prefill the prompt in two segments (<c>[0,k)</c> then
     /// <c>[k,N)</c>, the second with <c>startPos=k</c>) and assert the final-token
     /// logits are bit-identical between batched and sequential. Exercises the paths

--- a/tests/SharpInference.Tests.ForwardPass/CudaMatMulBatchedTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaMatMulBatchedTests.cs
@@ -1,0 +1,449 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #111 bit-exactness tests for <see cref="CudaBackend.MatMulBatched"/>
+/// (GEMM-N). The batched path must produce results <b>bit-identical</b> to N
+/// sequential <see cref="CudaBackend.MatMul"/> calls with the same weight matrix
+/// — not just within tolerance. The GEMM-N kernel runs the identical per-row
+/// reduction as the GEMV, only shifting the input/output base pointer per token,
+/// so any divergence means the reduction order was reordered (the failure mode
+/// the GDN/MTP byte-parity oracles trip on — see the K/V MatVecDual note).
+///
+/// Silently skips on hosts without CUDA, mirroring the other Cuda* test files.
+/// </summary>
+public sealed unsafe class CudaMatMulBatchedTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static ushort HalfToUshort(Half h) =>
+        BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+
+    /// Q4_K layout: 144 bytes per 256-element super-block (matches the GGUF path).
+    private static byte[] BuildQ4KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 144;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 144;
+                float d    = (float)(rng.NextDouble() * 0.05 + 0.005);
+                float dmin = (float)(rng.NextDouble() * 0.03 + 0.005);
+                ushort dh = HalfToUshort((Half)d), dmh = HalfToUshort((Half)dmin);
+                bytes[off + 0] = (byte)(dh & 0xFF); bytes[off + 1] = (byte)(dh >> 8);
+                bytes[off + 2] = (byte)(dmh & 0xFF); bytes[off + 3] = (byte)(dmh >> 8);
+                for (int i = 0; i < 12;  i++) bytes[off +   4 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 128; i++) bytes[off +  16 + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    private static void AssertBitIdentical(string label, int rows, int nTok,
+                                           float[] batched, float[][] reference)
+    {
+        for (int t = 0; t < nTok; t++)
+            for (int r = 0; r < rows; r++)
+            {
+                float bat = batched[(long)t * rows + r];
+                float refv = reference[t][r];
+                if (BitConverter.SingleToInt32Bits(bat) != BitConverter.SingleToInt32Bits(refv))
+                    Assert.Fail(
+                        $"{label}: token {t} row {r} GEMM-N={bat} (0x{BitConverter.SingleToInt32Bits(bat):X8}) " +
+                        $"!= sequential GEMV={refv} (0x{BitConverter.SingleToInt32Bits(refv):X8}). " +
+                        "MatMulBatched must be bit-identical to N sequential MatMul calls.");
+            }
+    }
+
+    [Fact]
+    public void MatMulBatched_Q4K_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols, int nTok) in
+                 new[] { (8, 256, 2), (33, 512, 5), (64, 1024, 17), (256, 2048, 64) })
+        {
+            var rng = new Random(20260603 + rows * 31 + cols * 7 + nTok);
+            byte[] weights = BuildQ4KMatrix(rows, cols, rng);
+
+            var inAll = new float[(long)nTok * cols];
+            for (int i = 0; i < inAll.Length; i++) inAll[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var gpuW = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q4_K);
+            var gpuInAll = gpu.Upload(inAll, TensorShape.D1((long)nTok * cols));
+            var gpuOutAll = gpu.Allocate(TensorShape.D1((long)nTok * rows));
+
+            gpu.MatMulBatched(gpuOutAll, gpuW, gpuInAll, nTok, DType.Q4_K);
+            gpu.Synchronize();
+            var batched = new float[(long)nTok * rows];
+            gpu.Download(gpuOutAll, batched);
+
+            // Sequential reference: one GEMV per token over the same weight.
+            var reference = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var inT = new float[cols];
+                Array.Copy(inAll, (long)t * cols, inT, 0, cols);
+                var gpuInT = gpu.Upload(inT, TensorShape.D1(cols));
+                var gpuRefT = gpu.Allocate(TensorShape.D1(rows));
+                gpu.MatMul(gpuRefT, gpuW, gpuInT, DType.Q4_K);
+                gpu.Synchronize();
+                reference[t] = new float[rows];
+                gpu.Download(gpuRefT, reference[t]);
+                gpu.Free(gpuInT); gpu.Free(gpuRefT);
+            }
+
+            gpu.Free(gpuW); gpu.Free(gpuInAll); gpu.Free(gpuOutAll);
+
+            AssertBitIdentical($"Q4_K rows={rows} cols={cols} nTok={nTok}", rows, nTok, batched, reference);
+        }
+    }
+
+    /// Q6_K layout: 210 bytes per 256-element super-block.
+    private static byte[] BuildQ6KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 210;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 210;
+                for (int i = 0; i < 128; i++) bytes[off + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 64;  i++) bytes[off + 128 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 16;  i++) bytes[off + 192 + i] = (byte)(rng.Next(33) - 16);
+                float d = (float)(rng.NextDouble() * 0.05 + 0.005);
+                ushort dh = HalfToUshort((Half)d);
+                bytes[off + 208] = (byte)(dh & 0xFF);
+                bytes[off + 209] = (byte)(dh >> 8);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void MatMulBatched_Q6K_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols, int nTok) in
+                 new[] { (8, 256, 2), (33, 512, 5), (64, 1024, 17), (256, 512, 64) })
+        {
+            var rng = new Random(20260603 + rows * 37 + cols * 11 + nTok);
+            byte[] weights = BuildQ6KMatrix(rows, cols, rng);
+
+            var inAll = new float[(long)nTok * cols];
+            for (int i = 0; i < inAll.Length; i++) inAll[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var gpuW = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q6_K);
+            var gpuInAll = gpu.Upload(inAll, TensorShape.D1((long)nTok * cols));
+            var gpuOutAll = gpu.Allocate(TensorShape.D1((long)nTok * rows));
+
+            gpu.MatMulBatched(gpuOutAll, gpuW, gpuInAll, nTok, DType.Q6_K);
+            gpu.Synchronize();
+            var batched = new float[(long)nTok * rows];
+            gpu.Download(gpuOutAll, batched);
+
+            var reference = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var inT = new float[cols];
+                Array.Copy(inAll, (long)t * cols, inT, 0, cols);
+                var gpuInT = gpu.Upload(inT, TensorShape.D1(cols));
+                var gpuRefT = gpu.Allocate(TensorShape.D1(rows));
+                gpu.MatMul(gpuRefT, gpuW, gpuInT, DType.Q6_K);
+                gpu.Synchronize();
+                reference[t] = new float[rows];
+                gpu.Download(gpuRefT, reference[t]);
+                gpu.Free(gpuInT); gpu.Free(gpuRefT);
+            }
+            gpu.Free(gpuW); gpu.Free(gpuInAll); gpu.Free(gpuOutAll);
+            AssertBitIdentical($"Q6_K rows={rows} cols={cols} nTok={nTok}", rows, nTok, batched, reference);
+        }
+    }
+
+    private static float[] Rand(int n, Random rng)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        return a;
+    }
+
+    private static void AssertRowsBitIdentical(string label, int rows, int nTok,
+                                               float[] batched, float[][] reference)
+    {
+        for (int t = 0; t < nTok; t++)
+            for (int r = 0; r < rows; r++)
+            {
+                float bat = batched[(long)t * rows + r];
+                float refv = reference[t][r];
+                if (BitConverter.SingleToInt32Bits(bat) != BitConverter.SingleToInt32Bits(refv))
+                    Assert.Fail($"{label}: token {t} idx {r} batched={bat} != single={refv}.");
+            }
+    }
+
+    [Fact]
+    public void RmsNormBatched_BitwiseMatchesSingle()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        foreach ((int dim, int nTok) in new[] { (256, 3), (2048, 17), (2048, 64) })
+        {
+            var rng = new Random(7 + dim + nTok);
+            var w = Rand(dim, rng);
+            var xAll = new float[(long)nTok * dim];
+            for (int i = 0; i < xAll.Length; i++) xAll[i] = (float)(rng.NextDouble() * 4 - 2);
+
+            var gpuW = gpu.Upload(w, TensorShape.D1(dim));
+            var gpuX = gpu.Upload(xAll, TensorShape.D1((long)nTok * dim));
+            var gpuOut = gpu.Allocate(TensorShape.D1((long)nTok * dim));
+            gpu.RmsNormBatched(gpuOut, gpuX, gpuW, nTok, dim, 1e-6f);
+            gpu.Synchronize();
+            var bat = new float[(long)nTok * dim]; gpu.Download(gpuOut, bat);
+
+            var refs = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var xt = new float[dim]; Array.Copy(xAll, (long)t * dim, xt, 0, dim);
+                var gx = gpu.Upload(xt, TensorShape.D1(dim));
+                var go = gpu.Allocate(TensorShape.D1(dim));
+                gpu.RmsNorm(go, gx, gpuW, 1e-6f);
+                gpu.Synchronize();
+                refs[t] = new float[dim]; gpu.Download(go, refs[t]);
+                gpu.Free(gx); gpu.Free(go);
+            }
+            gpu.Free(gpuW); gpu.Free(gpuX); gpu.Free(gpuOut);
+            AssertRowsBitIdentical($"RmsNorm dim={dim} nTok={nTok}", dim, nTok, bat, refs);
+        }
+    }
+
+    [Fact]
+    public void HeadNormBatched_BitwiseMatchesSingle()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        int numHeads = 16, headDim = 256;
+        foreach (int nTok in new[] { 3, 17, 64 })
+        {
+            var rng = new Random(11 + nTok);
+            var w = Rand(headDim, rng);
+            int qDim = numHeads * headDim;
+            var dataAll = new float[(long)nTok * qDim];
+            for (int i = 0; i < dataAll.Length; i++) dataAll[i] = (float)(rng.NextDouble() * 4 - 2);
+
+            var gpuW = gpu.Upload(w, TensorShape.D1(headDim));
+            var gpuData = gpu.Upload(dataAll, TensorShape.D1((long)nTok * qDim));
+            gpu.HeadNormBatched(gpuData, gpuW, numHeads, headDim, nTok, 1e-6f, false);
+            gpu.Synchronize();
+            var bat = new float[(long)nTok * qDim]; gpu.Download(gpuData, bat);
+
+            var refs = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var dt = new float[qDim]; Array.Copy(dataAll, (long)t * qDim, dt, 0, qDim);
+                var gd = gpu.Upload(dt, TensorShape.D1(qDim));
+                gpu.HeadNorm(gd, gpuW, numHeads, headDim, 1e-6f, false);
+                gpu.Synchronize();
+                refs[t] = new float[qDim]; gpu.Download(gd, refs[t]);
+                gpu.Free(gd);
+            }
+            gpu.Free(gpuW); gpu.Free(gpuData);
+            AssertRowsBitIdentical($"HeadNorm nTok={nTok}", qDim, nTok, bat, refs);
+        }
+    }
+
+    [Fact]
+    public void HeadNormBatched_PerChannelWeight_BitwiseMatchesSingle()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        int numHeads = 16, headDim = 256;
+        int qDim = numHeads * headDim;
+        foreach (int nTok in new[] { 3, 17, 64 })
+        {
+            var rng = new Random(101 + nTok);
+            // Per-channel weight is [numHeads * headDim] (OLMoE-style QK norm).
+            var w = Rand(qDim, rng);
+            var dataAll = new float[(long)nTok * qDim];
+            for (int i = 0; i < dataAll.Length; i++) dataAll[i] = (float)(rng.NextDouble() * 4 - 2);
+
+            var gpuW = gpu.Upload(w, TensorShape.D1(qDim));
+            var gpuData = gpu.Upload(dataAll, TensorShape.D1((long)nTok * qDim));
+            gpu.HeadNormBatched(gpuData, gpuW, numHeads, headDim, nTok, 1e-6f, perChannelWeight: true);
+            gpu.Synchronize();
+            var bat = new float[(long)nTok * qDim]; gpu.Download(gpuData, bat);
+
+            var refs = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var dt = new float[qDim]; Array.Copy(dataAll, (long)t * qDim, dt, 0, qDim);
+                var gd = gpu.Upload(dt, TensorShape.D1(qDim));
+                gpu.HeadNorm(gd, gpuW, numHeads, headDim, 1e-6f, perChannelWeight: true);
+                gpu.Synchronize();
+                refs[t] = new float[qDim]; gpu.Download(gd, refs[t]);
+                gpu.Free(gd);
+            }
+            gpu.Free(gpuW); gpu.Free(gpuData);
+            AssertRowsBitIdentical($"HeadNorm(perChannel) nTok={nTok}", qDim, nTok, bat, refs);
+        }
+    }
+
+    [Fact]
+    public void View_RoundTrips_FreeDoesNotFreeParent_AndBoundsChecked()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int n = 4096, off = 512, len = 1024;
+        var data = new float[n];
+        var rng = new Random(7);
+        for (int i = 0; i < n; i++) data[i] = (float)(rng.NextDouble() * 2 - 1);
+        var parent = gpu.Upload(data, TensorShape.D1(n));
+
+        // (a) View reads back the matching parent sub-range.
+        var view = gpu.View(parent, off, len);
+        var got = new float[len];
+        gpu.Download(view, got);
+        for (int i = 0; i < len; i++)
+            Assert.Equal(BitConverter.SingleToInt32Bits(data[off + i]), BitConverter.SingleToInt32Bits(got[i]));
+
+        // (b) Freeing the view must NOT free the parent — parent still reads back.
+        gpu.Free(view);
+        var parentAfter = new float[n];
+        gpu.Download(parent, parentAfter);
+        for (int i = 0; i < n; i++)
+            Assert.Equal(BitConverter.SingleToInt32Bits(data[i]), BitConverter.SingleToInt32Bits(parentAfter[i]));
+
+        // (c) Bounds + negative-arg checks throw.
+        Assert.Throws<ArgumentOutOfRangeException>(() => gpu.View(parent, n - 10, 100));
+        Assert.Throws<ArgumentOutOfRangeException>(() => gpu.View(parent, -1, 10));
+        Assert.Throws<ArgumentOutOfRangeException>(() => gpu.View(parent, 0, -10));
+
+        gpu.Free(parent);
+    }
+
+    [Fact]
+    public void SplitQGBatched_BitwiseMatchesSingle()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        int numHeads = 16, headDim = 256;
+        int qDim = numHeads * headDim;
+        foreach (int nTok in new[] { 2, 17, 64 })
+        {
+            var rng = new Random(13 + nTok);
+            var qgAll = Rand(nTok * qDim * 2, rng);
+            var gpuQg = gpu.Upload(qgAll, TensorShape.D1((long)nTok * qDim * 2));
+            var gpuQ = gpu.Allocate(TensorShape.D1((long)nTok * qDim));
+            var gpuG = gpu.Allocate(TensorShape.D1((long)nTok * qDim));
+            gpu.SplitQGBatched(gpuQ, gpuG, gpuQg, numHeads, headDim, nTok);
+            gpu.Synchronize();
+            var batQ = new float[(long)nTok * qDim]; gpu.Download(gpuQ, batQ);
+            var batG = new float[(long)nTok * qDim]; gpu.Download(gpuG, batG);
+
+            var refsQ = new float[nTok][];
+            var refsG = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var qgt = new float[qDim * 2]; Array.Copy(qgAll, (long)t * qDim * 2, qgt, 0, qDim * 2);
+                var gqg = gpu.Upload(qgt, TensorShape.D1(qDim * 2));
+                var gq = gpu.Allocate(TensorShape.D1(qDim));
+                var gg = gpu.Allocate(TensorShape.D1(qDim));
+                gpu.SplitQG(gq, gg, gqg, numHeads, headDim);
+                gpu.Synchronize();
+                refsQ[t] = new float[qDim]; gpu.Download(gq, refsQ[t]);
+                refsG[t] = new float[qDim]; gpu.Download(gg, refsG[t]);
+                gpu.Free(gqg); gpu.Free(gq); gpu.Free(gg);
+            }
+            gpu.Free(gpuQg); gpu.Free(gpuQ); gpu.Free(gpuG);
+            AssertRowsBitIdentical($"SplitQG-Q nTok={nTok}", qDim, nTok, batQ, refsQ);
+            AssertRowsBitIdentical($"SplitQG-G nTok={nTok}", qDim, nTok, batG, refsG);
+        }
+    }
+
+    [Fact]
+    public void RoPEPartialBatched_BitwiseMatchesSingle()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        int numHeads = 16, headDim = 256, ropeDim = 64;
+        int qDim = numHeads * headDim;
+        float theta = 1000000f;
+        foreach ((int basePos, int nTok) in new[] { (0, 3), (37, 17), (512, 64) })
+        {
+            var rng = new Random(17 + basePos + nTok);
+            var xAll = Rand(nTok * qDim, rng);
+            var gpuX = gpu.Upload(xAll, TensorShape.D1((long)nTok * qDim));
+            gpu.RoPEPartialBatched(gpuX, basePos, headDim, ropeDim, theta, numHeads, nTok, neox: true);
+            gpu.Synchronize();
+            var bat = new float[(long)nTok * qDim]; gpu.Download(gpuX, bat);
+
+            var refs = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var xt = new float[qDim]; Array.Copy(xAll, (long)t * qDim, xt, 0, qDim);
+                var gx = gpu.Upload(xt, TensorShape.D1(qDim));
+                gpu.RoPEPartial(gx, basePos + t, headDim, ropeDim, theta, neox: true);
+                gpu.Synchronize();
+                refs[t] = new float[qDim]; gpu.Download(gx, refs[t]);
+                gpu.Free(gx);
+            }
+            gpu.Free(gpuX);
+            AssertRowsBitIdentical($"RoPE basePos={basePos} nTok={nTok}", qDim, nTok, bat, refs);
+        }
+    }
+
+    [Fact]
+    public void MatMulBatched_F32_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols, int nTok) in
+                 new[] { (8, 256, 2), (33, 500, 5), (64, 1024, 17), (130, 2048, 40) })
+        {
+            var rng = new Random(20260603 + rows * 13 + cols * 3 + nTok);
+            var weights = new float[(long)rows * cols];
+            for (int i = 0; i < weights.Length; i++) weights[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var inAll = new float[(long)nTok * cols];
+            for (int i = 0; i < inAll.Length; i++) inAll[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var gpuW = gpu.Upload(weights, TensorShape.D1((long)rows * cols));
+            var gpuInAll = gpu.Upload(inAll, TensorShape.D1((long)nTok * cols));
+            var gpuOutAll = gpu.Allocate(TensorShape.D1((long)nTok * rows));
+
+            gpu.MatMulBatched(gpuOutAll, gpuW, gpuInAll, nTok, DType.Float32);
+            gpu.Synchronize();
+            var batched = new float[(long)nTok * rows];
+            gpu.Download(gpuOutAll, batched);
+
+            var reference = new float[nTok][];
+            for (int t = 0; t < nTok; t++)
+            {
+                var inT = new float[cols];
+                Array.Copy(inAll, (long)t * cols, inT, 0, cols);
+                var gpuInT = gpu.Upload(inT, TensorShape.D1(cols));
+                var gpuRefT = gpu.Allocate(TensorShape.D1(rows));
+                gpu.MatMul(gpuRefT, gpuW, gpuInT, DType.Float32);
+                gpu.Synchronize();
+                reference[t] = new float[rows];
+                gpu.Download(gpuRefT, reference[t]);
+                gpu.Free(gpuInT); gpu.Free(gpuRefT);
+            }
+
+            gpu.Free(gpuW); gpu.Free(gpuInAll); gpu.Free(gpuOutAll);
+
+            AssertBitIdentical($"F32 rows={rows} cols={cols} nTok={nTok}", rows, nTok, batched, reference);
+        }
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
@@ -244,6 +244,138 @@ public sealed unsafe class SimdKernelsQ8KSTests
     }
 
     /// <summary>
+    /// Issue #112: the two-input dequant-once <see cref="SimdKernels.DotQ3K_Q8KS_2In"/>
+    /// must be <b>bit-identical</b> to two separate <see cref="SimdKernels.DotQ3K_Q8KS"/>
+    /// calls — it decodes the weight row once but accumulates each input in the
+    /// identical sub-block order, so any divergence means the reduction was reordered
+    /// (the failure mode the routed-MoE byte-parity oracle trips on).
+    /// </summary>
+    [Fact]
+    public void DotQ3K_Q8KS_2In_BitwiseMatchesSingle()
+    {
+        if (!Avx2.IsSupported || !Fma.IsSupported) return;
+
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (8, 2048), (3, 4096) })
+        {
+            var rng = new Random(unchecked((int)0x112C0DE) ^ (rows * 131 + cols));
+            byte[] weightBytes = BuildQ3KMatrix(rows, cols, rng);
+
+            var in1 = new float[cols];
+            var in2 = new float[cols];
+            for (int i = 0; i < cols; i++)
+            {
+                in1[i] = (float)(rng.NextDouble() * 2 - 1);
+                in2[i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+
+            int bytesPerRow = (cols / 256) * 110;
+            int scratchBytes = SimdKernels.Q8KSScratchBytes(cols);
+            var s1 = new byte[scratchBytes];
+            var s2 = new byte[scratchBytes];
+
+            fixed (byte* wPtr = weightBytes)
+            fixed (byte* sp1 = s1)
+            fixed (byte* sp2 = s2)
+            fixed (float* i1 = in1)
+            fixed (float* i2 = in2)
+            {
+                SimdKernels.QuantizeRowToQ8KS(i1, cols, sp1);
+                SimdKernels.QuantizeRowToQ8KS(i2, cols, sp2);
+                for (int r = 0; r < rows; r++)
+                {
+                    byte* rowP = wPtr + (long)r * bytesPerRow;
+                    float ref1 = SimdKernels.DotQ3K_Q8KS(rowP, sp1, cols);
+                    float ref2 = SimdKernels.DotQ3K_Q8KS(rowP, sp2, cols);
+                    SimdKernels.DotQ3K_Q8KS_2In(rowP, sp1, sp2, cols, out float v1, out float v2);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(ref1), BitConverter.SingleToInt32Bits(v1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(ref2), BitConverter.SingleToInt32Bits(v2));
+                }
+            }
+        }
+    }
+
+    private static byte[] BuildQ4KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256, bytesPerRow = blocksPerRow * 144;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 144;
+                float d = (float)(rng.NextDouble() * 0.05 + 0.005), dmin = (float)(rng.NextDouble() * 0.03 + 0.005);
+                ushort dh = HalfToUshort((Half)d), dmh = HalfToUshort((Half)dmin);
+                bytes[off + 0] = (byte)(dh & 0xFF); bytes[off + 1] = (byte)(dh >> 8);
+                bytes[off + 2] = (byte)(dmh & 0xFF); bytes[off + 3] = (byte)(dmh >> 8);
+                for (int i = 0; i < 12; i++) bytes[off + 4 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 128; i++) bytes[off + 16 + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    private static byte[] BuildQ5KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256, bytesPerRow = blocksPerRow * 176;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 176;
+                float d = (float)(rng.NextDouble() * 0.09 + 0.01), dmin = (float)(rng.NextDouble() * 0.04 + 0.005);
+                ushort dh = HalfToUshort((Half)d), dmh = HalfToUshort((Half)dmin);
+                bytes[off + 0] = (byte)(dh & 0xFF); bytes[off + 1] = (byte)(dh >> 8);
+                bytes[off + 2] = (byte)(dmh & 0xFF); bytes[off + 3] = (byte)(dmh >> 8);
+                for (int i = 0; i < 12; i++) bytes[off + 4 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 32; i++) bytes[off + 16 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 128; i++) bytes[off + 48 + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    /// <summary>
+    /// Issue #112: the FP-path 2-input dots used by the routed-MoE pairing
+    /// (<c>DotQ4K_2In</c> / <c>DotQ5K_2In</c>, via <c>DispatchDot2In</c>) must be
+    /// <b>bit-identical</b> to two single <c>DotQ4K</c> / <c>DotQ5K</c> calls — the
+    /// pairing only amortizes the weight unpack, never the accumulation order.
+    /// </summary>
+    [Fact]
+    public void DotQ4K_And_Q5K_2In_BitwiseMatchSingle()
+    {
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (8, 2048), (3, 4096) })
+        {
+            var rng = new Random(unchecked((int)0x4112C0DE) ^ (rows * 131 + cols));
+            byte[] q4 = BuildQ4KMatrix(rows, cols, rng);
+            byte[] q5 = BuildQ5KMatrix(rows, cols, rng);
+            var in1 = new float[cols];
+            var in2 = new float[cols];
+            for (int i = 0; i < cols; i++) { in1[i] = (float)(rng.NextDouble() * 2 - 1); in2[i] = (float)(rng.NextDouble() * 2 - 1); }
+
+            int bprQ4 = (cols / 256) * 144, bprQ5 = (cols / 256) * 176;
+            fixed (byte* q4p = q4)
+            fixed (byte* q5p = q5)
+            fixed (float* i1 = in1)
+            fixed (float* i2 = in2)
+            {
+                for (int r = 0; r < rows; r++)
+                {
+                    byte* r4 = q4p + (long)r * bprQ4;
+                    SimdKernels.DotQ4K_2In(r4, i1, i2, cols, out float v1, out float v2);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i1, cols)),
+                                 BitConverter.SingleToInt32Bits(v1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i2, cols)),
+                                 BitConverter.SingleToInt32Bits(v2));
+
+                    byte* r5 = q5p + (long)r * bprQ5;
+                    SimdKernels.DotQ5K_2In(r5, i1, i2, cols, out float w1, out float w2);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i1, cols)),
+                                 BitConverter.SingleToInt32Bits(w1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i2, cols)),
+                                 BitConverter.SingleToInt32Bits(w2));
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Q8_0_Q8KS AVX2 dispatcher and production scalar must agree at
     /// FP-noise tolerance. Same envelope as Q3K_Q8KS.
     /// </summary>


### PR DESCRIPTION
@
Stacked on #113 (#110). **Merge #113 first**, then this PR.

Implements **#111** (GEMM-batch the non-recurrent prefill trunk projections) and **#112** (dequant-once 2-input routed-MoE dots) on the CUDA GDN-hybrid path.

## #111 — GEMM-batched trunk
- New **bit-exact** CUDA kernels: GEMM-N matvecs `llm_matvec_q4k/q6k/f32_gemm_n` (→ `CudaBackend.MatMulBatched`; each `(row, token)` runs the identical per-row reduction as the GEMV, so N tokens in one launch is bit-identical to N GEMV calls) and batched `llm_rmsnorm/head_norm/split_qg/rope_neox_partial`.
- `CudaBackend.View` — non-owning device slice — feeds the per-position kernels from `[N×dim]` batched buffers with no copy.
- `TrunkLayerBatched` / `GdnBlockBatched` / `AttnBlockBatched` batch the projections + per-head Q/K RMSNorm + RoPE + Q‖gate split + GLU gate + shared expert + both layer norms. **conv1d, delta-net recurrence, KV-append, SDPA stay per-position** as the issue scoped. `TrunkLayerSequential` kept for `SHARPI_BATCHED_TRUNK=0` / CPU-GDN.

## #112 — dequant-once MoE dots
- New `SimdKernels.DotQ3K_Q8KS_2In` (decode the Q3_K row once, two FP accumulators, bit-identical per input). `BatchedRoutedExperts` Phase A/C dot each expert row against its tokens in pairs via `DispatchDot2In` (Q4_K/Q5_K) / `DispatchDotQ8K2In` (Q3_K).

## Results (512-tok chunk, Carnice-35B-A3B, RTX 4070 Ti, CPU-MoE)
| phase | #110 baseline | this PR |
|---|---:|---:|
| trunk | 6.8 s | ~1.9 s |
| routed MoE | 4.7 s | ~3.1 s |
| **prefill** | ~40 tok/s | **~93 tok/s (~2.3×)** |

## Correctness (hard constraint)
`BatchedPrefill_BitwiseMatchesSequential_Carnice` (single + multi-chunk, prefill **and** MTP draft logits) bit-identical; new `BatchedTrunk_BitwiseMatchesSequentialTrunk_Carnice` oracle; new kernel bit-exactness unit tests (`CudaMatMulBatchedTests`, `SimdKernelsQ8KSTests`: `DotQ3K_Q8KS_2In`, `DotQ4K/Q5K_2In`, `View` lifecycle). All 305 non-Vulkan ForwardPass tests green; full solution builds with 0 warnings.

## Review hardening
`View` rejects negative offset/count; a fault latch (`ThrowIfFaulted`) blocks any forward call after a non-transactional batched-prefill fault corrupts GDN recurrent state.

Follow-up headroom tracked in #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@