### PR TITLE
perf(gemma4-cuda): CUDA Graph decode + CUDA 12 align + SnapKV post-eviction fix (#136)

### DIFF
--- a/src/SharpInference.Cuda/CuBlasInterop.cs
+++ b/src/SharpInference.Cuda/CuBlasInterop.cs
@@ -5,6 +5,12 @@ namespace SharpInference.Cuda;
 /// <summary>
 /// P/Invoke bindings for cuBLAS and CUDA runtime.
 /// Uses source-generated LibraryImport for NativeAOT compatibility.
+///
+/// Runtime is pinned to the <b>CUDA 12.x</b> SONAMEs (<c>cudart64_12</c> /
+/// <c>cublas64_12</c>) so the runtime/cuBLAS match the NVRTC the kernels are JIT'd
+/// with (<c>nvrtc64_120_0</c>, see <see cref="NvrtcInterop"/>). The driver API
+/// (<c>nvcuda</c>) and CUDA-graph calls are version-independent. On a machine with
+/// several toolkits installed, the loader picks the first 12.x <c>bin</c> on PATH.
 /// </summary>
 internal static partial class CuBlasInterop
 {
@@ -22,13 +28,13 @@ internal static partial class CuBlasInterop
 
     // ── cuBLAS handle lifecycle ──────────────────────────────────────────
 
-    [LibraryImport("cublas64_11", EntryPoint = "cublasCreate_v2")]
+    [LibraryImport("cublas64_12", EntryPoint = "cublasCreate_v2")]
     internal static partial int Create(out nint handle);
 
-    [LibraryImport("cublas64_11", EntryPoint = "cublasDestroy_v2")]
+    [LibraryImport("cublas64_12", EntryPoint = "cublasDestroy_v2")]
     internal static partial int Destroy(nint handle);
 
-    [LibraryImport("cublas64_11", EntryPoint = "cublasSetStream_v2")]
+    [LibraryImport("cublas64_12", EntryPoint = "cublasSetStream_v2")]
     internal static partial int SetStream(nint handle, nint stream);
 
     // CUBLAS_MATH_ALLOW_REDUCED_PRECISION_REDUCTION = 0 means standard FP32.
@@ -36,11 +42,11 @@ internal static partial class CuBlasInterop
     public const int CUBLAS_DEFAULT_MATH = 0;
     public const int CUBLAS_TF32_TENSOR_OP_MATH = 3;
 
-    [LibraryImport("cublas64_11", EntryPoint = "cublasSetMathMode")]
+    [LibraryImport("cublas64_12", EntryPoint = "cublasSetMathMode")]
     internal static partial int SetMathMode(nint handle, int mode);
 
     // ── cublasSgemm: C = alpha*op(A)*op(B) + beta*C (fp32) ──────────────
-    [LibraryImport("cublas64_11", EntryPoint = "cublasSgemm_v2")]
+    [LibraryImport("cublas64_12", EntryPoint = "cublasSgemm_v2")]
     internal static partial int Sgemm(
         nint handle,
         int transa, int transb,
@@ -53,7 +59,7 @@ internal static partial class CuBlasInterop
 
     // ── cublasGemmEx: mixed-precision GEMM (fp16/bf16 in, fp32 accum) ────
     // alpha and beta are float* when computeType == CUBLAS_COMPUTE_32F.
-    [LibraryImport("cublas64_11", EntryPoint = "cublasGemmEx")]
+    [LibraryImport("cublas64_12", EntryPoint = "cublasGemmEx")]
     internal static partial int GemmEx(
         nint handle,
         int transa, int transb,
@@ -68,67 +74,67 @@ internal static partial class CuBlasInterop
 
     // ── CUDA memory management ────────────────────────────────────────────
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaMalloc")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaMalloc")]
     internal static partial int CudaMalloc(out nint devPtr, nuint size);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaFree")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaFree")]
     internal static partial int CudaFree(nint devPtr);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaMemcpy")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaMemcpy")]
     internal static partial int CudaMemcpy(nint dst, nint src, nuint count, int kind);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaMemcpyAsync")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaMemcpyAsync")]
     internal static partial int CudaMemcpyAsync(nint dst, nint src, nuint count, int kind, nint stream);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaMemcpy2DAsync")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaMemcpy2DAsync")]
     internal static partial int CudaMemcpy2DAsync(
         nint dst, nuint dpitch,
         nint src, nuint spitch,
         nuint width, nuint height,
         int kind, nint stream);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaDeviceSynchronize")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaDeviceSynchronize")]
     internal static partial int DeviceSync();
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaStreamCreate")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaStreamCreate")]
     internal static partial int StreamCreate(out nint stream);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaStreamDestroy")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaStreamDestroy")]
     internal static partial int StreamDestroy(nint stream);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaStreamSynchronize")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaStreamSynchronize")]
     internal static partial int StreamSynchronize(nint stream);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaRuntimeGetVersion")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaRuntimeGetVersion")]
     internal static partial int RuntimeGetVersion(out int version);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaDeviceGetAttribute")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaDeviceGetAttribute")]
     internal static partial int DeviceGetAttribute(out int value, int attr, int device);
 
     /// <summary>cudaMemGetInfo: free and total VRAM on the current device, in bytes.</summary>
-    [LibraryImport("cudart64_110", EntryPoint = "cudaMemGetInfo")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaMemGetInfo")]
     internal static partial int MemGetInfo(out nuint free, out nuint total);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventCreate")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventCreate")]
     internal static partial int EventCreate(out nint ev);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventCreateWithFlags")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventCreateWithFlags")]
     internal static partial int EventCreateWithFlags(out nint ev, uint flags);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventRecord")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventRecord")]
     internal static partial int EventRecord(nint ev, nint stream);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventSynchronize")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventSynchronize")]
     internal static partial int EventSynchronize(nint ev);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventElapsedTime")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventElapsedTime")]
     internal static partial int EventElapsedTime(out float ms, nint start, nint stop);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventDestroy")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventDestroy")]
     internal static partial int EventDestroy(nint ev);
 
     /// <summary>cudaEventQuery: 0 = ready (cudaSuccess), 600 = not ready (cudaErrorNotReady).</summary>
-    [LibraryImport("cudart64_110", EntryPoint = "cudaEventQuery")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaEventQuery")]
     internal static partial int EventQuery(nint ev);
 
     /// <summary>
@@ -136,7 +142,7 @@ internal static partial class CuBlasInterop
     /// subsequent work. Cross-stream synchronization primitive — used to fence a compute
     /// stream behind a transfer recorded on an upload stream.
     /// </summary>
-    [LibraryImport("cudart64_110", EntryPoint = "cudaStreamWaitEvent")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaStreamWaitEvent")]
     internal static partial int StreamWaitEvent(nint stream, nint ev, uint flags);
 
     // cudaEventCreate flags
@@ -148,10 +154,10 @@ internal static partial class CuBlasInterop
 
     // ── Pinned host memory (enables DMA-based async transfers) ────────────
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaMallocHost")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaMallocHost")]
     internal static partial int MallocHost(out nint ptr, nuint size);
 
-    [LibraryImport("cudart64_110", EntryPoint = "cudaFreeHost")]
+    [LibraryImport("cudart64_12", EntryPoint = "cudaFreeHost")]
     internal static partial int FreeHost(nint ptr);
 
     // ── Constants ─────────────────────────────────────────────────────────

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -725,7 +725,12 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // Capture the launch-bound Gemma 4 decode region once, then replay it per token
     // with only the position-derived kernel-node params rewritten. The forward passes
     // bracket a PURE on-device-compute region (no H2D/D2H — those need a stream sync,
-    // illegal during capture) with TryBeginGraphCapture / TryEndGraphCaptureAndInstantiate
+    // illegal during capture; also no cudaMalloc/cudaFree, so any pooled scratch the
+    // captured kernels touch — e.g. the Q8_1 matvec buffer — must already be at its max
+    // size before capture. The supported Q8_0 Gemma 4 decode has no Q8_1 quantize and the
+    // Q4_K buffer is pre-grown during prefill, so this holds; a capture that does hit an
+    // illegal op errors the stream and degrades to direct launches) with
+    // TryBeginGraphCapture / TryEndGraphCaptureAndInstantiate
     // and replay via LaunchGraphForPosition. The five position-varying ops
     // (RoPE / RoPEWithFactors / KvAppend / Attention / AttentionSwa) self-register their
     // graph node during capture so replay can update just those scalars. Any failure
@@ -819,6 +824,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _graphCapturing = false;
             if (g != nint.Zero) NvrtcInterop.GraphDestroy(g);
         }
+        // A failure can also reach here *after* TryEndGraphCaptureAndInstantiate already
+        // built _graphExec/_capturedGraph (e.g. the first LaunchGraphForPosition threw):
+        // at that point _graphCapturing is already false, so free those handles too —
+        // otherwise "abort" leaks an exec graph and leaves GraphReady stuck true.
+        DiscardGraph();
         _graphPosNodes.Clear();
         _graphCaptureSupported = false;
     }

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -721,6 +721,189 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _stagingPendingSrc = null;
     }
 
+    // ── CUDA Graphs (issue #136) ──────────────────────────────────────────
+    // Capture the launch-bound Gemma 4 decode region once, then replay it per token
+    // with only the position-derived kernel-node params rewritten. The forward passes
+    // bracket a PURE on-device-compute region (no H2D/D2H — those need a stream sync,
+    // illegal during capture) with TryBeginGraphCapture / TryEndGraphCaptureAndInstantiate
+    // and replay via LaunchGraphForPosition. The five position-varying ops
+    // (RoPE / RoPEWithFactors / KvAppend / Attention / AttentionSwa) self-register their
+    // graph node during capture so replay can update just those scalars. Any failure
+    // flips _graphCaptureSupported off and the caller falls back to direct launches.
+    private bool _graphCaptureSupported = true;
+    private bool _graphCapturing;
+    private bool _graphCaptureFailed;
+    private nint _capturedGraph;   // CUgraph — kept alive: node handles below belong to it
+    private nint _graphExec;       // CUgraphExec
+    private readonly List<GraphPosNode> _graphPosNodes = new();
+
+    /// <summary>True while a graph capture is in progress on <see cref="Stream"/>.</summary>
+    public bool GraphCapturing => _graphCapturing;
+    /// <summary>True until graph capture is ruled out (e.g. a driver capture error).</summary>
+    public bool GraphCaptureSupported => _graphCaptureSupported;
+    /// <summary>True once a graph is captured + instantiated and ready to replay.</summary>
+    public bool GraphReady => _graphExec != nint.Zero;
+
+    private enum GraphPosKind { Position, PositionPlus1, SwaWindowStart, SwaWindowEnd }
+
+    // One captured kernel node whose params carry per-token-varying position scalars.
+    private sealed class GraphPosNode
+    {
+        public nint Node;
+        public nint Func;
+        public uint Gx, Gy, Gz, Bx, By, Bz, Sh;
+        public nint[] ArgValues = [];                         // snapshot of every kernel-arg cell
+        public (int Slot, GraphPosKind Kind, int Window)[] Updates = [];
+    }
+
+    // Pack a float's bit pattern into an arg cell (the kernel reads its low 4 bytes).
+    private static nint GraphFloatBits(float f) => (nint)(uint)BitConverter.SingleToInt32Bits(f);
+
+    /// <summary>
+    /// Begin capturing the decode region into a fresh graph. Drains pending async
+    /// transfers first so capture starts from a clean stream. Returns false (and
+    /// disables graphs) if the driver rejects capture.
+    /// </summary>
+    public bool TryBeginGraphCapture()
+    {
+        if (!_graphCaptureSupported || _graphCapturing) return false;
+        Synchronize();                 // drain in-flight H2D/D2H before capture starts
+        DiscardGraph();
+        _graphPosNodes.Clear();
+        _graphCaptureFailed = false;
+        int rc = NvrtcInterop.StreamBeginCapture(_stream, NvrtcInterop.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL);
+        if (rc != 0) { _graphCaptureSupported = false; return false; }
+        _graphCapturing = true;
+        return true;
+    }
+
+    /// <summary>
+    /// End the in-progress capture and instantiate it into a replayable exec graph.
+    /// Returns false (disabling graphs) on any capture/instantiate error or if a tracked
+    /// node failed to harvest mid-capture.
+    /// </summary>
+    public bool TryEndGraphCaptureAndInstantiate()
+    {
+        if (!_graphCapturing) return false;
+        int rc = NvrtcInterop.StreamEndCapture(_stream, out nint graph);
+        _graphCapturing = false;
+        if (rc != 0 || graph == nint.Zero || _graphCaptureFailed)
+        {
+            if (graph != nint.Zero) NvrtcInterop.GraphDestroy(graph);
+            _graphPosNodes.Clear();
+            _graphCaptureSupported = false;
+            return false;
+        }
+        rc = NvrtcInterop.GraphInstantiate(out nint exec, graph, 0);
+        if (rc != 0 || exec == nint.Zero)
+        {
+            NvrtcInterop.GraphDestroy(graph);
+            _graphPosNodes.Clear();
+            _graphCaptureSupported = false;
+            return false;
+        }
+        _capturedGraph = graph;
+        _graphExec = exec;
+        return true;
+    }
+
+    /// <summary>
+    /// Abort an in-progress capture (drains the stream out of capture mode) and give up
+    /// on graphs for this backend. Safe to call when not capturing.
+    /// </summary>
+    public void AbortGraphCapture()
+    {
+        if (_graphCapturing)
+        {
+            NvrtcInterop.StreamEndCapture(_stream, out nint g);
+            _graphCapturing = false;
+            if (g != nint.Zero) NvrtcInterop.GraphDestroy(g);
+        }
+        _graphPosNodes.Clear();
+        _graphCaptureSupported = false;
+    }
+
+    /// <summary>
+    /// Replay the captured decode graph for <paramref name="position"/>: rewrite each
+    /// tracked node's position-derived scalar params, then launch the exec graph on the
+    /// compute stream. Bit-identical to a direct-launch decode at the same position.
+    /// </summary>
+    public void LaunchGraphForPosition(int position)
+    {
+        if (_graphExec == nint.Zero)
+            throw new InvalidOperationException("LaunchGraphForPosition called before a graph was captured.");
+
+        const int MaxArgs = 16;
+        nint* cells = stackalloc nint[MaxArgs];
+        nint* ptrs  = stackalloc nint[MaxArgs];
+        foreach (var n in _graphPosNodes)
+        {
+            int cnt = n.ArgValues.Length;
+            for (int i = 0; i < cnt; i++) cells[i] = n.ArgValues[i];
+            foreach (var u in n.Updates)
+                cells[u.Slot] = u.Kind switch
+                {
+                    GraphPosKind.Position       => position,
+                    GraphPosKind.PositionPlus1  => position + 1,
+                    GraphPosKind.SwaWindowStart => Math.Max(0, position + 1 - u.Window),
+                    GraphPosKind.SwaWindowEnd   => position + 1,
+                    _                           => cells[u.Slot],
+                };
+            for (int i = 0; i < cnt; i++) ptrs[i] = (nint)(cells + i);
+
+            var p = new NvrtcInterop.CudaKernelNodeParams
+            {
+                Func = n.Func,
+                GridDimX = n.Gx, GridDimY = n.Gy, GridDimZ = n.Gz,
+                BlockDimX = n.Bx, BlockDimY = n.By, BlockDimZ = n.Bz,
+                SharedMemBytes = n.Sh,
+                KernelParams = (nint)ptrs,
+                Extra = nint.Zero,
+            };
+            int rc = NvrtcInterop.GraphExecKernelNodeSetParams(_graphExec, n.Node, &p);
+            if (rc != 0)
+                throw new InvalidOperationException($"cuGraphExecKernelNodeSetParams failed: {rc}");
+        }
+
+        int lr = NvrtcInterop.GraphLaunch(_graphExec, _stream);
+        if (lr != 0)
+            throw new InvalidOperationException($"cuGraphLaunch failed: {lr}");
+    }
+
+    private void DiscardGraph()
+    {
+        if (_graphExec != nint.Zero) { NvrtcInterop.GraphExecDestroy(_graphExec); _graphExec = nint.Zero; }
+        if (_capturedGraph != nint.Zero) { NvrtcInterop.GraphDestroy(_capturedGraph); _capturedGraph = nint.Zero; }
+    }
+
+    // Called by the position-varying op methods immediately after their cuLaunchKernel
+    // while a capture is active. Harvests the just-added graph node from the capture-info
+    // leaf set (a linearly-ordered stream has exactly one leaf) and snapshots its kernel-arg
+    // values so the position slots can be rewritten per replay. Marks the capture failed
+    // (→ fallback) if the leaf set isn't the expected single node.
+    private void TrackPositionNode(
+        nint func, uint gx, uint gy, uint gz, uint bx, uint by, uint bz, uint sh,
+        ReadOnlySpan<nint> argValues,
+        (int Slot, GraphPosKind Kind, int Window)[] updates)
+    {
+        if (_graphCaptureFailed) return;
+        int rc = NvrtcInterop.StreamGetCaptureInfo(
+            _stream, out int status, out _, out _, out nint deps, out nuint numDeps);
+        if (rc != 0 || status != NvrtcInterop.CU_STREAM_CAPTURE_STATUS_ACTIVE
+                    || numDeps != 1 || deps == nint.Zero || argValues.Length > 16)
+        {
+            _graphCaptureFailed = true;
+            return;
+        }
+        _graphPosNodes.Add(new GraphPosNode
+        {
+            Node = ((nint*)deps)[0], Func = func,
+            Gx = gx, Gy = gy, Gz = gz, Bx = bx, By = by, Bz = bz, Sh = sh,
+            ArgValues = argValues.ToArray(),
+            Updates = updates,
+        });
+    }
+
     // ── Pinned host memory exposed as device-accessible tensors ──
     // Vulkan exposes host-visible-device-local buffers as a single Tensor that
     // both the GPU shaders and CPU mapped pointer can use. Under UVA, CUDA's
@@ -1998,6 +2181,13 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         nint kernel = neox ? _ropeNeoxKernel : _ropeInterleavedKernel;
         int r = NvrtcInterop.LaunchKernel(kernel, grid, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rope) failed: {r}");
+
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[5];
+            av[0] = xPtr; av[1] = pNH; av[2] = pHD; av[3] = pPos; av[4] = GraphFloatBits(pT);
+            TrackPositionNode(kernel, grid, 1, 1, 256, 1, 1, 0, av, [(3, GraphPosKind.Position, 0)]);
+        }
     }
 
     /// <summary>
@@ -2103,6 +2293,15 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         uint grid = (uint)((totalPairs + 255) / 256);
         int r = NvrtcInterop.LaunchKernel(_ropeNeoxWithFactorsKernel, grid, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rope_neox_with_factors) failed: {r}");
+
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[6];
+            av[0] = xPtr; av[1] = pNH; av[2] = pHD; av[3] = pPos;
+            av[4] = GraphFloatBits(pT); av[5] = fPtr;
+            TrackPositionNode(_ropeNeoxWithFactorsKernel, grid, 1, 1, 256, 1, 1, 0, av,
+                [(3, GraphPosKind.Position, 0)]);
+        }
     }
 
     /// <summary>
@@ -2251,6 +2450,14 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         uint grid = (uint)((kvDim + 255) / 256);
         int r = NvrtcInterop.LaunchKernel(_kvAppendKernel, grid, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kv_append) failed: {r}");
+
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[7];
+            av[0] = kPtr; av[1] = vPtr; av[2] = kcP; av[3] = vcP;
+            av[4] = pKD; av[5] = pPos; av[6] = pMSL;
+            TrackPositionNode(_kvAppendKernel, grid, 1, 1, 256, 1, 1, 0, av, [(5, GraphPosKind.Position, 0)]);
+        }
     }
 
     /// <summary>
@@ -2287,6 +2494,17 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         };
         int r = NvrtcInterop.LaunchKernel(_attentionKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(attention) failed: {r}");
+
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[11];
+            av[0] = qP; av[1] = kP; av[2] = vP; av[3] = oP; av[4] = ssP;
+            av[5] = pNH; av[6] = pNKV; av[7] = pHD; av[8] = pSL; av[9] = pMSL;
+            av[10] = GraphFloatBits(pScale);
+            // pSL = seqLen = position + 1 in the decode path.
+            TrackPositionNode(_attentionKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, av,
+                [(8, GraphPosKind.PositionPlus1, 0)]);
+        }
     }
 
     /// <summary>
@@ -2333,6 +2551,17 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         };
         int r = NvrtcInterop.LaunchKernel(_attentionSwaKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(attention_swa) failed: {r}");
+
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[12];
+            av[0] = qP; av[1] = kP; av[2] = vP; av[3] = oP; av[4] = ssP;
+            av[5] = pNH; av[6] = pNKV; av[7] = pHD;
+            av[8] = pWS; av[9] = pWE; av[10] = pMSL; av[11] = GraphFloatBits(pScale);
+            // windowStart = max(0, position+1-window); windowEnd = position+1.
+            TrackPositionNode(_attentionSwaKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, av,
+                [(8, GraphPosKind.SwaWindowStart, windowSize), (9, GraphPosKind.SwaWindowEnd, 0)]);
+        }
     }
 
     /// <summary>
@@ -4147,6 +4376,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _waveScratchBuf = nint.Zero;
             _waveScratchBufSize = 0;
         }
+
+        // Tear down any captured CUDA graph (issue #136) before stream/context go away.
+        if (_graphCapturing)
+            NvrtcInterop.StreamEndCapture(_stream, out _);
+        DiscardGraph();
 
         CuBlasInterop.Destroy(_handle);
 

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -741,6 +741,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint _capturedGraph;   // CUgraph — kept alive: node handles below belong to it
     private nint _graphExec;       // CUgraphExec
     private readonly List<GraphPosNode> _graphPosNodes = new();
+    // Upper bound on a tracked kernel's arg count — sizes the reusable stackalloc cell/ptr
+    // buffers in LaunchGraphForPosition and bounds the per-node snapshot in TrackPositionNode.
+    // The widest position-varying op (AttentionSwa) has 12 args; 16 leaves headroom.
+    private const int GraphMaxKernelArgs = 16;
 
     /// <summary>True while a graph capture is in progress on <see cref="Stream"/>.</summary>
     public bool GraphCapturing => _graphCapturing;
@@ -843,9 +847,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         if (_graphExec == nint.Zero)
             throw new InvalidOperationException("LaunchGraphForPosition called before a graph was captured.");
 
-        const int MaxArgs = 16;
-        nint* cells = stackalloc nint[MaxArgs];
-        nint* ptrs  = stackalloc nint[MaxArgs];
+        nint* cells = stackalloc nint[GraphMaxKernelArgs];
+        nint* ptrs  = stackalloc nint[GraphMaxKernelArgs];
         foreach (var n in _graphPosNodes)
         {
             int cnt = n.ArgValues.Length;
@@ -900,7 +903,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         int rc = NvrtcInterop.StreamGetCaptureInfo(
             _stream, out int status, out _, out _, out nint deps, out nuint numDeps);
         if (rc != 0 || status != NvrtcInterop.CU_STREAM_CAPTURE_STATUS_ACTIVE
-                    || numDeps != 1 || deps == nint.Zero || argValues.Length > 16)
+                    || numDeps != 1 || deps == nint.Zero || argValues.Length > GraphMaxKernelArgs)
         {
             _graphCaptureFailed = true;
             return;

--- a/src/SharpInference.Cuda/NvrtcInterop.cs
+++ b/src/SharpInference.Cuda/NvrtcInterop.cs
@@ -135,6 +135,82 @@ internal static unsafe partial class NvrtcInterop
 
     internal const int CU_FUNC_ATTRIBUTE_NUM_REGS = 4;
 
+    // ── CUDA Graphs (issue #136) ──────────────────────────────────────────
+    // Driver-API graph capture/replay for the launch-bound Gemma 4 decode loop.
+    // All of these live in nvcuda.dll (the display driver), so they are
+    // independent of the CUDA toolkit version the rest of the backend binds to
+    // (cudart64_110 / cublas64_11 / nvrtc64_120_0). They are stable since
+    // CUDA 11.3+ and present in any modern driver.
+
+    /// <summary>Stream capture mode for <see cref="StreamBeginCapture"/>.</summary>
+    internal const int CU_STREAM_CAPTURE_MODE_GLOBAL = 0;
+    internal const int CU_STREAM_CAPTURE_MODE_THREAD_LOCAL = 1;
+    internal const int CU_STREAM_CAPTURE_MODE_RELAXED = 2;
+
+    /// <summary>Capture status returned by <see cref="StreamGetCaptureInfo"/>.</summary>
+    internal const int CU_STREAM_CAPTURE_STATUS_NONE = 0;
+    internal const int CU_STREAM_CAPTURE_STATUS_ACTIVE = 1;
+    internal const int CU_STREAM_CAPTURE_STATUS_INVALIDATED = 2;
+
+    /// <summary>
+    /// Driver-API kernel-node parameters (the <b>v1</b> ABI — 56 bytes on x64).
+    /// The base <c>cuGraphExecKernelNodeSetParams</c> symbol binds this layout;
+    /// the CUDA-12 <c>_v2</c> variant adds <c>kern</c>/<c>ctx</c> fields and we
+    /// deliberately avoid it. <c>kernelParams</c> / <c>extra</c> are
+    /// <c>void**</c> just like the <see cref="LaunchKernel"/> args array.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CudaKernelNodeParams
+    {
+        public nint Func;
+        public uint GridDimX, GridDimY, GridDimZ;
+        public uint BlockDimX, BlockDimY, BlockDimZ;
+        public uint SharedMemBytes;
+        public nint KernelParams; // void**
+        public nint Extra;        // void**
+    }
+
+    /// <summary>Begin capturing work enqueued on <paramref name="hStream"/> into a graph.</summary>
+    [LibraryImport("nvcuda", EntryPoint = "cuStreamBeginCapture_v2")]
+    internal static partial int StreamBeginCapture(nint hStream, int mode);
+
+    /// <summary>End capture and return the assembled graph.</summary>
+    [LibraryImport("nvcuda", EntryPoint = "cuStreamEndCapture")]
+    internal static partial int StreamEndCapture(nint hStream, out nint phGraph);
+
+    /// <summary>
+    /// Query the in-progress capture. <paramref name="dependencies"/> receives a
+    /// driver-owned pointer to the current leaf-node array (<c>CUgraphNode*</c>);
+    /// on a linearly-ordered stream this is the just-enqueued node. Do not free it.
+    /// </summary>
+    [LibraryImport("nvcuda", EntryPoint = "cuStreamGetCaptureInfo_v2")]
+    internal static partial int StreamGetCaptureInfo(
+        nint hStream, out int captureStatus, out ulong id,
+        out nint graph, out nint dependencies, out nuint numDependencies);
+
+    /// <summary>Instantiate a captured graph into an executable graph. flags = 0.</summary>
+    [LibraryImport("nvcuda", EntryPoint = "cuGraphInstantiateWithFlags")]
+    internal static partial int GraphInstantiate(out nint phGraphExec, nint hGraph, ulong flags);
+
+    /// <summary>Launch an executable graph on <paramref name="hStream"/>.</summary>
+    [LibraryImport("nvcuda", EntryPoint = "cuGraphLaunch")]
+    internal static partial int GraphLaunch(nint hGraphExec, nint hStream);
+
+    /// <summary>
+    /// Update one kernel node's params in an executable graph without re-instantiating.
+    /// The driver copies <paramref name="nodeParams"/> (and the values its
+    /// <c>kernelParams</c> point to) synchronously, so the caller may stack-allocate them.
+    /// </summary>
+    [LibraryImport("nvcuda", EntryPoint = "cuGraphExecKernelNodeSetParams")]
+    internal static partial int GraphExecKernelNodeSetParams(
+        nint hGraphExec, nint hNode, CudaKernelNodeParams* nodeParams);
+
+    [LibraryImport("nvcuda", EntryPoint = "cuGraphDestroy")]
+    internal static partial int GraphDestroy(nint hGraph);
+
+    [LibraryImport("nvcuda", EntryPoint = "cuGraphExecDestroy")]
+    internal static partial int GraphExecDestroy(nint hGraphExec);
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     /// <summary>Return a null-terminated UTF-8 byte array for use as a C string.</summary>

--- a/src/SharpInference.Cuda/NvrtcInterop.cs
+++ b/src/SharpInference.Cuda/NvrtcInterop.cs
@@ -139,7 +139,7 @@ internal static unsafe partial class NvrtcInterop
     // Driver-API graph capture/replay for the launch-bound Gemma 4 decode loop.
     // All of these live in nvcuda.dll (the display driver), so they are
     // independent of the CUDA toolkit version the rest of the backend binds to
-    // (cudart64_110 / cublas64_11 / nvrtc64_120_0). They are stable since
+    // (cudart64_12 / cublas64_12 / nvrtc64_120_0). They are stable since
     // CUDA 11.3+ and present in any modern driver.
 
     /// <summary>Stream capture mode for <see cref="StreamBeginCapture"/>.</summary>

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -2039,6 +2039,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass
                 "truncate inside the FP32 recent window.");
         _kvLength = length;
         _kvCache.TruncateTo(length);
+        // _kvEvictedCount is intentionally NOT reset here. TruncateTo only rewinds *decode*
+        // tokens (speculative decode rejects), whose logical positions stay >= the eviction
+        // point, so the physical mapping `slot = position - _kvEvictedCount` remains valid.
+        // (Rewinding below the eviction point would be nonsensical — those prompt tokens were
+        // compacted away — and SnapKV does not compose with speculative decode in practice.)
     }
 
     /// <inheritdoc />

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -777,6 +777,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     private bool _useCudaGraph =
         Environment.GetEnvironmentVariable("SHARPI_CUDA_GRAPH") == "1";
     private bool _graphCaptured;
+    // Set once SnapKV actually compacts the KV cache (K < N) — that's what breaks the
+    // captured seqLen == position+1 invariant. A merely *configured* SnapKV budget that
+    // never evicts (prompt <= budget) leaves the cache filling sequentially, so graphs
+    // stay valid. Reset on a full ResetCache.
+    private bool _snapKvEvicted;
 
     /// <summary>
     /// Enable/disable CUDA-graph capture+replay for the Gemma 4 decode loop. Defaults from
@@ -1151,9 +1156,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             return false;
 
         // Graphs bake in the standard decode invariant (fixed topology, seqLen ==
-        // position+1). SnapKV eviction (variable logical length) and TurboQuant (extra
-        // host-synced rotate/compress ops) break that, so stay on direct launches there.
-        if (_snapKvEffectiveBudget > 0 || _tqEnabled)
+        // position+1). TurboQuant (extra host-synced rotate/compress ops) and an *actual*
+        // SnapKV eviction (cache compacted, so cache-fill != absolute position) break that.
+        // A configured-but-unevicted SnapKV budget does not — the cache still fills
+        // sequentially — so gate on _snapKvEvicted, not on the budget being set.
+        if (_snapKvEvicted || _tqEnabled)
             return false;
 
         // Steady state: graph already captured — just replay at the new position.
@@ -1951,6 +1958,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         // CudaForwardPass — actual data lives in _gpuKCache/_gpuVCache.
         _kvLength = K;
         _kvCache.TruncateTo(K);
+        // The cache is now compacted (cache-fill K < absolute position), which breaks the
+        // CUDA-graph seqLen == position+1 invariant — disable graph replay for this
+        // sequence (re-enabled on a full ResetCache).
+        _snapKvEvicted = true;
     }
 
     private void EnsureSnapKvCaptureBuffer(int W)
@@ -2011,6 +2022,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         _tqCompressedLen = 0;
         _fp32WriteIdx = 0;
         _fp32Count = 0;
+        _snapKvEvicted = false; // fresh sequence — standard sequential cache state restored
     }
 
     private void GpuMatMul(Tensor output, Tensor weights, Tensor input)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -330,6 +330,21 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             }
         }
 
+        // SnapKV cannot compose with Gemma-4-like models: their SWA layers use
+        // sliding-window ring caches and layers carry per-layer head_dim, so the
+        // full-context scoring + uniform-kvDim compaction in ApplySnapKvEviction would
+        // mis-index those caches (out-of-range gather, wrong row stride). Force it off
+        // rather than silently corrupt the cache; warn only if it was explicitly asked for.
+        if (_isGemma4Like && _snapKvEffectiveBudget > 0)
+        {
+            if (_snapKvCfg.IsBudgetExplicit)
+                Console.Error.WriteLine(
+                    "[CudaForwardPass] SnapKV is not supported for Gemma-4-style models " +
+                    "(sliding-window ring caches + per-layer head_dim); ignoring the " +
+                    "configured budget and using the full KV cache.");
+            _snapKvEffectiveBudget = 0;
+        }
+
         Console.Error.WriteLine($"[CudaForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength}){(_tqEnabled ? " [TQ3]" : "")}");
 
         bool vramTrace = Environment.GetEnvironmentVariable("SHARPI_TRACE_VRAM") == "1";
@@ -777,11 +792,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     private bool _useCudaGraph =
         Environment.GetEnvironmentVariable("SHARPI_CUDA_GRAPH") == "1";
     private bool _graphCaptured;
-    // Set once SnapKV actually compacts the KV cache (K < N) — that's what breaks the
-    // captured seqLen == position+1 invariant. A merely *configured* SnapKV budget that
-    // never evicts (prompt <= budget) leaves the cache filling sequentially, so graphs
-    // stay valid. Reset on a full ResetCache.
-    private bool _snapKvEvicted;
+    // Number of KV entries SnapKV physically dropped when it compacted the cache
+    // (= N - K at eviction, 0 otherwise). Decode indexes the compacted cache by the
+    // *physical* slot `position - _kvEvictedCount` while RoPE keeps the logical
+    // `position`; without this the post-eviction decode reads stale/duplicated slots
+    // (cache-fill != absolute position). Also gates CUDA graphs off once > 0 — a
+    // compacted cache breaks the captured seqLen == position+1 invariant. A configured
+    // SnapKV budget that never evicts (prompt <= budget) leaves this 0, so the cache
+    // fills sequentially and graphs stay valid. Reset on a full ResetCache.
+    private int _kvEvictedCount;
 
     /// <summary>
     /// Enable/disable CUDA-graph capture+replay for the Gemma 4 decode loop. Defaults from
@@ -918,10 +937,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             }
             else
             {
-                _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer], kvDim, position, _maxSeqLen);
+                // Index the cache by the physical slot. After a SnapKV eviction the cache
+                // is compacted to K entries, so the next write lands at
+                // `position - _kvEvictedCount` (= position when nothing was evicted), and
+                // attention reads that many + 1. RoPE above still uses the logical position.
+                int kvSlot = position - _kvEvictedCount;
+                _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer], kvDim, kvSlot, _maxSeqLen);
                 _gpu.Attention(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
                     _attnScoresScratch,
-                    _numHeads, _numKvHeads, _headDim, position + 1, _maxSeqLen);
+                    _numHeads, _numKvHeads, _headDim, kvSlot + 1, _maxSeqLen);
             }
 
             GpuMatMul(_hidden, _wo[layer], _attnOut);
@@ -1159,8 +1183,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         // position+1). TurboQuant (extra host-synced rotate/compress ops) and an *actual*
         // SnapKV eviction (cache compacted, so cache-fill != absolute position) break that.
         // A configured-but-unevicted SnapKV budget does not — the cache still fills
-        // sequentially — so gate on _snapKvEvicted, not on the budget being set.
-        if (_snapKvEvicted || _tqEnabled)
+        // sequentially — so gate on an actual eviction (_kvEvictedCount > 0), not on the
+        // budget being set.
+        if (_kvEvictedCount > 0 || _tqEnabled)
             return false;
 
         // Steady state: graph already captured — just replay at the new position.
@@ -1336,10 +1361,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             }
 
             int kvDim = _numKvHeads * _headDim;
-            _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer], kvDim, position, _maxSeqLen);
+            // Physical KV slot (= position unless SnapKV compacted the cache). See the
+            // matching note in Forward.
+            int kvSlot = position - _kvEvictedCount;
+            _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer], kvDim, kvSlot, _maxSeqLen);
             _gpu.Attention(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
                 _attnScoresScratch,
-                _numHeads, _numKvHeads, _headDim, position + 1, _maxSeqLen);
+                _numHeads, _numKvHeads, _headDim, kvSlot + 1, _maxSeqLen);
             _gpu.Synchronize();
             AccPhase(PH_KV_ATTN, sw, ref t0);
 
@@ -1958,10 +1986,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         // CudaForwardPass — actual data lives in _gpuKCache/_gpuVCache.
         _kvLength = K;
         _kvCache.TruncateTo(K);
-        // The cache is now compacted (cache-fill K < absolute position), which breaks the
-        // CUDA-graph seqLen == position+1 invariant — disable graph replay for this
-        // sequence (re-enabled on a full ResetCache).
-        _snapKvEvicted = true;
+        // The cache is now compacted: K physical entries at slots [0, K) but the logical
+        // RoPE positions continue at N, N+1, … So decode must index the cache by the
+        // physical slot `position - _kvEvictedCount`. This also disables CUDA-graph replay
+        // for the sequence (the seqLen == position+1 invariant no longer holds); both are
+        // re-enabled on a full ResetCache.
+        _kvEvictedCount = N - K;
     }
 
     private void EnsureSnapKvCaptureBuffer(int W)
@@ -2022,7 +2052,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         _tqCompressedLen = 0;
         _fp32WriteIdx = 0;
         _fp32Count = 0;
-        _snapKvEvicted = false; // fresh sequence — standard sequential cache state restored
+        _kvEvictedCount = 0; // fresh sequence — standard sequential cache state restored
     }
 
     private void GpuMatMul(Tensor output, Tensor weights, Tensor input)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -768,6 +768,22 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     private static readonly string[] s_phaseName =
         ["embed", "qkv-matmul", "rope+qknorm", "kv+attn", "o-proj+res", "ffn", "final+download", "ple"];
 
+    // CUDA Graph decode (issue #136): the Gemma 4 layer + output region has static
+    // topology across decode tokens (only `position` varies), so capture it once on the
+    // first decode token and replay per token — collapsing ~1k host launches/token into
+    // one cuGraphLaunch + a handful of node-param updates. Off by default; opt in with
+    // SHARPI_CUDA_GRAPH=1 or the UseCudaGraph setter. Falls back to direct launches on
+    // any capture/replay failure.
+    private bool _useCudaGraph =
+        Environment.GetEnvironmentVariable("SHARPI_CUDA_GRAPH") == "1";
+    private bool _graphCaptured;
+
+    /// <summary>
+    /// Enable/disable CUDA-graph capture+replay for the Gemma 4 decode loop. Defaults from
+    /// the <c>SHARPI_CUDA_GRAPH</c> env var; set before the first decode (tests/bench).
+    /// </summary>
+    public bool UseCudaGraph { get => _useCudaGraph; set => _useCudaGraph = value; }
+
     /// <inheritdoc/>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
@@ -977,6 +993,24 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         if (_hp.HasPerLayerTokenEmbd)
             BuildPerLayerProjectionsGpu(token);
 
+        // 3. Transformer layers + final norm/output/softcap. Static topology across
+        //    tokens (only `position` varies), so optionally capture it once into a CUDA
+        //    graph and replay per token to kill the ~1k-launch/token host overhead (#136).
+        if (!TryRunGemma4DeviceRegionViaGraph(position))
+            RunGemma4DeviceRegion(position);
+
+        _gpu.Download(_logits, _logitsBuf);
+        _gpu.Synchronize();
+
+        _kvLength = Math.Max(_kvLength, position + 1);
+        return _logitsBuf;
+    }
+
+    // Transformer layer loop + final norm/output/softcap — the pure on-device-compute
+    // region the CUDA-graph path captures. Token-varying embedding + PLE run before it;
+    // the logits download + sync run after. Only `position` varies across tokens.
+    private void RunGemma4DeviceRegion(int position)
+    {
         int L = _hp.NumLayers;
         for (int layer = 0; layer < L; layer++)
         {
@@ -1105,12 +1139,53 @@ public sealed unsafe class CudaForwardPass : IForwardPass
 
         if (_hp.FinalLogitSoftcap > 0f)
             _gpu.SoftcapInPlace(_logits, _hp.FinalLogitSoftcap);
+    }
 
-        _gpu.Download(_logits, _logitsBuf);
-        _gpu.Synchronize();
+    // CUDA-graph capture/replay for the Gemma 4 decode region. Returns true if the logits
+    // were produced via the graph (captured on the first decode token, replayed after);
+    // false means the caller must run the region with direct launches. Any capture/replay
+    // failure disables graphs for the rest of the session and degrades to direct launches.
+    private bool TryRunGemma4DeviceRegionViaGraph(int position)
+    {
+        if (!_useCudaGraph || !_gpu.GraphCaptureSupported)
+            return false;
 
-        _kvLength = Math.Max(_kvLength, position + 1);
-        return _logitsBuf;
+        // Graphs bake in the standard decode invariant (fixed topology, seqLen ==
+        // position+1). SnapKV eviction (variable logical length) and TurboQuant (extra
+        // host-synced rotate/compress ops) break that, so stay on direct launches there.
+        if (_snapKvEffectiveBudget > 0 || _tqEnabled)
+            return false;
+
+        // Steady state: graph already captured — just replay at the new position.
+        if (_graphCaptured && _gpu.GraphReady)
+        {
+            try { _gpu.LaunchGraphForPosition(position); return true; }
+            catch { _useCudaGraph = false; _graphCaptured = false; return false; }
+        }
+
+        if (_graphCaptured)
+            return false; // latched but not ready — shouldn't happen; stay on direct launches
+
+        // First decode token: capture the region (records onto the stream without executing)
+        // then launch it for real. On any failure the region was NOT executed, so the caller
+        // re-runs it directly.
+        try
+        {
+            if (!_gpu.TryBeginGraphCapture())
+                return false;
+            RunGemma4DeviceRegion(position);
+            if (!_gpu.TryEndGraphCaptureAndInstantiate())
+                return false;
+            _gpu.LaunchGraphForPosition(position);
+            _graphCaptured = true;
+            return true;
+        }
+        catch
+        {
+            _gpu.AbortGraphCapture();
+            _useCudaGraph = false;
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -1544,6 +1544,65 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     //  for the GPU half and ForwardPass.Forward (Gemma 4 path) for the CPU half.
     // ================================================================
 
+    // CUDA Graph decode (issue #136): the GPU layer loop has static topology across
+    // decode tokens (only `position` varies), so capture it once on the first decode
+    // token and replay per token — collapsing the per-layer launches into one
+    // cuGraphLaunch + a handful of node-param updates. Off by default; opt in with
+    // SHARPI_CUDA_GRAPH=1 or the UseCudaGraph setter. Falls back to direct launches on
+    // any capture/replay failure. The hybrid win is smaller than the all-GPU path's
+    // since host transfers + CPU layers bracket only a fraction of the layers.
+    private bool _useCudaGraph =
+        Environment.GetEnvironmentVariable("SHARPI_CUDA_GRAPH") == "1";
+    private bool _graphCaptured;
+
+    /// <summary>
+    /// Enable/disable CUDA-graph capture+replay for the Gemma 4 GPU layer loop. Defaults
+    /// from the <c>SHARPI_CUDA_GRAPH</c> env var; set before the first decode (tests/bench).
+    /// </summary>
+    public bool UseCudaGraph { get => _useCudaGraph; set => _useCudaGraph = value; }
+
+    // CUDA-graph capture/replay for the Gemma 4 GPU layer loop. Returns true if the loop
+    // ran via the graph (captured on the first decode token, replayed after); false means
+    // the caller must run the layers with direct launches. Any failure disables graphs for
+    // the rest of the session and degrades to direct launches.
+    private bool TryRunGpuLayersGemma4ViaGraph(int position)
+    {
+        if (!_useCudaGraph || !_gpu.GraphCaptureSupported || _tqEnabled)
+            return false;
+
+        // Steady state: graph already captured — just replay at the new position.
+        if (_graphCaptured && _gpu.GraphReady)
+        {
+            try { _gpu.LaunchGraphForPosition(position); return true; }
+            catch { _useCudaGraph = false; _graphCaptured = false; return false; }
+        }
+
+        if (_graphCaptured)
+            return false;
+
+        // First decode token: capture the loop (records onto the stream without executing)
+        // then launch it for real. On any failure the loop was NOT executed, so the caller
+        // re-runs it directly.
+        try
+        {
+            if (!_gpu.TryBeginGraphCapture())
+                return false;
+            for (int i = 0; i < _nGpuLayers; i++)
+                GpuLayerGemma4(i, position);
+            if (!_gpu.TryEndGraphCaptureAndInstantiate())
+                return false;
+            _gpu.LaunchGraphForPosition(position);
+            _graphCaptured = true;
+            return true;
+        }
+        catch
+        {
+            _gpu.AbortGraphCapture();
+            _useCudaGraph = false;
+            return false;
+        }
+    }
+
     private ReadOnlySpan<float> ForwardGemma4(int token, int position)
     {
         // PLE pre-pass needs the hidden state, so embed first.
@@ -1603,8 +1662,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 _gpu.RecordBarrier();
             }
 
-            for (int i = 0; i < _nGpuLayers; i++)
-                GpuLayerGemma4(i, position);
+            // The GPU layer loop has static topology across decode tokens (only
+            // `position` varies), so optionally capture it once into a CUDA graph and
+            // replay per token (issue #136). Uploads above and the download below stay
+            // outside the captured region (they are host transfers).
+            if (!TryRunGpuLayersGemma4ViaGraph(position))
+                for (int i = 0; i < _nGpuLayers; i++)
+                    GpuLayerGemma4(i, position);
 
             if (_nCpuLayers > 0)
             {

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4CudaForwardPassTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4CudaForwardPassTests.cs
@@ -260,6 +260,51 @@ public sealed class Gemma4CudaForwardPassTests
             $"[{string.Join(",", cudaDecoded)}]. Output is degenerate.");
     }
 
+    /// <summary>
+    /// SnapKV must be force-disabled for Gemma-4-style models: their SWA layers use
+    /// sliding-window ring caches and layers carry per-layer head_dim, so the full-context
+    /// scoring + uniform-kvDim compaction in ApplySnapKvEviction would mis-index the cache.
+    /// With an explicit budget set and an over-budget prompt, KvLength must equal the full
+    /// prompt length (no eviction) rather than collapsing to the budget.
+    /// </summary>
+    [Fact]
+    public void Gemma4_E4B_CudaForward_SnapKvDisabled_NoEvictionEvenOverBudget()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 64;
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", budget.ToString());
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            Assert.NotNull(hp.LayerHeadDim); // confirms this is the Gemma-4-like path
+
+            // Build an over-budget prompt (N > budget AND N > SnapKV window) from valid
+            // mid-vocab token ids — enough to trip the eviction gate if it were enabled.
+            int bosId = ReadIntMetadata(model, "tokenizer.ggml.bos_token_id", fallback: 2);
+            int[] cycle = { 818, 5279, 529, 7001, 563, 1234, 4567, 8901 };
+            var tokens = new int[160];
+            tokens[0] = bosId;
+            for (int i = 1; i < tokens.Length; i++) tokens[i] = cycle[i % cycle.Length];
+
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 1024);
+            var logits = fwd.Prefill(tokens);
+
+            Assert.Equal(hp.VocabSize, logits.Length);
+            // The decisive assertion: SnapKV stayed off, so the cache keeps every token.
+            Assert.Equal(tokens.Length, fwd.KvLength);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev);
+        }
+    }
+
     private static int[] TopK(ReadOnlySpan<float> logits, int k)
     {
         var result = new int[k];

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4CudaGraphParityTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4CudaGraphParityTests.cs
@@ -1,0 +1,201 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Bit-parity oracle for CUDA Graph decode (issue #136). The captured-and-replayed
+/// Gemma 4 decode region runs the identical kernels in the identical order as the
+/// direct-launch path — only the launch mechanism differs — so graph-on vs graph-off
+/// logits must be <b>bit-identical</b> at every decode step, not merely argmax-equal.
+///
+/// Silent-skip pattern: no-ops when CUDA isn't available or the GGUF isn't on disk,
+/// matching the sibling Gemma4Cuda* test files.
+/// </summary>
+public sealed class Gemma4CudaGraphParityTests
+{
+    private const string ModelFile = "gemma-4-E4B-it-Q8_0.gguf";
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absoluteCandidates =
+        {
+            $@"E:\models\{ModelFile}",
+            $@"C:\p\sharpi\models\{ModelFile}",
+        };
+        foreach (var p in absoluteCandidates)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int ReadIntMetadata(GgufModel model, string key, int fallback)
+    {
+        if (!model.Metadata.TryGetValue(key, out var v) || v is null) return fallback;
+        try { return Convert.ToInt32(v); } catch { return fallback; }
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    [Fact]
+    public void Gemma4_E4B_CudaGraph_AllGpu_BitMatchesDirectLaunch()
+    {
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.NotNull(hp.LayerHeadDim);
+
+        int bosId = ReadIntMetadata(model, "tokenizer.ggml.bos_token_id", fallback: 2);
+        var tokens = new int[] { bosId, 818, 5279, 529, 7001, 563 }; // "The capital of France is"
+        const int NSteps = 8;
+
+        // Reference: graph OFF (direct launches). Capture full logits per decode step.
+        var refLogits = new float[NSteps][];
+        var refTokens = new int[NSteps];
+        using (var gpu = TryCreate())
+        {
+            if (gpu is null) return;
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 512) { UseCudaGraph = false };
+            var logits = fwd.Prefill(tokens);
+            refLogits[0] = logits.ToArray();
+            refTokens[0] = Argmax(logits);
+            int pos = tokens.Length;
+            for (int i = 1; i < NSteps; i++)
+            {
+                var step = fwd.Forward(refTokens[i - 1], pos++);
+                refLogits[i] = step.ToArray();
+                refTokens[i] = Argmax(step);
+            }
+        }
+
+        // Candidate: graph ON (capture on first decode token, replay after).
+        using (var gpu = TryCreate())
+        {
+            if (gpu is null) return;
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 512) { UseCudaGraph = true };
+            var logits = fwd.Prefill(tokens);
+            AssertBitIdentical(refLogits[0], logits, step: 0);
+            int pos = tokens.Length;
+            for (int i = 1; i < NSteps; i++)
+            {
+                // Drive the decode with the REFERENCE tokens so both runs see the same
+                // input sequence even if (hypothetically) an early step diverged.
+                var step = fwd.Forward(refTokens[i - 1], pos++);
+                AssertBitIdentical(refLogits[i], step, step: i);
+            }
+
+            // Guard against a silent fallback: the graph path must actually have engaged.
+            Assert.True(gpu.GraphReady,
+                "CUDA graph was never captured — the parity test silently ran direct launches " +
+                "on both sides and proves nothing. Check TryRunGemma4DeviceRegionViaGraph gating.");
+        }
+    }
+
+    [Fact]
+    public void Gemma4_E4B_CudaGraph_Hybrid_BitMatchesDirectLaunch()
+    {
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.NotNull(hp.LayerHeadDim);
+
+        int bosId = ReadIntMetadata(model, "tokenizer.ggml.bos_token_id", fallback: 2);
+        var tokens = new int[] { bosId, 818, 5279, 529, 7001, 563 };
+        const int NSteps = 8;
+        const int SafeGpuLayers = 22; // matches the bench -g 22 split; passes the KV-share guard
+
+        LayerPlacement Placement() => new(
+            GpuLayers: SafeGpuLayers,
+            CpuLayers: hp.NumLayers - SafeGpuLayers,
+            GpuWeightBytes: 0,
+            GpuKvBytes: 0,
+            RecommendedCtxSize: 512);
+
+        // Reference: graph OFF.
+        var refLogits = new float[NSteps][];
+        var refTokens = new int[NSteps];
+        using (var gpu = TryCreate())
+        {
+            if (gpu is null) return;
+            using var fwd = new CudaHybridForwardPass(model, gpu, hp, Placement()) { UseCudaGraph = false };
+            var logits = fwd.Prefill(tokens);
+            refLogits[0] = logits.ToArray();
+            refTokens[0] = Argmax(logits);
+            int pos = tokens.Length;
+            for (int i = 1; i < NSteps; i++)
+            {
+                var step = fwd.Forward(refTokens[i - 1], pos++);
+                refLogits[i] = step.ToArray();
+                refTokens[i] = Argmax(step);
+            }
+        }
+
+        // Candidate: graph ON.
+        using (var gpu = TryCreate())
+        {
+            if (gpu is null) return;
+            using var fwd = new CudaHybridForwardPass(model, gpu, hp, Placement()) { UseCudaGraph = true };
+            var logits = fwd.Prefill(tokens);
+            AssertBitIdentical(refLogits[0], logits, step: 0);
+            int pos = tokens.Length;
+            for (int i = 1; i < NSteps; i++)
+            {
+                var step = fwd.Forward(refTokens[i - 1], pos++);
+                AssertBitIdentical(refLogits[i], step, step: i);
+            }
+
+            Assert.True(gpu.GraphReady,
+                "CUDA graph was never captured for the hybrid GPU layer loop — the parity test " +
+                "silently ran direct launches on both sides. Check TryRunGpuLayersGemma4ViaGraph gating.");
+        }
+    }
+
+    private static void AssertBitIdentical(float[] expected, ReadOnlySpan<float> actual, int step)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        int diffs = 0, firstIdx = -1;
+        float firstE = 0, firstA = 0;
+        for (int k = 0; k < expected.Length; k++)
+        {
+            if (BitConverter.SingleToInt32Bits(expected[k]) != BitConverter.SingleToInt32Bits(actual[k]))
+            {
+                if (firstIdx < 0) { firstIdx = k; firstE = expected[k]; firstA = actual[k]; }
+                diffs++;
+            }
+        }
+        Assert.True(diffs == 0,
+            $"CUDA graph decode diverged from direct launch at step {step}: {diffs}/{expected.Length} " +
+            $"logits differ; first at idx {firstIdx} (direct={firstE:R} graph={firstA:R}). " +
+            "Graph replay must be bit-identical to direct launches.");
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4CudaGraphParityTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4CudaGraphParityTests.cs
@@ -180,6 +180,71 @@ public sealed class Gemma4CudaGraphParityTests
         }
     }
 
+    [Fact]
+    public void Gemma4_E4B_CudaGraph_AllGpu_SnapKvConfiguredNoEvict_BitMatches()
+    {
+        // Regression guard for the precise SnapKV gate: when a SnapKV budget is
+        // *configured* but the prompt fits under it (no eviction), the KV cache fills
+        // sequentially and the graph's seqLen == position+1 invariant still holds, so
+        // graphs MUST engage (and match bit-for-bit). The coarse "budget > 0" guard
+        // wrongly disabled them here — this is the default-bench scenario (972-token
+        // prompt under the 1024 auto-budget).
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "512"); // configured, but prompt << 512
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            Assert.NotNull(hp.LayerHeadDim);
+
+            int bosId = ReadIntMetadata(model, "tokenizer.ggml.bos_token_id", fallback: 2);
+            var tokens = new int[] { bosId, 818, 5279, 529, 7001, 563 }; // 6 tokens — no eviction
+            const int NSteps = 8;
+
+            var refLogits = new float[NSteps][];
+            var refTokens = new int[NSteps];
+            using (var gpu = TryCreate())
+            {
+                if (gpu is null) return;
+                using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 1024) { UseCudaGraph = false };
+                var logits = fwd.Prefill(tokens);
+                refLogits[0] = logits.ToArray();
+                refTokens[0] = Argmax(logits);
+                int pos = tokens.Length;
+                for (int i = 1; i < NSteps; i++)
+                {
+                    var step = fwd.Forward(refTokens[i - 1], pos++);
+                    refLogits[i] = step.ToArray();
+                    refTokens[i] = Argmax(step);
+                }
+            }
+
+            using (var gpu = TryCreate())
+            {
+                if (gpu is null) return;
+                using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 1024) { UseCudaGraph = true };
+                var logits = fwd.Prefill(tokens);
+                AssertBitIdentical(refLogits[0], logits, step: 0);
+                int pos = tokens.Length;
+                for (int i = 1; i < NSteps; i++)
+                    AssertBitIdentical(refLogits[i], fwd.Forward(refTokens[i - 1], pos++), step: i);
+
+                Assert.True(gpu.GraphReady,
+                    "Graphs must engage when SnapKV is configured but the prompt fits the budget " +
+                    "(no eviction). GraphReady=false means the _snapKvEvicted gate is over-broad " +
+                    "and the default-config win is lost.");
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev);
+        }
+    }
+
     private static void AssertBitIdentical(float[] expected, ReadOnlySpan<float> actual, int step)
     {
         Assert.Equal(expected.Length, actual.Length);

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4CudaGraphParityTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4CudaGraphParityTests.cs
@@ -183,12 +183,12 @@ public sealed class Gemma4CudaGraphParityTests
     [Fact]
     public void Gemma4_E4B_CudaGraph_AllGpu_SnapKvConfiguredNoEvict_BitMatches()
     {
-        // Regression guard for the precise SnapKV gate: when a SnapKV budget is
-        // *configured* but the prompt fits under it (no eviction), the KV cache fills
-        // sequentially and the graph's seqLen == position+1 invariant still holds, so
-        // graphs MUST engage (and match bit-for-bit). The coarse "budget > 0" guard
-        // wrongly disabled them here — this is the default-bench scenario (972-token
-        // prompt under the 1024 auto-budget).
+        // Regression guard: a configured SHARPI_SNAPKV_BUDGET must not break Gemma 4 graph
+        // decode. SnapKV is force-disabled for Gemma-4-style models (SWA ring caches +
+        // per-layer head_dim can't be SnapKV-compacted), so the cache fills sequentially
+        // and graphs MUST engage and match bit-for-bit. (Even on a full-attention model
+        // where SnapKV stays enabled, a configured-but-unevicted budget keeps
+        // _kvEvictedCount == 0, so the same invariant holds.)
         if (!CudaBackend.IsAvailable()) return;
         var path = FindModelPath();
         if (path is null) return;
@@ -234,9 +234,9 @@ public sealed class Gemma4CudaGraphParityTests
                     AssertBitIdentical(refLogits[i], fwd.Forward(refTokens[i - 1], pos++), step: i);
 
                 Assert.True(gpu.GraphReady,
-                    "Graphs must engage when SnapKV is configured but the prompt fits the budget " +
-                    "(no eviction). GraphReady=false means the _snapKvEvicted gate is over-broad " +
-                    "and the default-config win is lost.");
+                    "Graphs must engage when a SnapKV budget is set but no eviction occurs " +
+                    "(SnapKV is disabled for Gemma 4, or the prompt fits the budget). " +
+                    "GraphReady=false means the _kvEvictedCount gate is over-broad.");
             }
         }
         finally


### PR DESCRIPTION
## What

CUDA Graph capture/replay for the launch-bound Gemma 4 CUDA decode loop (issue #136), plus
a CUDA-12 runtime alignment and a fix for a pre-existing SnapKV decode bug found along the way.

### 1. CUDA Graph capture/replay (#136)
Capture the static-topology decode region once on the first decode token and replay it per
token — one `cuGraphLaunch` + a handful of node-param updates instead of ~1k `cuLaunchKernel`.
Implemented for both the all-GPU `CudaForwardPass` (layer loop + final output) and the hybrid
`CudaHybridForwardPass` (GPU layer loop). Only `position` varies per token; the five
position-varying ops (RoPE / RoPEWithFactors / KvAppend / Attention / AttentionSwa)
self-register their graph node during capture via `cuStreamGetCaptureInfo_v2`, and replay
rewrites just their position-derived scalars with `cuGraphExecKernelNodeSetParams` (v1
`CUDA_KERNEL_NODE_PARAMS` ABI). Driver-API bindings (`nvcuda`, toolkit-independent) live in
`NvrtcInterop`; the shared capture/replay facility lives in `CudaBackend`.

**Off by default behind `SHARPI_CUDA_GRAPH`** (or the `UseCudaGraph` setter), with a
direct-launch fallback on any capture/replay failure. Gated off under SnapKV eviction and
TurboQuant (they break the captured `seqLen == position+1` invariant).

**Measured (gemma-4-E4B-it-Q8_0, RTX 4070 Ti):** all-GPU decode **+5–6%** at ~1K ctx
(42→45 t/s); hybrid +1.6%; prefill unchanged. **But −9.7% at short context** (the ~168
`cuGraphExecKernelNodeSetParams`/token overhead exceeds the launch-collapse savings when
per-token GPU work is small) — which is **why it stays default-off**. Decode is largely
memory-bandwidth-bound at realistic ctx after #137's launch-fusions, so the win is single-digit.
Bit-parity proven (graph-on logits bit-identical to direct launches across decode steps, both
paths) in `Gemma4CudaGraphParityTests`.

### 2. CUDA 12.x runtime alignment
Pin `cudart64_12` / `cublas64_12` (was the 11.x SONAMEs) so the runtime/cuBLAS match the NVRTC
the kernels are JIT'd with (`nvrtc64_120_0`). Driver API + graph calls are toolkit-independent.
No parity change.

### 3. Fix: SnapKV post-eviction decode on the dense `CudaForwardPass`
Found while gating graphs against SnapKV: after eviction compacts the KV cache to K entries,
the dense decode kept passing the **absolute** `position` to KvAppend (slot) and Attention
(seqLen), so it wrote past the compacted region and attended stale/duplicated slots — silently
undoing the eviction (the hybrid-GDN path already did this right). Fix: index by the physical
slot `position - _kvEvictedCount` (RoPE keeps the logical position); bit-identical when nothing
evicted. Also **disable SnapKV for Gemma-4-style models** — their SWA ring caches + per-layer
head_dim make `ApplySnapKvEviction` incoherent regardless of indexing. New oracle asserts
`KvLength` stays full even with an explicit over-budget budget. The old finite/≥2-distinct test
was too weak to catch the bug.

## Test
- `Gemma4CudaGraphParityTests` (3): all-GPU, hybrid, SnapKV-configured-no-evict — bit-identical.
- `Gemma4CudaForwardPassTests` incl. new `SnapKvDisabled_NoEvictionEvenOverBudget`.
- `CudaForwardPassSnapKvTests` (Qwen3-8B): post-eviction path still coherent.
- Full non-ForwardPass suite (Core/Server/TurboQuant/Pipeline) green; clean Release build (0 warnings, AOT-safe).

## Follow-ups (deferred)
- Device-side `position` (1 memcpy + 1 launch vs ~168 node-param updates) to remove the
  short-context regression and earn a default-on flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
