### PR TITLE
GPU saturation gaps: chunked+packed prefill admission, KV budget, PCIe probe (#183)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Supporting libraries:
 - `PagedKvCache` (in Engine) — lazily allocated paged KV cache used by `ForwardPass`. Pages (16 positions) allocated on first write; `TruncateTo` is a soft operation (enables prefix reuse); `Reset` returns pages to warm pool.
 - `IInferenceEngine` (in Engine) — top-level generation interface used by the server: `GenerateAsync(prompt, sp, ct) → IAsyncEnumerable<string>`. Implemented by `InferenceEngine` (single-user, prefix caching) and `ContinuousBatchingEngine` (multi-user batching, activated via `SHARPI_MAX_BATCH`).
 - `ForwardPass.BatchForwardMulti(tokens[], positions[], caches[])` — batched multi-sequence decode; amortizes weight reads N× across concurrent users. Each sequence has its own `PagedKvCache`. Not supported for MoE or TurboQuant.
-- `ForwardPass.PrefillWithCache(tokens, cache, startPos)` — prefills a per-sequence cache (used by `ContinuousBatchingEngine` during request admission).
+- `ForwardPass.PrefillWithCache(tokens, cache, startPos)` — prefills a per-sequence cache (used by `ContinuousBatchingEngine` during request admission). Admission is chunked (`SHARPI_PREFILL_CHUNK`, default 256 tokens) and interleaved with decode steps; multiple in-flight prompts prefill as one packed pass via `ForwardPass.PrefillPackedMulti` and admission is gated by a KV token budget (`SHARPI_KV_BUDGET_MB`) — issue #183.
 - `ForwardPass` / `GpuForwardPass` in Engine dispatch the transformer layer sequence.
 - Hot paths use `NativeMemory`, `Span<T>`, and Vulkan buffers — no managed heap allocations.
 - Unsafe code is used throughout for performance. `AllowUnsafeBlocks` is enabled globally.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ dotnet run --project src/SharpInference.Cli -c Release -- \
   -p "Write a binary search in Rust" --temp 0
 
 # API server (OpenAI /v1/chat/completions + Anthropic /v1/messages, port 5000)
+# Multi-user: SHARPI_MAX_BATCH=8 enables continuous batching (CPU backend). Long-prompt
+# admission prefills in SHARPI_PREFILL_CHUNK-token slices (default 256, 0 = blocking)
+# interleaved with decode, packed across prompts; SHARPI_KV_BUDGET_MB caps total KV
+# memory for admission backpressure (default: half of RAM). See issue #183.
 SHARPI_MODEL=models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
   dotnet run --project src/SharpInference.Server.Host -c Release
 ```

--- a/benchmarks/SharpInference.Bench/ContinuousBatchingHarness.cs
+++ b/benchmarks/SharpInference.Bench/ContinuousBatchingHarness.cs
@@ -1,0 +1,220 @@
+using System.Diagnostics;
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Engine;
+
+namespace SharpInference.Bench;
+
+/// <summary>
+/// Manual A/B harness for issue #183 (GPU/CPU saturation under concurrent load):
+/// measures how much a long-prompt admission stalls already-decoding sequences,
+/// with legacy blocking prefill (chunk=0) vs chunked+packed interleaved prefill.
+///
+/// Scenario: 3 interactive requests decode continuously; once they are all streaming,
+/// a long-prompt request is injected. Reported per mode:
+///   - per-interactive-sequence max / p95 inter-token gap (the "stall")
+///   - long request time-to-first-token and total latency
+///   - aggregate generated tokens/s
+///
+/// Usage: dotnet run --project benchmarks/SharpInference.Bench -c Release -- --cb
+///        [--chunk N] (run a single chunk size instead of the 0-vs-256 A/B)
+///        [--long-tokens N] (approx. long-prompt token count, default 1024)
+///        [--decode N] (interactive MaxNewTokens, default 96)
+/// </summary>
+public static class ContinuousBatchingHarness
+{
+    private sealed record SeqResult(string Name, List<double> ChunkTimesMs, double SubmitMs, double DoneMs)
+    {
+        public int Tokens => ChunkTimesMs.Count;
+        public double TtftMs => ChunkTimesMs.Count > 0 ? ChunkTimesMs[0] - SubmitMs : double.NaN;
+
+        public (double Max, double P95) Gaps()
+        {
+            if (ChunkTimesMs.Count < 2) return (double.NaN, double.NaN);
+            var gaps = new List<double>(ChunkTimesMs.Count - 1);
+            for (int i = 1; i < ChunkTimesMs.Count; i++)
+                gaps.Add(ChunkTimesMs[i] - ChunkTimesMs[i - 1]);
+            gaps.Sort();
+            return (gaps[^1], gaps[(int)(gaps.Count * 0.95) is var k && k >= gaps.Count ? gaps.Count - 1 : k]);
+        }
+    }
+
+    public static async Task Run(string[] args)
+    {
+        int chunkArg = ArgInt(args, "--chunk", -1);
+        int longTokens = ArgInt(args, "--long-tokens", 1024);
+        int decodeTokens = ArgInt(args, "--decode", 96);
+
+        var path = BenchmarkHelper.FindModelPath("SmolLM2-1.7B-Instruct-Q4_K_M.gguf")
+            ?? throw new FileNotFoundException("SmolLM2-1.7B-Instruct-Q4_K_M.gguf not found");
+
+        Console.WriteLine($"[cb] model: {path}");
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var backend = new CpuBackend();
+        using var fwd = new ForwardPass(model, backend, hp);
+
+        // Long prompt: repeat filler text until the tokenizer crosses the target count.
+        const string filler = "The quick brown fox jumps over the lazy dog near the quiet river bank. ";
+        var sb = new System.Text.StringBuilder("<|im_start|>user\nSummarize the following text:\n");
+        while (tokenizer.Encode(sb.ToString()).Count < longTokens)
+            sb.Append(filler);
+        sb.Append("<|im_end|>\n<|im_start|>assistant\n");
+        string longPrompt = sb.ToString();
+        int longPromptTokens = tokenizer.Encode(longPrompt).Count;
+
+        const string shortPrompt = "<|im_start|>user\nTell me a short story about a lighthouse keeper.<|im_end|>\n<|im_start|>assistant\n";
+
+        // Warm the weight pages once so the first measured mode isn't penalized by
+        // cold mmap reads (see bench-cache-warmth feedback).
+        Console.WriteLine("[cb] warmup...");
+        {
+            using var warmEngine = new ContinuousBatchingEngine(fwd, tokenizer, "warmup", maxBatchSize: 1);
+            var wsp = new SamplingParams { Temperature = 0f, MaxNewTokens = 4 };
+            await foreach (var _ in warmEngine.GenerateAsync(shortPrompt, wsp)) { }
+        }
+
+        if (args.Contains("--packed"))
+        {
+            RunPackedPrefillAb(fwd, tokenizer, longPrompt);
+            return;
+        }
+
+        int[] modes = chunkArg >= 0 ? [chunkArg] : [0, 256];
+        foreach (int chunk in modes)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"══ mode: prefillChunkTokens={chunk} ({(chunk == 0 ? "legacy blocking prefill" : "chunked + packed interleaved")}) ══");
+            await RunMode(fwd, tokenizer, chunk, shortPrompt, longPrompt, longPromptTokens, decodeTokens);
+        }
+    }
+
+    /// <summary>
+    /// Direct A/B for issue #183 Gap 2: prefill S prompts of T tokens each, serially
+    /// (one PrefillWithCache per prompt) vs as ONE packed PrefillPackedMulti call.
+    /// Isolates the weight-read amortization across prompts from the scheduling change.
+    /// </summary>
+    private static void RunPackedPrefillAb(ForwardPass fwd, GgufTokenizer tokenizer, string longText)
+    {
+        const int S = 4, T = 256;
+        var all = tokenizer.Encode(longText).ToArray();
+        var prompts = new int[S][];
+        for (int s = 0; s < S; s++)
+            prompts[s] = all.AsSpan(s * T, T).ToArray();
+
+        const int PerSeq = 64; // chunk each prompt advances per round in the chunked modes
+
+        foreach (string mode in new[] { "whole-prompt serial", "chunked serial", "chunked packed" })
+        {
+            var sw = Stopwatch.StartNew();
+            var caches = new PagedKvCache[S];
+            for (int s = 0; s < S; s++) caches[s] = fwd.CreateCache();
+
+            switch (mode)
+            {
+                case "whole-prompt serial":
+                    // Pre-#183 admission: each prompt prefills alone, full length.
+                    for (int s = 0; s < S; s++)
+                        fwd.PrefillWithCache(prompts[s], caches[s]);
+                    break;
+
+                case "chunked serial":
+                    // Gap 1 without Gap 2: same rounds, but one small call per prompt —
+                    // each call re-pays the weight read/dequant for only PerSeq tokens.
+                    for (int consumed = 0; consumed < T; consumed += PerSeq)
+                    {
+                        int take = Math.Min(PerSeq, T - consumed);
+                        for (int s = 0; s < S; s++)
+                        {
+                            var segment = new ArraySegment<int>(prompts[s], consumed, take);
+                            fwd.PrefillWithCache(segment, caches[s], startPos: consumed);
+                        }
+                    }
+                    break;
+
+                case "chunked packed":
+                    // Gap 1 + Gap 2: the S per-prompt chunks run as ONE packed pass.
+                    for (int consumed = 0; consumed < T; consumed += PerSeq)
+                    {
+                        int take = Math.Min(PerSeq, T - consumed);
+                        var chunks = new ReadOnlyMemory<int>[S];
+                        var startPos = new int[S];
+                        var want = new bool[S];
+                        for (int s = 0; s < S; s++)
+                        {
+                            chunks[s] = prompts[s].AsMemory(consumed, take);
+                            startPos[s] = consumed;
+                            want[s] = consumed + take == T;
+                        }
+                        fwd.PrefillPackedMulti(chunks, startPos, caches, want);
+                    }
+                    break;
+            }
+
+            sw.Stop();
+            foreach (var c in caches) c.Dispose();
+            double tps = S * T / sw.Elapsed.TotalSeconds;
+            Console.WriteLine($"  {mode,-20} ({(mode == "whole-prompt serial" ? $"{T}/call" : $"{PerSeq}/prompt/round")}): {S}×{T} tokens in {sw.Elapsed.TotalMilliseconds,7:F0} ms → {tps,7:F1} tok/s");
+        }
+    }
+
+    private static async Task RunMode(
+        ForwardPass fwd, GgufTokenizer tokenizer, int chunk,
+        string shortPrompt, string longPrompt, int longPromptTokens, int decodeTokens)
+    {
+        using var engine = new ContinuousBatchingEngine(fwd, tokenizer, "cb-bench",
+            maxBatchSize: 8, prefillChunkTokens: chunk);
+
+        var clock = Stopwatch.StartNew();
+        var results = new List<Task<SeqResult>>();
+        var progress = new int[3]; // live token counters for the interactive sequences
+
+        Task<SeqResult> Launch(string name, string prompt, int maxNew, int progressSlot)
+        {
+            double submit = clock.Elapsed.TotalMilliseconds;
+            var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = maxNew };
+            return Task.Run(async () =>
+            {
+                var times = new List<double>(maxNew);
+                await foreach (var _ in engine.GenerateAsync(prompt, sp))
+                {
+                    times.Add(clock.Elapsed.TotalMilliseconds);
+                    if (progressSlot >= 0) Interlocked.Increment(ref progress[progressSlot]);
+                }
+                return new SeqResult(name, times, submit, clock.Elapsed.TotalMilliseconds);
+            });
+        }
+
+        // 3 interactive sequences decoding continuously.
+        for (int i = 0; i < 3; i++)
+            results.Add(Launch($"interactive-{i}", shortPrompt, decodeTokens, i));
+
+        // Wait until all three are visibly streaming, then inject the long prompt.
+        while (!results.All(r => r.IsCompleted)
+               && !Enumerable.Range(0, 3).All(i => Volatile.Read(ref progress[i]) >= 4 || results[i].IsCompleted))
+            await Task.Delay(25);
+
+        double injectAt = clock.Elapsed.TotalMilliseconds;
+        results.Add(Launch($"long-prompt({longPromptTokens}tok)", longPrompt, 8, -1));
+
+        var done = await Task.WhenAll(results);
+        double wallMs = clock.Elapsed.TotalMilliseconds;
+
+        int totalTokens = done.Sum(r => r.Tokens);
+        Console.WriteLine($"  long prompt injected at {injectAt,8:F0} ms");
+        Console.WriteLine($"  {"sequence",-22} {"tokens",6} {"ttft ms",9} {"max gap ms",11} {"p95 gap ms",11} {"done ms",9}");
+        foreach (var r in done)
+        {
+            var (max, p95) = r.Gaps();
+            Console.WriteLine($"  {r.Name,-22} {r.Tokens,6} {r.TtftMs,9:F0} {max,11:F0} {p95,11:F0} {r.DoneMs,9:F0}");
+        }
+        Console.WriteLine($"  wall {wallMs:F0} ms · generated {totalTokens} tokens · aggregate {totalTokens / (wallMs / 1000.0):F1} tok/s");
+    }
+
+    private static int ArgInt(string[] args, string name, int fallback)
+    {
+        int idx = Array.IndexOf(args, name);
+        return idx >= 0 && idx + 1 < args.Length && int.TryParse(args[idx + 1], out int v) ? v : fallback;
+    }
+}

--- a/benchmarks/SharpInference.Bench/Program.cs
+++ b/benchmarks/SharpInference.Bench/Program.cs
@@ -1,3 +1,10 @@
 using BenchmarkDotNet.Running;
 
+// Manual (non-BenchmarkDotNet) harnesses dispatch before the switcher.
+if (args.Contains("--cb"))
+{
+    await SharpInference.Bench.ContinuousBatchingHarness.Run(args);
+    return;
+}
+
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/docs/SharpInference-Design.md
+++ b/docs/SharpInference-Design.md
@@ -1942,6 +1942,44 @@ curl http://localhost:5000/v1/messages \
 
 **Tests**: 7 new tests in `ContinuousBatchingTests` covering `PrefillWithCache` correctness, `BatchForwardMulti` equivalence to sequential decode, concurrent engine requests, and dispose lifecycle. All 152 tests pass.
 
+#### Phase 7c follow-up: scheduling under concurrent load (issue #183, ✅ Complete)
+
+Three saturation gaps closed in the batcher (admission previously prefilled each prompt
+synchronously, stalling every active decode; no memory backpressure existed):
+
+- **Chunked / interleaved prefill (Gap 1)** — admitted prompts prefill
+  `prefillChunkTokens` (default 256, `SHARPI_PREFILL_CHUNK` / `PrefillChunkTokens`
+  option) per batcher iteration; every active sequence advances one
+  `BatchForwardMulti` decode step between chunks (Sarathi/vLLM-style). Cancellation
+  is honoured between chunks. `0` restores blocking prefill; SnapKV-enabled engines
+  fall back to blocking automatically (eviction scoring needs the whole prompt at
+  `startPos == 0`). Measured on SmolLM2 CPU (3 active decoders + 1040-token prompt
+  injection): worst decode stall 25.1 s → 7.9 s, ~12 % aggregate-throughput cost.
+  Smaller chunks cut the stall further but pay the per-GEMM weight-dequant cost more
+  often (CPU prefill collapsed 42 → 13 t/s at chunk 32) — 256 is the compromise.
+- **Packed multi-sequence prefill (Gap 2)** — `ForwardPass.PrefillPackedMulti(chunks,
+  startPos, caches, wantLogits)`: when several prompts are prefilling, their chunks
+  are concatenated into ONE packed batch (cu_seqlens-style: batched GEMMs over the
+  combined token count, per-token RoPE/append/attention against each sequence's own
+  cache, no padding, no cross-sequence attention). Logits are computed only for
+  chunks that complete a prompt. Same guards as `BatchForwardMulti` (no MoE /
+  TurboQuant / gemma4 per-layer head_dim).
+- **KV token-budget admission backpressure (Gap 3)** — each request reserves
+  `min(promptTokens + MaxNewTokens, MaxSeqLen)` KV tokens at admission
+  (`ForwardPass.KvBytesPerToken` converts a byte budget); when the head request
+  would exceed the budget it waits in a local FIFO instead of OOM-ing the host.
+  A lone oversized request is always admitted (no deadlock). Budget:
+  `kvBudgetBytes` ctor arg / `KvBudgetMb` option / `SHARPI_KV_BUDGET_MB`
+  (0 = auto: half of available RAM, negative = unlimited).
+- **Measured PCIe bandwidth** — `HardwareProfile.Detect(CudaBackend)` replaces the
+  VRAM-size-bucket guess with `CudaBackend.MeasurePcieBandwidthGBps()` (pinned
+  64 MiB `cudaMemcpy` probe, min of H2D/D2H, heuristic fallback). On the reference
+  RTX 4070 Ti box: measured ~26 GB/s vs the old 20 GB/s bucket.
+
+A/B harness: `dotnet run --project benchmarks/SharpInference.Bench -c Release -- --cb`
+(3 interactive decoders + injected long prompt; reports per-sequence inter-token gap
+percentiles and aggregate t/s for legacy vs chunked admission).
+
 ---
 
 #### Phase 8: API Completeness — Metrics, Observability, LogitBias (✅ Complete)

--- a/src/SharpInference.Cuda/CuBlasInterop.cs
+++ b/src/SharpInference.Cuda/CuBlasInterop.cs
@@ -11,11 +11,17 @@ namespace SharpInference.Cuda;
 /// with (<c>nvrtc64_120_0</c>, see <see cref="NvrtcInterop"/>). The driver API
 /// (<c>nvcuda</c>) and CUDA-graph calls are version-independent. On a machine with
 /// several toolkits installed, the loader picks the first 12.x <c>bin</c> on PATH.
+/// <see cref="CudaLibraryResolver"/> can remap the pair to the CUDA 13 SONAMEs
+/// (opt-in via <c>SHARPI_CUDA13=1</c>, or automatically on 13-only installs).
 /// </summary>
 internal static partial class CuBlasInterop
 {
     static CuBlasInterop()
     {
+        // Must run before the first P/Invoke in this class binds, so the
+        // cudart/cublas major-version selection applies (see CudaLibraryResolver).
+        CudaLibraryResolver.Register();
+
         // CUDA 11.7+ defaults to lazy module loading: SASS for each kernel is JIT'd from
         // PTX on the first cuLaunchKernel, not at cuModuleLoadData time. For an LLM that
         // launches ~700 kernels per token, the cold-cache JIT cost lands in the middle

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -419,6 +419,59 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     public int SmVersion => _smVersion;
 
     /// <summary>
+    /// Measures effective host↔device transfer bandwidth with a pinned 64 MiB
+    /// <c>cudaMemcpy</c> probe (issue #183: replaces <c>HardwareProfile</c>'s
+    /// VRAM-size-bucket PCIe guess with a real number). Returns the slower of the
+    /// H2D and D2H directions in GB/s — streaming-cost estimates shouldn't assume
+    /// the faster one. Costs ~100 ms; intended to run once at model load. Returns
+    /// 0 on any failure so callers can fall back to a heuristic.
+    /// </summary>
+    public double MeasurePcieBandwidthGBps()
+    {
+        nuint Size = 64 * 1024 * 1024;
+        nint host = 0, dev = 0;
+        try
+        {
+            if (CuBlasInterop.MallocHost(out host, Size) != 0) return 0;
+            if (CuBlasInterop.CudaMalloc(out dev, Size) != 0) return 0;
+
+            // Warm both directions once (the driver lazily maps the pinned range).
+            if (CuBlasInterop.CudaMemcpy(dev, host, Size, CuBlasInterop.HostToDevice) != 0) return 0;
+            if (CuBlasInterop.CudaMemcpy(host, dev, Size, CuBlasInterop.DeviceToHost) != 0) return 0;
+
+            double h2d = TimeDirection(dev, host, CuBlasInterop.HostToDevice, Size);
+            double d2h = TimeDirection(host, dev, CuBlasInterop.DeviceToHost, Size);
+            if (h2d <= 0 || d2h <= 0) return 0;
+            return Math.Min(h2d, d2h);
+        }
+        catch
+        {
+            return 0;
+        }
+        finally
+        {
+            if (dev != 0) _ = CuBlasInterop.CudaFree(dev);
+            if (host != 0) _ = CuBlasInterop.FreeHost(host);
+        }
+
+        static double TimeDirection(nint dst, nint src, int kind, nuint size)
+        {
+            const int Reps = 3;
+            double best = 0;
+            for (int i = 0; i < Reps; i++)
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                if (CuBlasInterop.CudaMemcpy(dst, src, size, kind) != 0) return 0;
+                sw.Stop();
+                // Synchronous cudaMemcpy returns only after the copy completes, so
+                // wall time is the transfer time. Best-of-3 rejects scheduler noise.
+                best = Math.Max(best, size / sw.Elapsed.TotalSeconds / 1e9);
+            }
+            return best;
+        }
+    }
+
+    /// <summary>
     /// CUDA stream that all kernels and memcpys are enqueued on. Callers that need to
     /// schedule their own async work against the backend pipeline can use this handle —
     /// it is owned by the backend and synchronized by <see cref="Synchronize"/>.

--- a/src/SharpInference.Cuda/CudaLibraryResolver.cs
+++ b/src/SharpInference.Cuda/CudaLibraryResolver.cs
@@ -1,0 +1,72 @@
+using System.Runtime.InteropServices;
+
+namespace SharpInference.Cuda;
+
+/// <summary>
+/// The assembly's single <see cref="DllImportResolver"/> (only one may be registered
+/// per assembly): handles NVRTC version probing and CUDA runtime/cuBLAS major-version
+/// selection. Registered from the static constructors of both <see cref="NvrtcInterop"/>
+/// and <see cref="CuBlasInterop"/> so it is in place before the first P/Invoke binds,
+/// whichever interop class is touched first.
+///
+/// The runtime imports stay pinned to the CUDA 12 SONAMEs (<c>cudart64_12</c> /
+/// <c>cublas64_12</c>). Resolution policy:
+///   - <c>SHARPI_CUDA13=1</c> prefers the CUDA 13 pair when both DLLs load (A/B knob —
+///     every entry point we import exists unchanged in 13.x);
+///   - otherwise CUDA 12 is used when present (default, matches the NVRTC the kernels
+///     are JIT'd against; PTX is forward-compatible via the driver);
+///   - when 12 is absent (CUDA-13-only toolkit installs), 13 loads as a fallback
+///     instead of hard-failing model load.
+/// cudart and cublas are decided as a PAIR so a mixed 12/13 process never occurs.
+/// </summary>
+internal static class CudaLibraryResolver
+{
+    private static int s_registered;
+    private static int s_runtimeMajor; // 0 = undecided; then 12 or 13
+
+    internal static void Register()
+    {
+        if (Interlocked.Exchange(ref s_registered, 1) != 0) return;
+        NativeLibrary.SetDllImportResolver(typeof(CudaLibraryResolver).Assembly, Resolve);
+    }
+
+    private static nint Resolve(string name, System.Reflection.Assembly asm, DllImportSearchPath? path)
+    {
+        if (name == "nvrtc")
+        {
+            foreach (var candidate in new[] { "nvrtc64_120_0", "nvrtc64_112_0", "nvrtc64_11" })
+                if (NativeLibrary.TryLoad(candidate, out nint h)) return h;
+            return nint.Zero;
+        }
+        if (name is "cudart64_12" or "cublas64_12")
+        {
+            string target = DecideRuntimeMajor() == 13 ? name.Replace("_12", "_13") : name;
+            return NativeLibrary.TryLoad(target, out nint h) ? h : nint.Zero;
+        }
+        return nint.Zero;
+    }
+
+    private static int DecideRuntimeMajor()
+    {
+        int major = Volatile.Read(ref s_runtimeMajor);
+        if (major != 0) return major;
+
+        bool prefer13 = Environment.GetEnvironmentVariable("SHARPI_CUDA13") == "1";
+        bool has13 = CanLoadPair("cudart64_13", "cublas64_13");
+        bool has12 = CanLoadPair("cudart64_12", "cublas64_12");
+        major = prefer13 && has13 ? 13
+              : has12 ? 12
+              : has13 ? 13
+              : 12; // neither loads — keep the pinned name so the standard load error surfaces
+        if (major == 13)
+        {
+            Console.Error.WriteLine("[SharpInference] CUDA runtime: using cudart64_13/cublas64_13"
+                + (prefer13 ? " (SHARPI_CUDA13=1)" : " (CUDA 12 runtime not found)"));
+        }
+        Volatile.Write(ref s_runtimeMajor, major);
+        return major;
+
+        static bool CanLoadPair(string cudart, string cublas) =>
+            NativeLibrary.TryLoad(cudart, out _) && NativeLibrary.TryLoad(cublas, out _);
+    }
+}

--- a/src/SharpInference.Cuda/CudaLibraryResolver.cs
+++ b/src/SharpInference.Cuda/CudaLibraryResolver.cs
@@ -51,13 +51,22 @@ internal static class CudaLibraryResolver
         int major = Volatile.Read(ref s_runtimeMajor);
         if (major != 0) return major;
 
+        // Probe the preferred pair first and only fall back to the other major when it
+        // is absent, so the unused version's DLLs are never pulled into the process
+        // (TryLoad maps the library; cublas alone is hundreds of MB of image). Probe
+        // handles are freed — the resolver reloads the chosen pair on demand, which is
+        // a cheap refcount bump on the OS loader cache.
         bool prefer13 = Environment.GetEnvironmentVariable("SHARPI_CUDA13") == "1";
-        bool has13 = CanLoadPair("cudart64_13", "cublas64_13");
-        bool has12 = CanLoadPair("cudart64_12", "cublas64_12");
-        major = prefer13 && has13 ? 13
-              : has12 ? 12
-              : has13 ? 13
-              : 12; // neither loads — keep the pinned name so the standard load error surfaces
+        if (prefer13)
+        {
+            major = CanLoadPair("cudart64_13", "cublas64_13") ? 13 : 12;
+        }
+        else
+        {
+            major = CanLoadPair("cudart64_12", "cublas64_12") ? 12
+                  : CanLoadPair("cudart64_13", "cublas64_13") ? 13
+                  : 12; // neither loads — keep the pinned name so the standard load error surfaces
+        }
         if (major == 13)
         {
             Console.Error.WriteLine("[SharpInference] CUDA runtime: using cudart64_13/cublas64_13"
@@ -66,7 +75,13 @@ internal static class CudaLibraryResolver
         Volatile.Write(ref s_runtimeMajor, major);
         return major;
 
-        static bool CanLoadPair(string cudart, string cublas) =>
-            NativeLibrary.TryLoad(cudart, out _) && NativeLibrary.TryLoad(cublas, out _);
+        static bool CanLoadPair(string cudart, string cublas)
+        {
+            if (!NativeLibrary.TryLoad(cudart, out nint hRt)) return false;
+            bool ok = NativeLibrary.TryLoad(cublas, out nint hBlas);
+            NativeLibrary.Free(hRt);
+            if (ok) NativeLibrary.Free(hBlas);
+            return ok;
+        }
     }
 }

--- a/src/SharpInference.Cuda/NvrtcInterop.cs
+++ b/src/SharpInference.Cuda/NvrtcInterop.cs
@@ -14,13 +14,9 @@ internal static unsafe partial class NvrtcInterop
 {
     static NvrtcInterop()
     {
-        NativeLibrary.SetDllImportResolver(typeof(NvrtcInterop).Assembly, static (name, _, _) =>
-        {
-            if (name == "nvrtc")
-                foreach (var candidate in new[] { "nvrtc64_120_0", "nvrtc64_112_0", "nvrtc64_11" })
-                    if (NativeLibrary.TryLoad(candidate, out nint h)) return h;
-            return nint.Zero;
-        });
+        // NVRTC probing now lives in the assembly-wide resolver (shared with the
+        // cudart/cublas major-version selection — see CudaLibraryResolver).
+        CudaLibraryResolver.Register();
     }
 
     // ── NVRTC ─────────────────────────────────────────────────────────────

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -10,9 +10,15 @@ namespace SharpInference.Engine;
 ///
 /// Flow:
 ///   1. Caller enqueues requests via <see cref="GenerateChunksAsync"/>.
-///   2. Background batcher admits pending requests one at a time (prefilling each individually).
-///   3. All active sequences are decoded together in a single <see cref="ForwardPass.BatchForwardMulti"/> call.
-///   4. Sequences that hit EOS or max tokens are retired; their caches are returned to the pool.
+///   2. Background batcher admits pending requests under a KV token budget (issue #183 Gap 3:
+///      admission backpressure — a burst of long prompts queues instead of exhausting memory).
+///   3. Admitted prompts prefill in chunks interleaved with decode steps (issue #183 Gap 1:
+///      a long prompt no longer stalls every active sequence). When several prompts are
+///      prefilling at once, their chunks run as one packed forward pass
+///      (<see cref="ForwardPass.PrefillPackedMulti"/>, issue #183 Gap 2) so weight reads are
+///      amortized across prompts exactly like decode batching.
+///   4. All active sequences are decoded together in a single <see cref="ForwardPass.BatchForwardMulti"/> call.
+///   5. Sequences that hit EOS or max tokens are retired; their caches are returned to the pool.
 ///
 /// Not supported for MoE models or when TurboQuant KV cache is enabled.
 ///
@@ -29,6 +35,20 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     private readonly int _maxBatchSize;
     private readonly int _thinkTokenId;
     private readonly int _endThinkTokenId;
+    private readonly bool _thinkingEnabled;
+
+    // Issue #183 Gap 1: tokens of prompt prefilled per batcher iteration. Between chunks
+    // every active sequence advances one decode step. 0 disables chunking (a prompt
+    // prefills in one blocking call — the pre-#183 behavior). SnapKV also disables
+    // chunking: its prefill eviction only runs on a fresh full-prompt prefill.
+    private readonly int _prefillChunkTokens;
+    private readonly bool _chunkingEnabled;
+
+    // Issue #183 Gap 3: max total KV tokens committed across admitted sequences. Each
+    // sequence reserves promptTokens + MaxNewTokens (clamped to MaxSeqLen) at admission
+    // and releases the reservation when it retires. long.MaxValue = unlimited.
+    private readonly long _kvTokenBudget;
+    private long _committedTokens; // batcher-thread only
 
     private readonly Channel<PendingRequest> _queue =
         Channel.CreateUnbounded<PendingRequest>(new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
@@ -45,6 +65,17 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         public readonly SamplingParams Sp = sp;
         public readonly CancellationToken Ct = ct;
         public readonly Channel<GenerateChunk> Output = output;
+        public int[]? Tokens; // memoized tokenization (admission may retry under backpressure)
+    }
+
+    /// <summary>A sequence whose prompt is being prefilled chunk-by-chunk.</summary>
+    private sealed class PrefillingSeq
+    {
+        public required PendingRequest Req;
+        public required int[] Tokens;
+        public required PagedKvCache Cache;
+        public required long ProjectedTokens; // KV budget reservation, released on retire
+        public int Consumed;                  // prompt tokens prefilled so far
     }
 
     private sealed class ActiveSeq
@@ -57,6 +88,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         public required System.Collections.Immutable.ImmutableArray<int> StopIds;
         public required Random Rng;
         public required CancellationToken Ct;
+        public required long ProjectedTokens;
         public int TokenCount;
         // Per-sequence stateful UTF-8 decoders: reassembles multi-byte characters
         // split across tokens (CJK, emoji, smart quotes). Independent decoders for
@@ -79,13 +111,23 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     /// Token ID of the model's <c>&lt;/think&gt;</c> marker, or <c>-1</c>. Must be paired with
     /// a non-negative <paramref name="thinkTokenId"/> to enable reasoning-stream splitting.
     /// </param>
+    /// <param name="prefillChunkTokens">
+    /// Prompt tokens prefilled per batcher iteration (issue #183 Gap 1); active sequences
+    /// decode one step between chunks. <c>0</c> = prefill each prompt in one blocking call.
+    /// </param>
+    /// <param name="kvBudgetBytes">
+    /// KV-memory budget gating admission (issue #183 Gap 3). <c>0</c> = auto (half of
+    /// available system RAM), negative = unlimited, positive = explicit byte budget.
+    /// </param>
     public ContinuousBatchingEngine(
         ForwardPass fwd,
         ITokenizer tokenizer,
         string modelId,
         int maxBatchSize = 8,
         int thinkTokenId = -1,
-        int endThinkTokenId = -1)
+        int endThinkTokenId = -1,
+        int prefillChunkTokens = 256,
+        long kvBudgetBytes = 0)
     {
         _fwd = fwd;
         _tokenizer = tokenizer;
@@ -93,6 +135,21 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         _maxBatchSize = Math.Max(1, maxBatchSize);
         _thinkTokenId = thinkTokenId;
         _endThinkTokenId = endThinkTokenId;
+        _thinkingEnabled = thinkTokenId >= 0 && endThinkTokenId >= 0;
+
+        _prefillChunkTokens = prefillChunkTokens;
+        _chunkingEnabled = prefillChunkTokens > 0 && !fwd.SnapKvEnabled;
+
+        long budgetBytes = kvBudgetBytes switch
+        {
+            < 0 => long.MaxValue,
+            0 => GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 2,
+            _ => kvBudgetBytes,
+        };
+        _kvTokenBudget = budgetBytes == long.MaxValue
+            ? long.MaxValue
+            : Math.Max(1, budgetBytes / Math.Max(1, fwd.KvBytesPerToken));
+
         _batcherTask = Task.Run(BatcherLoop);
     }
 
@@ -101,8 +158,11 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     /// <summary>Number of requests queued but not yet being generated.</summary>
     public int QueueDepth => _pendingCount;
 
-    /// <summary>Number of requests currently in the active decode batch.</summary>
+    /// <summary>Number of requests currently being prefilled or decoded.</summary>
     public int ActiveRequests => _activeCount;
+
+    /// <summary>Total KV token budget gating admission (issue #183 Gap 3).</summary>
+    public long KvTokenBudget => _kvTokenBudget;
 
     /// <summary>
     /// Continuous batching does not (yet) share KV state across requests — each admitted
@@ -150,8 +210,18 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
 
         Interlocked.Increment(ref _pendingCount);
-        await _queue.Writer.WriteAsync(new PendingRequest(prompt, sp, ct, channel), ct)
-            .ConfigureAwait(false);
+        try
+        {
+            await _queue.Writer.WriteAsync(new PendingRequest(prompt, sp, ct, channel), ct)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Disposed concurrently (writer completed) or caller-cancelled before the
+            // write landed — undo the counter so QueueDepth doesn't drift.
+            Interlocked.Decrement(ref _pendingCount);
+            throw;
+        }
 
         await foreach (var chunk in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
             yield return chunk;
@@ -159,31 +229,27 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
 
     private async Task BatcherLoop()
     {
+        var pending = new Queue<PendingRequest>();
+        var prefilling = new List<PrefillingSeq>();
         var active = new List<ActiveSeq>(_maxBatchSize);
         var tokensBuf = new int[_maxBatchSize];
         var posBuf = new int[_maxBatchSize];
         var cacheBuf = new PagedKvCache[_maxBatchSize];
-        bool thinkingEnabled = _thinkTokenId >= 0 && _endThinkTokenId >= 0;
 
         while (!_disposed)
         {
-            // Admit pending requests into available batch slots
-            while (active.Count < _maxBatchSize && _queue.Reader.TryRead(out var req))
-            {
-                Interlocked.Decrement(ref _pendingCount);
-                try
-                {
-                    AdmitRequest(req, active, thinkingEnabled);
-                }
-                catch (Exception ex)
-                {
-                    req.Output.Writer.TryComplete(ex);
-                }
-            }
+            // Pull everything queued so far into the local pending queue. Channels have
+            // no peek, and admission backpressure needs to inspect the head request's
+            // size without consuming it — hence the local FIFO.
+            while (_queue.Reader.TryRead(out var queued))
+                pending.Enqueue(queued);
 
-            if (active.Count == 0)
+            AdmitPending(pending, prefilling, active);
+
+            if (active.Count == 0 && prefilling.Count == 0)
             {
-                // No active work — wait for a new request
+                // No active work — wait for a new request. (Admission always starts the
+                // head request when nothing is running, so pending is empty here.)
                 try
                 {
                     bool hasMore = await _queue.Reader.WaitToReadAsync().ConfigureAwait(false);
@@ -195,6 +261,14 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 }
                 continue;
             }
+
+            // Advance prefilling prompts by one chunk, then give every active sequence
+            // one decode step — the interleave that keeps decode from stalling.
+            if (prefilling.Count > 0)
+                RunPrefillStep(prefilling, active);
+
+            if (active.Count == 0)
+                continue;
 
             // Build batched inputs
             int n = active.Count;
@@ -219,7 +293,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 // boundary branch below and is fed back as the next CurrentToken so the
                 // model continues from its post-think state on the next batched step.
                 int next;
-                if (thinkingEnabled && seq.InThinking && seq.Sp.MaxThinkingTokens > 0
+                if (_thinkingEnabled && seq.InThinking && seq.Sp.MaxThinkingTokens > 0
                     && seq.ThinkingCount >= seq.Sp.MaxThinkingTokens && _endThinkTokenId > 0)
                 {
                     next = _endThinkTokenId;
@@ -238,9 +312,8 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 if (done)
                 {
                     FlushAndComplete(seq);
-                    seq.Cache.Dispose();
+                    RetireSeq(seq);
                     active.RemoveAt(i);
-                    Interlocked.Decrement(ref _activeCount);
                 }
                 else
                 {
@@ -248,20 +321,20 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                     // open, otherwise increment whenever seq.InThinking was true on entry to
                     // this step. That includes the </think> boundary token — so N reasoning
                     // tokens trip the force-close on step N+1.
-                    if (thinkingEnabled && next == _thinkTokenId) seq.ThinkingCount = 0;
+                    if (_thinkingEnabled && next == _thinkTokenId) seq.ThinkingCount = 0;
                     else if (seq.InThinking) seq.ThinkingCount++;
 
                     // Reasoning boundary tokens: flip state, consume the token, do NOT emit content.
                     // Each direction requires the opposite state, so malformed double <think>
                     // or orphan </think> falls through to the content path below.
-                    if (thinkingEnabled && next == _thinkTokenId && !seq.InThinking)
+                    if (_thinkingEnabled && next == _thinkTokenId && !seq.InThinking)
                     {
                         var textTail = seq.TextDec.Flush();
                         if (textTail.Length > 0)
                             seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
                         seq.InThinking = true;
                     }
-                    else if (thinkingEnabled && next == _endThinkTokenId && seq.InThinking)
+                    else if (_thinkingEnabled && next == _endThinkTokenId && seq.InThinking)
                     {
                         var thinkTail = seq.ThinkDec.Flush();
                         if (thinkTail.Length > 0)
@@ -292,7 +365,25 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             }
         }
 
-        // Drain: complete any remaining active sequences
+        // Drain: complete everything still in flight. Pull any requests still sitting
+        // in the channel first — written between our last TryRead pass and the writer
+        // completing — or their output channels would never complete and the caller's
+        // await-foreach would hang.
+        while (_queue.Reader.TryRead(out var stranded))
+            pending.Enqueue(stranded);
+        foreach (var req in pending)
+        {
+            Interlocked.Decrement(ref _pendingCount);
+            req.Output.Writer.TryComplete();
+        }
+        pending.Clear();
+        foreach (var p in prefilling)
+        {
+            p.Req.Output.Writer.TryComplete();
+            p.Cache.Dispose();
+            Interlocked.Decrement(ref _activeCount);
+        }
+        prefilling.Clear();
         foreach (var seq in active)
         {
             FlushAndComplete(seq);
@@ -300,6 +391,202 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             Interlocked.Decrement(ref _activeCount);
         }
         active.Clear();
+    }
+
+    /// <summary>
+    /// Moves requests from the local pending queue into the prefilling set while batch
+    /// slots are free and the KV token budget allows (issue #183 Gap 3). FIFO: a
+    /// too-large head request blocks the queue until running sequences retire — except
+    /// when nothing is running, where it is always admitted so a single oversized
+    /// request can't deadlock the engine (it then fails in prefill if it truly can't fit).
+    /// </summary>
+    private void AdmitPending(Queue<PendingRequest> pending, List<PrefillingSeq> prefilling, List<ActiveSeq> active)
+    {
+        while (pending.Count > 0 && active.Count + prefilling.Count < _maxBatchSize)
+        {
+            var req = pending.Peek();
+            if (req.Ct.IsCancellationRequested)
+            {
+                pending.Dequeue();
+                Interlocked.Decrement(ref _pendingCount);
+                req.Output.Writer.TryComplete();
+                continue;
+            }
+
+            int[] tokens;
+            try
+            {
+                tokens = req.Tokens ??= _tokenizer.Encode(req.Prompt).ToArray();
+            }
+            catch (Exception ex)
+            {
+                pending.Dequeue();
+                Interlocked.Decrement(ref _pendingCount);
+                req.Output.Writer.TryComplete(ex);
+                continue;
+            }
+            if (tokens.Length == 0)
+            {
+                pending.Dequeue();
+                Interlocked.Decrement(ref _pendingCount);
+                req.Output.Writer.TryComplete();
+                continue;
+            }
+
+            long projected = Math.Min(
+                tokens.Length + Math.Max(0L, req.Sp.MaxNewTokens), _fwd.MaxSeqLen);
+            if (_committedTokens + projected > _kvTokenBudget
+                && (active.Count > 0 || prefilling.Count > 0))
+            {
+                break; // backpressure: re-evaluated next iteration as sequences retire
+            }
+
+            pending.Dequeue();
+            Interlocked.Decrement(ref _pendingCount);
+
+            PagedKvCache cache;
+            try
+            {
+                cache = _fwd.CreateCache();
+            }
+            catch (Exception ex)
+            {
+                req.Output.Writer.TryComplete(ex);
+                continue;
+            }
+
+            _committedTokens += projected;
+            prefilling.Add(new PrefillingSeq
+            {
+                Req = req,
+                Tokens = tokens,
+                Cache = cache,
+                ProjectedTokens = projected,
+            });
+            Interlocked.Increment(ref _activeCount);
+        }
+    }
+
+    /// <summary>
+    /// Advances prefilling prompts by one chunk budget (issue #183 Gap 1). With several
+    /// prompts in flight the chunk budget is split across them and run as one packed
+    /// forward pass (Gap 2) so weight reads amortize across prompts. Prompts whose final
+    /// chunk completes are sampled and promoted to the active decode set.
+    /// </summary>
+    private void RunPrefillStep(List<PrefillingSeq> prefilling, List<ActiveSeq> active)
+    {
+        // Cancellation sweep between chunks — a benefit chunking adds for free:
+        // a cancelled long-prompt request stops mid-prefill instead of running to the end.
+        for (int i = prefilling.Count - 1; i >= 0; i--)
+        {
+            var p = prefilling[i];
+            if (p.Req.Ct.IsCancellationRequested)
+            {
+                p.Req.Output.Writer.TryComplete();
+                DropPrefilling(prefilling, i);
+            }
+        }
+        if (prefilling.Count == 0) return;
+
+        if (!_chunkingEnabled)
+        {
+            // Unchunked path (prefillChunkTokens == 0, or SnapKV active — its prefill
+            // eviction only runs on a whole-prompt startPos==0 prefill). One prompt per
+            // iteration, blocking, exactly the pre-#183 behavior.
+            var p = prefilling[0];
+            float[] logits;
+            try
+            {
+                logits = _fwd.PrefillWithCache(p.Tokens, p.Cache).ToArray();
+            }
+            catch (Exception ex)
+            {
+                p.Req.Output.Writer.TryComplete(ex);
+                DropPrefilling(prefilling, 0);
+                return;
+            }
+            prefilling.RemoveAt(0);
+            ActivateSeq(p, logits, active);
+            return;
+        }
+
+        // Split this iteration's chunk budget across all prefilling prompts (≥1 token
+        // each). The budget bounds the decode stall per iteration regardless of how
+        // many prompts are prefilling, because the packed pass amortizes weights.
+        int sCount = prefilling.Count;
+        int perSeq = Math.Max(1, _prefillChunkTokens / sCount);
+
+        var chunks = new ReadOnlyMemory<int>[sCount];
+        var startPos = new int[sCount];
+        var caches = new PagedKvCache[sCount];
+        var wantLogits = new bool[sCount];
+        var takes = new int[sCount];
+        for (int s = 0; s < sCount; s++)
+        {
+            var p = prefilling[s];
+            int take = Math.Min(p.Tokens.Length - p.Consumed, perSeq);
+            chunks[s] = p.Tokens.AsMemory(p.Consumed, take);
+            startPos[s] = p.Consumed;
+            caches[s] = p.Cache;
+            wantLogits[s] = p.Consumed + take == p.Tokens.Length;
+            takes[s] = take;
+        }
+
+        float[]?[] logitsPerSeq;
+        try
+        {
+            if (sCount == 1)
+            {
+                var p = prefilling[0];
+                var segment = new ArraySegment<int>(p.Tokens, p.Consumed, takes[0]);
+                var logits = _fwd.PrefillWithCache(segment, p.Cache, startPos: p.Consumed);
+                logitsPerSeq = [wantLogits[0] ? logits.ToArray() : null];
+            }
+            else
+            {
+                logitsPerSeq = _fwd.PrefillPackedMulti(chunks, startPos, caches, wantLogits);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A failed packed pass leaves the involved caches in an indeterminate state;
+            // fail every involved request rather than guessing which ones survived.
+            for (int i = prefilling.Count - 1; i >= 0; i--)
+            {
+                prefilling[i].Req.Output.Writer.TryComplete(ex);
+                DropPrefilling(prefilling, i);
+            }
+            return;
+        }
+
+        for (int s = sCount - 1; s >= 0; s--)
+        {
+            var p = prefilling[s];
+            p.Consumed += takes[s];
+            if (logitsPerSeq[s] is { } logits)
+            {
+                prefilling.RemoveAt(s);
+                ActivateSeq(p, logits, active);
+            }
+        }
+    }
+
+    /// <summary>Removes prefilling[i], disposing its cache and releasing its budget reservation.</summary>
+    private void DropPrefilling(List<PrefillingSeq> prefilling, int i)
+    {
+        var p = prefilling[i];
+        p.Cache.Dispose();
+        _committedTokens -= p.ProjectedTokens;
+        prefilling.RemoveAt(i);
+        Interlocked.Decrement(ref _activeCount);
+    }
+
+    /// <summary>Releases a retired decode sequence's cache and budget reservation.</summary>
+    private void RetireSeq(ActiveSeq seq)
+    {
+        seq.Cache.Dispose();
+        _committedTokens -= seq.ProjectedTokens;
+        Interlocked.Decrement(ref _activeCount);
     }
 
     private static void FlushAndComplete(ActiveSeq seq)
@@ -313,23 +600,15 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         seq.Output.Writer.TryComplete();
     }
 
-    private void AdmitRequest(PendingRequest req, List<ActiveSeq> active, bool thinkingEnabled)
+    /// <summary>
+    /// Promotes a fully prefilled prompt to the active decode set: samples the first
+    /// token from the prefill logits, seeds the reasoning state machine, and emits the
+    /// first chunk. A first token that is already a stop token completes the request
+    /// immediately.
+    /// </summary>
+    private void ActivateSeq(PrefillingSeq p, float[] logits, List<ActiveSeq> active)
     {
-        if (req.Ct.IsCancellationRequested)
-        {
-            req.Output.Writer.TryComplete();
-            return;
-        }
-
-        var tokens = _tokenizer.Encode(req.Prompt).ToArray();
-        if (tokens.Length == 0)
-        {
-            req.Output.Writer.TryComplete();
-            return;
-        }
-
-        var cache = _fwd.CreateCache();
-        ReadOnlySpan<float> logits = _fwd.PrefillWithCache(tokens, cache);
+        var req = p.Req;
 
         // Stop on ANY end-of-generation token, not just the configured EOS — matches the
         // single-user InferenceEngine path. A model with an alternate end token (e.g. Gemma's
@@ -345,7 +624,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         if (stopIds.Contains(firstToken))
         {
             req.Output.Writer.TryComplete();
-            cache.Dispose();
+            p.Cache.Dispose();
+            _committedTokens -= p.ProjectedTokens;
+            Interlocked.Decrement(ref _activeCount);
             return;
         }
 
@@ -354,9 +635,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         // via their chat template, so the model is already inside a reasoning
         // block before the first sampled token.
         bool promptInThinking = false;
-        if (thinkingEnabled)
+        if (_thinkingEnabled)
         {
-            foreach (int tok in tokens)
+            foreach (int tok in p.Tokens)
             {
                 if (tok == _thinkTokenId) promptInThinking = true;
                 else if (tok == _endThinkTokenId) promptInThinking = false;
@@ -366,13 +647,14 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         var seq = new ActiveSeq
         {
             CurrentToken = firstToken,
-            Position = tokens.Length,
-            Cache = cache,
+            Position = p.Tokens.Length,
+            Cache = p.Cache,
             Sp = req.Sp,
             Output = req.Output,
             StopIds = stopIds,
             Rng = rng,
             Ct = req.Ct,
+            ProjectedTokens = p.ProjectedTokens,
             TokenCount = 1,
             InThinking = promptInThinking,
         };
@@ -381,11 +663,11 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         // A `<think>` here without an open block opens one; a `</think>` while in a prompt-
         // seeded block closes it. A stray `</think>` outside a block falls through to
         // content (same fall-through as decode).
-        if (thinkingEnabled && firstToken == _thinkTokenId && !seq.InThinking)
+        if (_thinkingEnabled && firstToken == _thinkTokenId && !seq.InThinking)
         {
             seq.InThinking = true;
         }
-        else if (thinkingEnabled && firstToken == _endThinkTokenId && seq.InThinking)
+        else if (_thinkingEnabled && firstToken == _endThinkTokenId && seq.InThinking)
         {
             seq.InThinking = false;
         }
@@ -407,7 +689,6 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         }
 
         active.Add(seq);
-        Interlocked.Increment(ref _activeCount);
     }
 
     public void Dispose()

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -236,6 +236,13 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         var posBuf = new int[_maxBatchSize];
         var cacheBuf = new PagedKvCache[_maxBatchSize];
 
+        // An exception the per-request handlers didn't isolate (e.g. a backend failure
+        // inside BatchForwardMulti) must not kill the batcher silently: without the
+        // catch + finally-drain below, every in-flight caller would hang forever on a
+        // never-completed channel and the per-sequence caches would leak.
+        Exception? fatal = null;
+        try
+        {
         while (!_disposed)
         {
             // Pull everything queued so far into the local pending queue. Channels have
@@ -364,33 +371,41 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 }
             }
         }
-
-        // Drain: complete everything still in flight. Pull any requests still sitting
-        // in the channel first — written between our last TryRead pass and the writer
-        // completing — or their output channels would never complete and the caller's
-        // await-foreach would hang.
-        while (_queue.Reader.TryRead(out var stranded))
-            pending.Enqueue(stranded);
-        foreach (var req in pending)
-        {
-            Interlocked.Decrement(ref _pendingCount);
-            req.Output.Writer.TryComplete();
         }
-        pending.Clear();
-        foreach (var p in prefilling)
+        catch (Exception ex)
         {
-            p.Req.Output.Writer.TryComplete();
-            p.Cache.Dispose();
-            Interlocked.Decrement(ref _activeCount);
+            fatal = ex;
         }
-        prefilling.Clear();
-        foreach (var seq in active)
+        finally
         {
-            FlushAndComplete(seq);
-            seq.Cache.Dispose();
-            Interlocked.Decrement(ref _activeCount);
+            // Drain: complete everything still in flight — with the fatal exception when
+            // the loop died, so callers observe the failure instead of hanging. Pull any
+            // requests still sitting in the channel first (written between our last
+            // TryRead pass and the writer completing).
+            while (_queue.Reader.TryRead(out var stranded))
+                pending.Enqueue(stranded);
+            foreach (var req in pending)
+            {
+                Interlocked.Decrement(ref _pendingCount);
+                req.Output.Writer.TryComplete(fatal);
+            }
+            pending.Clear();
+            foreach (var p in prefilling)
+            {
+                p.Req.Output.Writer.TryComplete(fatal);
+                p.Cache.Dispose();
+                Interlocked.Decrement(ref _activeCount);
+            }
+            prefilling.Clear();
+            foreach (var seq in active)
+            {
+                if (fatal is null) FlushAndComplete(seq);
+                else seq.Output.Writer.TryComplete(fatal);
+                seq.Cache.Dispose();
+                Interlocked.Decrement(ref _activeCount);
+            }
+            active.Clear();
         }
-        active.Clear();
     }
 
     /// <summary>

--- a/src/SharpInference.Engine/ForwardPass.cs
+++ b/src/SharpInference.Engine/ForwardPass.cs
@@ -487,6 +487,23 @@ public sealed unsafe class ForwardPass : IForwardPass
     public int MaxSeqLen => _kvCache.MaxSeqLen;
 
     /// <summary>
+    /// Bytes of (fp32) KV cache one token occupies across all layers. Used by
+    /// <see cref="ContinuousBatchingEngine"/> to convert a memory budget into a token
+    /// budget for admission backpressure (issue #183). Page-granularity slack in
+    /// <see cref="PagedKvCache"/> (16-position pages) is not included — the budget is
+    /// a planning estimate, not an exact accounting.
+    /// </summary>
+    public long KvBytesPerToken => (long)_hp.NumLayers * _numKvHeads * _headDim * 2 * sizeof(float);
+
+    /// <summary>
+    /// Whether SnapKV prefill eviction is configured (via SHARPI_SNAPKV*). The
+    /// continuous-batching engine checks this to disable chunked/packed prefill:
+    /// SnapKV scoring only runs on a fresh full-prompt prefill (startPos == 0), so
+    /// splitting the prompt into chunks would silently skip eviction.
+    /// </summary>
+    public bool SnapKvEnabled => _snapKvCfg.Enabled;
+
+    /// <summary>
     /// Truncate the KV cache to the given length, discarding positions >= length.
     /// Used by speculative decoding to rewind rejected draft tokens.
     /// Not supported when TurboQuant is enabled and the target length falls in the compressed range.
@@ -2349,6 +2366,226 @@ public sealed unsafe class ForwardPass : IForwardPass
                 FusedMatVec(_logits, _outputWeight, h, _hp.VocabSize, _embDim);
                 result[n] = new float[_hp.VocabSize];
                 new ReadOnlySpan<float>(_logits, _hp.VocabSize).CopyTo(result[n]);
+            }
+            return result;
+        }
+        finally
+        {
+            NativeMemory.Free(batchHidden);
+            NativeMemory.Free(batchResidual);
+        }
+    }
+
+    /// <summary>
+    /// Packed multi-sequence prefill (issue #183 Gap 2): processes one chunk of prompt
+    /// tokens from each of S sequences in a single forward pass. All chunks are
+    /// concatenated into one packed batch so every GEMM amortizes weight reads across
+    /// the combined token count — the multi-prompt analogue of what
+    /// <see cref="BatchForwardMulti"/> does for decode. Attention stays per-token
+    /// against each sequence's own cache (varlen / cu_seqlens-style: no cross-sequence
+    /// attention, no padding).
+    ///
+    /// SnapKV eviction is never applied here — chunked admission feeds this with
+    /// startPos &gt; 0 segments where SnapKV scoring doesn't run; callers that want
+    /// SnapKV must use whole-prompt <see cref="PrefillWithCache"/> instead (the engine
+    /// gates on <see cref="SnapKvEnabled"/>).
+    /// </summary>
+    /// <param name="chunks">Per-sequence token chunk (each non-empty).</param>
+    /// <param name="startPos">Per-sequence cache position at which its chunk begins.</param>
+    /// <param name="caches">Per-sequence KV cache.</param>
+    /// <param name="wantLogits">
+    /// Per-sequence: compute logits for the chunk's last token (true for a sequence's
+    /// final chunk; intermediate chunks skip the vocab projection).
+    /// </param>
+    /// <returns>Per-sequence logits array, null where <paramref name="wantLogits"/> was false.</returns>
+    public float[]?[] PrefillPackedMulti(
+        ReadOnlyMemory<int>[] chunks, int[] startPos, PagedKvCache[] caches, bool[] wantLogits)
+    {
+        if (_tqKvCache != null)
+            throw new NotSupportedException("PrefillPackedMulti is not supported when TurboQuant KV cache is enabled.");
+        if (_hp.IsMoE)
+            throw new NotSupportedException("PrefillPackedMulti is not supported for MoE models.");
+        if (_layerHeadDim is not null)
+            throw new NotSupportedException(
+                "gemma4 per-layer head_dim not yet supported on PrefillPackedMulti.");
+
+        int S = chunks.Length;
+        if (S == 0) return Array.Empty<float[]?>();
+        if (startPos.Length != S || caches.Length != S || wantLogits.Length != S)
+            throw new ArgumentException("chunks/startPos/caches/wantLogits lengths must match.");
+
+        // Packed offsets: sequence s owns packed rows [off[s], off[s+1]).
+        var off = new int[S + 1];
+        for (int s = 0; s < S; s++)
+        {
+            if (chunks[s].IsEmpty)
+                throw new ArgumentException($"Chunk for sequence {s} is empty.", nameof(chunks));
+            off[s + 1] = off[s] + chunks[s].Length;
+        }
+        int N = off[S];
+
+        int qDim = _numHeads * _headDim;
+        int kvDim = _numKvHeads * _headDim;
+        var batchHidden = (float*)NativeMemory.AllocZeroed((nuint)((long)N * _embDim * sizeof(float)));
+        var batchResidual = (float*)NativeMemory.AllocZeroed((nuint)((long)N * _embDim * sizeof(float)));
+        try
+        {
+            for (int s = 0; s < S; s++)
+            {
+                var span = chunks[s].Span;
+                for (int i = 0; i < span.Length; i++)
+                    EmbedTokenInto(span[i], batchHidden + (long)(off[s] + i) * _embDim);
+            }
+
+            var batchNorm = (float*)NativeMemory.AllocZeroed((nuint)((long)N * _embDim * sizeof(float)));
+            var batchQ = (float*)NativeMemory.AllocZeroed((nuint)((long)N * qDim * sizeof(float)));
+            var batchK = (float*)NativeMemory.AllocZeroed((nuint)((long)N * kvDim * sizeof(float)));
+            var batchV = (float*)NativeMemory.AllocZeroed((nuint)((long)N * kvDim * sizeof(float)));
+            var batchAttnOut = (float*)NativeMemory.AllocZeroed((nuint)((long)N * qDim * sizeof(float)));
+            var batchFfnGate = (float*)NativeMemory.AllocZeroed((nuint)((long)N * _intermDim * sizeof(float)));
+            var batchFfnUp = (float*)NativeMemory.AllocZeroed((nuint)((long)N * _intermDim * sizeof(float)));
+            try
+            {
+                for (int layer = 0; layer < _hp.NumLayers; layer++)
+                {
+                    // Rewind each cache so this layer's appends land at startPos[s]
+                    // (Append advances the shared position counter every layer; same
+                    // per-layer soft reset PrefillCore does for its single cache).
+                    for (int s = 0; s < S; s++)
+                        caches[s].TruncateTo(startPos[s]);
+
+                    var normW = GetNormWeight(_attnNorm[layer]);
+                    for (int n = 0; n < N; n++)
+                    {
+                        Copy(batchResidual + (long)n * _embDim, batchHidden + (long)n * _embDim, _embDim);
+                        SimdKernels.RmsNorm(batchNorm + (long)n * _embDim,
+                            batchHidden + (long)n * _embDim, normW, _embDim, _hp.RmsNormEps);
+                    }
+
+                    SimdKernels.MatMulBatched(batchQ, _wq[layer].DataPtr, batchNorm,
+                        N, qDim, _embDim, _wq[layer].DType);
+                    SimdKernels.MatMulBatched(batchK, _wk[layer].DataPtr, batchNorm,
+                        N, kvDim, _embDim, _wk[layer].DType);
+                    SimdKernels.MatMulBatched(batchV, _wv[layer].DataPtr, batchNorm,
+                        N, kvDim, _embDim, _wv[layer].DType);
+
+                    if (_hasAttnBias)
+                    {
+                        for (int n = 0; n < N; n++)
+                        {
+                            SimdKernels.AddInPlace(batchQ + (long)n * qDim, _bq[layer], qDim);
+                            SimdKernels.AddInPlace(batchK + (long)n * kvDim, _bk[layer], kvDim);
+                            SimdKernels.AddInPlace(batchV + (long)n * kvDim, _bv[layer], kvDim);
+                        }
+                    }
+
+                    bool useRoPE = _hp.NoRopeLayerStep == 0
+                        || (layer + 1) % _hp.NoRopeLayerStep != 0;
+
+                    // Per-token: RoPE at the token's own absolute position, KV append
+                    // into the token's own cache, causal attention over that cache only.
+                    for (int s = 0; s < S; s++)
+                    {
+                        for (int i = 0; i < chunks[s].Length; i++)
+                        {
+                            int n = off[s] + i;
+                            int pos = startPos[s] + i;
+                            float* qn = batchQ + (long)n * qDim;
+                            float* kn = batchK + (long)n * kvDim;
+                            float* vn = batchV + (long)n * kvDim;
+
+                            if (_hasQkNorm && !_hp.UseL2QkNorm)
+                            {
+                                ApplyQkNorm(qn, kn, layer);
+                            }
+                            if (useRoPE)
+                            {
+                                ApplyRope(qn, pos, _numHeads);
+                                ApplyRope(kn, pos, _numKvHeads);
+                            }
+                            if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
+                            {
+                                PerHeadPureRmsNorm(qn, _numHeads, _headDim, _hp.RmsNormEps);
+                                PerHeadPureRmsNorm(kn, _numKvHeads, _headDim, _hp.RmsNormEps);
+                            }
+
+                            caches[s].Append(layer,
+                                new ReadOnlySpan<float>(kn, kvDim),
+                                new ReadOnlySpan<float>(vn, kvDim));
+                            caches[s].IncrementPosition();
+
+                            Copy(_q, qn, qDim);
+                            Attention(caches[s], layer, pos);
+                            Copy(batchAttnOut + (long)n * qDim, _attnOut, qDim);
+                        }
+                    }
+
+                    SimdKernels.MatMulBatched(batchNorm, _wo[layer].DataPtr, batchAttnOut,
+                        N, _embDim, qDim, _wo[layer].DType);
+                    if (_hasAttnBias)
+                    {
+                        for (int n = 0; n < N; n++)
+                            SimdKernels.AddInPlace(batchNorm + (long)n * _embDim, _bo[layer], _embDim);
+                    }
+                    for (int n = 0; n < N; n++)
+                    {
+                        float* h = batchHidden + (long)n * _embDim;
+                        Copy(h, batchNorm + (long)n * _embDim, _embDim);
+                        SimdKernels.AddInPlace(h, batchResidual + (long)n * _embDim, _embDim);
+                    }
+
+                    var ffnNormW = GetNormWeight(_ffnNorm[layer]);
+                    for (int n = 0; n < N; n++)
+                    {
+                        Copy(batchResidual + (long)n * _embDim, batchHidden + (long)n * _embDim, _embDim);
+                        SimdKernels.RmsNorm(batchNorm + (long)n * _embDim,
+                            batchHidden + (long)n * _embDim, ffnNormW, _embDim, _hp.RmsNormEps);
+                    }
+                    SimdKernels.MatMulBatched(batchFfnGate, _wGate[layer].DataPtr, batchNorm,
+                        N, _intermDim, _embDim, _wGate[layer].DType);
+                    SimdKernels.MatMulBatched(batchFfnUp, _wUp[layer].DataPtr, batchNorm,
+                        N, _intermDim, _embDim, _wUp[layer].DType);
+                    for (int n = 0; n < N; n++)
+                        SimdKernels.SiLuMul(batchFfnGate + (long)n * _intermDim,
+                            batchFfnUp + (long)n * _intermDim, _intermDim);
+                    SimdKernels.MatMulBatched(batchNorm, _wDown[layer].DataPtr, batchFfnGate,
+                        N, _embDim, _intermDim, _wDown[layer].DType);
+                    for (int n = 0; n < N; n++)
+                    {
+                        float* h = batchHidden + (long)n * _embDim;
+                        Copy(h, batchNorm + (long)n * _embDim, _embDim);
+                        SimdKernels.AddInPlace(h, batchResidual + (long)n * _embDim, _embDim);
+                    }
+                }
+
+                // Leave every cache at its post-chunk length for subsequent decode/chunks.
+                for (int s = 0; s < S; s++)
+                    caches[s].TruncateTo(startPos[s] + chunks[s].Length);
+            }
+            finally
+            {
+                NativeMemory.Free(batchNorm);
+                NativeMemory.Free(batchQ);
+                NativeMemory.Free(batchK);
+                NativeMemory.Free(batchV);
+                NativeMemory.Free(batchAttnOut);
+                NativeMemory.Free(batchFfnGate);
+                NativeMemory.Free(batchFfnUp);
+            }
+
+            // Final norm + vocab projection only for sequences whose chunk completes
+            // their prompt — intermediate chunks never need logits.
+            var outNormW = GetNormWeight(_outputNorm);
+            var result = new float[]?[S];
+            for (int s = 0; s < S; s++)
+            {
+                if (!wantLogits[s]) continue;
+                float* lastHidden = batchHidden + (long)(off[s + 1] - 1) * _embDim;
+                SimdKernels.RmsNorm(lastHidden, lastHidden, outNormW, _embDim, _hp.RmsNormEps);
+                FusedMatVec(_logits, _outputWeight, lastHidden, _hp.VocabSize, _embDim);
+                var arr = new float[_hp.VocabSize];
+                new ReadOnlySpan<float>(_logits, _hp.VocabSize).CopyTo(arr);
+                result[s] = arr;
             }
             return result;
         }

--- a/src/SharpInference.Engine/HardwareProfile.cs
+++ b/src/SharpInference.Engine/HardwareProfile.cs
@@ -11,11 +11,19 @@ public sealed record HardwareProfile(
     bool HasAvx512)
 {
     /// <summary>
-    /// Detect hardware capabilities given a CUDA device's VRAM. Used by the CUDA hybrid
-    /// path; the underlying placement math only needs total VRAM bytes regardless of
-    /// which GPU backend reported them.
+    /// Detect hardware capabilities given a CUDA device. Used by the CUDA hybrid path.
+    /// PCIe bandwidth is measured with a real pinned-copy probe (issue #183) instead of
+    /// the VRAM-size bucket guess; the heuristic remains as fallback when the probe
+    /// fails (e.g. not enough free VRAM for the 64 MiB scratch).
     /// </summary>
-    public static HardwareProfile Detect(Cuda.CudaBackend gpu) => DetectFromVram((long)gpu.VramBytes);
+    public static HardwareProfile Detect(Cuda.CudaBackend gpu)
+    {
+        var profile = DetectFromVram((long)gpu.VramBytes);
+        double measured = gpu.MeasurePcieBandwidthGBps();
+        if (measured > 0)
+            profile = profile with { EstPcieBandwidthGBps = Math.Clamp(measured, 5.0, 64.0) };
+        return profile;
+    }
 
     /// <summary>
     /// Detect hardware capabilities from the current system and Vulkan device.

--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -19,6 +19,14 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     if (int.TryParse(Environment.GetEnvironmentVariable("SHARPI_MAX_BATCH"), out int maxBatch) && maxBatch > 0)
         opts.MaxBatchSize = maxBatch;
 
+    // Continuous-batching scheduling knobs (issue #183): prefill chunk size (Gap 1)
+    // and KV admission budget in MiB (Gap 3). Same precedence as SHARPI_MAX_BATCH.
+    if (int.TryParse(Environment.GetEnvironmentVariable("SHARPI_PREFILL_CHUNK"), out int prefillChunk) && prefillChunk >= 0)
+        opts.PrefillChunkTokens = prefillChunk;
+
+    if (long.TryParse(Environment.GetEnvironmentVariable("SHARPI_KV_BUDGET_MB"), out long kvBudgetMb) && kvBudgetMb != 0)
+        opts.KvBudgetMb = kvBudgetMb;
+
     // SHARPI_BACKEND ∈ {auto, cpu, cuda, vulkan} — case-insensitive. Lets a
     // smoke test or ad-hoc run override the appsettings.Local.json backend
     // without editing the file (matches the SHARPI_MODEL pattern above).

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -147,8 +147,11 @@ public static class InferenceEngineLoader
             owned.Add(dense);
             if (turboQuant)
                 dense.EnableTurboQuant(fp32WindowSize: 256, bits: 3);
-            // ContinuousBatchingEngine doesn't yet support MoE or TurboQuant fan-out.
-            bool batchOk = !hp.IsMoE && !turboQuant;
+            // ContinuousBatchingEngine doesn't yet support MoE, TurboQuant fan-out, or
+            // gemma4 per-layer head_dim (PrefillWithCache / BatchForwardMulti /
+            // PrefillPackedMulti all throw NotSupportedException) — those fall back to
+            // the single-user InferenceEngine instead of failing every request.
+            bool batchOk = !hp.IsMoE && !turboQuant && hp.LayerHeadDim is null;
             return (dense, batchOk);
         }
 

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -94,7 +94,9 @@ public static class InferenceEngineLoader
         if (opts.MaxBatchSize > 1 && batchingSupported && fwd is ForwardPass cpuFwd)
         {
             engine = new ContinuousBatchingEngine(cpuFwd, tokenizer, modelId, opts.MaxBatchSize,
-                thinkTokenId, endThinkTokenId);
+                thinkTokenId, endThinkTokenId,
+                prefillChunkTokens: opts.PrefillChunkTokens,
+                kvBudgetBytes: opts.KvBudgetMb > 0 ? opts.KvBudgetMb * 1024 * 1024 : opts.KvBudgetMb);
             // ContinuousBatchingEngine doesn't accept owned[] disposables; transfer
             // disposal responsibility by wrapping it in a composite disposable.
             engine = new OwnedDisposableEngine(engine, owned);

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -106,6 +106,26 @@ public sealed class SharpInferenceServerOptions
     /// </summary>
     public int MaxBatchSize { get; set; } = 1;
 
+    /// <summary>
+    /// Prompt tokens prefilled per batcher iteration under continuous batching
+    /// (issue #183 Gap 1). Active sequences advance one decode step between chunks, so
+    /// a long inbound prompt no longer freezes every in-flight generation. <c>0</c>
+    /// disables chunking (each prompt prefills in one blocking call). Only consulted
+    /// when <see cref="MaxBatchSize"/> &gt; 1. Mirrors <c>SHARPI_PREFILL_CHUNK</c>.
+    /// </summary>
+    public int PrefillChunkTokens { get; set; } = 256;
+
+    /// <summary>
+    /// KV-cache memory budget in MiB gating request admission under continuous batching
+    /// (issue #183 Gap 3). Each admitted sequence reserves
+    /// <c>promptTokens + max_tokens</c> worth of KV; when the next request would exceed
+    /// the budget it waits in the queue instead of risking memory exhaustion.
+    /// <c>0</c> = auto (half of available system RAM), negative = unlimited, positive =
+    /// explicit MiB. Only consulted when <see cref="MaxBatchSize"/> &gt; 1. Mirrors
+    /// <c>SHARPI_KV_BUDGET_MB</c>.
+    /// </summary>
+    public long KvBudgetMb { get; set; } = 0;
+
     // ── MoE expert-cache tuning ──────────────────────────────────────────────
     //
     // These knobs only have effect on Vulkan-hybrid MoE today; the engine reads them from

--- a/tests/SharpInference.Tests.ForwardPass/ContinuousBatchingTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/ContinuousBatchingTests.cs
@@ -258,4 +258,235 @@ public sealed class ContinuousBatchingTests
         // The engine shut down without crashing — that's the invariant we care about.
         Assert.True(true);
     }
+
+    // ── Issue #183: chunked prefill, packed multi-seq prefill, KV budget ──
+
+    [Fact]
+    public void PrefillWithCache_Chunked_MatchesFull()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        using var backend = new CpuBackend();
+
+        using var fwdRef = new Engine.ForwardPass(model, backend, hp);
+        using var fwdTest = new Engine.ForwardPass(model, backend, hp);
+
+        int[] tokens = [1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37];
+
+        using var refCache = fwdRef.CreateCache();
+        float[] refArr = fwdRef.PrefillWithCache(tokens, refCache).ToArray();
+
+        // Same prompt prefilled in 3 chunks via successive startPos calls — the
+        // continuation pattern the chunked-admission engine path uses (issue #183 Gap 1).
+        using var cache = fwdTest.CreateCache();
+        const int chunk = 5;
+        float[] testArr = [];
+        for (int start = 0; start < tokens.Length; start += chunk)
+        {
+            int take = Math.Min(chunk, tokens.Length - start);
+            var segment = new ArraySegment<int>(tokens, start, take);
+            testArr = fwdTest.PrefillWithCache(segment, cache, startPos: start).ToArray();
+        }
+
+        Assert.Equal(tokens.Length, cache.Length);
+        Assert.Equal(refArr.Length, testArr.Length);
+        // Chunk boundaries change GEMM batch sizes (different FP accumulation order),
+        // so assert close logits + same argmax rather than bit equality.
+        for (int i = 0; i < refArr.Length; i++)
+            Assert.Equal(refArr[i], testArr[i], precision: 2);
+        Assert.Equal(Sampler.Greedy(refArr), Sampler.Greedy(testArr));
+    }
+
+    [Fact]
+    public void PrefillPackedMulti_MatchesSequentialPrefill()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        using var backend = new CpuBackend();
+
+        int[] promptA = [1, 2, 3, 5, 7, 11, 13];
+        int[] promptB = [4, 5, 6, 8];
+
+        // Reference: each prompt prefilled alone on its own ForwardPass instance.
+        float[] refA, refB;
+        using (var fwdRef = new Engine.ForwardPass(model, backend, hp))
+        {
+            using var cA = fwdRef.CreateCache();
+            refA = fwdRef.PrefillWithCache(promptA, cA).ToArray();
+            using var cB = fwdRef.CreateCache();
+            refB = fwdRef.PrefillWithCache(promptB, cB).ToArray();
+        }
+
+        // Test: both prompts in ONE packed forward pass.
+        using var fwdPacked = new Engine.ForwardPass(model, backend, hp);
+        using var cacheA = fwdPacked.CreateCache();
+        using var cacheB = fwdPacked.CreateCache();
+
+        float[]?[] packed = fwdPacked.PrefillPackedMulti(
+            [promptA.AsMemory(), promptB.AsMemory()],
+            [0, 0],
+            [cacheA, cacheB],
+            [true, true]);
+
+        Assert.Equal(promptA.Length, cacheA.Length);
+        Assert.Equal(promptB.Length, cacheB.Length);
+        Assert.NotNull(packed[0]);
+        Assert.NotNull(packed[1]);
+
+        for (int i = 0; i < refA.Length; i++)
+            Assert.Equal(refA[i], packed[0]![i], precision: 2);
+        for (int i = 0; i < refB.Length; i++)
+            Assert.Equal(refB[i], packed[1]![i], precision: 2);
+        Assert.Equal(Sampler.Greedy(refA), Sampler.Greedy(packed[0]!));
+        Assert.Equal(Sampler.Greedy(refB), Sampler.Greedy(packed[1]!));
+    }
+
+    [Fact]
+    public void PrefillPackedMulti_ChunkedContinuation_MatchesFull()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        using var backend = new CpuBackend();
+
+        int[] promptA = [1, 2, 3, 5, 7, 11, 13];
+        int[] promptB = [4, 5, 6, 8];
+
+        float[] refA, refB;
+        using (var fwdRef = new Engine.ForwardPass(model, backend, hp))
+        {
+            using var cA = fwdRef.CreateCache();
+            refA = fwdRef.PrefillWithCache(promptA, cA).ToArray();
+            using var cB = fwdRef.CreateCache();
+            refB = fwdRef.PrefillWithCache(promptB, cB).ToArray();
+        }
+
+        // Two packed rounds: first a partial chunk of each prompt (no logits wanted),
+        // then the remainder (logits wanted) — the exact shape the engine produces when
+        // several prompts prefill chunk-by-chunk (issue #183 Gaps 1+2 combined).
+        using var fwdPacked = new Engine.ForwardPass(model, backend, hp);
+        using var cacheA = fwdPacked.CreateCache();
+        using var cacheB = fwdPacked.CreateCache();
+
+        float[]?[] round1 = fwdPacked.PrefillPackedMulti(
+            [promptA.AsMemory(0, 4), promptB.AsMemory(0, 2)],
+            [0, 0],
+            [cacheA, cacheB],
+            [false, false]);
+        Assert.Null(round1[0]);
+        Assert.Null(round1[1]);
+        Assert.Equal(4, cacheA.Length);
+        Assert.Equal(2, cacheB.Length);
+
+        float[]?[] round2 = fwdPacked.PrefillPackedMulti(
+            [promptA.AsMemory(4), promptB.AsMemory(2)],
+            [4, 2],
+            [cacheA, cacheB],
+            [true, true]);
+
+        Assert.Equal(promptA.Length, cacheA.Length);
+        Assert.Equal(promptB.Length, cacheB.Length);
+
+        for (int i = 0; i < refA.Length; i++)
+            Assert.Equal(refA[i], round2[0]![i], precision: 2);
+        for (int i = 0; i < refB.Length; i++)
+            Assert.Equal(refB[i], round2[1]![i], precision: 2);
+        Assert.Equal(Sampler.Greedy(refA), Sampler.Greedy(round2[0]!));
+        Assert.Equal(Sampler.Greedy(refB), Sampler.Greedy(round2[1]!));
+    }
+
+    [Fact]
+    public async Task ContinuousBatchingEngine_ChunkedPrefill_MatchesUnchunked()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var backend = new CpuBackend();
+
+        const string prompt = "The capital of France is";
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 8 };
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+
+        // Reference: legacy blocking prefill (chunking disabled), single request.
+        string refText;
+        using (var fwdRef = new Engine.ForwardPass(model, backend, hp))
+        using (var engineRef = new ContinuousBatchingEngine(fwdRef, tokenizer, "test-model",
+                   maxBatchSize: 2, prefillChunkTokens: 0))
+        {
+            var sb = new System.Text.StringBuilder();
+            await foreach (var chunk in engineRef.GenerateAsync(prompt, sp, cts.Token))
+                sb.Append(chunk);
+            refText = sb.ToString();
+        }
+        Assert.False(string.IsNullOrEmpty(refText));
+
+        // Test: tiny chunk size + two concurrent identical requests so admission runs
+        // the packed multi-prompt prefill path between decode steps.
+        using var fwd = new Engine.ForwardPass(model, backend, hp);
+        using var engine = new ContinuousBatchingEngine(fwd, tokenizer, "test-model",
+            maxBatchSize: 4, prefillChunkTokens: 4);
+
+        var tasks = Enumerable.Range(0, 2).Select(_ => Task.Run(async () =>
+        {
+            var sb = new System.Text.StringBuilder();
+            await foreach (var chunk in engine.GenerateAsync(prompt, sp, cts.Token))
+                sb.Append(chunk);
+            return sb.ToString();
+        })).ToArray();
+
+        string[] results = await Task.WhenAll(tasks);
+
+        // Greedy decode of the same prompt must reproduce the unchunked output —
+        // decode-coherence assertion, not just "non-null" (see feedback memory).
+        Assert.Equal(refText, results[0]);
+        Assert.Equal(refText, results[1]);
+    }
+
+    [Fact]
+    public async Task ContinuousBatchingEngine_TinyKvBudget_AllRequestsComplete()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var backend = new CpuBackend();
+        using var fwd = new Engine.ForwardPass(model, backend, hp);
+
+        // Budget of 16 KV tokens: one request (prompt ~2 + 4 new = ~6 projected) fits,
+        // three at once (≥18) do not — admission must serialize, not reject or OOM.
+        long budgetBytes = fwd.KvBytesPerToken * 16;
+        using var engine = new ContinuousBatchingEngine(fwd, tokenizer, "test-model",
+            maxBatchSize: 4, prefillChunkTokens: 4, kvBudgetBytes: budgetBytes);
+        Assert.Equal(16, engine.KvTokenBudget);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 4 };
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+
+        var tasks = new[] { "Hello", "World", "Paris" }.Select(p => Task.Run(async () =>
+        {
+            var sb = new System.Text.StringBuilder();
+            await foreach (var chunk in engine.GenerateAsync(p, sp, cts.Token))
+                sb.Append(chunk);
+            return sb.ToString();
+        })).ToArray();
+
+        string[] results = await Task.WhenAll(tasks);
+
+        // All three complete despite the budget forcing serialized admission.
+        Assert.Equal(3, results.Length);
+        Assert.All(results, r => Assert.NotNull(r));
+    }
 }

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4Cuda12BForwardPassTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4Cuda12BForwardPassTests.cs
@@ -27,9 +27,25 @@ namespace SharpInference.Tests.ForwardPass;
 /// Silent-skip: if CUDA isn't available (CPU-only tests still run) OR the GGUF isn't on
 /// disk, the relevant tests no-op.
 /// </summary>
-public sealed class Gemma4Cuda12BForwardPassTests
+public sealed class Gemma4Cuda12BForwardPassTests : IDisposable
 {
     private const string ModelFile = "gemma-4-12b-it-qat-q4_0.gguf";
+
+    // Pin the KV cache to fp32 for these tests. Since #185, CudaForwardPass
+    // auto-narrows the KV dtype when fp32 won't fit the VRAM budget — on a 12 GB
+    // card the 12B at ctx 4096 narrows to bf16, making the effective dtype
+    // environment-dependent. These tests greedy-decode a synthetic OOD token
+    // prompt where the top-logit margin is tiny, and bf16 rounding noise tips it
+    // into a single-token repetition attractor (fails the ≥2-distinct assertion)
+    // even though the bf16 path is coherent on real prompts (validated via CLI to
+    // 128K, #179/#184; q8_0's different rounding happens to pass). The guards
+    // here target trunk math (k_eq_v, per-layer KV, embed), so the dtype must be
+    // deterministic. Restored in Dispose.
+    private readonly string? _prevKvDType = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+    public Gemma4Cuda12BForwardPassTests() =>
+        Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", "fp32");
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", _prevKvDType);
 
     // Synthetic BOS-led mid-vocab prompt: the 12B IT model emits a 1-token EOS on real
     // factual prompts, so coherence is asserted on arbitrary tokens (see task notes).


### PR DESCRIPTION
Closes #183.

## Gap 1 — chunked / interleaved prefill admission
Admitted prompts prefill in `prefillChunkTokens` slices (default 256; `SHARPI_PREFILL_CHUNK` / `PrefillChunkTokens`; `0` = legacy blocking) with one `BatchForwardMulti` decode step between chunks. Cancellation honoured between chunks; SnapKV-enabled engines fall back to blocking (eviction needs the whole prompt at `startPos==0`).

**A/B** (`SharpInference.Bench -- --cb`, SmolLM2 CPU, 3 active decoders + 1040-token prompt injected):

| | worst decode stall | aggregate |
|---|---|---|
| blocking (pre-#183) | **25.1 s** | 8.1 tok/s |
| chunked+packed (256) | **7.9 s** | 7.1 tok/s |

Smaller chunks are a trap on CPU — every `MatMulBatched` call re-pays weight dequant, so prefill collapses 42→20→13 t/s at chunk 256/64/32. 256 is the default compromise, operator-tunable.

## Gap 2 — packed multi-sequence prefill
`ForwardPass.PrefillPackedMulti(chunks, startPos, caches, wantLogits)`: in-flight prompts' chunks run as ONE packed varlen pass — batched GEMMs over the combined token count, per-token RoPE/append/attention against each sequence's own `PagedKvCache`, no padding, no cross-sequence attention. Logits only for prompt-completing chunks. Same guards as `BatchForwardMulti` (no MoE/TQ/gemma4).

**A/B** (`--cb --packed`, 4×256-token prompts): whole-prompt serial 35.8 tok/s · chunked serial 20.4 · **chunked packed 33.7 (+65% vs serial chunks, −6% vs blocking)**.

## Gap 3 — KV token-budget admission backpressure
Each request reserves `min(prompt + MaxNewTokens, MaxSeqLen)` KV tokens at admission (`ForwardPass.KvBytesPerToken`); the head request waits when the budget would be exceeded instead of risking OOM. A lone oversized request is always admitted (no deadlock). `SHARPI_KV_BUDGET_MB` / `KvBudgetMb`: 0 = auto (half RAM), negative = unlimited.

## HardwareProfile: measured PCIe bandwidth
`CudaBackend.MeasurePcieBandwidthGBps()` (pinned 64 MiB probe, min(H2D, D2H), heuristic fallback) replaces the VRAM-bucket guess in `Detect(CudaBackend)`. 4070 Ti: ~26 GB/s measured vs 20 guessed.

## CUDA 13.3 evaluation (no default change)
All pinned entry points exist in 13.3. Qwen3-8B `-g -1`: prefill 2354→2390 t/s (+1.5%), decode 58.0→57.9 (noise) — decode is HBM-bound in our NVRTC kernels. `CudaLibraryResolver` (assembly's single `DllImportResolver`, NVRTC probing folded in) keeps CUDA 12 default, `SHARPI_CUDA13=1` opts into the 13 pair, and 13-only installs now load instead of hard-failing.

## Test-suite fix found along the way
`Gemma4_12B_CudaForward_ProducesCoherentDecode` has been failing on master at default settings since #186: #185's auto-narrow makes the 12B tests run with bf16 KV on a 12 GB card, and their synthetic OOD prompt's tiny logit margin lets bf16 rounding tip greedy into a one-token attractor (forced bf16 failed identically at #184 — nothing regressed; CLI bf16 output is coherent). The 12B tests now pin `SHARPI_KV_DTYPE=fp32` (they guard trunk math, not dtype noise).

## Tests
5 new in `ContinuousBatchingTests` (chunked parity, packed parity incl. `startPos>0` continuation, engine chunked-vs-unchunked greedy equality, tiny-budget completion). Full suite green: Core 134, ForwardPass 481→ all passing after the 12B pin, Pipeline 37, TurboQuant 41, Server 103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)