### PR TITLE
perf(cpu,engine): register-tiled N-input routed-MoE dots (#114-A)

### DIFF
--- a/src/SharpInference.Cpu/SimdKernels.cs
+++ b/src/SharpInference.Cpu/SimdKernels.cs
@@ -737,6 +737,103 @@ public static unsafe class SimdKernels
     }
 
     // ================================================================
+    //  Q4_K Fused four-input dot (issue #114) — register-tiled extension
+    //  of DotQ4K_2In: decode each block ONCE and FMA against FOUR inputs
+    //  in the same pass. Amortizes the nibble unpack decode/4 instead of
+    //  decode/2. Each input's lo/hi accumulators follow the single-input
+    //  order exactly, so the result is bit-identical to four DotQ4K calls.
+    // ================================================================
+
+    public static void DotQ4K_4In(byte* row,
+        float* input0, float* input1, float* input2, float* input3, int cols,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        int numBlocks = cols / 256;
+
+        if (Avx512F.IsSupported)
+        {
+            DotQ4K_4In_Avx512(row, input0, input1, input2, input3, numBlocks,
+                out sum0, out sum1, out sum2, out sum3);
+            return;
+        }
+        // Fallback: four single dots (no fused-dequant win, still correct).
+        sum0 = DotQ4K(row, input0, cols);
+        sum1 = DotQ4K(row, input1, cols);
+        sum2 = DotQ4K(row, input2, cols);
+        sum3 = DotQ4K(row, input3, cols);
+    }
+
+    private static void DotQ4K_4In_Avx512(byte* row,
+        float* input0, float* input1, float* input2, float* input3, int numBlocks,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        // Two accumulators (lo/hi nibble) per input.
+        var accLo0 = Vector512<float>.Zero; var accHi0 = Vector512<float>.Zero;
+        var accLo1 = Vector512<float>.Zero; var accHi1 = Vector512<float>.Zero;
+        var accLo2 = Vector512<float>.Zero; var accHi2 = Vector512<float>.Zero;
+        var accLo3 = Vector512<float>.Zero; var accHi3 = Vector512<float>.Zero;
+        var mask0F = Vector512.Create(0x0F);
+        int elemOff = 0;
+
+        for (int b = 0; b < numBlocks; b++)
+        {
+            byte* x = row + b * 144;
+            float d = HalfToFloat(x[0], x[1]);
+            float dmin = HalfToFloat(x[2], x[3]);
+            byte* sc = x + 4;
+            byte* qs = x + 16;
+
+            int qIdx = 0;
+            int scIdx = 0;
+
+            for (int chunk = 0; chunk < 4; chunk++)
+            {
+                GetScaleMinK4(scIdx, sc, out byte sc1, out byte m1);
+                GetScaleMinK4(scIdx + 1, sc, out byte sc2, out byte m2);
+
+                var d1     = Vector512.Create(d * sc1);
+                var negDm1 = Vector512.Create(-(dmin * m1));
+                var d2     = Vector512.Create(d * sc2);
+                var negDm2 = Vector512.Create(-(dmin * m2));
+
+                int bo = elemOff + chunk * 64;
+
+                for (int l = 0; l < 32; l += 16)
+                {
+                    // Single byte→int load shared by all inputs.
+                    var bytes16 = Vector128.LoadUnsafe(ref *(qs + qIdx + l));
+                    var ints = Avx512F.ConvertToVector512Int32(bytes16);
+
+                    // Lower nibble: dequant once, FMA against all four inputs.
+                    var lo = Avx512F.And(ints, mask0F);
+                    var deqLo = Avx512F.FusedMultiplyAdd(d1, Avx512F.ConvertToVector512Single(lo), negDm1);
+                    accLo0 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input0 + bo + l)), accLo0);
+                    accLo1 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input1 + bo + l)), accLo1);
+                    accLo2 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input2 + bo + l)), accLo2);
+                    accLo3 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input3 + bo + l)), accLo3);
+
+                    // Upper nibble: dequant once, FMA against all four inputs.
+                    var hi = Avx512F.And(Avx512F.ShiftRightLogical(ints, 4), mask0F);
+                    var deqHi = Avx512F.FusedMultiplyAdd(d2, Avx512F.ConvertToVector512Single(hi), negDm2);
+                    accHi0 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input0 + bo + 32 + l)), accHi0);
+                    accHi1 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input1 + bo + 32 + l)), accHi1);
+                    accHi2 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input2 + bo + 32 + l)), accHi2);
+                    accHi3 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input3 + bo + 32 + l)), accHi3);
+                }
+
+                qIdx += 32;
+                scIdx += 2;
+            }
+            elemOff += 256;
+        }
+
+        sum0 = HSum512(Avx512F.Add(accLo0, accHi0));
+        sum1 = HSum512(Avx512F.Add(accLo1, accHi1));
+        sum2 = HSum512(Avx512F.Add(accLo2, accHi2));
+        sum3 = HSum512(Avx512F.Add(accLo3, accHi3));
+    }
+
+    // ================================================================
     //  Q6_K Fused MatVec
     // ================================================================
 
@@ -2677,6 +2774,188 @@ public static unsafe class SimdKernels
         }
         sum1 = HSum256(acc1);
         sum2 = HSum256(acc2);
+    }
+
+    // ================================================================
+    //  Q3_K · Q8_KS Dot Product — four-input dequant-once (issue #114)
+    // ================================================================
+    // Generalizes <see cref="DotQ3K_Q8KS_2In"/> to a register-tiled tile of FOUR
+    // Q8_KS-prepacked inputs: the 3-bit unpack + 6-bit scale decode is done ONCE
+    // per sub-block and reused across all four inputs, so the (dominant) weight
+    // decode is amortized decode/4 instead of decode/2. Each input's accumulation
+    // is byte-for-byte identical to <see cref="DotQ3K_Q8KS"/> — same sub-block
+    // order, same int MAdd / offset-correction / FP FMA chain — so the result is
+    // bit-identical to four single dots. Used by the batched routed-MoE path to
+    // amortize the unpack across token quads routing to the same expert.
+    public static void DotQ3K_Q8KS_4In(byte* row,
+        byte* scratch0, byte* scratch1, byte* scratch2, byte* scratch3, int cols,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        int numBlocks = cols / 256;
+        if (Avx2.IsSupported && Fma.IsSupported)
+        {
+            DotQ3K_Q8KS_4In_Avx2(row, scratch0, scratch1, scratch2, scratch3, numBlocks,
+                out sum0, out sum1, out sum2, out sum3);
+            return;
+        }
+        sum0 = DotQ3K_Q8KS_Scalar(row, scratch0, numBlocks);
+        sum1 = DotQ3K_Q8KS_Scalar(row, scratch1, numBlocks);
+        sum2 = DotQ3K_Q8KS_Scalar(row, scratch2, numBlocks);
+        sum3 = DotQ3K_Q8KS_Scalar(row, scratch3, numBlocks);
+    }
+
+    private static void DotQ3K_Q8KS_4In_Avx2(byte* row,
+        byte* scratch0, byte* scratch1, byte* scratch2, byte* scratch3, int numBlocks,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        const uint kmask1 = 0x03030303;
+        const uint kmask2 = 0x0f0f0f0f;
+        float* dArr0 = (float*)scratch0;
+        sbyte* qsArr0 = (sbyte*)(scratch0 + numBlocks * 32);
+        short* bsumsArr0 = (short*)(scratch0 + numBlocks * 32 + numBlocks * 256);
+        float* dArr1 = (float*)scratch1;
+        sbyte* qsArr1 = (sbyte*)(scratch1 + numBlocks * 32);
+        short* bsumsArr1 = (short*)(scratch1 + numBlocks * 32 + numBlocks * 256);
+        float* dArr2 = (float*)scratch2;
+        sbyte* qsArr2 = (sbyte*)(scratch2 + numBlocks * 32);
+        short* bsumsArr2 = (short*)(scratch2 + numBlocks * 32 + numBlocks * 256);
+        float* dArr3 = (float*)scratch3;
+        sbyte* qsArr3 = (sbyte*)(scratch3 + numBlocks * 32);
+        short* bsumsArr3 = (short*)(scratch3 + numBlocks * 32 + numBlocks * 256);
+
+        var m3 = Vector256.Create((byte)0x03);
+        var m1 = Vector256.Create((byte)0x01);
+        var acc0 = Vector256<float>.Zero;
+        var acc1 = Vector256<float>.Zero;
+        var acc2 = Vector256<float>.Zero;
+        var acc3 = Vector256<float>.Zero;
+        Span<uint> aux = stackalloc uint[4];
+        Span<sbyte> scales = stackalloc sbyte[16];
+
+        for (int b = 0; b < numBlocks; b++)
+        {
+            byte* x = row + b * 110;
+            float dAll = HalfToFloat(x[108], x[109]);
+            float* dSub0 = dArr0 + b * 8;
+            float* dSub1 = dArr1 + b * 8;
+            float* dSub2 = dArr2 + b * 8;
+            float* dSub3 = dArr3 + b * 8;
+
+            // Scales decode (shared between all four inputs).
+            aux[0] = *(uint*)(x + 96);
+            aux[1] = *(uint*)(x + 100);
+            uint tmp = *(uint*)(x + 104);
+            aux[2] = ((aux[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+            aux[3] = ((aux[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+            aux[0] = (aux[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+            aux[1] = (aux[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+            for (int i = 0; i < 4; i++)
+            {
+                scales[i * 4 + 0] = (sbyte)((byte)(aux[i] >> 0) - 32);
+                scales[i * 4 + 1] = (sbyte)((byte)(aux[i] >> 8) - 32);
+                scales[i * 4 + 2] = (sbyte)((byte)(aux[i] >> 16) - 32);
+                scales[i * 4 + 3] = (sbyte)((byte)(aux[i] >> 24) - 32);
+            }
+
+            short* bsums0 = bsumsArr0 + b * 16;
+            short* bsums1 = bsumsArr1 + b * 16;
+            short* bsums2 = bsumsArr2 + b * 16;
+            short* bsums3 = bsumsArr3 + b * 16;
+            var hm_v = Vector256.LoadUnsafe(ref *(x + 0));
+            sbyte* q8_0 = qsArr0 + b * 256;
+            sbyte* q8_1 = qsArr1 + b * 256;
+            sbyte* q8_2 = qsArr2 + b * 256;
+            sbyte* q8_3 = qsArr3 + b * 256;
+            byte* qs = x + 32;
+
+            for (int half = 0; half < 2; half++)
+            {
+                var qs_v = Vector256.LoadUnsafe(ref *(qs + half * 32));
+
+                for (int j = 0; j < 4; j++)
+                {
+                    int sub = half * 4 + j;
+
+                    var qloShifted = j switch
+                    {
+                        0 => qs_v,
+                        1 => Avx2.ShiftRightLogical(qs_v.AsInt16(), 2).AsByte(),
+                        2 => Avx2.ShiftRightLogical(qs_v.AsInt16(), 4).AsByte(),
+                        _ => Avx2.ShiftRightLogical(qs_v.AsInt16(), 6).AsByte(),
+                    };
+                    var qlo = Avx2.And(qloShifted, m3);
+
+                    var hmShifted = (half, j) switch
+                    {
+                        (0, 0) => hm_v,
+                        (0, 1) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 1).AsByte(),
+                        (0, 2) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 2).AsByte(),
+                        (0, 3) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 3).AsByte(),
+                        (1, 0) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 4).AsByte(),
+                        (1, 1) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 5).AsByte(),
+                        (1, 2) => Avx2.ShiftRightLogical(hm_v.AsInt16(), 6).AsByte(),
+                        _      => Avx2.ShiftRightLogical(hm_v.AsInt16(), 7).AsByte(),
+                    };
+                    var hbit = Avx2.ShiftLeftLogical(
+                        Avx2.And(hmShifted, m1).AsInt16(), 2).AsByte();
+                    var q3u = Avx2.Or(qlo, hbit);   // shared weight quants
+
+                    int isc = half * 8 + 2 * j;
+                    sbyte scA = scales[isc + 0];
+                    sbyte scB = scales[isc + 1];
+                    var sc16 = Vector256.Create(
+                        Vector128.Create((short)scA),
+                        Vector128.Create((short)scB));
+
+                    // Each input — same accumulation as the single-input kernel,
+                    // reusing the decoded q3u / sc16.
+                    {
+                        var q8_v = Vector256.LoadUnsafe(ref *(q8_0 + half * 128 + j * 32)).AsSByte();
+                        var p16 = Avx2.MultiplyAddAdjacent(q3u, q8_v);
+                        var sub_i32 = Avx2.MultiplyAddAdjacent(sc16, p16);
+                        int subCorr = ((int)scA * bsums0[isc] + (int)scB * bsums0[isc + 1]) << 2;
+                        sub_i32 = sub_i32.WithElement(0, sub_i32.GetElement(0) - subCorr);
+                        var sub_fp = Avx.ConvertToVector256Single(sub_i32);
+                        float scaleSub = dAll * dSub0[sub];
+                        acc0 = Fma.MultiplyAdd(Vector256.Create(scaleSub), sub_fp, acc0);
+                    }
+                    {
+                        var q8_v = Vector256.LoadUnsafe(ref *(q8_1 + half * 128 + j * 32)).AsSByte();
+                        var p16 = Avx2.MultiplyAddAdjacent(q3u, q8_v);
+                        var sub_i32 = Avx2.MultiplyAddAdjacent(sc16, p16);
+                        int subCorr = ((int)scA * bsums1[isc] + (int)scB * bsums1[isc + 1]) << 2;
+                        sub_i32 = sub_i32.WithElement(0, sub_i32.GetElement(0) - subCorr);
+                        var sub_fp = Avx.ConvertToVector256Single(sub_i32);
+                        float scaleSub = dAll * dSub1[sub];
+                        acc1 = Fma.MultiplyAdd(Vector256.Create(scaleSub), sub_fp, acc1);
+                    }
+                    {
+                        var q8_v = Vector256.LoadUnsafe(ref *(q8_2 + half * 128 + j * 32)).AsSByte();
+                        var p16 = Avx2.MultiplyAddAdjacent(q3u, q8_v);
+                        var sub_i32 = Avx2.MultiplyAddAdjacent(sc16, p16);
+                        int subCorr = ((int)scA * bsums2[isc] + (int)scB * bsums2[isc + 1]) << 2;
+                        sub_i32 = sub_i32.WithElement(0, sub_i32.GetElement(0) - subCorr);
+                        var sub_fp = Avx.ConvertToVector256Single(sub_i32);
+                        float scaleSub = dAll * dSub2[sub];
+                        acc2 = Fma.MultiplyAdd(Vector256.Create(scaleSub), sub_fp, acc2);
+                    }
+                    {
+                        var q8_v = Vector256.LoadUnsafe(ref *(q8_3 + half * 128 + j * 32)).AsSByte();
+                        var p16 = Avx2.MultiplyAddAdjacent(q3u, q8_v);
+                        var sub_i32 = Avx2.MultiplyAddAdjacent(sc16, p16);
+                        int subCorr = ((int)scA * bsums3[isc] + (int)scB * bsums3[isc + 1]) << 2;
+                        sub_i32 = sub_i32.WithElement(0, sub_i32.GetElement(0) - subCorr);
+                        var sub_fp = Avx.ConvertToVector256Single(sub_i32);
+                        float scaleSub = dAll * dSub3[sub];
+                        acc3 = Fma.MultiplyAdd(Vector256.Create(scaleSub), sub_fp, acc3);
+                    }
+                }
+            }
+        }
+        sum0 = HSum256(acc0);
+        sum1 = HSum256(acc1);
+        sum2 = HSum256(acc2);
+        sum3 = HSum256(acc3);
     }
 
     // ================================================================

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -3759,7 +3759,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // without a 4In kernel fall back to two 2In pairs — never worse than the prior
     // pairing path, still correct.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DispatchDot4In(byte* row, float* in0, float* in1, float* in2, float* in3,
+    internal static void DispatchDot4In(byte* row, float* in0, float* in1, float* in2, float* in3,
         int cols, DType dtype, out float v0, out float v1, out float v2, out float v3)
     {
         switch (dtype)
@@ -3779,7 +3779,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // Bit-identical to four DispatchDotQ8K calls. Other dtypes fall back to two 2In
     // pairs (Q8_0 has no expensive unpack; this keeps it correct without regressing).
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DispatchDotQ8K4In(byte* row, byte* s0, byte* s1, byte* s2, byte* s3,
+    internal static void DispatchDotQ8K4In(byte* row, byte* s0, byte* s1, byte* s2, byte* s3,
         int cols, DType dtype, out float v0, out float v1, out float v2, out float v3)
     {
         switch (dtype)

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -1907,10 +1907,42 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             byte* gateRow = gateP + (long)e * expertDimL * bprG + (long)r * bprG;
             byte* upRow   = upP   + (long)e * expertDimL * bprU + (long)r * bprU;
             int pStart = expStart[e], pEnd = expStart[e + 1];
-            // Issue #112: dot each gate/up row against the expert's tokens in PAIRS,
-            // decoding the (Q4_K/Q5_K/Q3_K) weight row once per pair. Bit-identical to
-            // the per-token dots (the 2In kernels mirror the single accumulation order).
+            // Issue #114: dot each gate/up row against the expert's tokens in QUADS,
+            // decoding the (Q4_K/Q3_K) weight row once per quad (decode/4). Then mop up
+            // remaining tokens in PAIRS (issue #112, decode/2) and a final single.
+            // Every tier is bit-identical to the per-token dot (the 4In/2In kernels
+            // mirror the single accumulation order) — only the unpack is amortized.
             int p = pStart;
+            for (; p + 3 < pEnd; p += 4)
+            {
+                int i0 = expTokI[p],     k0 = expTokK[p];
+                int i1 = expTokI[p + 1], k1 = expTokK[p + 1];
+                int i2 = expTokI[p + 2], k2 = expTokK[p + 2];
+                int i3 = expTokI[p + 3], k3 = expTokK[p + 3];
+                long o0 = ((long)i0 * naL + k0) * expertDimL + r;
+                long o1 = ((long)i1 * naL + k1) * expertDimL + r;
+                long o2 = ((long)i2 * naL + k2) * expertDimL + r;
+                long o3 = ((long)i3 * naL + k3) * expertDimL + r;
+                float a0, a1, a2, a3;
+                if (useQ8KGate)
+                    DispatchDotQ8K4In(gateRow, normAllQ8K + (long)i0 * q8kEmbStride,
+                        normAllQ8K + (long)i1 * q8kEmbStride, normAllQ8K + (long)i2 * q8kEmbStride,
+                        normAllQ8K + (long)i3 * q8kEmbStride, embDimL, gateDt, out a0, out a1, out a2, out a3);
+                else
+                    DispatchDot4In(gateRow, normAll + (long)i0 * embDimL, normAll + (long)i1 * embDimL,
+                        normAll + (long)i2 * embDimL, normAll + (long)i3 * embDimL, embDimL, gateDt,
+                        out a0, out a1, out a2, out a3);
+                gateAll[o0] = a0; gateAll[o1] = a1; gateAll[o2] = a2; gateAll[o3] = a3;
+                if (useQ8KUp)
+                    DispatchDotQ8K4In(upRow, normAllQ8K + (long)i0 * q8kEmbStride,
+                        normAllQ8K + (long)i1 * q8kEmbStride, normAllQ8K + (long)i2 * q8kEmbStride,
+                        normAllQ8K + (long)i3 * q8kEmbStride, embDimL, upDt, out a0, out a1, out a2, out a3);
+                else
+                    DispatchDot4In(upRow, normAll + (long)i0 * embDimL, normAll + (long)i1 * embDimL,
+                        normAll + (long)i2 * embDimL, normAll + (long)i3 * embDimL, embDimL, upDt,
+                        out a0, out a1, out a2, out a3);
+                upAll[o0] = a0; upAll[o1] = a1; upAll[o2] = a2; upAll[o3] = a3;
+            }
             for (; p + 1 < pEnd; p += 2)
             {
                 int i0 = expTokI[p],     k0 = expTokK[p];
@@ -1964,9 +1996,30 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             int e = used[u];
             byte* downRow = downP + (long)e * embDimL * bprD + (long)r * bprD;
             int pStart = expStart[e], pEnd = expStart[e + 1];
-            // Issue #112: down row dotted against the expert's silu'd-gate slices in
-            // PAIRS, decoding the weight row once per pair (bit-identical to per-token).
+            // Issue #114: down row dotted against the expert's silu'd-gate slices in
+            // QUADS (decode/4), then PAIRS (issue #112, decode/2), then a final single.
+            // Every tier is bit-identical to the per-token dot.
             int p = pStart;
+            for (; p + 3 < pEnd; p += 4)
+            {
+                long s0 = (long)expTokI[p]     * naL + expTokK[p];
+                long s1 = (long)expTokI[p + 1] * naL + expTokK[p + 1];
+                long s2 = (long)expTokI[p + 2] * naL + expTokK[p + 2];
+                long s3 = (long)expTokI[p + 3] * naL + expTokK[p + 3];
+                float d0, d1, d2, d3;
+                if (useQ8KDown)
+                    DispatchDotQ8K4In(downRow, gateAllQ8K + s0 * q8kExpStride,
+                        gateAllQ8K + s1 * q8kExpStride, gateAllQ8K + s2 * q8kExpStride,
+                        gateAllQ8K + s3 * q8kExpStride, expertDimL, downDt, out d0, out d1, out d2, out d3);
+                else
+                    DispatchDot4In(downRow, gateAll + s0 * expertDimL, gateAll + s1 * expertDimL,
+                        gateAll + s2 * expertDimL, gateAll + s3 * expertDimL, expertDimL, downDt,
+                        out d0, out d1, out d2, out d3);
+                downPartial[s0 * embDimL + r] = d0;
+                downPartial[s1 * embDimL + r] = d1;
+                downPartial[s2 * embDimL + r] = d2;
+                downPartial[s3 * embDimL + r] = d3;
+            }
             for (; p + 1 < pEnd; p += 2)
             {
                 long s0 = (long)expTokI[p]     * naL + expTokK[p];
@@ -3694,6 +3747,49 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             default:
                 v1 = DispatchDotQ8K(row, scr1, cols, dtype);
                 v2 = DispatchDotQ8K(row, scr2, cols, dtype);
+                break;
+        }
+    }
+
+    // Issue #114: dequant-once FOUR-input dispatch — register-tiled extension of
+    // DispatchDot2In. Decodes the quantized weight row ONCE and dots it against four
+    // token inputs (decode/4 vs the pairing's decode/2). Bit-identical to four
+    // DispatchDot calls (the 4In kernels mirror the single-input accumulator order;
+    // proven by the SimdKernelsQ8KSTests *_4In_BitwiseMatchesSingle oracles). Dtypes
+    // without a 4In kernel fall back to two 2In pairs — never worse than the prior
+    // pairing path, still correct.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDot4In(byte* row, float* in0, float* in1, float* in2, float* in3,
+        int cols, DType dtype, out float v0, out float v1, out float v2, out float v3)
+    {
+        switch (dtype)
+        {
+            case DType.Q4_K:
+                SimdKernels.DotQ4K_4In(row, in0, in1, in2, in3, cols, out v0, out v1, out v2, out v3);
+                break;
+            default:
+                DispatchDot2In(row, in0, in1, cols, dtype, out v0, out v1);
+                DispatchDot2In(row, in2, in3, cols, dtype, out v2, out v3);
+                break;
+        }
+    }
+
+    // Issue #114: dequant-once four-input dispatch for the Q8_KS-prepacked path.
+    // Decodes the Q3_K weight row once and dots against four prepacked token inputs.
+    // Bit-identical to four DispatchDotQ8K calls. Other dtypes fall back to two 2In
+    // pairs (Q8_0 has no expensive unpack; this keeps it correct without regressing).
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDotQ8K4In(byte* row, byte* s0, byte* s1, byte* s2, byte* s3,
+        int cols, DType dtype, out float v0, out float v1, out float v2, out float v3)
+    {
+        switch (dtype)
+        {
+            case DType.Q3_K:
+                SimdKernels.DotQ3K_Q8KS_4In(row, s0, s1, s2, s3, cols, out v0, out v1, out v2, out v3);
+                break;
+            default:
+                DispatchDotQ8K2In(row, s0, s1, cols, dtype, out v0, out v1);
+                DispatchDotQ8K2In(row, s2, s3, cols, dtype, out v2, out v3);
                 break;
         }
     }

--- a/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
@@ -1,5 +1,7 @@
 using System.Runtime.Intrinsics.X86;
+using SharpInference.Core;
 using SharpInference.Cpu;
+using SharpInference.Engine;
 
 namespace SharpInference.Tests.ForwardPass;
 
@@ -469,6 +471,120 @@ public sealed unsafe class SimdKernelsQ8KSTests
                                  BitConverter.SingleToInt32Bits(v2));
                     Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i3, cols)),
                                  BitConverter.SingleToInt32Bits(v3));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #114: <see cref="CudaHybridGdnForwardPass.DispatchDot4In"/> (the FP-path
+    /// quad dispatcher used by routed-MoE Phase A/C) must produce all four outputs
+    /// bit-identical to four single dots, for BOTH the primary dtype (Q4_K → the
+    /// register-tiled kernel) and the fallback dtype (Q5_K → two 2In pairs). This is
+    /// the only pure-CPU test of the dispatcher's quad-split: it would catch a
+    /// mis-mapping like (in0,in2)+(in1,in3) that silently corrupts token slots, which
+    /// the kernel-level tests (calling the kernels directly) cannot see.
+    /// </summary>
+    [Fact]
+    public void DispatchDot4In_BitwiseMatchesFourSingle()
+    {
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (3, 2048) })
+        {
+            var rng = new Random(unchecked((int)0xD15D04) ^ (rows * 131 + cols));
+            byte[] q4 = BuildQ4KMatrix(rows, cols, rng);
+            byte[] q5 = BuildQ5KMatrix(rows, cols, rng);
+            var inp = new float[4][];
+            for (int t = 0; t < 4; t++)
+            {
+                inp[t] = new float[cols];
+                for (int i = 0; i < cols; i++) inp[t][i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+            int bprQ4 = (cols / 256) * 144, bprQ5 = (cols / 256) * 176;
+
+            fixed (byte* q4p = q4) fixed (byte* q5p = q5)
+            fixed (float* i0 = inp[0]) fixed (float* i1 = inp[1])
+            fixed (float* i2 = inp[2]) fixed (float* i3 = inp[3])
+            {
+                for (int r = 0; r < rows; r++)
+                {
+                    // Q4_K — primary register-tiled path.
+                    byte* r4 = q4p + (long)r * bprQ4;
+                    CudaHybridGdnForwardPass.DispatchDot4In(r4, i0, i1, i2, i3, cols, DType.Q4_K,
+                        out float a0, out float a1, out float a2, out float a3);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i0, cols)), BitConverter.SingleToInt32Bits(a0));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i1, cols)), BitConverter.SingleToInt32Bits(a1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i2, cols)), BitConverter.SingleToInt32Bits(a2));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i3, cols)), BitConverter.SingleToInt32Bits(a3));
+
+                    // Q5_K — fallback (two DotQ5K_2In pairs).
+                    byte* r5 = q5p + (long)r * bprQ5;
+                    CudaHybridGdnForwardPass.DispatchDot4In(r5, i0, i1, i2, i3, cols, DType.Q5_K,
+                        out float b0, out float b1, out float b2, out float b3);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i0, cols)), BitConverter.SingleToInt32Bits(b0));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i1, cols)), BitConverter.SingleToInt32Bits(b1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i2, cols)), BitConverter.SingleToInt32Bits(b2));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i3, cols)), BitConverter.SingleToInt32Bits(b3));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #114: <see cref="CudaHybridGdnForwardPass.DispatchDotQ8K4In"/> (the
+    /// Q8_KS-prepacked quad dispatcher) must produce all four outputs bit-identical to
+    /// four single dots, for the primary dtype (Q3_K → register-tiled kernel) and the
+    /// fallback (Q8_0 → two 2In pairs → singles, since Q8_0 has no expensive unpack).
+    /// </summary>
+    [Fact]
+    public void DispatchDotQ8K4In_BitwiseMatchesFourSingle()
+    {
+        if (!Avx2.IsSupported || !Fma.IsSupported) return;
+
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (3, 2048) })
+        {
+            var rng = new Random(unchecked((int)0xD15D08) ^ (rows * 131 + cols));
+            byte[] q3 = BuildQ3KMatrix(rows, cols, rng);
+            byte[] q8 = BuildQ8_0Matrix(rows, cols, rng);
+            var inp = new float[4][];
+            for (int t = 0; t < 4; t++)
+            {
+                inp[t] = new float[cols];
+                for (int i = 0; i < cols; i++) inp[t][i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+            int bprQ3 = (cols / 256) * 110, bprQ8 = (cols / 32) * 34;
+            int scratchBytes = SimdKernels.Q8KSScratchBytes(cols);
+            var s = new byte[4][];
+            for (int t = 0; t < 4; t++) s[t] = new byte[scratchBytes];
+
+            fixed (byte* q3p = q3) fixed (byte* q8p = q8)
+            fixed (byte* sp0 = s[0]) fixed (byte* sp1 = s[1])
+            fixed (byte* sp2 = s[2]) fixed (byte* sp3 = s[3])
+            fixed (float* i0 = inp[0]) fixed (float* i1 = inp[1])
+            fixed (float* i2 = inp[2]) fixed (float* i3 = inp[3])
+            {
+                SimdKernels.QuantizeRowToQ8KS(i0, cols, sp0);
+                SimdKernels.QuantizeRowToQ8KS(i1, cols, sp1);
+                SimdKernels.QuantizeRowToQ8KS(i2, cols, sp2);
+                SimdKernels.QuantizeRowToQ8KS(i3, cols, sp3);
+                for (int r = 0; r < rows; r++)
+                {
+                    // Q3_K — primary register-tiled path.
+                    byte* r3 = q3p + (long)r * bprQ3;
+                    CudaHybridGdnForwardPass.DispatchDotQ8K4In(r3, sp0, sp1, sp2, sp3, cols, DType.Q3_K,
+                        out float a0, out float a1, out float a2, out float a3);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ3K_Q8KS(r3, sp0, cols)), BitConverter.SingleToInt32Bits(a0));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ3K_Q8KS(r3, sp1, cols)), BitConverter.SingleToInt32Bits(a1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ3K_Q8KS(r3, sp2, cols)), BitConverter.SingleToInt32Bits(a2));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ3K_Q8KS(r3, sp3, cols)), BitConverter.SingleToInt32Bits(a3));
+
+                    // Q8_0 — fallback.
+                    byte* r8 = q8p + (long)r * bprQ8;
+                    CudaHybridGdnForwardPass.DispatchDotQ8K4In(r8, sp0, sp1, sp2, sp3, cols, DType.Q8_0,
+                        out float b0, out float b1, out float b2, out float b3);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ8_0_Q8KS(r8, sp0, cols)), BitConverter.SingleToInt32Bits(b0));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ8_0_Q8KS(r8, sp1, cols)), BitConverter.SingleToInt32Bits(b1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ8_0_Q8KS(r8, sp2, cols)), BitConverter.SingleToInt32Bits(b2));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ8_0_Q8KS(r8, sp3, cols)), BitConverter.SingleToInt32Bits(b3));
                 }
             }
         }

--- a/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
@@ -294,6 +294,63 @@ public sealed unsafe class SimdKernelsQ8KSTests
         }
     }
 
+    /// <summary>
+    /// Issue #114: the four-input dequant-once <see cref="SimdKernels.DotQ3K_Q8KS_4In"/>
+    /// must be <b>bit-identical</b> to four separate <see cref="SimdKernels.DotQ3K_Q8KS"/>
+    /// calls — it decodes the weight row once but accumulates each input in the
+    /// identical sub-block order (same failure mode the routed-MoE byte-parity oracle
+    /// trips on). Mirrors <see cref="DotQ3K_Q8KS_2In_BitwiseMatchesSingle"/>.
+    /// </summary>
+    [Fact]
+    public void DotQ3K_Q8KS_4In_BitwiseMatchesSingle()
+    {
+        if (!Avx2.IsSupported || !Fma.IsSupported) return;
+
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (8, 2048), (3, 4096) })
+        {
+            var rng = new Random(unchecked((int)0x114C0DE) ^ (rows * 131 + cols));
+            byte[] weightBytes = BuildQ3KMatrix(rows, cols, rng);
+
+            var inputs = new float[4][];
+            for (int t = 0; t < 4; t++)
+            {
+                inputs[t] = new float[cols];
+                for (int i = 0; i < cols; i++) inputs[t][i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+
+            int bytesPerRow = (cols / 256) * 110;
+            int scratchBytes = SimdKernels.Q8KSScratchBytes(cols);
+            var s = new byte[4][];
+            for (int t = 0; t < 4; t++) s[t] = new byte[scratchBytes];
+
+            fixed (byte* wPtr = weightBytes)
+            fixed (byte* sp0 = s[0]) fixed (byte* sp1 = s[1])
+            fixed (byte* sp2 = s[2]) fixed (byte* sp3 = s[3])
+            fixed (float* i0 = inputs[0]) fixed (float* i1 = inputs[1])
+            fixed (float* i2 = inputs[2]) fixed (float* i3 = inputs[3])
+            {
+                SimdKernels.QuantizeRowToQ8KS(i0, cols, sp0);
+                SimdKernels.QuantizeRowToQ8KS(i1, cols, sp1);
+                SimdKernels.QuantizeRowToQ8KS(i2, cols, sp2);
+                SimdKernels.QuantizeRowToQ8KS(i3, cols, sp3);
+                for (int r = 0; r < rows; r++)
+                {
+                    byte* rowP = wPtr + (long)r * bytesPerRow;
+                    float ref0 = SimdKernels.DotQ3K_Q8KS(rowP, sp0, cols);
+                    float ref1 = SimdKernels.DotQ3K_Q8KS(rowP, sp1, cols);
+                    float ref2 = SimdKernels.DotQ3K_Q8KS(rowP, sp2, cols);
+                    float ref3 = SimdKernels.DotQ3K_Q8KS(rowP, sp3, cols);
+                    SimdKernels.DotQ3K_Q8KS_4In(rowP, sp0, sp1, sp2, sp3, cols,
+                        out float v0, out float v1, out float v2, out float v3);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(ref0), BitConverter.SingleToInt32Bits(v0));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(ref1), BitConverter.SingleToInt32Bits(v1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(ref2), BitConverter.SingleToInt32Bits(v2));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(ref3), BitConverter.SingleToInt32Bits(v3));
+                }
+            }
+        }
+    }
+
     private static byte[] BuildQ4KMatrix(int rows, int cols, Random rng)
     {
         int blocksPerRow = cols / 256, bytesPerRow = blocksPerRow * 144;
@@ -370,6 +427,48 @@ public sealed unsafe class SimdKernelsQ8KSTests
                                  BitConverter.SingleToInt32Bits(w1));
                     Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ5K(r5, i2, cols)),
                                  BitConverter.SingleToInt32Bits(w2));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #114: the four-input FP-path <see cref="SimdKernels.DotQ4K_4In"/> must be
+    /// <b>bit-identical</b> to four single <c>DotQ4K</c> calls — the register-tiled
+    /// quad only amortizes the nibble unpack, never the per-input accumulation order.
+    /// </summary>
+    [Fact]
+    public void DotQ4K_4In_BitwiseMatchesSingle()
+    {
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (8, 2048), (3, 4096) })
+        {
+            var rng = new Random(unchecked((int)0x4114C0DE) ^ (rows * 131 + cols));
+            byte[] q4 = BuildQ4KMatrix(rows, cols, rng);
+            var inputs = new float[4][];
+            for (int t = 0; t < 4; t++)
+            {
+                inputs[t] = new float[cols];
+                for (int i = 0; i < cols; i++) inputs[t][i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+
+            int bprQ4 = (cols / 256) * 144;
+            fixed (byte* q4p = q4)
+            fixed (float* i0 = inputs[0]) fixed (float* i1 = inputs[1])
+            fixed (float* i2 = inputs[2]) fixed (float* i3 = inputs[3])
+            {
+                for (int r = 0; r < rows; r++)
+                {
+                    byte* r4 = q4p + (long)r * bprQ4;
+                    SimdKernels.DotQ4K_4In(r4, i0, i1, i2, i3, cols,
+                        out float v0, out float v1, out float v2, out float v3);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i0, cols)),
+                                 BitConverter.SingleToInt32Bits(v0));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i1, cols)),
+                                 BitConverter.SingleToInt32Bits(v1));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i2, cols)),
+                                 BitConverter.SingleToInt32Bits(v2));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(SimdKernels.DotQ4K(r4, i3, cols)),
+                                 BitConverter.SingleToInt32Bits(v3));
                 }
             }
         }


### PR DESCRIPTION
## Summary

Direction (A) of #114 — the larger, lower-risk remaining GDN-hybrid prefill cost after #110/#111/#112. Generalizes #112's dequant-once **2-input** pairing to register-tiled **4-input** dots in the CPU-MoE batched routed-expert path, so the (dominant) Q3_K/Q4_K weight unpack is decoded **once per token quad** instead of once per pair — `decode/4` vs `decode/2`.

After #111/#112, `routedMoE` is the dominant per-chunk cost (~57% of wall at low context). This shaves it ~1.34×.

## Changes

**Kernels** (`SimdKernels.cs`):
- `DotQ3K_Q8KS_4In` — AVX2, 4 FP accumulators register-tiled, mirrors `DotQ3K_Q8KS_2In`
- `DotQ4K_4In` — AVX512, 8 lo/hi accumulators, mirrors `DotQ4K_2In`

Both reuse the shared weight decode across all four inputs while keeping each token's accumulation in the **identical sub-block order** as the single-input kernel — so each result is **bit-identical** to four single dots (the hard parity constraint from `feedback_q4k_q8k_no_parity_win`).

**Wiring** (`CudaHybridGdnForwardPass.BatchedRoutedExperts`): Phase A (gate+up) and Phase C (down) tile each expert's token list by 4 (`DispatchDot4In` / `DispatchDotQ8K4In`), then mop up remaining tokens with the #112 pair path, then a final single. Dtypes without a 4In kernel (Q5_K, Q8_0) fall back to two 2In pairs — never worse than the prior pairing path.

Carnice's 41 MoE blocks are 31× Q3_K + 9× Q4_K + 1× Q8_0 routed, so both kernels are on the hot path.

## Performance

`routedMoE` per 512-token chunk on `Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact` (CUDA hybrid + `SHARPI_CPU_MOE=1`, matched startPos):

| startPos | baseline | this PR | speedup |
|---|---|---|---|
| 512  | 3237 ms | 2463 ms | 1.31× |
| 1024 | 3210 ms | 2415 ms | 1.33× |
| 1536 | 3206 ms | 2401 ms | 1.34× |
| 2048 | 3210 ms | 2399 ms | 1.34× |
| 2560 | 3196 ms | 2378 ms | 1.34× |

**~1.34×**, in the targeted 1.2–1.5× range.

## Validation

Bit-parity held everywhere:
- `BatchedPrefill_BitwiseMatchesSequential_Carnice` (+ multi-chunk + `BatchedTrunk_BitwiseMatchesSequentialTrunk_Carnice`)
- `MtpDecoder_GreedyParity_LlamaCpp`
- Full 320-test `SharpInference.Tests.ForwardPass` suite green
- New per-kernel oracles `DotQ3K_Q8KS_4In_BitwiseMatchesSingle` / `DotQ4K_4In_BitwiseMatchesSingle`

Clean Release build (0 warnings, `TreatWarningsAsErrors`).

## Not in this PR

Direction (B) — the residual per-position trunk (per-token `GdnRecurrenceDecode` + `KvAppend`+`Attention` launches, which grow with context) — is higher complexity/parity-risk and left as a follow-up under #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
