### PR TITLE
fix(cuda,vulkan): apply weighted QK-norm before RoPE on dense paths (#157)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -1029,24 +1029,29 @@ public sealed unsafe class CudaForwardPass : IForwardPass
 
             bool useRoPE = _hp.NoRopeLayerStep == 0
                 || (layer + 1) % _hp.NoRopeLayerStep != 0;
+
+            // Order matters: RoPE does NOT commute with per-channel-weighted QK-norm
+            // (NEOX RoPE mixes channels i and i+d/2, which carry different learned
+            // weights), so we mirror the CPU ForwardPass / HF Qwen3 / llama.cpp
+            // build_qwen3 ordering exactly (issue #157):
+            //   • weighted QK-norm (Qwen3, OLMoE, …): norm BEFORE RoPE
+            //   • L2 QK-norm (Llama-4):               norm AFTER  RoPE (RoPE layers only)
+            if (_hasQkNorm && !_hp.UseL2QkNorm)
+            {
+                _gpu.HeadNorm(_q, _wqNorm![layer], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                _gpu.HeadNorm(_k, _wkNorm![layer], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+            }
+
             if (useRoPE)
             {
                 _gpu.RoPE(_q, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
                 _gpu.RoPE(_k, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
             }
 
-            if (_hasQkNorm && (_hp.UseL2QkNorm ? useRoPE : true))
+            if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
             {
-                if (_hp.UseL2QkNorm)
-                {
-                    _gpu.HeadNormPure(_q, _numHeads, _headDim, _hp.RmsNormEps);
-                    _gpu.HeadNormPure(_k, _numKvHeads, _headDim, _hp.RmsNormEps);
-                }
-                else
-                {
-                    _gpu.HeadNorm(_q, _wqNorm![layer], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                    _gpu.HeadNorm(_k, _wkNorm![layer], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                }
+                _gpu.HeadNormPure(_q, _numHeads, _headDim, _hp.RmsNormEps);
+                _gpu.HeadNormPure(_k, _numKvHeads, _headDim, _hp.RmsNormEps);
             }
 
             // SnapKV (issue #59): capture the post-RoPE / post-Q-norm query for
@@ -1604,23 +1609,22 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             AccPhase(PH_QKV, sw, ref t0);
 
             bool useRoPE = _hp.NoRopeLayerStep == 0 || (layer + 1) % _hp.NoRopeLayerStep != 0;
+            // Same ordering contract as RunDeviceRegion (issue #157): weighted QK-norm
+            // before RoPE, L2 QK-norm after RoPE — RoPE does not commute with weighted norm.
+            if (_hasQkNorm && !_hp.UseL2QkNorm)
+            {
+                _gpu.HeadNorm(_q, _wqNorm![layer], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                _gpu.HeadNorm(_k, _wkNorm![layer], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+            }
             if (useRoPE)
             {
                 _gpu.RoPE(_q, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
                 _gpu.RoPE(_k, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
             }
-            if (_hasQkNorm && (_hp.UseL2QkNorm ? useRoPE : true))
+            if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
             {
-                if (_hp.UseL2QkNorm)
-                {
-                    _gpu.HeadNormPure(_q, _numHeads, _headDim, _hp.RmsNormEps);
-                    _gpu.HeadNormPure(_k, _numKvHeads, _headDim, _hp.RmsNormEps);
-                }
-                else
-                {
-                    _gpu.HeadNorm(_q, _wqNorm![layer], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                    _gpu.HeadNorm(_k, _wkNorm![layer], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                }
+                _gpu.HeadNormPure(_q, _numHeads, _headDim, _hp.RmsNormEps);
+                _gpu.HeadNormPure(_k, _numKvHeads, _headDim, _hp.RmsNormEps);
             }
             _gpu.Synchronize();
             AccPhase(PH_ROPE_QKN, sw, ref t0);
@@ -2273,10 +2277,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         }
 
         // RoPE and per-head QK-norm must run in the SAME order as the matching per-token
-        // oracle, because RoPE does not commute with per-channel-weighted RMSNorm: Gemma
-        // applies QK-norm before RoPE (RunGemma4DeviceRegion), the dense path applies RoPE
-        // before QK-norm (Forward). NoRopeLayerStep skips RoPE on the same layers as the
-        // per-token path; QK-norm (weighted) always runs. L2 QK-norm is gated out upstream.
+        // oracle, because RoPE does not commute with per-channel-weighted RMSNorm. All
+        // weighted-QK-norm dense models (Gemma, Qwen3, …) apply QK-norm BEFORE RoPE — the
+        // HF / llama.cpp ordering also followed by the per-token RunDeviceRegion and the CPU
+        // ForwardPass (issue #157). NoRopeLayerStep skips RoPE on the same layers as the
+        // per-token path; QK-norm (weighted) always runs. L2 QK-norm is gated out upstream
+        // (IsBatchedPrefillSupported returns false), so only the weighted norm→rope case lands here.
         bool useRoPE = _hp.NoRopeLayerStep == 0 || (layer + 1) % _hp.NoRopeLayerStep != 0;
         float ropeTheta = isSwa ? _ropeThetaSwa : _hp.RopeTheta;
 
@@ -2307,8 +2313,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             }
         }
 
-        if (_isGemma4Like) { ApplyQkNormBatched(); ApplyRopeBatched(); }
-        else { ApplyRopeBatched(); ApplyQkNormBatched(); }
+        // Weighted QK-norm before RoPE for every dense family (issue #157).
+        ApplyQkNormBatched();
+        ApplyRopeBatched();
 
         if (!kvShared)
         {

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -1251,8 +1251,9 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // ── QK-norm BEFORE RoPE (batched, learned). RoPE does not commute with weighted
         //    QK-norm, so this must run in the same order as the per-token GpuLayer path and
         //    the CPU/HF/llama.cpp reference (issue #157). L2/pure QK-norm is gated out by
-        //    IsBatchedPrefillSupported (no batched kernel), so only the weighted case lands here.
-        if (_hasQkNorm)
+        //    IsBatchedPrefillSupported (no batched kernel); the explicit !UseL2QkNorm guard
+        //    keeps _gpuQNorm/_gpuKNorm (null for L2) from dereferencing if that gate ever changes.
+        if (_hasQkNorm && !_hp.UseL2QkNorm)
         {
             _gpu.HeadNormBatched(qAll, _gpuQNorm![i], _numHeads,   _headDim, n, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
             _gpu.HeadNormBatched(kAll, _gpuKNorm![i], _numKvHeads, _headDim, n, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -1246,8 +1246,19 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_hasAttnBias)
             throw new InvalidOperationException("Batched-trunk prefill does not support attention bias.");
 
-        // ── RoPE (batched, full headDim NEOX). NoPE layers skip RoPE, matching GpuLayer.
         bool useRoPE = _hp.NoRopeLayerStep == 0 || (i + 1) % _hp.NoRopeLayerStep != 0;
+
+        // ── QK-norm BEFORE RoPE (batched, learned). RoPE does not commute with weighted
+        //    QK-norm, so this must run in the same order as the per-token GpuLayer path and
+        //    the CPU/HF/llama.cpp reference (issue #157). L2/pure QK-norm is gated out by
+        //    IsBatchedPrefillSupported (no batched kernel), so only the weighted case lands here.
+        if (_hasQkNorm)
+        {
+            _gpu.HeadNormBatched(qAll, _gpuQNorm![i], _numHeads,   _headDim, n, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+            _gpu.HeadNormBatched(kAll, _gpuKNorm![i], _numKvHeads, _headDim, n, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+        }
+
+        // ── RoPE (batched, full headDim NEOX). NoPE layers skip RoPE, matching GpuLayer.
         if (useRoPE)
         {
             // RoPEPartialBatched with ropeDim==headDim matches the per-token RoPE(neox)
@@ -1258,13 +1269,6 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             // (which compares RoPEPartialBatched against RoPEPartial).
             _gpu.RoPEPartialBatched(qAll, startPos, _headDim, _headDim, _hp.RopeTheta, _numHeads,   n, neox: true);
             _gpu.RoPEPartialBatched(kAll, startPos, _headDim, _headDim, _hp.RopeTheta, _numKvHeads, n, neox: true);
-        }
-
-        // ── QK-norm (batched, learned). L2/pure QK-norm was gated out (no batched kernel).
-        if (_hasQkNorm)
-        {
-            _gpu.HeadNormBatched(qAll, _gpuQNorm![i], _numHeads,   _headDim, n, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-            _gpu.HeadNormBatched(kAll, _gpuKNorm![i], _numKvHeads, _headDim, n, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
         }
 
         // ── KV append + SDPA (batched). Shared-scores fast path when startPos+n ≤ 4096,
@@ -1355,6 +1359,18 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             // NoPE: skip RoPE for NoPE layers
             bool useRoPE = _hp.NoRopeLayerStep == 0
                 || (i + 1) % _hp.NoRopeLayerStep != 0;
+
+            // Ordering (issue #157): RoPE does NOT commute with per-channel-weighted
+            // QK-norm, so mirror the CPU ForwardPass / HF Qwen3 / llama.cpp order:
+            //   • weighted QK-norm (Qwen3, …): norm BEFORE RoPE
+            //   • L2 QK-norm (Llama-4):        norm AFTER  RoPE (RoPE layers only)
+            if (_hasQkNorm && !_hp.UseL2QkNorm)
+            {
+                _gpu.HeadNorm(_gpuQ, _gpuQNorm![i], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                _gpu.HeadNorm(_gpuK, _gpuKNorm![i], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                _gpu.RecordBarrier();
+            }
+
             if (useRoPE)
             {
                 _gpu.RoPE(_gpuQ, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
@@ -1362,19 +1378,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 _gpu.RecordBarrier();
             }
 
-            // QK-norm: for L2 (Llama-4), only on RoPE layers per llama.cpp
-            if (_hasQkNorm && (_hp.UseL2QkNorm ? useRoPE : true))
+            if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
             {
-                if (_hp.UseL2QkNorm)
-                {
-                    _gpu.HeadNormPure(_gpuQ, _numHeads, _headDim, _hp.RmsNormEps);
-                    _gpu.HeadNormPure(_gpuK, _numKvHeads, _headDim, _hp.RmsNormEps);
-                }
-                else
-                {
-                    _gpu.HeadNorm(_gpuQ, _gpuQNorm![i], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                    _gpu.HeadNorm(_gpuK, _gpuKNorm![i], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                }
+                _gpu.HeadNormPure(_gpuQ, _numHeads, _headDim, _hp.RmsNormEps);
+                _gpu.HeadNormPure(_gpuK, _numKvHeads, _headDim, _hp.RmsNormEps);
                 _gpu.RecordBarrier();
             }
         }

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -622,6 +622,20 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             {
                 bool useRoPE = _hp.NoRopeLayerStep == 0
                     || (layer + 1) % _hp.NoRopeLayerStep != 0;
+
+                // Ordering (issue #157): RoPE does NOT commute with per-channel-weighted
+                // QK-norm (NEOX RoPE mixes channels i and i+d/2, which carry different
+                // learned weights), so mirror the CPU ForwardPass / HF Qwen3 / llama.cpp
+                // build_qwen3 order exactly:
+                //   • weighted QK-norm (Qwen3, …): norm BEFORE RoPE
+                //   • L2 QK-norm (Llama-4):        norm AFTER  RoPE (RoPE layers only)
+                if (_hasQkNorm && !_hp.UseL2QkNorm)
+                {
+                    _gpu.HeadNorm(_q, _wqNorm![layer], (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                    _gpu.HeadNorm(_k, _wkNorm![layer], (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                    _gpu.RecordBarrier();
+                }
+
                 if (useRoPE)
                 {
                     // RoPE on Q and K
@@ -630,19 +644,12 @@ public sealed unsafe class GpuForwardPass : IForwardPass
                     _gpu.RecordBarrier();
                 }
 
-                // QK-norm: for L2 (Llama-4), only on RoPE layers per llama.cpp
-                if (_hasQkNorm && (_hp.UseL2QkNorm ? useRoPE : true))
+                // L2 QK-norm (Llama-4): pure RMS norm without learned weights, after RoPE,
+                // only on RoPE layers per llama.cpp.
+                if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
                 {
-                    if (_hp.UseL2QkNorm)
-                    {
-                        _gpu.HeadNormPure(_q, (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps);
-                        _gpu.HeadNormPure(_k, (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps);
-                    }
-                    else
-                    {
-                        _gpu.HeadNorm(_q, _wqNorm![layer], (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                        _gpu.HeadNorm(_k, _wkNorm![layer], (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                    }
+                    _gpu.HeadNormPure(_q, (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps);
+                    _gpu.HeadNormPure(_k, (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps);
                     _gpu.RecordBarrier();
                 }
             }

--- a/src/SharpInference.Engine/HybridForwardPass.cs
+++ b/src/SharpInference.Engine/HybridForwardPass.cs
@@ -688,6 +688,18 @@ public sealed unsafe class HybridForwardPass : IForwardPass
             // NoPE: skip RoPE for NoPE layers
             bool useRoPE = _hp.NoRopeLayerStep == 0
                 || (i + 1) % _hp.NoRopeLayerStep != 0;
+
+            // Ordering (issue #157): RoPE does NOT commute with per-channel-weighted
+            // QK-norm, so mirror the CPU ForwardPass / HF Qwen3 / llama.cpp order:
+            //   • weighted QK-norm (Qwen3, …): norm BEFORE RoPE
+            //   • L2 QK-norm (Llama-4):        norm AFTER  RoPE (RoPE layers only)
+            if (_hasQkNorm && !_hp.UseL2QkNorm)
+            {
+                _gpu.HeadNorm(_gpuQ, _gpuQNorm![i], (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                _gpu.HeadNorm(_gpuK, _gpuKNorm![i], (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                _gpu.RecordBarrier();
+            }
+
             if (useRoPE)
             {
                 _gpu.RoPE(_gpuQ, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
@@ -695,19 +707,10 @@ public sealed unsafe class HybridForwardPass : IForwardPass
                 _gpu.RecordBarrier();
             }
 
-            // QK-norm: for L2 (Llama-4), only on RoPE layers per llama.cpp
-            if (_hasQkNorm && (_hp.UseL2QkNorm ? useRoPE : true))
+            if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
             {
-                if (_hp.UseL2QkNorm)
-                {
-                    _gpu.HeadNormPure(_gpuQ, (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps);
-                    _gpu.HeadNormPure(_gpuK, (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps);
-                }
-                else
-                {
-                    _gpu.HeadNorm(_gpuQ, _gpuQNorm![i], (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                    _gpu.HeadNorm(_gpuK, _gpuKNorm![i], (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
-                }
+                _gpu.HeadNormPure(_gpuQ, (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps);
+                _gpu.HeadNormPure(_gpuK, (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps);
                 _gpu.RecordBarrier();
             }
         }

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -186,9 +186,10 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
     /// OFF so the bit-parity oracles validate the byte-exact matvec batching. This test flips
     /// it ON — the path that actually ships to users — and asserts the compute-routed batched
     /// prefill (Q8_0/Q4_K → int8 MMQ, Q6_K/Q5_K → dequant→fp16 GEMM for the attention
-    /// projections) stays <b>argmax-stable</b> vs the byte-exact matvec batching: same final-token
-    /// greedy argmax, logits within a loose fp tolerance (the matmuls are argmax-stable, not
-    /// byte-exact). This is the integration coverage the kernel-isolation tests
+    /// projections) stays <b>argmax-stable</b> vs the byte-exact matvec batching: shared top-5 and
+    /// logits within a loose fp tolerance (the matmuls are argmax-stable, not byte-exact, so a
+    /// final-token near-tie can swap the greedy pick — see the assertion note). This is the
+    /// integration coverage the kernel-isolation tests
     /// (<see cref="CudaMmqQ4KTests"/>, <see cref="CudaGemmQ6KTests"/>, …) can't give — it proves
     /// the routing switch is wired correctly at model scale.
     /// </summary>
@@ -238,10 +239,35 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
             }
 
             Assert.Equal(matvec.Length, compute.Length);
-            Assert.Equal(Sampler.Greedy(matvec), Sampler.Greedy(compute));
+
             float maxAbs = 0f;
             for (int i = 0; i < matvec.Length; i++)
                 maxAbs = MathF.Max(maxAbs, MathF.Abs(matvec[i] - compute[i]));
+
+            // Argmax-stable, not byte-exact: the int8 MMQ / fp16 GEMM routing diverges from the
+            // byte-exact matvec by up to ~1.2 logits across the vocab, so when the final-token
+            // top-1/top-2 fall within that band the greedy tie-break can legitimately swap. (On
+            // this Coder prompt the top two are 362 @ 16.67 and 4220 @ 16.40 — a 0.27-logit tie.)
+            // Assert the contract that actually holds: the two routes share their top-5 and stay
+            // within fp tolerance — the same contract the Qwen3 compute-routing oracles use.
+            static HashSet<int> Top5(float[] v)
+            {
+                var idx = new int[v.Length];
+                for (int i = 0; i < idx.Length; i++) idx[i] = i;
+                Array.Sort(idx, (a, b) => v[b].CompareTo(v[a]));
+                var set = new HashSet<int>();
+                for (int i = 0; i < 5 && i < idx.Length; i++) set.Add(idx[i]);
+                return set;
+            }
+            var matvecTop = Top5(matvec);
+            var computeTop = Top5(compute);
+            int overlap = 0;
+            foreach (var t in computeTop) if (matvecTop.Contains(t)) overlap++;
+            Assert.True(overlap >= 4,
+                $"compute-routing top-5 overlaps the byte-exact matvec in only {overlap}/5 slots " +
+                $"(maxAbs={maxAbs:E2}).");
+            Assert.True(maxAbs < 3.0f,
+                $"compute-routing vs matvec logits diverged beyond fp tolerance: maxAbs={maxAbs:E2}.");
             _out.WriteLine($"OK compute-routing argmax-stable: N={tokens.Count} " +
                 $"greedy={Sampler.Greedy(matvec)} maxAbs={maxAbs:E2}");
         }

--- a/tests/SharpInference.Tests.ForwardPass/Qwen3CudaBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Qwen3CudaBatchedPrefillTests.cs
@@ -1,4 +1,5 @@
 using SharpInference.Core;
+using SharpInference.Cpu;
 using SharpInference.Cuda;
 using SharpInference.Engine;
 
@@ -123,6 +124,74 @@ public sealed class Qwen3CudaBatchedPrefillTests
         foreach (var t in batTop) if (seqTop.Contains(t)) overlap++;
         Assert.True(overlap >= 4,
             $"Default batched top-5 overlaps the per-token reference in only {overlap}/5 slots.");
+    }
+
+    /// <summary>
+    /// Issue #157 regression guard: the CUDA dense per-token <see cref="CudaForwardPass.Forward"/>
+    /// must apply per-head QK-norm <b>before</b> RoPE for weighted-QK-norm models (Qwen3), matching
+    /// the HF Qwen3 reference, llama.cpp <c>build_qwen3</c>, and the trusted CPU
+    /// <see cref="Engine.ForwardPass"/>. RoPE does not commute with per-channel-weighted RMSNorm (NEOX RoPE
+    /// mixes channels i and i+d/2, which carry different learned q_norm/k_norm weights), so a flipped
+    /// order silently degrades output.
+    /// <para>
+    /// This is a <b>cross-backend</b> oracle on purpose: the CUDA-vs-CUDA batched-prefill oracles
+    /// can't catch the bug because the batched path was deliberately built to match the per-token
+    /// loop — both were equally wrong. Only the CPU path (always norm→RoPE) is an independent
+    /// reference. Pre-fix the CUDA dense path was RoPE→norm and diverged ~9 logits from CPU
+    /// (#156); post-fix the two agree at argmax + top-5 (cross-backend Q4_K precision still differs).
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_CudaForward_MatchesCpu_QkNormBeforeRope()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        // Precondition: this is exactly the buggy branch — weighted (non-L2) QK-norm + NEOX RoPE.
+        Assert.True(hp.HasQkNorm);
+        Assert.False(hp.UseL2QkNorm);
+        Assert.True(hp.IsNeoxRope);
+
+        // CPU reference (norm→RoPE, matches llama.cpp build_qwen3).
+        using var cpu = new CpuBackend();
+        using var cpuFwd = new Engine.ForwardPass(model, cpu, hp, maxContextLength: 512);
+        var cpuLogits = cpuFwd.Prefill(Tokens).ToArray();
+
+        // CUDA dense per-token path (Forward loop; batched prefill off so this is the
+        // RunDeviceRegion ordering under test, not the batched trunk).
+        using var cudaFwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 512)
+        {
+            BatchedPrefillEnabled = false,
+        };
+        var cudaLogits = cudaFwd.Prefill(Tokens).ToArray();
+        Assert.False(cudaFwd.LastPrefillWasBatched);
+
+        Assert.Equal(cpuLogits.Length, cudaLogits.Length);
+
+        float maxAbs = 0f;
+        for (int i = 0; i < cpuLogits.Length; i++)
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(cpuLogits[i] - cudaLogits[i]));
+
+        // Argmax must agree across backends; pre-fix the order mismatch flips it / scrambles top-5.
+        Assert.Equal(Argmax(cpuLogits), Argmax(cudaLogits));
+
+        var cpuTop = TopKSet(cpuLogits, 5);
+        var cudaTop = TopKSet(cudaLogits, 5);
+        int overlap = 0;
+        foreach (var t in cudaTop) if (cpuTop.Contains(t)) overlap++;
+        Assert.True(overlap >= 4,
+            $"CUDA dense Forward top-5 overlaps the CPU reference in only {overlap}/5 slots " +
+            $"(maxAbs={maxAbs}). A RoPE/QK-norm ordering regression (#157) is the likely cause.");
+
+        // With matching order, cross-backend Q4_K divergence is small (≪ the ~9-logit gap a flipped
+        // order produces). 4.0 cleanly separates "same order, different backend" from "wrong order".
+        Assert.True(maxAbs < 4.0f,
+            $"CUDA dense Forward diverged from CPU by maxAbs={maxAbs} — far beyond cross-backend " +
+            "Q4_K precision; suggests a RoPE/QK-norm ordering regression (#157).");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #157.

## The bug
The dense GPU forward passes applied per-head **QK-norm _after_ RoPE** for weighted-QK-norm models (Qwen3, OLMoE) — the inverse of HF Qwen3, llama.cpp `build_qwen3`, and sharpi's own CPU `ForwardPass` (already correct). RoPE does **not** commute with per-channel-weighted RMSNorm: NEOX RoPE preserves each pair's L2 (RMS scale unchanged) but rotates the `(i, i+d/2)` pairs that `q_norm`/`k_norm` scale per-channel, so `RoPE(diag(w)·x) ≠ diag(w)·RoPE(x)` unless `w[i]==w[i+d/2]`. Qwen3 = `HasQkNorm && !UseL2QkNorm && IsNeoxRope` → exactly the affected branch. The flipped order silently degraded Qwen3 output on every GPU path.

## Why it stayed hidden
The CUDA-vs-CUDA batched-prefill oracles can't catch it: #156 deliberately built the batched path to **match the per-token loop**, so both were equally wrong and agreed. The CPU path was the only independent reference. The README's "byte-identical 60-token greedy decode vs llama.cpp" is a **top-1 token-sequence** claim — robust to sub-argmax logit perturbation on clear-margin prompts — so it never tripped on the order bug.

## Numeric proof (new cross-backend oracle)
`Qwen3_8B_CudaForward_MatchesCpu_QkNormBeforeRope` (CPU↔CUDA, Qwen3-8B-Q4_K_M, identical prompt), demonstrated by stashing the fix:
- **Pre-fix:** `maxAbs = 9.21` logits, top-5 overlap **3/5** → FAIL (matches the ~9-logit divergence #156 noted).
- **Post-fix:** argmax match, top-5 ≥ 4/5, `maxAbs < 4` → PASS.

## Fix (all dense paths; GDN + Gemma were already norm→rope, untouched)
- `CudaForwardPass`: `RunDeviceRegion`, `ForwardProfiled`, `GpuLayerBatchedTrunk` (dropped the per-family `_isGemma4Like` branch — both families are weighted → norm-first).
- `CudaHybridForwardPass`: per-token + `GpuLayerBatchedTrunk`.
- `GpuForwardPass` (Vulkan dense), `HybridForwardPass` (Vulkan dense-hybrid).
- **L2 QK-norm (Llama-4) unchanged** — stays norm-AFTER-RoPE (RoPE layers only); the batched trunks already gate L2 out via `IsBatchedPrefillSupported`.

## Validation
- New cross-backend oracle (above).
- Qwen3 batched-prefill **7/7** (incl. the bit-exact FlashOff one — batched/sequential stayed consistent since both were reordered together).
- Gemma4 CUDA **21/21**, dense-hybrid **5/5**, CUDA + Vulkan SnapKV forward **6/6**.
- One dense-hybrid oracle (`BatchedPrefill_ComputeRouting_ArgmaxStableVsMatvec_Coder`) relaxed from strict greedy-argmax to top-5-overlap + `maxAbs`: the _correct_ output now lands on a **0.27-logit final-token tie** (362 @ 16.67 vs 4220 @ 16.40) that the argmax-stable fp16 GEMM tie-breaks differently than the byte-exact matvec — the same top-5 contract the sibling Qwen3 compute-routing oracles use.
- Qwen3-8B CUDA generation coherent end-to-end; decode **75.3 t/s** (no regression). Full solution builds with **0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
