### PR TITLE
perf(sampler): top-k-first fast path — Gemma 4 E4B decode 48.7→70.3 t/s (#142)

### DIFF
--- a/scripts/bench-textgen.ps1
+++ b/scripts/bench-textgen.ps1
@@ -13,8 +13,12 @@ $stdoutPath = Join-Path $OutDir "$Tag.out"
 $stderrPath = Join-Path $OutDir "$Tag.err"
 
 $cliDll = ".\src\SharpInference.Cli\bin\Release\net10.0\sharpi-cli.dll"
+# NOTE: --verbose-prompt is deliberately NOT passed. Its per-token debug logging does a
+# full-vocabulary LINQ OrderByDescending (262144 elements for Gemma 4) every decode step,
+# which adds ~1.5-2.5 ms/token of CPU overhead and badly understates the measured decode
+# t/s. Benchmarks must run without it to reflect real generation throughput.
 $argList = @("$cliDll", "-m", "$Model", "-p", "$Prompt", "--temp", "0",
-             "-n", "$NTokens", "--verbose-prompt", "--single-turn") + $ExtraArgs
+             "-n", "$NTokens", "--single-turn") + $ExtraArgs
 
 Write-Host "[$Tag] $($ExtraArgs -join ' ') (timeout ${TimeoutSec}s)" -ForegroundColor DarkGray
 $dotnetExe = (Get-Command dotnet).Source
@@ -69,12 +73,14 @@ if ($stdout -match 'MTP accept:\s+([\d\.]+)\s*%') {
     $mtpAccept = Parse-Double $matches[1]
 }
 
-# First 12 decoded tokens for sanity check
-$decTexts = @()
-[regex]::Matches($stderr, "next=\d+\('([^']*)'\)") | Select-Object -First 12 | ForEach-Object {
-    $decTexts += $_.Groups[1].Value
-}
-$sample = ($decTexts -join "") -replace "`r","" -replace "`n","\\n"
+# Generation sample for a sanity check. Without --verbose-prompt there are no per-token
+# debug lines, so take the decoded text from stdout: strip the prompt echo and the
+# trailing "Prefill: ... | Decode: ..." stats line, then keep a short snippet.
+$genText = $stdout -replace "`r",""
+$genText = ($genText -split "Prefill:")[0]
+if ($genText.StartsWith($Prompt)) { $genText = $genText.Substring($Prompt.Length) }
+$sample = ($genText -replace "`n","\\n").Trim()
+if ($sample.Length -gt 80) { $sample = $sample.Substring(0, 80) }
 
 [PSCustomObject]@{
     Tag         = $Tag

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -1081,6 +1081,8 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     /// </summary>
     private ReadOnlySpan<float> ForwardGemma4(int token, int position)
     {
+        if (s_regionProfile) return ForwardGemma4RegionProfiled(token, position);
+
         // 1. Embedding lookup
         if (_embIsQuantized)
         {
@@ -1108,6 +1110,53 @@ public sealed unsafe class CudaForwardPass : IForwardPass
 
         _gpu.Download(_logits, _logitsBuf);
         _gpu.Synchronize();
+
+        _kvLength = Math.Max(_kvLength, position + 1);
+        return _logitsBuf;
+    }
+
+    // Region profiler (SHARPI_DECODE_REGIONS=1): splits the graphs-ON decode token into
+    // (a) embed+PLE-prepass, (b) graphed device region, (c) logits download+sync, each
+    // bracketed by a Synchronize so the wall-clock is attributable. The syncs add ~µs of
+    // overhead but reveal where the per-token time goes (the SHARPI_CUDA_PROFILE path runs
+    // graphs-off, which inflates the launch-bound phases). Prints every 64 tokens.
+    private static readonly bool s_regionProfile =
+        Environment.GetEnvironmentVariable("SHARPI_DECODE_REGIONS") == "1";
+    private readonly System.Diagnostics.Stopwatch _rpSw = new();
+    private double _rpEmbedPle, _rpDevice, _rpDownload;
+    private long _rpCount;
+
+    private ReadOnlySpan<float> ForwardGemma4RegionProfiled(int token, int position)
+    {
+        _rpSw.Restart();
+        if (_embIsQuantized)
+        {
+            var embDType = _weightDTypes.GetValueOrDefault(_gpuEmbedding.Handle, DType.Q4_K);
+            if (embDType == DType.Q8_0) _gpu.EmbedLookupQ8_0(_gpuEmbedding, _hidden, token, _embDim);
+            else _gpu.EmbedLookupQ4K(_gpuEmbedding, _hidden, token, _embDim);
+        }
+        else _gpu.EmbedLookup(_gpuEmbedding, _hidden, token, _embDim);
+        if (_hp.EmbeddingScale != 1f) _gpu.ScaleInPlace(_hidden, _hp.EmbeddingScale);
+        if (_hp.HasPerLayerTokenEmbd) BuildPerLayerProjectionsGpu(token);
+        _gpu.Synchronize();
+        _rpEmbedPle += _rpSw.Elapsed.TotalMilliseconds; _rpSw.Restart();
+
+        if (!TryRunGemma4DeviceRegionViaGraph(position))
+            RunGemma4DeviceRegion(position);
+        _gpu.Synchronize();
+        _rpDevice += _rpSw.Elapsed.TotalMilliseconds; _rpSw.Restart();
+
+        _gpu.Download(_logits, _logitsBuf);
+        _gpu.Synchronize();
+        _rpDownload += _rpSw.Elapsed.TotalMilliseconds;
+
+        if (++_rpCount % 64 == 0)
+        {
+            double n = _rpCount;
+            Console.Error.WriteLine(
+                $"[regions] n={_rpCount} embed+ple={_rpEmbedPle / n:F3}ms device={_rpDevice / n:F3}ms " +
+                $"download={_rpDownload / n:F3}ms total={(_rpEmbedPle + _rpDevice + _rpDownload) / n:F3}ms");
+        }
 
         _kvLength = Math.Max(_kvLength, position + 1);
         return _logitsBuf;

--- a/src/SharpInference.Engine/Sampler.cs
+++ b/src/SharpInference.Engine/Sampler.cs
@@ -73,7 +73,16 @@ public static class Sampler
 
         // Top-k filtering
         if (p.TopK > 0 && p.TopK < vocabSize)
+        {
             ApplyTopK(probs, p.TopK);
+            // Renormalize the surviving probabilities over the top-k set before min-p /
+            // top-p, so the nucleus cutoff is taken over the post-top-k distribution. This
+            // is the llama.cpp ordering (top-k → renormalize → top-p) and keeps this path
+            // consistent with the SampleTopK fast path, which softmaxes over the k
+            // survivors directly. (min-p is a ratio test, so it is unaffected by the
+            // renormalization; top-p's cumulative cutoff is not.)
+            Normalize(probs);
+        }
 
         // Min-p filtering
         if (p.MinP > 0f)
@@ -93,32 +102,28 @@ public static class Sampler
     /// <summary>
     /// Top-k-first sampling fast path (no logit bias). Selects the top-k logits in one
     /// O(vocab) pass, then applies temperature, softmax, min-p, and top-p over only those
-    /// k candidates — avoiding any full-vocabulary softmax, sort, or allocation.
-    /// Probabilities are normalised over the kept candidates (the same renormalisation the
-    /// full path performs), so the per-token distribution matches.
+    /// k candidates — avoiding the full-vocabulary softmax, sort, and allocation of the
+    /// slow path. Probabilities are softmaxed over the k survivors (i.e. renormalised over
+    /// the top-k set), which is the llama.cpp ordering (top-k → renormalise → top-p) and
+    /// matches the slow path's behaviour: <see cref="Sample"/> renormalises after
+    /// <see cref="ApplyTopK"/> for exactly this reason.
     ///
     /// Repetition penalty (<paramref name="hasPenalty"/>) only ever *lowers* the logits of
     /// recently seen tokens, so it cannot promote a token from outside the top-(k+W) raw
-    /// logits into the post-penalty top-k (W = number of penalised tokens). We therefore
-    /// over-select the top-(k+W) raw candidates, apply the penalty to that small set,
-    /// re-sort, and keep the top-k — bit-identical to penalising the full vocabulary.
+    /// logits into the post-penalty top-k (W = number of penalised tokens, bounded above by
+    /// <c>PreviousTokens.Count</c>). We therefore over-select the top-(k+W) raw candidates,
+    /// apply the penalty to that small set, re-sort, and keep the top-k.
     /// </summary>
     private static int SampleTopK(ReadOnlySpan<float> logits, SamplingParams p, Random rng, bool hasPenalty)
     {
         int k = p.TopK;
         int vocab = logits.Length;
 
-        // Penalty occurrence counts (per-occurrence compounding, matching the full path).
-        Dictionary<int, int>? penCounts = null;
-        int sel = k;
-        if (hasPenalty)
-        {
-            penCounts = new Dictionary<int, int>(p.PreviousTokens!.Count);
-            foreach (int id in p.PreviousTokens!)
-                if ((uint)id < (uint)vocab)
-                    penCounts[id] = penCounts.TryGetValue(id, out int pc) ? pc + 1 : 1;
-            sel = Math.Min(vocab, k + penCounts.Count);   // over-select to cover demotions
-        }
+        // Over-select to cover penalty demotions. W ≤ PreviousTokens.Count (using the raw
+        // count, an upper bound on distinct penalised tokens, avoids a per-token dictionary
+        // allocation on this hot path; the candidate set stays tiny).
+        int prevCount = hasPenalty ? p.PreviousTokens!.Count : 0;
+        int sel = Math.Min(vocab, k + prevCount);
 
         // Select the top-`sel` (idx, logit) descending by logit via threshold insertion.
         Span<int>   idx  = sel <= 256 ? stackalloc int[sel]   : new int[sel];
@@ -134,18 +139,29 @@ public static class Sampler
             vals[j] = v; idx[j] = i;
         }
 
+        // Degenerate guard: no finite logit was selected (e.g. an all -inf vector). Fall
+        // back to greedy over the raw logits, which always yields a valid token index
+        // rather than the Fill(-1) sentinel.
+        if (idx[0] < 0 || float.IsNegativeInfinity(vals[0]))
+            return Greedy(logits);
+
         // Apply repetition penalty to the selected candidates, then re-sort so the top-k
         // reflects the post-penalty order. Penalty is in logit space: positive logits are
-        // divided, negative ones multiplied, once per occurrence.
-        if (penCounts is not null)
+        // divided, negative ones multiplied, once per occurrence in PreviousTokens (the
+        // same per-occurrence compounding as the slow path).
+        if (hasPenalty)
         {
             for (int t = 0; t < sel; t++)
             {
-                if (idx[t] < 0 || !penCounts.TryGetValue(idx[t], out int pc)) continue;
-                float pen = MathF.Pow(p.RepetitionPenalty, pc);
+                if (idx[t] < 0) continue;
+                int occ = 0;
+                foreach (int id in p.PreviousTokens!)
+                    if (id == idx[t]) occ++;
+                if (occ == 0) continue;
+                float pen = MathF.Pow(p.RepetitionPenalty, occ);
                 vals[t] = vals[t] > 0f ? vals[t] / pen : vals[t] * pen;
             }
-            // Insertion re-sort (sel is tiny: k + #distinct-recent ≤ ~128).
+            // Insertion re-sort (sel is tiny: k + PreviousTokens.Count).
             for (int a = 1; a < sel; a++)
             {
                 float v = vals[a]; int id = idx[a]; int b = a - 1;
@@ -162,7 +178,7 @@ public static class Sampler
         for (int t = 0; t < k; t++)
         {
             // Tokens past the real vocab tail (k > #finite logits) stay at -inf → exp = 0.
-            float e = vals[t] == float.NegativeInfinity ? 0f : MathF.Exp(vals[t] * invTemp - max);
+            float e = float.IsNegativeInfinity(vals[t]) ? 0f : MathF.Exp(vals[t] * invTemp - max);
             probs[t] = e;
             sum += e;
         }
@@ -191,7 +207,9 @@ public static class Sampler
             }
         }
 
-        // Sample proportionally over the kept candidates [0, count).
+        // Sample proportionally over the kept candidates [0, count). idx[0] is the argmax
+        // and always valid (guarded above), so it is the safe rounding/empty-set fallback —
+        // never the Fill(-1) sentinel.
         float keptSum = 0f;
         for (int t = 0; t < count; t++) keptSum += probs[t];
         float r = (float)rng.NextDouble() * keptSum;
@@ -199,9 +217,9 @@ public static class Sampler
         for (int t = 0; t < count; t++)
         {
             c += probs[t];
-            if (r <= c) return idx[t];
+            if (r <= c && idx[t] >= 0) return idx[t];
         }
-        return idx[count > 0 ? count - 1 : 0];
+        return idx[0];
     }
 
     /// <summary>

--- a/src/SharpInference.Engine/Sampler.cs
+++ b/src/SharpInference.Engine/Sampler.cs
@@ -17,6 +17,19 @@ public static class Sampler
         rng ??= Random.Shared;
         int vocabSize = logits.Length;
 
+        bool hasBias = p.LogitBias is { Count: > 0 };
+        bool hasPenalty = p.RepetitionPenalty != 1.0f && p.PreviousTokens is { Count: > 0 };
+
+        // Fast path: top-k bounds the candidate set to a handful of tokens, so there is
+        // no need to softmax/normalize/sort the whole vocabulary (262144 for Gemma 4) —
+        // the dominant decode-time sampling cost. Select the top-k logits in a single
+        // pass, then run temperature / softmax / min-p / top-p over just those k. This is
+        // the llama.cpp ordering (top-k → softmax(survivors) → top-p). Repetition penalty
+        // only *demotes* the recent tokens, so it is folded in by over-selecting (see
+        // SampleTopK). Logit bias can promote *arbitrary* tokens, so it keeps the full path.
+        if (p.TopK > 0 && p.TopK < vocabSize && !hasBias)
+            return SampleTopK(logits, p, rng, hasPenalty);
+
         // Copy logits so we can modify them
         Span<float> probs = vocabSize <= 4096
             ? stackalloc float[vocabSize]
@@ -75,6 +88,120 @@ public static class Sampler
 
         // Sample from the distribution
         return SampleFromDistribution(probs, rng);
+    }
+
+    /// <summary>
+    /// Top-k-first sampling fast path (no logit bias). Selects the top-k logits in one
+    /// O(vocab) pass, then applies temperature, softmax, min-p, and top-p over only those
+    /// k candidates — avoiding any full-vocabulary softmax, sort, or allocation.
+    /// Probabilities are normalised over the kept candidates (the same renormalisation the
+    /// full path performs), so the per-token distribution matches.
+    ///
+    /// Repetition penalty (<paramref name="hasPenalty"/>) only ever *lowers* the logits of
+    /// recently seen tokens, so it cannot promote a token from outside the top-(k+W) raw
+    /// logits into the post-penalty top-k (W = number of penalised tokens). We therefore
+    /// over-select the top-(k+W) raw candidates, apply the penalty to that small set,
+    /// re-sort, and keep the top-k — bit-identical to penalising the full vocabulary.
+    /// </summary>
+    private static int SampleTopK(ReadOnlySpan<float> logits, SamplingParams p, Random rng, bool hasPenalty)
+    {
+        int k = p.TopK;
+        int vocab = logits.Length;
+
+        // Penalty occurrence counts (per-occurrence compounding, matching the full path).
+        Dictionary<int, int>? penCounts = null;
+        int sel = k;
+        if (hasPenalty)
+        {
+            penCounts = new Dictionary<int, int>(p.PreviousTokens!.Count);
+            foreach (int id in p.PreviousTokens!)
+                if ((uint)id < (uint)vocab)
+                    penCounts[id] = penCounts.TryGetValue(id, out int pc) ? pc + 1 : 1;
+            sel = Math.Min(vocab, k + penCounts.Count);   // over-select to cover demotions
+        }
+
+        // Select the top-`sel` (idx, logit) descending by logit via threshold insertion.
+        Span<int>   idx  = sel <= 256 ? stackalloc int[sel]   : new int[sel];
+        Span<float> vals = sel <= 256 ? stackalloc float[sel] : new float[sel];
+        vals.Fill(float.NegativeInfinity);
+        idx.Fill(-1);
+        for (int i = 0; i < vocab; i++)
+        {
+            float v = logits[i];
+            if (v <= vals[sel - 1]) continue;
+            int j = sel - 1;
+            while (j > 0 && vals[j - 1] < v) { vals[j] = vals[j - 1]; idx[j] = idx[j - 1]; j--; }
+            vals[j] = v; idx[j] = i;
+        }
+
+        // Apply repetition penalty to the selected candidates, then re-sort so the top-k
+        // reflects the post-penalty order. Penalty is in logit space: positive logits are
+        // divided, negative ones multiplied, once per occurrence.
+        if (penCounts is not null)
+        {
+            for (int t = 0; t < sel; t++)
+            {
+                if (idx[t] < 0 || !penCounts.TryGetValue(idx[t], out int pc)) continue;
+                float pen = MathF.Pow(p.RepetitionPenalty, pc);
+                vals[t] = vals[t] > 0f ? vals[t] / pen : vals[t] * pen;
+            }
+            // Insertion re-sort (sel is tiny: k + #distinct-recent ≤ ~128).
+            for (int a = 1; a < sel; a++)
+            {
+                float v = vals[a]; int id = idx[a]; int b = a - 1;
+                while (b >= 0 && vals[b] < v) { vals[b + 1] = vals[b]; idx[b + 1] = idx[b]; b--; }
+                vals[b + 1] = v; idx[b + 1] = id;
+            }
+        }
+
+        // Temperature + softmax over the top-k candidates (vals[0] is the max logit).
+        float invTemp = p.Temperature == 1.0f ? 1.0f : 1.0f / p.Temperature;
+        float max = vals[0] * invTemp;
+        Span<float> probs = k <= 256 ? stackalloc float[k] : new float[k];
+        float sum = 0f;
+        for (int t = 0; t < k; t++)
+        {
+            // Tokens past the real vocab tail (k > #finite logits) stay at -inf → exp = 0.
+            float e = vals[t] == float.NegativeInfinity ? 0f : MathF.Exp(vals[t] * invTemp - max);
+            probs[t] = e;
+            sum += e;
+        }
+        float invSum = sum > 0f ? 1.0f / sum : 0f;
+        for (int t = 0; t < k; t++) probs[t] *= invSum;
+
+        int count = k;
+
+        // Min-p: drop candidates below minP × max prob. Descending order ⇒ first failure
+        // bounds the survivors. The ratio probs[t]/probs[0] is normalisation-invariant.
+        if (p.MinP > 0f)
+        {
+            float thr = p.MinP * probs[0];
+            for (int t = 0; t < count; t++)
+                if (probs[t] < thr) { count = t; break; }
+        }
+
+        // Top-p (nucleus): smallest prefix whose cumulative prob reaches topP.
+        if (p.TopP < 1.0f && p.TopP > 0f)
+        {
+            float cum = 0f;
+            for (int t = 0; t < count; t++)
+            {
+                cum += probs[t];
+                if (cum >= p.TopP) { count = t + 1; break; }
+            }
+        }
+
+        // Sample proportionally over the kept candidates [0, count).
+        float keptSum = 0f;
+        for (int t = 0; t < count; t++) keptSum += probs[t];
+        float r = (float)rng.NextDouble() * keptSum;
+        float c = 0f;
+        for (int t = 0; t < count; t++)
+        {
+            c += probs[t];
+            if (r <= c) return idx[t];
+        }
+        return idx[count > 0 ? count - 1 : 0];
     }
 
     /// <summary>
@@ -149,14 +276,32 @@ public static class Sampler
     /// <summary>
     /// Keep only the smallest set of tokens whose cumulative probability >= topP.
     /// </summary>
+    /// <remarks>
+    /// Only the non-zero entries are sorted. With a large vocabulary (Gemma 4 =
+    /// 262144) and top-k applied first, all but ~k entries are already zero, so
+    /// sorting the full span (the old behaviour) was an O(V·logV) delegate-comparator
+    /// sort + V-element allocation per token — the dominant decode-time sampling cost.
+    /// Zeros never affect the cumulative sum or the cutoff (they would sort to the
+    /// tail), so gathering and sorting only the survivors is bit-identical.
+    /// </remarks>
     private static void ApplyTopP(Span<float> probs, float topP)
     {
-        // Build index-probability pairs and sort descending
-        var indexed = new (int idx, float prob)[probs.Length];
+        // Gather non-zero (idx, prob) survivors. After top-k this is ~k entries;
+        // without top-k it can be the whole vocab (same cost as before, no regression).
+        int n = 0;
         for (int i = 0; i < probs.Length; i++)
-            indexed[i] = (i, probs[i]);
+            if (probs[i] > 0f) n++;
+        if (n == 0) return;
 
-        Array.Sort(indexed, (a, b) => b.prob.CompareTo(a.prob));
+        Span<(int idx, float prob)> indexed = n <= 512
+            ? stackalloc (int, float)[n]
+            : new (int, float)[n];
+        int j = 0;
+        for (int i = 0; i < probs.Length; i++)
+            if (probs[i] > 0f) indexed[j++] = (i, probs[i]);
+
+        // Descending sort by probability (survivors only).
+        MemoryExtensions.Sort(indexed, static (a, b) => b.prob.CompareTo(a.prob));
 
         // Find cutoff
         float cumSum = 0;

--- a/tests/SharpInference.Tests.ForwardPass/CudaDecodeMatvecRooflineProbe.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDecodeMatvecRooflineProbe.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using SharpInference.Core;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #142 DECODE roofline probe (not a correctness test): times the Q8_0 dp4a
+/// decode matvec (<see cref="CudaBackend.MatMul(Tensor,Tensor,Tensor,DType)"/> on the
+/// <c>llm_matvec_q8_0_dp4a</c> / <c>_soa</c> path) at the real decode shape (nTok=1)
+/// for Gemma 4 E4B's FFN / qkv / o-proj weights, and reports achieved HBM bandwidth
+/// vs the RTX 4070 Ti's ~504 GB/s peak. Decode is bandwidth-bound; this quantifies
+/// whether the matvec kernel is near the memory ceiling (gap is elsewhere — launch /
+/// clock / attention) or has read-efficiency headroom (coalescing / load width /
+/// per-block scale overhead). Probes both the AoS and SoA (#149) weight layouts.
+///
+/// Run explicitly: --filter FullyQualifiedName~CudaDecodeMatvecRooflineProbe. Silent
+/// no-op without CUDA. Always asserts true — it only prints the measurement.
+/// </summary>
+public sealed unsafe class CudaDecodeMatvecRooflineProbe
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static ushort HalfToUshort(Half h) => BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+
+    private static byte[] BuildQ8_0Matrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 32, bytesPerRow = blocksPerRow * 34;
+        var bytes = new byte[(long)rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                long off = (long)r * bytesPerRow + b * 34;
+                ushort dHalf = HalfToUshort((Half)(float)(rng.NextDouble() * 0.09 + 0.01));
+                bytes[off] = (byte)(dHalf & 0xFF); bytes[off + 1] = (byte)(dHalf >> 8);
+                for (int i = 0; i < 32; i++) bytes[off + 2 + i] = (byte)(sbyte)(rng.Next(255) - 127);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void DecodeMatvec_Q8_0_AchievedBandwidth_AtDecodeShape()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        // Gemma-4-E4B decode matvecs (rows=out, cols=in), nTok=1.
+        (int rows, int cols, string what)[] shapes =
+        {
+            (16384, 2048, "ffn-gate"),   // intermediate=16384 hidden=2048
+            (16384, 2048, "ffn-up"),
+            (2048, 16384, "ffn-down"),
+            (5120, 2048, "qkv"),         // q+k+v fused-ish width
+            (2048, 4096, "o-proj"),
+        };
+        const double peakGBs = 504.0;     // RTX 4070 Ti HBM peak
+
+        var rng = new Random(20260606);
+        foreach (var (rows, cols, what) in shapes)
+        {
+            byte[] weightBytes = BuildQ8_0Matrix(rows, cols, rng);
+            var vec = new float[cols];
+            for (int i = 0; i < vec.Length; i++) vec[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var gpuX = gpu.Upload(vec, TensorShape.D1(cols));
+            var gpuY = gpu.Allocate(TensorShape.D1(rows));
+
+            // Real decode touches each weight once/token against a working set = the
+            // whole model (>> the 4070 Ti's 48 MB L2), so every read is a cold HBM read.
+            // A single looped buffer (<48 MB) stays L2-resident and overstates BW. Rotate
+            // over enough distinct buffers (~256 MB) to exceed L2 and force cold reads.
+            double oneMB = (double)rows * cols / 32.0 * 34.0 / 1e6;
+            int pool = Math.Max(2, (int)Math.Ceiling(256.0 / oneMB));
+
+            foreach (var layout in new[] { "AoS", "SoA" })
+            {
+                var ws = new Tensor[pool];
+                for (int p = 0; p < pool; p++)
+                {
+                    ws[p] = gpu.UploadRaw(weightBytes, TensorShape.D1(weightBytes.Length), DType.Q8_0);
+                    if (layout == "SoA") ws[p] = gpu.RepackQ8_0Soa(ws[p], rows, cols);
+                }
+
+                for (int i = 0; i < pool * 2; i++) gpu.MatMul(gpuY, ws[i % pool], gpuX, DType.Q8_0);
+                gpu.Synchronize();
+
+                const int iters = 400;
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < iters; i++) gpu.MatMul(gpuY, ws[i % pool], gpuX, DType.Q8_0);
+                gpu.Synchronize();
+                sw.Stop();
+
+                for (int p = 0; p < pool; p++) gpu.Free(ws[p]);
+
+                double msPer = sw.Elapsed.TotalMilliseconds / iters;
+                // Bytes moved: Q8_0 weight (34 B/32) + Q8_1 act read + fp32 out (negligible).
+                double wBytes = (double)rows * cols / 32.0 * 34.0;
+                double gbs = wBytes / (msPer * 1e-3) / 1e9;
+                Console.WriteLine(
+                    $"matvec {what,-9} [{rows}x{cols}] {layout}: {msPer:F4} ms  {gbs:F0} GB/s  ({100 * gbs / peakGBs:F0}% of ~{peakGBs:F0} peak)");
+            }
+
+            gpu.Free(gpuX); gpu.Free(gpuY);
+        }
+        Assert.True(true);
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/SamplerTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SamplerTests.cs
@@ -207,4 +207,125 @@ public sealed class SamplerTests
 
         Assert.Equal(4, sampled.Count);
     }
+
+    // ── Top-k-first fast path (SampleTopK) ────────────────────────────────────
+    // The fast path runs when TopK>0 and there is no logit bias. Adding an out-of-range
+    // LogitBias entry (never applied — the id is bounds-checked away) forces the otherwise
+    // identical slow path, giving a differential oracle for the fast path.
+    private static readonly IReadOnlyDictionary<int, float> ForceSlowPath =
+        new Dictionary<int, float> { { -1, 0f } };
+
+    private static float[] RandomLogits(int vocab, int seed)
+    {
+        var rng = new Random(seed);
+        var l = new float[vocab];
+        for (int i = 0; i < vocab; i++) l[i] = (float)(rng.NextDouble() * 12 - 6);
+        return l;
+    }
+
+    private static HashSet<int> ReachableSet(float[] logits, SamplingParams p, int seed, int trials)
+    {
+        var rng = new Random(seed);
+        var set = new HashSet<int>();
+        for (int i = 0; i < trials; i++) set.Add(Sampler.Sample(logits, p, rng));
+        return set;
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(99)]
+    public void SampleTopK_FastPath_MatchesSlowPath_ReachableSet(int seed)
+    {
+        // Same config, same logits: the fast path (no bias) and the slow path (forced via
+        // out-of-range bias) must reach exactly the same set of tokens — both apply
+        // top-k → renormalize → min-p → top-p over the same nucleus.
+        float[] logits = RandomLogits(96, seed);
+        var prev = new List<int> { 3, 3, 10, 25 };
+        var baseP = new SamplingParams
+        {
+            Temperature = 0.8f, TopK = 16, TopP = 0.9f, MinP = 0.02f,
+            RepetitionPenalty = 1.3f, PreviousTokens = prev,
+        };
+
+        var fast = ReachableSet(logits, baseP, seed: 1234, trials: 4000);
+        var slow = ReachableSet(logits, baseP with { LogitBias = ForceSlowPath }, seed: 1234, trials: 4000);
+
+        Assert.Equal(slow.OrderBy(x => x), fast.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void SampleTopK_Penalty_DemotesPenalizedTokenOutOfTopK()
+    {
+        // Token 1 is the 2nd-highest raw logit; penalising it pushes it below token 2, so
+        // with TopK=2 the surviving pair becomes {0, 2} rather than {0, 1}.
+        float[] logits = [10f, 8f, 7f, 1f, 0f];
+        var p = new SamplingParams
+        {
+            Temperature = 1f, TopK = 2, RepetitionPenalty = 4f,
+            PreviousTokens = new List<int> { 1 },
+        };
+        var reach = ReachableSet(logits, p, seed: 5, trials: 500);
+        Assert.DoesNotContain(1, reach);          // demoted out of the top-2
+        Assert.True(reach.IsSubsetOf(new[] { 0, 2 }), $"got {string.Join(",", reach)}");
+        Assert.Contains(2, reach);                // token 2 took the freed slot
+    }
+
+    [Fact]
+    public void SampleTopK_Penalty_DuplicateOccurrences_Compound()
+    {
+        // Token 1 (logit 8) sits 2nd; token 2 has logit 6.5. One penalty occurrence:
+        // 8/1.2 = 6.67 > 6.5, so token 1 stays in the top-2. Three occurrences (compounded):
+        // 8/1.2^3 = 4.63 < 6.5, so token 1 is demoted below token 2.
+        float[] logits = [9f, 8f, 6.5f, 1f];
+        var once = new SamplingParams
+        {
+            Temperature = 1f, TopK = 2, RepetitionPenalty = 1.2f,
+            PreviousTokens = new List<int> { 1 },
+        };
+        var thrice = once with { PreviousTokens = new List<int> { 1, 1, 1 } };
+
+        var reachOnce = ReachableSet(logits, once, seed: 9, trials: 500);
+        var reachThrice = ReachableSet(logits, thrice, seed: 9, trials: 500);
+
+        Assert.Contains(1, reachOnce);            // single occurrence keeps it in the top-2
+        Assert.DoesNotContain(1, reachThrice);    // compounded penalty demotes it
+        Assert.Contains(2, reachThrice);          // token 2 takes the freed slot
+    }
+
+    [Fact]
+    public void SampleTopK_NegInfLogits_NeverReturnsInvalidToken()
+    {
+        // Masked tokens (-inf) must never be selected, and the sentinel index must never
+        // leak out: every returned token is a valid, finite-logit index.
+        float[] logits = [2f, float.NegativeInfinity, 5f, float.NegativeInfinity, 1f, 3f];
+        var p = new SamplingParams { Temperature = 1f, TopK = 5, TopP = 0.95f };
+        var rng = new Random(3);
+        for (int i = 0; i < 1000; i++)
+        {
+            int tok = Sampler.Sample(logits, p, rng);
+            Assert.InRange(tok, 0, logits.Length - 1);
+            Assert.False(float.IsNegativeInfinity(logits[tok]), $"sampled masked token {tok}");
+        }
+    }
+
+    [Fact]
+    public void SampleTopK_AllNegInf_FallsBackToValidToken()
+    {
+        float[] logits = [float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity];
+        var p = new SamplingParams { Temperature = 1f, TopK = 2, TopP = 0.9f };
+        int tok = Sampler.Sample(logits, p, new Random(1));
+        Assert.InRange(tok, 0, logits.Length - 1);   // valid index, not the -1 sentinel
+    }
+
+    [Fact]
+    public void SampleTopK_TopKThenTopP_NucleusTakenAfterTopK()
+    {
+        // top-k keeps the 3 highest; after renormalising over them, top-p=0.5 keeps the
+        // smallest leading prefix reaching 0.5 — here just token 0 (dominant).
+        float[] logits = [6f, 3f, 2.5f, 0f, 0f, 0f, 0f, 0f];
+        var p = new SamplingParams { Temperature = 1f, TopK = 3, TopP = 0.5f };
+        var reach = ReachableSet(logits, p, seed: 2, trials: 500);
+        Assert.True(reach.IsSubsetOf(new[] { 0 }), $"got {string.Join(",", reach)}");
+    }
 }


### PR DESCRIPTION
## Summary

Recommended-args decode on **Gemma 4 E4B Q8_0** (RTX 4070 Ti) was bottlenecked by the **CPU sampler**, not the CUDA kernels. With `--temp 1.0 --top-k 64 --top-p 0.95` decode goes **48.7 → 70.3 t/s (+44%)** (goal ≥70 met). Greedy decode is **71.5 t/s** (the sampler is now near-free).

## Diagnosis (measure-before-optimize)

- **Decode is HBM-bandwidth-bound.** New `CudaDecodeMatvecRooflineProbe` shows the big FFN matvecs (49% of decode) already run at **88–91% of the 4070 Ti's ~504 GB/s peak** — near-optimal, no kernel headroom. (Caveat baked into the probe: a single looped 35 MB weight reads >700 GB/s because it stays resident in the 48 MB L2; the probe rotates over >L2 of buffers to force the true cold-read rate.)
- **No low-context clock cliff** — the GPU holds 2865 MHz (92% of the 3120 boost), 97–99% util, 180/285 W, 54 °C during sustained decode.
- `SHARPI_DECODE_REGIONS=1` region profiler: the 42-layer device region is 95% of forward time; PLE prepass 0.5 ms and logits download 0.1 ms are negligible.

So the gap to llama.cpp (76.6 t/s greedy) was **not** in the core matvec kernels.

## Root causes (CPU)

1. **`Sampler.Sample`** recommended-args path ran `ApplyTopP` as an `Array.Sort` over a **262144-element `(int,float)[]` with a delegate comparator + 2 MB allocation every token**, even though `ApplyTopK` had already left only ~64 non-zero entries, plus a full-vocab softmax/normalize/sample. The CLI defaults `--rep-penalty 1.1`, which routed every token through this path.
2. **`bench-textgen.ps1`** hard-coded `--verbose-prompt`, whose per-token `DecodeLoop` debug log does a full-vocab LINQ `OrderByDescending` — ~1.5–2.5 ms/token that understated measured decode by 10–25%. Removed from the bench.

## Changes

- **`Sampler.cs`** — top-k-first fast path: select the top-(k+W) logits in **one** vocab pass, then run temperature / softmax / min-p / top-p over just those k (the llama.cpp ordering: top-k → renormalize → top-p). Repetition penalty only *demotes* recent tokens, so it is folded in by over-selecting `W = PreviousTokens.Count`, penalising that small set, re-sorting, and keeping the top-k — exact, no full-vocab work and no per-token allocation. The slow path (reached via logit bias / `TopK=0`) now also renormalizes after top-k so both paths agree. Degenerate/`-inf` inputs fall back to a valid greedy token (never the sentinel). Greedy path unchanged.
- **`bench-textgen.ps1`** — drop `--verbose-prompt`; take the sanity-check sample from stdout.
- **`CudaForwardPass.cs`** — `SHARPI_DECODE_REGIONS=1` region profiler (env-gated, off by default), used in the diagnosis.
- **`CudaDecodeMatvecRooflineProbe.cs`** — decode-shape roofline probe (explicit `--filter`, silent no-op without CUDA).

## Review cycle (pr-review-toolkit)

Three reviewers (code-reviewer, pr-test-analyzer, silent-failure-hunter) flagged: (1) fast/slow top-p divergence → fixed by renormalizing the slow path after top-k; (2) the fast path could return the `Fill(-1)` sentinel on `-inf` logits → fixed with a greedy fallback; (3) a per-token `Dictionary` allocation → removed. Plus 8 new tests including a fast-vs-slow differential oracle.

## Testing

- `SamplerTests`: **23/23 green** (15 original + 8 new).
- Full CUDA forward-pass suite (`--filter ~Cuda`): **132/132 green** (25m, incl. the new probe).
- Generation verified coherent with recommended args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)