### PR TITLE
feat(cuda): #190 dense continuous batching (+ #183 follow-ups #189/#191)

### DIFF
--- a/benchmarks/SharpInference.Bench/ContinuousBatchingHarness.cs
+++ b/benchmarks/SharpInference.Bench/ContinuousBatchingHarness.cs
@@ -55,6 +55,16 @@ public static class ContinuousBatchingHarness
         using var backend = new CpuBackend();
         using var fwd = new ForwardPass(model, backend, hp);
 
+        // Issue #189: report the dequant-once weight-cache state so the prefill A/B below is
+        // interpretable. Force it off for the "before" numbers with SHARPI_PREFILL_DEQUANT_MB=0.
+        Console.WriteLine($"[cb] OpenBLAS: {(SimdKernels.BlasAvailable ? "LOADED" : "not found")}");
+        string budgetStr = fwd.PrefillDequantCacheBudgetBytes == long.MaxValue
+            ? "unlimited"
+            : $"{fwd.PrefillDequantCacheBudgetBytes / (1024 * 1024)} MiB";
+        Console.WriteLine($"[cb] dequant cache: {(fwd.PrefillDequantCacheActive
+            ? $"ACTIVE ({budgetStr} budget, covers model)"
+            : fwd.PrefillDequantCacheBudgetBytes > 0 ? "partial (budget < model)" : "off")}");
+
         // Long prompt: repeat filler text until the tokenizer crosses the target count.
         const string filler = "The quick brown fox jumps over the lazy dog near the quiet river bank. ";
         var sb = new System.Text.StringBuilder("<|im_start|>user\nSummarize the following text:\n");
@@ -77,7 +87,9 @@ public static class ContinuousBatchingHarness
 
         if (args.Contains("--packed"))
         {
-            RunPackedPrefillAb(fwd, tokenizer, longPrompt);
+            // --chunk N drives the per-prompt chunk size of the chunked modes so the A/B can
+            // reproduce the issue #189 chunk sweep (e.g. --packed --chunk 32 / 64). Default 64.
+            RunPackedPrefillAb(fwd, tokenizer, longPrompt, chunkArg > 0 ? chunkArg : 64);
             return;
         }
 
@@ -95,7 +107,7 @@ public static class ContinuousBatchingHarness
     /// (one PrefillWithCache per prompt) vs as ONE packed PrefillPackedMulti call.
     /// Isolates the weight-read amortization across prompts from the scheduling change.
     /// </summary>
-    private static void RunPackedPrefillAb(ForwardPass fwd, GgufTokenizer tokenizer, string longText)
+    private static void RunPackedPrefillAb(ForwardPass fwd, GgufTokenizer tokenizer, string longText, int perSeqChunk)
     {
         const int S = 4, T = 256;
         var all = tokenizer.Encode(longText).ToArray();
@@ -103,7 +115,8 @@ public static class ContinuousBatchingHarness
         for (int s = 0; s < S; s++)
             prompts[s] = all.AsSpan(s * T, T).ToArray();
 
-        const int PerSeq = 64; // chunk each prompt advances per round in the chunked modes
+        int perSeq = Math.Clamp(perSeqChunk, 1, T); // chunk each prompt advances per round in the chunked modes
+        Console.WriteLine($"  (per-prompt chunk = {perSeq} tokens)");
 
         foreach (string mode in new[] { "whole-prompt serial", "chunked serial", "chunked packed" })
         {
@@ -121,10 +134,10 @@ public static class ContinuousBatchingHarness
 
                 case "chunked serial":
                     // Gap 1 without Gap 2: same rounds, but one small call per prompt —
-                    // each call re-pays the weight read/dequant for only PerSeq tokens.
-                    for (int consumed = 0; consumed < T; consumed += PerSeq)
+                    // each call re-pays the weight read/dequant for only perSeq tokens.
+                    for (int consumed = 0; consumed < T; consumed += perSeq)
                     {
-                        int take = Math.Min(PerSeq, T - consumed);
+                        int take = Math.Min(perSeq, T - consumed);
                         for (int s = 0; s < S; s++)
                         {
                             var segment = new ArraySegment<int>(prompts[s], consumed, take);
@@ -135,9 +148,9 @@ public static class ContinuousBatchingHarness
 
                 case "chunked packed":
                     // Gap 1 + Gap 2: the S per-prompt chunks run as ONE packed pass.
-                    for (int consumed = 0; consumed < T; consumed += PerSeq)
+                    for (int consumed = 0; consumed < T; consumed += perSeq)
                     {
-                        int take = Math.Min(PerSeq, T - consumed);
+                        int take = Math.Min(perSeq, T - consumed);
                         var chunks = new ReadOnlyMemory<int>[S];
                         var startPos = new int[S];
                         var want = new bool[S];
@@ -155,7 +168,7 @@ public static class ContinuousBatchingHarness
             sw.Stop();
             foreach (var c in caches) c.Dispose();
             double tps = S * T / sw.Elapsed.TotalSeconds;
-            Console.WriteLine($"  {mode,-20} ({(mode == "whole-prompt serial" ? $"{T}/call" : $"{PerSeq}/prompt/round")}): {S}×{T} tokens in {sw.Elapsed.TotalMilliseconds,7:F0} ms → {tps,7:F1} tok/s");
+            Console.WriteLine($"  {mode,-20} ({(mode == "whole-prompt serial" ? $"{T}/call" : $"{perSeq}/prompt/round")}): {S}×{T} tokens in {sw.Elapsed.TotalMilliseconds,7:F0} ms → {tps,7:F1} tok/s");
         }
     }
 

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -128,6 +128,11 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [DefaultValue(0)]
         public int MinBatchBlas { get; init; }
 
+        [CommandOption("--prefill-dequant-cache-mb")]
+        [Description("Dequant-once BLAS weight-cache budget in MiB for CPU prefill (issue #189): caches the F32 dequant per projection weight so chunked prefill re-pays no dequant (bit-identical). Auto (env SHARPI_PREFILL_DEQUANT_MB / fit-25%-RAM) by default; 0 = off, negative = unlimited. CPU only.")]
+        [DefaultValue(long.MinValue)]
+        public long PrefillDequantCacheMb { get; init; }
+
         [CommandOption("--rep-penalty")]
         [Description("Repetition penalty (1.0 = disabled, >1.0 penalizes repeated tokens, default: 1.1)")]
         [DefaultValue(1.1f)]
@@ -291,7 +296,16 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             if (hybridFwd.HasMtpHead) mtpFwd = hybridFwd;
         }
         else if (!hp.IsHybridSsm)
-            fwd = new ForwardPass(model, cpuBackend, hp);
+        {
+            // #189 dequant cache: only the pure-CPU path (no GPU offload) runs the batched
+            // CPU prefill that consults it; under -g it would be a wasted F32 model copy.
+            long dequantBytes = settings.NGpuLayers != 0
+                ? 0
+                : settings.PrefillDequantCacheMb == long.MinValue
+                    ? long.MinValue // auto / SHARPI_PREFILL_DEQUANT_MB
+                    : ForwardPass.MbToBudgetBytes(settings.PrefillDequantCacheMb);
+            fwd = new ForwardPass(model, cpuBackend, hp, prefillDequantCacheBytes: dequantBytes);
+        }
 
         // Create backend-specific forward pass
         IDisposable? gpuBackend = null;

--- a/src/SharpInference.Cpu/SimdKernels.cs
+++ b/src/SharpInference.Cpu/SimdKernels.cs
@@ -113,6 +113,36 @@ public static unsafe class SimdKernels
 
     }
 
+    /// <summary>Whether OpenBLAS was found, i.e. whether the SGEMM batched-prefill path is live.</summary>
+    public static bool BlasAvailable => BlasInterop.IsAvailable;
+
+    /// <summary>
+    /// Batched matrix multiply against an <b>already-dequantized F32</b> weight matrix —
+    /// the dequant-free twin of <see cref="MatMulBatched"/>. Issue #189: chunked prompt
+    /// admission re-walks the same layer weights every chunk, so <see cref="MatMulBatched"/>
+    /// re-pays the full Q→F32 dequant on every call. When a caller (ForwardPass) holds the
+    /// F32 dequant of a weight in a reuse cache, it routes here to skip dequant entirely.
+    /// Bit-identical to <see cref="MatMulBatched"/>'s BLAS path: same F32 weights, same SGEMM.
+    /// </summary>
+    public static void MatMulBatchedF32(float* output, float* weightsF32, float* input,
+        int batchSize, int rows, int cols)
+    {
+        if (batchSize < MinBatchForBlas || !BlasInterop.IsAvailable)
+        {
+            // Mirror the small-batch / no-BLAS fallback, but the weights are already F32.
+            for (int n = 0; n < batchSize; n++)
+                MatVecF32(output + n * rows, weightsF32, input + n * cols, rows, cols);
+            return;
+        }
+
+        BlasInterop.Sgemm(
+            BlasInterop.RowMajor, BlasInterop.NoTrans, BlasInterop.Trans,
+            batchSize, rows, cols,
+            1.0f, input, cols,
+            weightsF32, cols,
+            0.0f, output, rows);
+    }
+
     // ================================================================
     //  Dispatchers
     // ================================================================

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -132,6 +132,8 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         int prefillChunkTokens = -1,
         long kvBudgetBytes = 0)
     {
+        ArgumentNullException.ThrowIfNull(fwd);
+        ArgumentNullException.ThrowIfNull(tokenizer);
         _fwd = fwd;
         _tokenizer = tokenizer;
         ModelId = modelId;

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -30,7 +30,7 @@ namespace SharpInference.Engine;
 /// </summary>
 public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
 {
-    private readonly ForwardPass _fwd;
+    private readonly IBatchedForwardPass _fwd;
     private readonly ITokenizer _tokenizer;
     private readonly int _maxBatchSize;
     private readonly int _thinkTokenId;
@@ -73,7 +73,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     {
         public required PendingRequest Req;
         public required int[] Tokens;
-        public required PagedKvCache Cache;
+        public required ISequenceKvCache Cache;
         public required long ProjectedTokens; // KV budget reservation, released on retire
         public int Consumed;                  // prompt tokens prefilled so far
     }
@@ -82,7 +82,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     {
         public required int CurrentToken;
         public required int Position;       // position at which CurrentToken will be decoded
-        public required PagedKvCache Cache;
+        public required ISequenceKvCache Cache;
         public required SamplingParams Sp;
         public required Channel<GenerateChunk> Output;
         public required System.Collections.Immutable.ImmutableArray<int> StopIds;
@@ -114,19 +114,22 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     /// <param name="prefillChunkTokens">
     /// Prompt tokens prefilled per batcher iteration (issue #183 Gap 1); active sequences
     /// decode one step between chunks. <c>0</c> = prefill each prompt in one blocking call.
+    /// <c>-1</c> = auto (issue #189): <c>64</c> when the forward pass's dequant-once weight
+    /// cache covers the model — small chunks are then nearly free, so a low decode-stall
+    /// chunk is safe — otherwise <c>256</c> to keep the per-chunk re-dequant amortized.
     /// </param>
     /// <param name="kvBudgetBytes">
     /// KV-memory budget gating admission (issue #183 Gap 3). <c>0</c> = auto (half of
     /// available system RAM), negative = unlimited, positive = explicit byte budget.
     /// </param>
     public ContinuousBatchingEngine(
-        ForwardPass fwd,
+        IBatchedForwardPass fwd,
         ITokenizer tokenizer,
         string modelId,
         int maxBatchSize = 8,
         int thinkTokenId = -1,
         int endThinkTokenId = -1,
-        int prefillChunkTokens = 256,
+        int prefillChunkTokens = -1,
         long kvBudgetBytes = 0)
     {
         _fwd = fwd;
@@ -137,8 +140,13 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         _endThinkTokenId = endThinkTokenId;
         _thinkingEnabled = thinkTokenId >= 0 && endThinkTokenId >= 0;
 
-        _prefillChunkTokens = prefillChunkTokens;
-        _chunkingEnabled = prefillChunkTokens > 0 && !fwd.SnapKvEnabled;
+        // -1 = auto (issue #189): a small chunk minimizes decode stall but normally collapses
+        // prefill throughput (per-chunk weight re-dequant); pick it only when the dequant-once
+        // cache covers the model so small chunks re-pay no dequant. Otherwise keep 256.
+        _prefillChunkTokens = prefillChunkTokens >= 0
+            ? prefillChunkTokens
+            : (fwd.PrefillDequantCacheActive ? 64 : 256);
+        _chunkingEnabled = _prefillChunkTokens > 0 && !fwd.SnapKvEnabled;
 
         long budgetBytes = kvBudgetBytes switch
         {
@@ -234,7 +242,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         var active = new List<ActiveSeq>(_maxBatchSize);
         var tokensBuf = new int[_maxBatchSize];
         var posBuf = new int[_maxBatchSize];
-        var cacheBuf = new PagedKvCache[_maxBatchSize];
+        var cacheBuf = new ISequenceKvCache[_maxBatchSize];
 
         // An exception the per-request handlers didn't isolate (e.g. a backend failure
         // inside BatchForwardMulti) must not kill the batcher silently: without the
@@ -459,7 +467,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             pending.Dequeue();
             Interlocked.Decrement(ref _pendingCount);
 
-            PagedKvCache cache;
+            ISequenceKvCache cache;
             try
             {
                 cache = _fwd.CreateCache();
@@ -533,7 +541,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
 
         var chunks = new ReadOnlyMemory<int>[sCount];
         var startPos = new int[sCount];
-        var caches = new PagedKvCache[sCount];
+        var caches = new ISequenceKvCache[sCount];
         var wantLogits = new bool[sCount];
         var takes = new int[sCount];
         for (int s = 0; s < sCount; s++)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -38,7 +38,7 @@ namespace SharpInference.Engine;
 ///   • MoE + TurboQuant combination not validated (no test model has both;
 ///     should compose but the dispatch never sees the combination today).
 /// </summary>
-public sealed unsafe class CudaForwardPass : IForwardPass
+public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
 {
     private readonly CudaBackend _gpu;
     private readonly GgufModel _model;
@@ -100,8 +100,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     // Non-TQ path: full FP32 cache [maxSeqLen, numKvHeads*headDim] per layer.
     // TQ path:     FP32 ring window [tqFp32Window, numKvHeads*headDim] per layer,
     //              plus TurboQuant-compressed storage for older positions.
-    private readonly Tensor[] _gpuKCache;
-    private readonly Tensor[] _gpuVCache;
+    //
+    // Mutable (issue #190): the continuous-batching path swaps in a per-sequence
+    // CudaSequenceKvCache's K/V arrays via BindCache around a Prefill call, then restores
+    // the owned arrays. _ownedKCache/_ownedVCache are the real allocation home — the only
+    // arrays Dispose frees — so a torn bind (mid-exception) never leaks or double-frees.
+    private Tensor[] _gpuKCache;
+    private Tensor[] _gpuVCache;
+    private Tensor[] _ownedKCache = null!;
+    private Tensor[] _ownedVCache = null!;
 
     // KV-cache element dtype (issue #179). F32 (default) or BFloat16 — the latter
     // halves the cache footprint to unlock long context on a 12 GB card. Arithmetic
@@ -333,6 +340,36 @@ public sealed unsafe class CudaForwardPass : IForwardPass
     private float[]? _bpPleRowHostAll;                     // managed [N × L*pleWidth]
     /// <summary>True if the most recent <see cref="Prefill"/> used the batched trunk.</summary>
     public bool LastPrefillWasBatched { get; private set; }
+
+    // Batched-decode logits scratch (issue #190): the output projection is the single
+    // largest matmul, so BatchForwardMulti runs it once over all N decode rows (weight
+    // read amortized N×) into this [N × vocab] device buffer, downloads it in one copy
+    // into _decodeLogitsHost, then splits into the per-sequence float[] results. Lazily
+    // (re)sized to the current decode batch N (small + changes only as the batch grows).
+    private Tensor? _decodeLogitsAll;
+    private float[]? _decodeLogitsHost;
+    private int _decodeLogitsCapacity;
+
+    // Batched-decode matmul path (issue #190). false (default): the GEMM-N matvec
+    // (_gpu.MatMulBatched) — bit-closest to the per-token decode oracle. It reads each weight
+    // tile once PER token-block (grid Y = nTok), so it amortizes launch overhead + L2 weight
+    // reuse, not the weight HBM reads. true (SHARPI_BATCH_DECODE_GEMM=1): the compute-bound
+    // GEMM/MMQ path (GpuMatMulBatchedCore) that reads each weight ONCE per batch — argmax-stable,
+    // not bit-exact (same contract the prefill batched trunk holds).
+    //
+    // Measured on Qwen3-8B Q4_K_M @ 4070 Ti (aggregate t/s, single-user Forward = 75): GEMM-N
+    // beats compute-bound at every realistic decode batch — N=1 70 vs 15, N=4 99 vs 57, N=8 106
+    // vs 98 — because the compute-bound kernels carry large per-step fixed costs (int8 activation
+    // conversion + the Q6_K output-weight fp16 dequant every step) that only amortize at the
+    // N=4096 scale prefill runs at. So GEMM-N is the default; the toggle is kept for very high
+    // concurrency (the curves converge near N=8, so compute-bound may overtake at N≳16).
+    private readonly bool _batchDecodeComputeBound =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_GEMM") == "1";
+
+    // Empty (no-aliasing) layer set shared by every dense per-sequence cache CreateCache
+    // hands out — dense models never share KV across layers (that's the Gemma 4 tail,
+    // excluded from batching), so nothing is ever skipped on CudaSequenceKvCache.Dispose.
+    private static readonly IReadOnlySet<int> s_noAliasedLayers = new HashSet<int>();
 
     // SWA RoPE freq base (10K for Gemma 4 SWA layers). 0 when no SWA layers.
     private readonly float _ropeThetaSwa;
@@ -669,6 +706,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         int kvDim = _numKvHeads * _headDim;
         _gpuKCache = new Tensor[hp.NumLayers];
         _gpuVCache = new Tensor[hp.NumLayers];
+        // The owned arrays are filled in-place by the branches below; capture the array
+        // references now so BindCache/RestoreOwned (issue #190) and Dispose always target
+        // the real allocation home regardless of any transient rebind.
+        _ownedKCache = _gpuKCache;
+        _ownedVCache = _gpuVCache;
         if (_tqEnabled)
         {
             if (hp.LayerHeadDim is not null)
@@ -2872,6 +2914,447 @@ public sealed unsafe class CudaForwardPass : IForwardPass
         _kvEvictedCount = 0; // fresh sequence — standard sequential cache state restored
     }
 
+    // ── IBatchedForwardPass (issue #190): CUDA continuous batching, dense path ──────────
+    //
+    // The continuous-batching engine drives this forward pass through the backend-agnostic
+    // IBatchedForwardPass surface: it allocates one per-sequence GPU KV cache per admitted
+    // request (CreateCache), prefills each (PrefillWithCache / PrefillPackedMulti), then
+    // decodes all active sequences together in one weight-amortized batched step
+    // (BatchForwardMulti). All calls land on the engine's single batcher thread, so the
+    // shared scratch + the BindCache rebind below never race.
+    //
+    // Scope is DENSE only. MoE (router Download mid-layer), Gemma-4-like (per-layer
+    // head_dim / SWA rings / shared-KV aliasing), TurboQuant (compressed ring), and an
+    // active SnapKV budget (eviction only runs on the owned cache during a whole-prompt
+    // prefill) all throw NotSupportedException here, and the loader keeps
+    // batchingSupported=false for them so those models fall back to the single-user engine.
+
+    /// <summary>Whether SnapKV prefill eviction is configured/active (issue #59). The engine
+    /// disables chunked/packed prefill when true; the loader keeps batching off when true.</summary>
+    public bool SnapKvEnabled => _snapKvEffectiveBudget > 0;
+
+    /// <summary>Bytes of KV one token occupies across all layers (issue #183) — the engine
+    /// turns a memory budget into a token admission budget. Honors the KV dtype (#179) via
+    /// block-aware <see cref="DTypeInfo.ByteSize"/> — <see cref="DTypeInfo.BytesPerElement"/>
+    /// throws for quantized stores (q8_0 packs 32 elements into a 34-byte block).</summary>
+    public long KvBytesPerToken =>
+        (long)_hp.NumLayers * 2 * DTypeInfo.ByteSize((long)_numKvHeads * _headDim, _kvDType);
+
+    /// <summary>The dequant-once CPU weight cache (issue #189) is a CPU-path optimization;
+    /// the CUDA path keeps all weights resident in VRAM, so it never applies here.</summary>
+    public bool PrefillDequantCacheActive => false;
+
+    /// <summary>Dtypes the batched-decode GEMM-N matvec (<see cref="CudaBackend.MatMulBatched"/>)
+    /// supports. Excludes Q4_0 — it has compute-bound GEMM/MMQ prefill kernels but NO GEMM-N
+    /// matvec, so a Q4_0 trunk/output weight would throw at the first batched decode step. Dense
+    /// Q4_0 is otherwise rare (the common Q4_0 model, Gemma 4 12B QAT, is already excluded as
+    /// per-layer head_dim).</summary>
+    private static bool GemmNBatchable(DType d) =>
+        d is DType.Q4_K or DType.Q5_K or DType.Q6_K or DType.Q8_0 or DType.Float32;
+
+    /// <summary>Fail-closed dtype check for a batched-decode weight: an unregistered handle is
+    /// treated as NOT batchable, so a weight whose dtype isn't tracked can't slip into the
+    /// GEMM-N path and be misdispatched (mirrors <see cref="BatchableWeight"/>).</summary>
+    private bool DecodeBatchable(Tensor t) =>
+        _weightDTypes.TryGetValue(t.Handle, out var d) && GemmNBatchable(d);
+
+    /// <summary>
+    /// Whether this instance can be driven by the continuous-batching engine (issue #190).
+    /// Single source of truth for both the loader gate and the runtime guard, so they can't
+    /// diverge: dense (non-MoE, non-Gemma-4), no TurboQuant, no active SnapKV, no final-logit
+    /// softcap (a dense softcap arch would cap prefill logits but not the un-softcapped batched
+    /// decode — keep them out until a batched softcap is wired), and every trunk + output weight
+    /// in a GEMM-N-batchable dtype (excludes Q4_0).
+    /// </summary>
+    public bool SupportsContinuousBatching
+    {
+        get
+        {
+            if (_isMoE || _isGemma4Like || _tqEnabled || _snapKvEffectiveBudget > 0) return false;
+            if (_hp.FinalLogitSoftcap > 0f) return false;
+            for (int i = 0; i < _hp.NumLayers; i++)
+            {
+                if (!DecodeBatchable(_wq[i]) || !DecodeBatchable(_wk[i]) ||
+                    !DecodeBatchable(_wo[i]) || !DecodeBatchable(_wGate[i]) ||
+                    !DecodeBatchable(_wUp[i]) || !DecodeBatchable(_wDown[i]))
+                    return false;
+                // Dense layers must own a separate V projection (k_eq_v is Gemma-4-only);
+                // a null _wv would NRE in BatchForwardMulti, so disable batching defensively.
+                if (_wv[i] is not { } wv || !DecodeBatchable(wv)) return false;
+            }
+            return DecodeBatchable(_wOutput);
+        }
+    }
+
+    /// <summary>
+    /// Guards the batched-serving entry points: continuous batching on the CUDA path is
+    /// implemented for dense transformers only. Anything that needs the owned-cache state
+    /// machine (TQ ring, SnapKV eviction), per-layer geometry (Gemma 4), a logit softcap, or a
+    /// weight dtype the GEMM-N matvec can't drive (Q4_0) is out of scope.
+    /// </summary>
+    private void ThrowIfBatchingUnsupported()
+    {
+        if (_isMoE)
+            throw new NotSupportedException(
+                "CUDA continuous batching is not supported for MoE models (router Download/Synchronize per layer).");
+        if (_isGemma4Like)
+            throw new NotSupportedException(
+                "CUDA continuous batching is not supported for Gemma-4-style models (per-layer head_dim, SWA rings, shared-KV aliasing).");
+        if (_tqEnabled)
+            throw new NotSupportedException(
+                "CUDA continuous batching is not supported with the TurboQuant KV cache.");
+        if (_snapKvEffectiveBudget > 0)
+            throw new NotSupportedException(
+                "CUDA continuous batching is not supported with an active SnapKV budget (eviction runs only on a whole-prompt prefill of the owned cache).");
+        if (_hp.FinalLogitSoftcap > 0f)
+            throw new NotSupportedException(
+                "CUDA continuous batching is not supported with a final-logit softcap (the batched decode finisher does not apply it).");
+        // Reaching here, only the weight-dtype loop can make it unsupported.
+        if (!SupportsContinuousBatching)
+            throw new NotSupportedException(
+                "CUDA continuous batching requires every trunk + output weight in a GEMM-N-batchable " +
+                "dtype (Q4_K/Q5_K/Q6_K/Q8_0/F32); a Q4_0 weight has no batched-decode matvec kernel.");
+    }
+
+    /// <summary>
+    /// Allocate a fresh, empty per-sequence GPU KV cache: NumLayers full-context K/V pairs
+    /// at the model-wide head_dim / KV-head count and the active KV dtype (#179), mirroring
+    /// the dense branch of the constructor's owned-cache allocation. Dense models never
+    /// alias KV across layers, so the cache frees every layer on dispose.
+    /// </summary>
+    internal CudaSequenceKvCache CreateCache()
+    {
+        ThrowIfBatchingUnsupported();
+
+        // The per-token CUDA-graph decode path bakes the OWNED cache's device pointers into
+        // the captured graph; replaying it after BindCache swapped in a per-sequence cache
+        // would touch a stale (foreign) pointer. Batched decode issues direct launches and
+        // never captures a graph; the only graph-eligible path the engine can still reach is
+        // Prefill's single-token Forward fallback. So once this instance is driven by the
+        // batching engine (first CreateCache), disable graphs for its lifetime.
+        _useCudaGraph = false;
+
+        int kvDim = _numKvHeads * _headDim;
+        // q8_0 KV packs 32 elements/block; the store kernels assume each layer's kvDim is a
+        // multiple of 32 (mirrors the owned-cache guard in the constructor's dense branch).
+        if (_kvDType == DType.Q8_0 && (kvDim & 31) != 0)
+            throw new NotSupportedException(
+                $"SHARPI_KV_DTYPE=q8_0 requires kvDim % 32 == 0 (block_q8_0 = 32 elements/block); kvDim={kvDim}.");
+
+        int L = _hp.NumLayers;
+        var k = new Tensor[L];
+        var v = new Tensor[L];
+        // OOM mid-loop is the realistic failure under batch pressure (each admitted sequence
+        // reserves 2·NumLayers full-context tensors). Free the partial allocations on throw so
+        // the engine's AdmitPending catch (which fails just that request and keeps running)
+        // doesn't strand VRAM that no CudaSequenceKvCache owns.
+        try
+        {
+            for (int i = 0; i < L; i++)
+            {
+                k[i] = _gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), _kvDType);
+                v[i] = _gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), _kvDType);
+            }
+        }
+        catch
+        {
+            for (int i = 0; i < L; i++)
+            {
+                if (k[i] is { } ki) _gpu.Free(ki);
+                if (v[i] is { } vi) _gpu.Free(vi);
+            }
+            throw;
+        }
+        return new CudaSequenceKvCache(_gpu, k, v, s_noAliasedLayers);
+    }
+
+    /// <summary>Swap the owned KV-cache pointers for a per-sequence cache's, plumbing its
+    /// logical length into the position counter so Prefill appends at the right slots.</summary>
+    private void BindCache(CudaSequenceKvCache cache)
+    {
+        _gpuKCache = cache.K;
+        _gpuVCache = cache.V;
+        _kvLength = cache.Length;
+    }
+
+    /// <summary>Restore the owned KV-cache pointers after a BindCache. Always called in a
+    /// finally so an exception mid-Prefill can't leave a foreign cache bound.</summary>
+    private void RestoreOwned()
+    {
+        _gpuKCache = _ownedKCache;
+        _gpuVCache = _ownedVCache;
+    }
+
+    /// <summary>
+    /// Prefill <paramref name="tokens"/> into the per-sequence <paramref name="cache"/> at
+    /// <paramref name="startPos"/>. Binds the cache, delegates to the existing
+    /// <see cref="Prefill"/> (its batched trunk is both correct and weight-amortized; prefill
+    /// captures no per-token graph, so the rebind is safe), writes the advanced length back,
+    /// and always restores the owned cache. Returns the logits at the chunk's final token.
+    /// </summary>
+    internal ReadOnlySpan<float> PrefillWithCache(IReadOnlyList<int> tokens, CudaSequenceKvCache cache, int startPos = 0)
+    {
+        ThrowIfBatchingUnsupported();
+        if (tokens is null || tokens.Count == 0)
+            throw new ArgumentException("Token list is empty", nameof(tokens));
+
+        int savedKvLength = _kvLength;
+        BindCache(cache);
+        try
+        {
+            var logits = Prefill(tokens, startPos);
+            cache.Length = _kvLength;
+            return logits;
+        }
+        finally
+        {
+            RestoreOwned();
+            _kvLength = savedKvLength;
+        }
+    }
+
+    /// <summary>
+    /// Prefill several pending sequences' chunks. Cross-prompt packing into one forward pass
+    /// is a follow-up (issue #190); for now each chunk prefills sequentially into its own
+    /// per-sequence cache via <see cref="PrefillWithCache"/> — still correct and still
+    /// amortizing the batched-trunk GEMMs within each chunk, just not across prompts.
+    /// </summary>
+    internal float[]?[] PrefillPackedMulti(
+        ReadOnlyMemory<int>[] chunks, int[] startPos, CudaSequenceKvCache[] caches, bool[] wantLogits)
+    {
+        ThrowIfBatchingUnsupported();
+        int S = chunks.Length;
+        if (S == 0) return Array.Empty<float[]?>();
+        if (startPos.Length != S || caches.Length != S || wantLogits.Length != S)
+            throw new ArgumentException("chunks/startPos/caches/wantLogits lengths must match.");
+
+        var result = new float[]?[S];
+        for (int s = 0; s < S; s++)
+        {
+            var logits = PrefillWithCache(AsList(chunks[s]), caches[s], startPos[s]);
+            result[s] = wantLogits[s] ? logits.ToArray() : null;
+        }
+        return result;
+    }
+
+    /// <summary>Expose a token chunk as IReadOnlyList without copying when it's array-backed
+    /// (the engine always builds chunks from <c>int[].AsMemory</c>).</summary>
+    private static IReadOnlyList<int> AsList(ReadOnlyMemory<int> mem) =>
+        MemoryMarshal.TryGetArray(mem, out ArraySegment<int> seg) ? seg : mem.ToArray();
+
+    /// <summary>One batched-decode matmul, routed by <see cref="_batchDecodeComputeBound"/>:
+    /// the GEMM-N matvec (default) or the compute-bound GEMM/MMQ path that amortizes the weight
+    /// HBM read across the batch (the same routing <see cref="GpuMatMulBatchedCore"/> uses for
+    /// prefill).</summary>
+    private void BatchDecodeMatMul(Tensor outAll, Tensor weights, Tensor inAll, int n)
+    {
+        if (_batchDecodeComputeBound)
+            GpuMatMulBatchedCore(outAll, weights, inAll, n);
+        else
+            _gpu.MatMulBatched(outAll, weights, inAll, n, WDType(weights));
+    }
+
+    /// <summary>
+    /// Ragged batched decode (issue #190): one token per sequence, each at its own position
+    /// against its own per-sequence cache, with the dense weight reads amortized N× across
+    /// the batch. This is a TRUE batched pass — it issues direct launches and never replays
+    /// the per-token CUDA graph (which would bake in owned-cache pointers). It adapts the
+    /// batched-trunk prefill (<see cref="PrefillBatchedTrunk"/>) to N sequences: batched
+    /// embed → per layer {batched RmsNorm + batched QKV GEMM-N, then per-sequence RoPE /
+    /// QK-norm / KV-append / single-query attention against that sequence's cache, then
+    /// batched O-proj + batched FFN} → per-row final norm + one batched output GEMM. The
+    /// per-sequence attention block mirrors the dense <see cref="RunDeviceRegion"/> ordering
+    /// exactly (QK-norm before RoPE, #157), so it is argmax-stable vs the single-user loop.
+    /// </summary>
+    internal float[][] BatchForwardMulti(int[] tokens, int[] positions, CudaSequenceKvCache[] caches)
+    {
+        ThrowIfBatchingUnsupported();
+        int N = tokens.Length;
+        if (N == 0) return Array.Empty<float[]>();
+        if (positions.Length != N || caches.Length != N)
+            throw new ArgumentException("tokens/positions/caches lengths must match.");
+
+        int embDim = _embDim;
+        int qDim = _numHeads * _headDim;
+        int kvDim = _numKvHeads * _headDim;
+        int vocab = _hp.VocabSize;
+
+        EnsureBatchedTrunkScratch(N);
+        EnsureDecodeLogits(N);
+
+        // Per-sequence views into the batched Q/K/V/attnOut scratch. The offsets are fixed
+        // across layers (the batched buffers are reused each layer), so build them once and
+        // free them at the end rather than per-layer. _maxHeadDim == _headDim on the dense
+        // path, so the q/k/v/attn buffers are exactly N×qDim / N×kvDim with no padding stride.
+        // (The O-projection bias add needs per-row hidden views too, but only when _hasAttnBias
+        // — created inline in that rare branch so the common no-bias path allocates nothing extra.)
+        var qViews = new Tensor[N];
+        var kViews = new Tensor[N];
+        var vViews = new Tensor[N];
+        var aViews = new Tensor[N];
+        for (int n = 0; n < N; n++)
+        {
+            qViews[n] = _gpu.View(_bpQ!, (long)n * qDim, qDim);
+            kViews[n] = _gpu.View(_bpK!, (long)n * kvDim, kvDim);
+            vViews[n] = _gpu.View(_bpV!, (long)n * kvDim, kvDim);
+            aViews[n] = _gpu.View(_bpAttnOut!, (long)n * qDim, qDim);
+        }
+        try
+        {
+            // 1. Embed each sequence's current token into the batched hidden buffer. (No
+            //    embedding scale: the dense per-token Forward oracle applies none — that
+            //    sqrt(embDim) factor is Gemma-only, which is out of scope here.)
+            for (int n = 0; n < N; n++)
+            {
+                EmbedTokenGpu(tokens[n]); // writes _hidden
+                _gpu.CopyDeviceRegion(_bpHidden!, (long)n * embDim * sizeof(float),
+                                      _hidden, 0, (long)embDim * sizeof(float));
+            }
+
+            // 2. Transformer layers: batched dense GEMMs + per-sequence attention.
+            for (int layer = 0; layer < _hp.NumLayers; layer++)
+            {
+                _gpu.CopyDevice(_bpResidual!, _bpHidden!);
+                _gpu.RmsNormBatched(_bpNorm!, _bpHidden!, _wAttnNorm[layer], N, embDim, _hp.RmsNormEps);
+
+                // Batched QKV. Default GEMM-N matvec (bit-closest to the per-token oracle);
+                // SHARPI_BATCH_DECODE_GEMM=1 routes the compute-bound GEMM/MMQ that amortizes
+                // the weight HBM read across the batch (argmax-stable, see BatchDecodeMatMul).
+                BatchDecodeMatMul(_bpQ!, _wq[layer], _bpNorm!, N);
+                BatchDecodeMatMul(_bpK!, _wk[layer], _bpNorm!, N);
+                BatchDecodeMatMul(_bpV!, _wv[layer]!, _bpNorm!, N);
+
+                bool useRoPE = _hp.NoRopeLayerStep == 0 || (layer + 1) % _hp.NoRopeLayerStep != 0;
+
+                // Per-sequence: bias → QK-norm/RoPE (same order as RunDeviceRegion, #157) →
+                // KV append into that sequence's own cache → single-query attention over its
+                // [0, pos+1). _kvEvictedCount is 0 (SnapKV is rejected for batching), so the
+                // physical slot is simply pos.
+                for (int n = 0; n < N; n++)
+                {
+                    int pos = positions[n];
+                    Tensor qv = qViews[n], kv = kViews[n], vv = vViews[n], av = aViews[n];
+
+                    if (_hasAttnBias)
+                    {
+                        _gpu.AddInPlace(qv, _bq![layer]);
+                        _gpu.AddInPlace(kv, _bk![layer]);
+                        _gpu.AddInPlace(vv, _bv![layer]);
+                    }
+
+                    if (_hasQkNorm && !_hp.UseL2QkNorm)
+                    {
+                        _gpu.HeadNorm(qv, _wqNorm![layer], _numHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                        _gpu.HeadNorm(kv, _wkNorm![layer], _numKvHeads, _headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                    }
+                    if (useRoPE)
+                    {
+                        _gpu.RoPE(qv, pos, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                        _gpu.RoPE(kv, pos, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                    }
+                    if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
+                    {
+                        _gpu.HeadNormPure(qv, _numHeads, _headDim, _hp.RmsNormEps);
+                        _gpu.HeadNormPure(kv, _numKvHeads, _headDim, _hp.RmsNormEps);
+                    }
+
+                    Tensor kc = caches[n].K[layer], vc = caches[n].V[layer];
+                    KvAppendKv(kv, vv, kc, vc, kvDim, pos, _maxSeqLen);
+                    AttentionKv(qv, kc, vc, av, _attnScoresScratch,
+                        _numHeads, _numKvHeads, _headDim, pos + 1, _maxSeqLen, _attnScale);
+                    caches[n].Length = pos + 1;
+                }
+
+                // Batched O-projection + residual. The attn-output bias is per-row, so it needs
+                // a per-sequence hidden view; created inline here (rare branch) to keep the
+                // common no-bias decode path free of unused per-row views.
+                BatchDecodeMatMul(_bpHidden!, _wo[layer], _bpAttnOut!, N);
+                if (_hasAttnBias)
+                    for (int n = 0; n < N; n++)
+                    {
+                        var hv = _gpu.View(_bpHidden!, (long)n * embDim, embDim);
+                        _gpu.AddInPlace(hv, _bo![layer]);
+                        _gpu.Free(hv);
+                    }
+                _gpu.AddInPlace(_bpHidden!, _bpResidual!);
+
+                // FFN (dense SwiGLU), batched across N.
+                _gpu.CopyDevice(_bpResidual!, _bpHidden!);
+                _gpu.RmsNormBatched(_bpNorm!, _bpHidden!, _wFfnNorm[layer], N, embDim, _hp.RmsNormEps);
+                BatchDecodeMatMul(_bpFfnGate!, _wGate[layer], _bpNorm!, N);
+                BatchDecodeMatMul(_bpFfnUp!,   _wUp[layer],   _bpNorm!, N);
+                _gpu.SiLuMul(_bpFfnGate!, _bpFfnUp!);
+                BatchDecodeMatMul(_bpHidden!, _wDown[layer], _bpFfnGate!, N);
+                _gpu.AddInPlace(_bpHidden!, _bpResidual!);
+            }
+
+            // 3. Final norm + output projection, batched (the output weight is the largest
+            //    single matmul, so amortizing its read across N is the main throughput win).
+            _gpu.RmsNormBatched(_bpHidden!, _bpHidden!, _wOutputNorm, N, embDim, _hp.RmsNormEps);
+            BatchDecodeMatMul(_decodeLogitsAll!, _wOutput, _bpHidden!, N);
+            _gpu.Download(_decodeLogitsAll!, _decodeLogitsHost.AsSpan(0, N * vocab));
+            _gpu.Synchronize();
+
+            var result = new float[N][];
+            for (int n = 0; n < N; n++)
+            {
+                result[n] = new float[vocab];
+                Array.Copy(_decodeLogitsHost!, (long)n * vocab, result[n], 0, vocab);
+            }
+            return result;
+        }
+        finally
+        {
+            for (int n = 0; n < N; n++)
+            {
+                _gpu.Free(qViews[n]); _gpu.Free(kViews[n]);
+                _gpu.Free(vViews[n]); _gpu.Free(aViews[n]);
+            }
+        }
+    }
+
+    /// <summary>(Re)allocate the batched-decode logits buffer [<paramref name="n"/> × vocab]
+    /// and its host download buffer when the decode batch size changes.</summary>
+    private void EnsureDecodeLogits(int n)
+    {
+        if (_decodeLogitsCapacity == n) return;
+        // The device buffer + Array.Copy offsets are computed in long, but the host array
+        // length and Download span are int (array lengths are int). Guard the int*int product
+        // so an extreme batch×vocab can't silently wrap to a too-small host buffer (unreachable
+        // at sane batch sizes — N ≤ maxBatch, ~14K at vocab 152K — but fail loud, not corrupt).
+        long total = (long)n * _hp.VocabSize;
+        if (total > int.MaxValue)
+            throw new NotSupportedException(
+                $"Batched decode logits buffer ({n}×{_hp.VocabSize}) exceeds int.MaxValue; reduce SHARPI_MAX_BATCH.");
+        if (_decodeLogitsAll is { } old) _gpu.Free(old);
+        _decodeLogitsAll = _gpu.Allocate(TensorShape.D1(total));
+        _decodeLogitsHost = new float[(int)total];
+        _decodeLogitsCapacity = n;
+    }
+
+    // Explicit IBatchedForwardPass surface: the engine holds caches as opaque
+    // ISequenceKvCache handles; unwrap them to the concrete CUDA cache the methods above take.
+    ISequenceKvCache IBatchedForwardPass.CreateCache() => CreateCache();
+
+    ReadOnlySpan<float> IBatchedForwardPass.PrefillWithCache(
+        IReadOnlyList<int> tokens, ISequenceKvCache cache, int startPos)
+        => PrefillWithCache(tokens, (CudaSequenceKvCache)cache, startPos);
+
+    float[]?[] IBatchedForwardPass.PrefillPackedMulti(
+        ReadOnlyMemory<int>[] chunks, int[] startPos, ISequenceKvCache[] caches, bool[] wantLogits)
+        => PrefillPackedMulti(chunks, startPos, Cast(caches), wantLogits);
+
+    float[][] IBatchedForwardPass.BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        => BatchForwardMulti(tokens, positions, Cast(caches));
+
+    private static CudaSequenceKvCache[] Cast(ISequenceKvCache[] caches)
+    {
+        var r = new CudaSequenceKvCache[caches.Length];
+        for (int i = 0; i < caches.Length; i++)
+            r[i] = (CudaSequenceKvCache)caches[i];
+        return r;
+    }
+
     private void GpuMatMul(Tensor output, Tensor weights, Tensor input)
     {
         var dtype = _weightDTypes.GetValueOrDefault(weights.Handle, DType.Q4_K);
@@ -3490,9 +3973,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass
             // Without this guard the second Free() on the same device pointer would
             // hit a CUDA double-free / use-after-free.
             if (_kvAliasedLayers.Contains(i)) continue;
-            _gpu.Free(_gpuKCache[i]);
-            _gpu.Free(_gpuVCache[i]);
+            // Free the OWNED arrays (issue #190): _gpuKCache/_gpuVCache may transiently
+            // point at a per-sequence cache mid-bind, but every bind restores in a finally,
+            // so at teardown they equal the owned arrays — free those directly to be robust.
+            _gpu.Free(_ownedKCache[i]);
+            _gpu.Free(_ownedVCache[i]);
         }
+
+        // Batched-decode logits scratch (issue #190; allocated only if batching ran).
+        if (_decodeLogitsAll is { } dl) _gpu.Free(dl);
 
         if (_tqEnabled)
         {

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -3094,6 +3094,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// </summary>
     internal ReadOnlySpan<float> PrefillWithCache(IReadOnlyList<int> tokens, CudaSequenceKvCache cache, int startPos = 0)
     {
+        ArgumentNullException.ThrowIfNull(cache);
         ThrowIfBatchingUnsupported();
         if (tokens is null || tokens.Count == 0)
             throw new ArgumentException("Token list is empty", nameof(tokens));
@@ -3122,6 +3123,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     internal float[]?[] PrefillPackedMulti(
         ReadOnlyMemory<int>[] chunks, int[] startPos, CudaSequenceKvCache[] caches, bool[] wantLogits)
     {
+        ArgumentNullException.ThrowIfNull(chunks);
+        ArgumentNullException.ThrowIfNull(startPos);
+        ArgumentNullException.ThrowIfNull(caches);
+        ArgumentNullException.ThrowIfNull(wantLogits);
         ThrowIfBatchingUnsupported();
         int S = chunks.Length;
         if (S == 0) return Array.Empty<float[]?>();
@@ -3168,6 +3173,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// </summary>
     internal float[][] BatchForwardMulti(int[] tokens, int[] positions, CudaSequenceKvCache[] caches)
     {
+        ArgumentNullException.ThrowIfNull(tokens);
+        ArgumentNullException.ThrowIfNull(positions);
+        ArgumentNullException.ThrowIfNull(caches);
         ThrowIfBatchingUnsupported();
         int N = tokens.Length;
         if (N == 0) return Array.Empty<float[]>();
@@ -3188,19 +3196,21 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         // path, so the q/k/v/attn buffers are exactly N×qDim / N×kvDim with no padding stride.
         // (The O-projection bias add needs per-row hidden views too, but only when _hasAttnBias
         // — created inline in that rare branch so the common no-bias path allocates nothing extra.)
+        // Allocated INSIDE the try so a mid-loop View throw still frees the views taken so far.
         var qViews = new Tensor[N];
         var kViews = new Tensor[N];
         var vViews = new Tensor[N];
         var aViews = new Tensor[N];
-        for (int n = 0; n < N; n++)
-        {
-            qViews[n] = _gpu.View(_bpQ!, (long)n * qDim, qDim);
-            kViews[n] = _gpu.View(_bpK!, (long)n * kvDim, kvDim);
-            vViews[n] = _gpu.View(_bpV!, (long)n * kvDim, kvDim);
-            aViews[n] = _gpu.View(_bpAttnOut!, (long)n * qDim, qDim);
-        }
         try
         {
+            for (int n = 0; n < N; n++)
+            {
+                qViews[n] = _gpu.View(_bpQ!, (long)n * qDim, qDim);
+                kViews[n] = _gpu.View(_bpK!, (long)n * kvDim, kvDim);
+                vViews[n] = _gpu.View(_bpV!, (long)n * kvDim, kvDim);
+                aViews[n] = _gpu.View(_bpAttnOut!, (long)n * qDim, qDim);
+            }
+
             // 1. Embed each sequence's current token into the batched hidden buffer. (No
             //    embedding scale: the dense per-token Forward oracle applies none — that
             //    sqrt(embDim) factor is Gemma-only, which is out of scope here.)
@@ -3262,7 +3272,8 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                     KvAppendKv(kv, vv, kc, vc, kvDim, pos, _maxSeqLen);
                     AttentionKv(qv, kc, vc, av, _attnScoresScratch,
                         _numHeads, _numKvHeads, _headDim, pos + 1, _maxSeqLen, _attnScale);
-                    caches[n].Length = pos + 1;
+                    // caches[n].Length is advanced once after the pass completes (below), not
+                    // here — a mid-pass throw then leaves the logical length unadvanced.
                 }
 
                 // Batched O-projection + residual. The attn-output bias is per-row, so it needs
@@ -3300,15 +3311,23 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             {
                 result[n] = new float[vocab];
                 Array.Copy(_decodeLogitsHost!, (long)n * vocab, result[n], 0, vocab);
+                // Advance each sequence's logical length now that the append + attention for
+                // this token have completed and synchronized (transactional: a mid-pass throw
+                // leaves Length untouched).
+                caches[n].Length = positions[n] + 1;
             }
             return result;
         }
         finally
         {
+            // View arrays may be partially populated if a View call above threw — null-check
+            // each (Tensor is a ref type; Free(null) would NRE) so cleanup is exception-safe.
             for (int n = 0; n < N; n++)
             {
-                _gpu.Free(qViews[n]); _gpu.Free(kViews[n]);
-                _gpu.Free(vViews[n]); _gpu.Free(aViews[n]);
+                if (qViews[n] is { } qv) _gpu.Free(qv);
+                if (kViews[n] is { } kv) _gpu.Free(kv);
+                if (vViews[n] is { } vv) _gpu.Free(vv);
+                if (aViews[n] is { } av) _gpu.Free(av);
             }
         }
     }

--- a/src/SharpInference.Engine/CudaSequenceKvCache.cs
+++ b/src/SharpInference.Engine/CudaSequenceKvCache.cs
@@ -37,6 +37,10 @@ internal sealed class CudaSequenceKvCache : ISequenceKvCache
 
     public CudaSequenceKvCache(CudaBackend gpu, Tensor[] k, Tensor[] v, IReadOnlySet<int> aliasedLayers)
     {
+        ArgumentNullException.ThrowIfNull(gpu);
+        ArgumentNullException.ThrowIfNull(k);
+        ArgumentNullException.ThrowIfNull(v);
+        ArgumentNullException.ThrowIfNull(aliasedLayers);
         _gpu = gpu;
         K = k;
         V = v;

--- a/src/SharpInference.Engine/CudaSequenceKvCache.cs
+++ b/src/SharpInference.Engine/CudaSequenceKvCache.cs
@@ -1,0 +1,61 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+
+namespace SharpInference.Engine;
+
+/// <summary>
+/// A per-sequence GPU KV cache for CUDA continuous batching (issue #190, step 1). Unlike the
+/// single owned cache hardwired into <see cref="CudaForwardPass"/>, this is a detachable bundle
+/// of per-layer device K/V tensors that the continuous-batching engine allocates once per
+/// admitted sequence (via <c>CudaForwardPass.CreateCache</c>) and threads back through the
+/// batched forward-pass calls as an opaque <see cref="ISequenceKvCache"/>.
+///
+/// The tensors are allocated by the forward pass, which owns the geometry (per-layer head_dim,
+/// SWA ring sizing, k_eq_v / shared-KV aliasing, and the KV dtype) — this type just holds them
+/// and frees the non-aliased ones on dispose, mirroring <see cref="CudaForwardPass"/>'s own
+/// KV-cache teardown. <see cref="Length"/> is the logical token count the forward pass advances
+/// as it appends; it lives here (not on the forward pass) so each sequence tracks its own.
+/// </summary>
+internal sealed class CudaSequenceKvCache : ISequenceKvCache
+{
+    private readonly CudaBackend _gpu;
+
+    /// <summary>Per-layer key cache. Aliased layers (see <see cref="_aliasedLayers"/>) share the
+    /// source layer's tensor instance, exactly as the forward pass's owned cache does.</summary>
+    public Tensor[] K { get; }
+
+    /// <summary>Per-layer value cache (aliased layers share the source layer's tensor).</summary>
+    public Tensor[] V { get; }
+
+    /// <summary>Layers whose K/V alias a source layer (Gemma 4 shared-KV tail) — never freed here.</summary>
+    private readonly IReadOnlySet<int> _aliasedLayers;
+
+    /// <summary>Logical KV positions stored so far (the forward pass reads/advances this).</summary>
+    public int Length;
+
+    private bool _disposed;
+
+    public CudaSequenceKvCache(CudaBackend gpu, Tensor[] k, Tensor[] v, IReadOnlySet<int> aliasedLayers)
+    {
+        _gpu = gpu;
+        K = k;
+        V = v;
+        _aliasedLayers = aliasedLayers;
+        Length = 0;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        for (int i = 0; i < K.Length; i++)
+        {
+            // Skip aliased layers: their handles are owned by the source layer, which frees
+            // them on its own iteration. A second Free() on the same device pointer would be a
+            // CUDA double-free (same guard as CudaForwardPass.Dispose).
+            if (_aliasedLayers.Contains(i)) continue;
+            _gpu.Free(K[i]);
+            _gpu.Free(V[i]);
+        }
+    }
+}

--- a/src/SharpInference.Engine/ForwardPass.cs
+++ b/src/SharpInference.Engine/ForwardPass.cs
@@ -12,7 +12,7 @@ namespace SharpInference.Engine;
 /// Optimized CPU forward pass for a dense LLaMA-family transformer.
 /// Uses AVX2 SIMD, fused dequant-matvec, and multi-threading.
 /// </summary>
-public sealed unsafe class ForwardPass : IForwardPass
+public sealed unsafe class ForwardPass : IForwardPass, IBatchedForwardPass
 {
     private readonly GgufModel _model;
     private readonly ModelHyperparams _hp;
@@ -21,6 +21,19 @@ public sealed unsafe class ForwardPass : IForwardPass
 
     // Norm weight cache: only tiny F32 weights (2048 floats = 8KB each)
     private readonly Dictionary<string, nint> _normCache = new();
+
+    // Dequant-once BLAS weight cache (issue #189). The batched-prefill BLAS path
+    // (SimdKernels.MatMulBatched) re-dequantizes each projection weight to F32 on every
+    // call; chunked prompt admission re-walks all layers per chunk, so small chunks re-pay
+    // the full dequant N times. We cache the F32 dequant per weight tensor (keyed by name)
+    // and reuse it across chunks. Reuse distance is a full model sweep, so the cache only
+    // pays off if it can hold *every* batched projection weight — hence _dequantCacheCovers.
+    // Populated lazily on the single batcher thread (same no-lock assumption as _normCache).
+    private readonly Dictionary<string, nint> _dequantWeightCache = new();
+    private readonly bool _dequantCacheEnabled;
+    private readonly bool _dequantCacheCovers;     // budget holds the whole model
+    private readonly long _dequantCacheBudgetBytes; // 0 = off, long.MaxValue = unlimited
+    private long _dequantCacheUsedBytes;
 
     // Preallocated scratch buffers
     private readonly float* _hidden;     // [embDim]
@@ -155,7 +168,7 @@ public sealed unsafe class ForwardPass : IForwardPass
     private readonly float* _pleY;            // [embDim] inner scratch
 
     public ForwardPass(GgufModel model, IComputeBackend backend, ModelHyperparams hp,
-        int maxContextLength = 0)
+        int maxContextLength = 0, long prefillDequantCacheBytes = long.MinValue)
     {
         _model = model;
         _hp = hp;
@@ -424,8 +437,66 @@ public sealed unsafe class ForwardPass : IForwardPass
             _pleY = Alloc(_embDim);
         }
 
+        // ── Dequant-once BLAS weight cache budget (issue #189) ──────────────────────
+        // Only dense models route batched prefill through MatMulBatched: MoE uses its own
+        // expert path and Gemma 4 per-layer head_dim falls back to sequential Forward, so
+        // neither would ever consult the cache. And without OpenBLAS the batched path stays
+        // on the fused register-dequant MatVec, where a separate F32 cache is a net loss.
+        bool cacheable = SimdKernels.BlasAvailable && !_hp.IsMoE && _layerHeadDim is null;
+        long fullF32Bytes = 0;
+        if (cacheable)
+        {
+            // Sum only weights that will actually be cached: skip unset tensors (a default
+            // TensorRef has a null Dimensions array, whose ElementCount throws), e.g. the
+            // absent attn_v on k_eq_v layers. MatMulBatchedCached caches the same set.
+            static long F32Bytes(in TensorRef t) =>
+                t.DataPtr is null ? 0 : t.Info.ElementCount * sizeof(float);
+            for (int l = 0; l < _hp.NumLayers; l++)
+                fullF32Bytes += F32Bytes(_wq[l]) + F32Bytes(_wk[l]) + F32Bytes(_wv[l])
+                    + F32Bytes(_wo[l]) + F32Bytes(_wGate[l]) + F32Bytes(_wUp[l]) + F32Bytes(_wDown[l]);
+        }
+        _dequantCacheBudgetBytes = ResolveDequantCacheBudget(prefillDequantCacheBytes, fullF32Bytes, cacheable);
+        _dequantCacheEnabled = _dequantCacheBudgetBytes > 0;
+        _dequantCacheCovers = _dequantCacheEnabled && fullF32Bytes > 0
+            && _dequantCacheBudgetBytes >= fullF32Bytes;
+
         PrefaultWeights();
     }
+
+    /// <summary>
+    /// Resolve the issue #189 dequant-cache byte budget. <paramref name="requested"/> is the
+    /// programmatic override in <i>bytes</i> (<c>long.MinValue</c> = resolve from the
+    /// <c>SHARPI_PREFILL_DEQUANT_MB</c> env var); for both sources <c>0</c> = off,
+    /// negative = unlimited, positive = explicit budget. The env "auto" default (unset or
+    /// <c>auto</c>) enables the cache only when a full F32 copy of the projection weights
+    /// fits within a quarter of available RAM (as reported by <see cref="GC.GetGCMemoryInfo"/>,
+    /// which reflects the container/cgroup limit when the runtime detects one), mirroring the
+    /// engine's KV-budget auto-sizing.
+    /// </summary>
+    private static long ResolveDequantCacheBudget(long requested, long fullF32Bytes, bool cacheable)
+    {
+        if (!cacheable) return 0;
+
+        if (requested != long.MinValue)
+            return requested == 0 ? 0 : requested < 0 ? long.MaxValue : requested;
+
+        var raw = Environment.GetEnvironmentVariable("SHARPI_PREFILL_DEQUANT_MB");
+        if (raw is null || raw.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            || !long.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out long mb))
+        {
+            long avail = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            return fullF32Bytes > 0 && fullF32Bytes <= avail / 4 ? fullF32Bytes : 0;
+        }
+        return MbToBudgetBytes(mb);
+    }
+
+    /// <summary>MiB→byte budget with the #189 sign convention (0=off, &lt;0=unlimited), saturating
+    /// to <see cref="long.MaxValue"/> instead of overflowing on an absurdly large MiB value.</summary>
+    public static long MbToBudgetBytes(long mb) =>
+        mb == 0 ? 0
+        : mb < 0 || mb > long.MaxValue / (1024 * 1024) ? long.MaxValue
+        : mb * 1024 * 1024;
 
     /// <summary>
     /// Touch every 4KB page of all weight tensors to force OS page-in,
@@ -502,6 +573,18 @@ public sealed unsafe class ForwardPass : IForwardPass
     /// splitting the prompt into chunks would silently skip eviction.
     /// </summary>
     public bool SnapKvEnabled => _snapKvCfg.Enabled;
+
+    /// <summary>
+    /// Whether the issue #189 dequant-once BLAS weight cache is active <i>and</i> budgeted to
+    /// hold every batched-prefill projection weight. When true, chunked prefill at small chunk
+    /// sizes re-pays no dequant after the first sweep, so <see cref="ContinuousBatchingEngine"/>
+    /// can default to a small prefill chunk (low decode-stall) without the throughput collapse
+    /// the per-chunk re-dequant would otherwise cause.
+    /// </summary>
+    public bool PrefillDequantCacheActive => _dequantCacheCovers;
+
+    /// <summary>Resolved dequant-cache byte budget (issue #189): 0 = off, long.MaxValue = unlimited.</summary>
+    public long PrefillDequantCacheBudgetBytes => _dequantCacheBudgetBytes;
 
     /// <summary>
     /// Truncate the KV cache to the given length, discarding positions >= length.
@@ -582,6 +665,71 @@ public sealed unsafe class ForwardPass : IForwardPass
     /// Batched prefill core: processes N tokens layer-by-layer into the given cache.
     /// Used by <see cref="Prefill"/> (with _kvCache) and <see cref="PrefillWithCache"/> (with an external cache).
     /// </summary>
+    /// <summary>
+    /// Batched projection used by the prefill cores. When the issue #189 dequant cache is
+    /// active and this is a BLAS-engaged quantized GEMM, it dequantizes the weight once into
+    /// the cache and reuses it across chunks; otherwise it falls back to the standard
+    /// <see cref="SimdKernels.MatMulBatched"/> (dequant-per-call). The cached path is
+    /// bit-identical: same F32 weights, same SGEMM.
+    /// </summary>
+    private void MatMulBatchedCached(float* output, in TensorRef w, float* input,
+        int N, int rows, int cols)
+    {
+        if (_dequantCacheEnabled && w.DType != DType.Float32 && N >= SimdKernels.MinBatchForBlas)
+        {
+            float* wf32 = GetDequantWeightF32(in w, rows, cols);
+            if (wf32 != null)
+            {
+                SimdKernels.MatMulBatchedF32(output, wf32, input, N, rows, cols);
+                return;
+            }
+        }
+        SimdKernels.MatMulBatched(output, w.DataPtr, input, N, rows, cols, w.DType);
+    }
+
+    /// <summary>
+    /// Return the F32 dequant of a weight tensor from the issue #189 reuse cache, populating
+    /// it on a miss. Returns <c>null</c> when adding this tensor would exceed the byte budget
+    /// (fill-and-stop, no eviction — the reuse distance is a whole model sweep, so an LRU
+    /// smaller than the model just thrashes) so the caller re-dequants per call instead.
+    /// </summary>
+    private float* GetDequantWeightF32(in TensorRef w, int rows, int cols)
+    {
+        if (_dequantWeightCache.TryGetValue(w.Name, out var hit))
+            return (float*)hit;
+
+        long elems = (long)rows * cols;
+        long totalBytes = DTypeInfo.ByteSize(elems, w.DType);
+        // The quant source span and the F32 destination span are addressed with int lengths.
+        // A weight too large for that can't be cached (it would also break the per-call
+        // MatMulBatched path) — fall back to per-call dequant rather than truncate silently.
+        if (elems > int.MaxValue || totalBytes > int.MaxValue)
+            return null;
+
+        long bytes = elems * sizeof(float);
+        if (_dequantCacheUsedBytes + bytes > _dequantCacheBudgetBytes)
+            return null;
+
+        // Zeroed (not Alloc) so a partial dequant can never leave uninitialized tail bytes;
+        // Dequantize.ToFloat32 writes the full element count for block-aligned GGUF tensors.
+        var buf = (float*)NativeMemory.AllocZeroed((nuint)bytes);
+        try
+        {
+            Dequantize.ToFloat32(
+                new ReadOnlySpan<byte>(w.DataPtr, (int)totalBytes),
+                new Span<float>(buf, (int)elems),
+                w.DType, elems);
+        }
+        catch
+        {
+            NativeMemory.Free(buf); // don't orphan the allocation if dequant throws
+            throw;
+        }
+        _dequantWeightCache[w.Name] = (nint)buf;
+        _dequantCacheUsedBytes += bytes;
+        return buf;
+    }
+
     private ReadOnlySpan<float> PrefillCore(IReadOnlyList<int> tokens, PagedKvCache cache, int startPos)
     {
         int N = tokens.Count;
@@ -637,12 +785,9 @@ public sealed unsafe class ForwardPass : IForwardPass
                     }
 
                     // Batched Q/K/V projections (single GEMM per weight matrix)
-                    SimdKernels.MatMulBatched(batchQ, _wq[layer].DataPtr, batchNorm,
-                        N, qDim, _embDim, _wq[layer].DType);
-                    SimdKernels.MatMulBatched(batchK, _wk[layer].DataPtr, batchNorm,
-                        N, kvDim, _embDim, _wk[layer].DType);
-                    SimdKernels.MatMulBatched(batchV, _wv[layer].DataPtr, batchNorm,
-                        N, kvDim, _embDim, _wv[layer].DType);
+                    MatMulBatchedCached(batchQ, in _wq[layer], batchNorm, N, qDim, _embDim);
+                    MatMulBatchedCached(batchK, in _wk[layer], batchNorm, N, kvDim, _embDim);
+                    MatMulBatchedCached(batchV, in _wv[layer], batchNorm, N, kvDim, _embDim);
 
                     // Apply QKV biases per token (Qwen models)
                     if (_hasAttnBias)
@@ -710,8 +855,7 @@ public sealed unsafe class ForwardPass : IForwardPass
                     }
 
                     // Batched output projection
-                    SimdKernels.MatMulBatched(batchNorm, _wo[layer].DataPtr, batchAttnOut,
-                        N, _embDim, qDim, _wo[layer].DType);
+                    MatMulBatchedCached(batchNorm, in _wo[layer], batchAttnOut, N, _embDim, qDim);
 
                     // Apply output projection bias (Qwen models)
                     if (_hasAttnBias)
@@ -739,18 +883,15 @@ public sealed unsafe class ForwardPass : IForwardPass
                             batchHidden + (long)n * _embDim, ffnNormW, _embDim, _hp.RmsNormEps);
                     }
 
-                    SimdKernels.MatMulBatched(batchFfnGate, _wGate[layer].DataPtr, batchNorm,
-                        N, _intermDim, _embDim, _wGate[layer].DType);
-                    SimdKernels.MatMulBatched(batchFfnUp, _wUp[layer].DataPtr, batchNorm,
-                        N, _intermDim, _embDim, _wUp[layer].DType);
+                    MatMulBatchedCached(batchFfnGate, in _wGate[layer], batchNorm, N, _intermDim, _embDim);
+                    MatMulBatchedCached(batchFfnUp, in _wUp[layer], batchNorm, N, _intermDim, _embDim);
 
                     // Per-token SiLU(gate) * up
                     for (int n = 0; n < N; n++)
                         SimdKernels.SiLuMul(batchFfnGate + (long)n * _intermDim,
                             batchFfnUp + (long)n * _intermDim, _intermDim);
 
-                    SimdKernels.MatMulBatched(batchNorm, _wDown[layer].DataPtr, batchFfnGate,
-                        N, _embDim, _intermDim, _wDown[layer].DType);
+                    MatMulBatchedCached(batchNorm, in _wDown[layer], batchFfnGate, N, _embDim, _intermDim);
 
                     // Residual add
                     for (int n = 0; n < N; n++)
@@ -2122,6 +2263,33 @@ public sealed unsafe class ForwardPass : IForwardPass
     public PagedKvCache CreateCache() =>
         new PagedKvCache(_hp.NumLayers, _hp.NumKvHeads, _headDim);
 
+    // ── IBatchedForwardPass (issue #190) ────────────────────────────────────────
+    // The engine drives this forward pass through the backend-agnostic interface, holding
+    // caches as opaque ISequenceKvCache handles. For the CPU path the handle IS the concrete
+    // PagedKvCache the methods above already take, so these explicit implementations just
+    // unwrap it. SnapKvEnabled / KvBytesPerToken / PrefillDequantCacheActive are public and
+    // satisfy the interface implicitly.
+    ISequenceKvCache IBatchedForwardPass.CreateCache() => CreateCache();
+
+    ReadOnlySpan<float> IBatchedForwardPass.PrefillWithCache(
+        IReadOnlyList<int> tokens, ISequenceKvCache cache, int startPos)
+        => PrefillWithCache(tokens, (PagedKvCache)cache, startPos);
+
+    float[]?[] IBatchedForwardPass.PrefillPackedMulti(
+        ReadOnlyMemory<int>[] chunks, int[] startPos, ISequenceKvCache[] caches, bool[] wantLogits)
+        => PrefillPackedMulti(chunks, startPos, AsPaged(caches), wantLogits);
+
+    float[][] IBatchedForwardPass.BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        => BatchForwardMulti(tokens, positions, AsPaged(caches));
+
+    private static PagedKvCache[] AsPaged(ISequenceKvCache[] caches)
+    {
+        var r = new PagedKvCache[caches.Length];
+        for (int i = 0; i < caches.Length; i++)
+            r[i] = (PagedKvCache)caches[i];
+        return r;
+    }
+
     /// <summary>
     /// Forward pass for a single token using the provided explicit cache (no TurboQuant).
     /// Used by <see cref="PrefillWithCache"/> for single-token prompts and MoE sequential prefill.
@@ -2462,12 +2630,9 @@ public sealed unsafe class ForwardPass : IForwardPass
                             batchHidden + (long)n * _embDim, normW, _embDim, _hp.RmsNormEps);
                     }
 
-                    SimdKernels.MatMulBatched(batchQ, _wq[layer].DataPtr, batchNorm,
-                        N, qDim, _embDim, _wq[layer].DType);
-                    SimdKernels.MatMulBatched(batchK, _wk[layer].DataPtr, batchNorm,
-                        N, kvDim, _embDim, _wk[layer].DType);
-                    SimdKernels.MatMulBatched(batchV, _wv[layer].DataPtr, batchNorm,
-                        N, kvDim, _embDim, _wv[layer].DType);
+                    MatMulBatchedCached(batchQ, in _wq[layer], batchNorm, N, qDim, _embDim);
+                    MatMulBatchedCached(batchK, in _wk[layer], batchNorm, N, kvDim, _embDim);
+                    MatMulBatchedCached(batchV, in _wv[layer], batchNorm, N, kvDim, _embDim);
 
                     if (_hasAttnBias)
                     {
@@ -2520,8 +2685,7 @@ public sealed unsafe class ForwardPass : IForwardPass
                         }
                     }
 
-                    SimdKernels.MatMulBatched(batchNorm, _wo[layer].DataPtr, batchAttnOut,
-                        N, _embDim, qDim, _wo[layer].DType);
+                    MatMulBatchedCached(batchNorm, in _wo[layer], batchAttnOut, N, _embDim, qDim);
                     if (_hasAttnBias)
                     {
                         for (int n = 0; n < N; n++)
@@ -2541,15 +2705,12 @@ public sealed unsafe class ForwardPass : IForwardPass
                         SimdKernels.RmsNorm(batchNorm + (long)n * _embDim,
                             batchHidden + (long)n * _embDim, ffnNormW, _embDim, _hp.RmsNormEps);
                     }
-                    SimdKernels.MatMulBatched(batchFfnGate, _wGate[layer].DataPtr, batchNorm,
-                        N, _intermDim, _embDim, _wGate[layer].DType);
-                    SimdKernels.MatMulBatched(batchFfnUp, _wUp[layer].DataPtr, batchNorm,
-                        N, _intermDim, _embDim, _wUp[layer].DType);
+                    MatMulBatchedCached(batchFfnGate, in _wGate[layer], batchNorm, N, _intermDim, _embDim);
+                    MatMulBatchedCached(batchFfnUp, in _wUp[layer], batchNorm, N, _intermDim, _embDim);
                     for (int n = 0; n < N; n++)
                         SimdKernels.SiLuMul(batchFfnGate + (long)n * _intermDim,
                             batchFfnUp + (long)n * _intermDim, _intermDim);
-                    SimdKernels.MatMulBatched(batchNorm, _wDown[layer].DataPtr, batchFfnGate,
-                        N, _embDim, _intermDim, _wDown[layer].DType);
+                    MatMulBatchedCached(batchNorm, in _wDown[layer], batchFfnGate, N, _embDim, _intermDim);
                     for (int n = 0; n < N; n++)
                     {
                         float* h = batchHidden + (long)n * _embDim;
@@ -2618,6 +2779,10 @@ public sealed unsafe class ForwardPass : IForwardPass
         foreach (var ptr in _normCache.Values)
             NativeMemory.Free((void*)ptr);
         _normCache.Clear();
+
+        foreach (var ptr in _dequantWeightCache.Values)
+            NativeMemory.Free((void*)ptr);
+        _dequantWeightCache.Clear();
 
         if (_hasAttnBias)
         {

--- a/src/SharpInference.Engine/IBatchedForwardPass.cs
+++ b/src/SharpInference.Engine/IBatchedForwardPass.cs
@@ -1,0 +1,70 @@
+namespace SharpInference.Engine;
+
+/// <summary>
+/// An opaque per-sequence KV-cache handle owned by <see cref="ContinuousBatchingEngine"/>. The
+/// engine allocates one per admitted sequence via <see cref="IBatchedForwardPass.CreateCache"/>,
+/// threads it back through the batched forward-pass calls, and disposes it on retirement — it
+/// never inspects the contents, so the concrete type (the CPU <see cref="PagedKvCache"/> today,
+/// a GPU-resident cache tomorrow) stays private to the forward pass that produced it (issue #190).
+/// </summary>
+public interface ISequenceKvCache : IDisposable
+{
+}
+
+/// <summary>
+/// The forward-pass surface <see cref="ContinuousBatchingEngine"/> needs, decoupled from any
+/// concrete backend (issue #190). The engine drives prefill + ragged batched decode and reads a
+/// few scheduling properties; it holds per-sequence caches only as opaque
+/// <see cref="ISequenceKvCache"/> handles. Implemented by the CPU <see cref="ForwardPass"/>
+/// today; a CUDA implementation (per-sequence GPU KV caches + batched decode) can slot in behind
+/// the same interface without the engine knowing which backend it drives.
+/// </summary>
+public interface IBatchedForwardPass
+{
+    /// <summary>Allocate a fresh, empty per-sequence KV cache for one admitted sequence.</summary>
+    ISequenceKvCache CreateCache();
+
+    /// <summary>
+    /// Prefill <paramref name="tokens"/> into <paramref name="cache"/> starting at
+    /// <paramref name="startPos"/> (chunked admission calls this repeatedly with advancing
+    /// <paramref name="startPos"/>); returns the logits at the final token.
+    /// </summary>
+    ReadOnlySpan<float> PrefillWithCache(IReadOnlyList<int> tokens, ISequenceKvCache cache, int startPos = 0);
+
+    /// <summary>
+    /// Prefill several pending sequences' chunks in ONE packed forward pass (weights amortized
+    /// across the prompts, like <see cref="BatchForwardMulti"/> does for decode). Returns the
+    /// per-sequence logits where <paramref name="wantLogits"/> is set (the chunk completes that
+    /// prompt), and null otherwise.
+    /// </summary>
+    float[]?[] PrefillPackedMulti(
+        ReadOnlyMemory<int>[] chunks, int[] startPos, ISequenceKvCache[] caches, bool[] wantLogits);
+
+    /// <summary>
+    /// Ragged batched decode: one token per sequence, each at its own <paramref name="positions"/>
+    /// against its own <paramref name="caches"/> entry, with the weight reads amortized N× across
+    /// the batch. Returns the per-sequence next-token logits.
+    /// </summary>
+    float[][] BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches);
+
+    /// <summary>
+    /// Whether SnapKV prefill eviction is configured. The engine disables chunked/packed prefill
+    /// when true (SnapKV scoring only runs on a fresh full-prompt prefill).
+    /// </summary>
+    bool SnapKvEnabled { get; }
+
+    /// <summary>
+    /// Bytes of KV one token occupies across all layers — the engine converts a memory budget
+    /// into a token budget for admission backpressure (issue #183).
+    /// </summary>
+    long KvBytesPerToken { get; }
+
+    /// <summary>Maximum supported sequence length; caps each request's projected KV reservation.</summary>
+    int MaxSeqLen { get; }
+
+    /// <summary>
+    /// Whether the dequant-once weight cache is budgeted to cover the model (issue #189); the
+    /// engine picks a smaller default prefill chunk when true.
+    /// </summary>
+    bool PrefillDequantCacheActive { get; }
+}

--- a/src/SharpInference.Engine/PagedKvCache.cs
+++ b/src/SharpInference.Engine/PagedKvCache.cs
@@ -17,7 +17,7 @@ namespace SharpInference.Engine;
 /// all layer pages together. Total memory at any point:
 ///   allocatedBlocks × numLayers × PageSize × kvDim × 2 × sizeof(float)
 /// </summary>
-public sealed unsafe class PagedKvCache : IDisposable
+public sealed unsafe class PagedKvCache : ISequenceKvCache
 {
     /// <summary>Number of KV positions stored per page block.</summary>
     public const int PageSize = 16;

--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -27,6 +27,10 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     if (long.TryParse(Environment.GetEnvironmentVariable("SHARPI_KV_BUDGET_MB"), out long kvBudgetMb) && kvBudgetMb != 0)
         opts.KvBudgetMb = kvBudgetMb;
 
+    // Dequant-once BLAS weight-cache budget in MiB (issue #189). null/unset = auto.
+    if (long.TryParse(Environment.GetEnvironmentVariable("SHARPI_PREFILL_DEQUANT_MB"), out long dequantMb))
+        opts.PrefillDequantCacheMb = dequantMb;
+
     // SHARPI_BACKEND ∈ {auto, cpu, cuda, vulkan} — case-insensitive. Lets a
     // smoke test or ad-hoc run override the appsettings.Local.json backend
     // without editing the file (matches the SHARPI_MODEL pattern above).

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -77,7 +77,8 @@ public static class InferenceEngineLoader
 
         try
         {
-            (fwd, batchingSupported) = BuildForwardPass(model, hp, arch, ctxSize, nGpuLayers, opts.Backend, turboQuant, owned);
+            (fwd, batchingSupported) = BuildForwardPass(model, hp, arch, ctxSize, nGpuLayers, opts.Backend, turboQuant, owned,
+                DequantCacheBytes(opts.PrefillDequantCacheMb));
             owned.Add(model);
         }
         catch
@@ -91,9 +92,9 @@ public static class InferenceEngineLoader
         // ForwardPass — it isn't built for the GPU / hybrid paths — so we honour
         // MaxBatchSize > 1 only when batching is structurally possible.
         IInferenceEngine engine;
-        if (opts.MaxBatchSize > 1 && batchingSupported && fwd is ForwardPass cpuFwd)
+        if (opts.MaxBatchSize > 1 && batchingSupported && fwd is IBatchedForwardPass batchFwd)
         {
-            engine = new ContinuousBatchingEngine(cpuFwd, tokenizer, modelId, opts.MaxBatchSize,
+            engine = new ContinuousBatchingEngine(batchFwd, tokenizer, modelId, opts.MaxBatchSize,
                 thinkTokenId, endThinkTokenId,
                 prefillChunkTokens: opts.PrefillChunkTokens,
                 kvBudgetBytes: opts.KvBudgetMb > 0 ? opts.KvBudgetMb * 1024 * 1024 : opts.KvBudgetMb);
@@ -112,9 +113,18 @@ public static class InferenceEngineLoader
 
     // ── Backend dispatch ─────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Translate <see cref="SharpInferenceServerOptions.PrefillDequantCacheMb"/> (MiB, nullable)
+    /// into the <see cref="ForwardPass"/> constructor's byte budget: <c>null</c> → defer to the
+    /// <c>SHARPI_PREFILL_DEQUANT_MB</c> env / auto-sizing; <c>0</c> → off; negative → unlimited;
+    /// positive → that many MiB (saturating, never overflowing).
+    /// </summary>
+    private static long DequantCacheBytes(long? mb) =>
+        mb is null ? long.MinValue : ForwardPass.MbToBudgetBytes(mb.Value);
+
     private static (IForwardPass Fwd, bool BatchingSupported) BuildForwardPass(
         GgufModel model, ModelHyperparams hp, string arch, int ctxSize, int nGpuLayers,
-        ServerBackend backend, bool turboQuant, List<IDisposable> owned)
+        ServerBackend backend, bool turboQuant, List<IDisposable> owned, long prefillDequantCacheBytes)
     {
         // Resolve "auto" first so the rest of the method can treat backend as concrete.
         if (nGpuLayers != 0 && backend == ServerBackend.Auto)
@@ -143,7 +153,8 @@ public static class InferenceEngineLoader
                 return (hybrid, BatchingSupported: false);
             }
 
-            var dense = new ForwardPass(model, cpuBackend, hp);
+            var dense = new ForwardPass(model, cpuBackend, hp,
+                prefillDequantCacheBytes: prefillDequantCacheBytes);
             owned.Add(dense);
             if (turboQuant)
                 dense.EnableTurboQuant(fp32WindowSize: 256, bits: 3);
@@ -157,7 +168,10 @@ public static class InferenceEngineLoader
 
         // GPU paths share a CPU baseline (for the hybrid-CPU half of partial offload).
         // For full GPU paths the dense CPU fwd is unused but still cheap to construct.
-        ForwardPass? cpuDense = hp.IsHybridSsm ? null : new ForwardPass(model, cpuBackend, hp);
+        // The #189 dequant cache is off here: GPU/hybrid never drive the batched CPU prefill
+        // that consults it, so a full F32 model copy would be pure wasted RAM.
+        ForwardPass? cpuDense = hp.IsHybridSsm ? null
+            : new ForwardPass(model, cpuBackend, hp, prefillDequantCacheBytes: 0);
         if (cpuDense is not null) owned.Add(cpuDense);
 
         if (backend == ServerBackend.Cuda)

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -90,22 +90,33 @@ public static class InferenceEngineLoader
 
         // ── 5. Wrap in the right engine. ContinuousBatchingEngine takes the concrete
         // ForwardPass — it isn't built for the GPU / hybrid paths — so we honour
-        // MaxBatchSize > 1 only when batching is structurally possible.
+        // MaxBatchSize > 1 only when batching is structurally possible. Mirror the
+        // BuildForwardPass guard above: if an engine constructor throws, dispose everything
+        // in owned[] (the backend, the multi-GB forward pass, the GGUF handle) rather than
+        // leaking it — ownership only transfers once construction succeeds.
         IInferenceEngine engine;
-        if (opts.MaxBatchSize > 1 && batchingSupported && fwd is IBatchedForwardPass batchFwd)
+        try
         {
-            engine = new ContinuousBatchingEngine(batchFwd, tokenizer, modelId, opts.MaxBatchSize,
-                thinkTokenId, endThinkTokenId,
-                prefillChunkTokens: opts.PrefillChunkTokens,
-                kvBudgetBytes: opts.KvBudgetMb > 0 ? opts.KvBudgetMb * 1024 * 1024 : opts.KvBudgetMb);
-            // ContinuousBatchingEngine doesn't accept owned[] disposables; transfer
-            // disposal responsibility by wrapping it in a composite disposable.
-            engine = new OwnedDisposableEngine(engine, owned);
+            if (opts.MaxBatchSize > 1 && batchingSupported && fwd is IBatchedForwardPass batchFwd)
+            {
+                engine = new ContinuousBatchingEngine(batchFwd, tokenizer, modelId, opts.MaxBatchSize,
+                    thinkTokenId, endThinkTokenId,
+                    prefillChunkTokens: opts.PrefillChunkTokens,
+                    kvBudgetBytes: opts.KvBudgetMb > 0 ? opts.KvBudgetMb * 1024 * 1024 : opts.KvBudgetMb);
+                // ContinuousBatchingEngine doesn't accept owned[] disposables; transfer
+                // disposal responsibility by wrapping it in a composite disposable.
+                engine = new OwnedDisposableEngine(engine, owned);
+            }
+            else
+            {
+                engine = new InferenceEngine(fwd, tokenizer, modelId, thinkTokenId, endThinkTokenId,
+                    owned.ToArray());
+            }
         }
-        else
+        catch
         {
-            engine = new InferenceEngine(fwd, tokenizer, modelId, thinkTokenId, endThinkTokenId,
-                owned.ToArray());
+            foreach (var d in owned) try { d.Dispose(); } catch { /* fall through to rethrow */ }
+            throw;
         }
 
         return new LoadedEngine(engine, arch, tokenizer.ChatTemplate);
@@ -215,7 +226,13 @@ public static class InferenceEngineLoader
             {
                 var cfwd = new CudaForwardPass(model, cuda, hp, ctxSize, enableTurboQuant: turboQuant);
                 owned.Add(cfwd);
-                return (cfwd, BatchingSupported: false);
+                // Issue #190: dense CUDA full-offload supports continuous batching (per-sequence
+                // GPU KV caches + true batched decode). SupportsContinuousBatching is the single
+                // source of truth shared with CudaForwardPass's runtime guard, so the loader gate
+                // can't diverge from what the batched methods accept — it folds in MoE, Gemma-4
+                // (per-layer head_dim), TurboQuant, an auto/explicit SnapKV budget, a final-logit
+                // softcap, and any non-GEMM-N-batchable trunk/output weight dtype (Q4_0).
+                return (cfwd, cfwd.SupportsContinuousBatching);
             }
 
             var planForHybrid = TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize)

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -110,10 +110,22 @@ public sealed class SharpInferenceServerOptions
     /// Prompt tokens prefilled per batcher iteration under continuous batching
     /// (issue #183 Gap 1). Active sequences advance one decode step between chunks, so
     /// a long inbound prompt no longer freezes every in-flight generation. <c>0</c>
-    /// disables chunking (each prompt prefills in one blocking call). Only consulted
-    /// when <see cref="MaxBatchSize"/> &gt; 1. Mirrors <c>SHARPI_PREFILL_CHUNK</c>.
+    /// disables chunking (each prompt prefills in one blocking call). <c>-1</c> = auto
+    /// (issue #189): <c>64</c> when <see cref="PrefillDequantCacheMb"/> makes small chunks
+    /// free, else <c>256</c>. Only consulted when <see cref="MaxBatchSize"/> &gt; 1. Mirrors
+    /// <c>SHARPI_PREFILL_CHUNK</c>.
     /// </summary>
-    public int PrefillChunkTokens { get; set; } = 256;
+    public int PrefillChunkTokens { get; set; } = -1;
+
+    /// <summary>
+    /// Dequant-once BLAS weight-cache budget in MiB (issue #189). The CPU batched-prefill
+    /// path re-dequantizes each projection weight to F32 on every call, so small prefill
+    /// chunks re-pay the full dequant repeatedly; caching the F32 dequant per weight removes
+    /// that cost (bit-identical). <c>null</c> = auto (cache the model iff a full F32 copy fits
+    /// a quarter of available RAM), <c>0</c> = off, negative = unlimited, positive = explicit
+    /// MiB. Only meaningful for the CPU forward pass. Mirrors <c>SHARPI_PREFILL_DEQUANT_MB</c>.
+    /// </summary>
+    public long? PrefillDequantCacheMb { get; set; }
 
     /// <summary>
     /// KV-cache memory budget in MiB gating request admission under continuous batching

--- a/tests/SharpInference.Tests.ForwardPass/ContinuousBatchingTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/ContinuousBatchingTests.cs
@@ -301,6 +301,53 @@ public sealed class ContinuousBatchingTests
     }
 
     [Fact]
+    public void PrefillWithCache_DequantCacheOnOff_BitIdentical()
+    {
+        // Issue #189: the dequant-once weight cache must be transparent — chunked prefill with
+        // the cache active produces bit-for-bit the same logits as with it off (same F32
+        // dequant feeds the same SGEMM, just sourced from the cache on reuse).
+        var path = FindModelPath();
+        if (path is null) return;
+        // The cache only diverts the OpenBLAS SGEMM path; without BLAS both runs are identical
+        // by construction and the test proves nothing.
+        if (!SimdKernels.BlasAvailable) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+        using var backend = new CpuBackend();
+
+        // 48 tokens prefilled in 16-token chunks: each chunk is at/above MinBatchForBlas so the
+        // SGEMM+cache path runs, and chunks 2-3 read weights the cache filled during chunk 1.
+        int[] tokens = [1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47,
+                        53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127,
+                        131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211];
+
+        float[] cacheOff = ChunkedPrefillLogits(model, backend, hp, tokens, chunk: 16, dequantCacheBytes: 0);
+        float[] cacheOn = ChunkedPrefillLogits(model, backend, hp, tokens, chunk: 16, dequantCacheBytes: -1);
+
+        Assert.Equal(cacheOff.Length, cacheOn.Length);
+        for (int i = 0; i < cacheOff.Length; i++)
+            Assert.Equal(cacheOff[i], cacheOn[i]);
+    }
+
+    private static float[] ChunkedPrefillLogits(
+        GgufModel model, CpuBackend backend, ModelHyperparams hp,
+        int[] tokens, int chunk, long dequantCacheBytes)
+    {
+        using var fwd = new Engine.ForwardPass(model, backend, hp,
+            prefillDequantCacheBytes: dequantCacheBytes);
+        using var cache = fwd.CreateCache();
+        float[] logits = [];
+        for (int start = 0; start < tokens.Length; start += chunk)
+        {
+            int take = Math.Min(chunk, tokens.Length - start);
+            var segment = new ArraySegment<int>(tokens, start, take);
+            logits = fwd.PrefillWithCache(segment, cache, startPos: start).ToArray();
+        }
+        return logits;
+    }
+
+    [Fact]
     public void PrefillPackedMulti_MatchesSequentialPrefill()
     {
         var path = FindModelPath();

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
@@ -1,0 +1,311 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #190: CUDA continuous batching on the dense path. <see cref="CudaForwardPass"/> now
+/// implements <see cref="IBatchedForwardPass"/> — the continuous-batching engine drives
+/// per-sequence GPU KV caches (<see cref="CudaSequenceKvCache"/>) through prefill + true
+/// batched decode. These oracles validate that the batched-serving entry points agree with
+/// the trusted single-user <see cref="CudaForwardPass.Prefill"/> / <see cref="CudaForwardPass.Forward"/>
+/// loop on a dense <b>Qwen3-8B Q4_K</b> (QK-norm, NEOX RoPE, SwiGLU, no PLE/SWA/MoE).
+///
+/// One ~5 GB model instance per test (a second instance would double VRAM beyond 12 GB), so
+/// the single-user reference runs first (with a <c>ResetCache</c> between sequences) and the
+/// batched run follows. Silent-skips when CUDA or the GGUF is absent — mirrors
+/// <see cref="Qwen3CudaBatchedPrefillTests"/>.
+/// </summary>
+public sealed class CudaBatchForwardMultiTests
+{
+    private const string ModelFile = "Qwen3-8B-Q4_K_M.gguf";
+
+    // Two distinct ≥2-token prompts (so prefill takes the batched trunk, not the N==1
+    // per-token Forward fallback). Ordinary Qwen3 vocab ids.
+    private static readonly int[] PromptA = { 9707, 11, 1879, 0, 358 };
+    private static readonly int[] PromptB = { 1079, 264, 4108, 1614, 13, 220, 17 };
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    // Construct with SnapKV pinned off: continuous batching is unsupported under an active
+    // SnapKV budget (it throws), and VRAM-scaled auto-SnapKV could otherwise engage at this
+    // context on a smaller GPU and make these oracles non-deterministic across machines.
+    private static CudaForwardPass NewFwd(GgufModel model, CudaBackend gpu, ModelHyperparams hp, int ctx = 512)
+    {
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0");
+        try { return new CudaForwardPass(model, gpu, hp, maxContextLength: ctx); }
+        finally { Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev); }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absolute = { $@"E:\models\{ModelFile}", $@"C:\p\sharpi\models\{ModelFile}" };
+        foreach (var p in absolute)
+            if (File.Exists(p)) return p;
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    private static HashSet<int> TopKSet(ReadOnlySpan<float> logits, int k)
+    {
+        var idx = new int[logits.Length];
+        for (int i = 0; i < idx.Length; i++) idx[i] = i;
+        var arr = logits.ToArray();
+        Array.Sort(idx, (a, b) => arr[b].CompareTo(arr[a]));
+        var set = new HashSet<int>();
+        for (int i = 0; i < k && i < idx.Length; i++) set.Add(idx[i]);
+        return set;
+    }
+
+    private static (float maxAbs, int overlap) Compare(float[] reference, float[] candidate)
+    {
+        Assert.Equal(reference.Length, candidate.Length);
+        float maxAbs = 0f;
+        for (int i = 0; i < reference.Length; i++)
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(reference[i] - candidate[i]));
+        var refTop = TopKSet(reference, 5);
+        var candTop = TopKSet(candidate, 5);
+        int overlap = 0;
+        foreach (var t in candTop) if (refTop.Contains(t)) overlap++;
+        return (maxAbs, overlap);
+    }
+
+    /// <summary>
+    /// Headline #190 oracle: a 2-sequence <see cref="CudaForwardPass.BatchForwardMulti"/>
+    /// decode step (each sequence at its own position against its own per-sequence cache,
+    /// weight reads amortized 2×) must reproduce the next-token logits of two independent
+    /// single-user prefill+decode passes. Same backend / dtype, so argmax must match and the
+    /// batched GEMM-N reassociation stays well within the cross-path tolerance (the contract
+    /// the prefill batched-trunk oracles hold).
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_BatchForwardMulti_N2_MatchesSingleUser()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        // Precondition: dense, non-Gemma, non-MoE — the supported batching path.
+        Assert.Null(hp.LayerHeadDim);
+        Assert.False(hp.IsMoE);
+
+        using var fwd = NewFwd(model, gpu, hp);
+
+        // ── Single-user reference: prefill each prompt, greedy-decode one token, decode it. ──
+        fwd.ResetCache();
+        int tokA = Argmax(fwd.Prefill(PromptA));
+        float[] refLogitsA = fwd.Forward(tokA, PromptA.Length).ToArray();
+
+        fwd.ResetCache();
+        int tokB = Argmax(fwd.Prefill(PromptB));
+        float[] refLogitsB = fwd.Forward(tokB, PromptB.Length).ToArray();
+
+        // ── Batched: prefill two per-sequence caches, then one batched decode step. ──
+        using var cacheA = fwd.CreateCache();
+        using var cacheB = fwd.CreateCache();
+        fwd.PrefillWithCache(PromptA, cacheA);
+        fwd.PrefillWithCache(PromptB, cacheB);
+
+        float[][] batch = fwd.BatchForwardMulti(
+            [tokA, tokB],
+            [PromptA.Length, PromptB.Length],
+            [cacheA, cacheB]);
+
+        Assert.Equal(2, batch.Length);
+
+        var (maxAbsA, overlapA) = Compare(refLogitsA, batch[0]);
+        Assert.Equal(Argmax(refLogitsA), Argmax(batch[0]));
+        Assert.True(overlapA >= 4,
+            $"Seq A batched top-5 overlaps the single-user reference in only {overlapA}/5 slots (maxAbs={maxAbsA}).");
+        Assert.True(maxAbsA < 1.0f,
+            $"Seq A batched vs single-user logits diverged beyond tolerance: maxAbs={maxAbsA}.");
+
+        var (maxAbsB, overlapB) = Compare(refLogitsB, batch[1]);
+        Assert.Equal(Argmax(refLogitsB), Argmax(batch[1]));
+        Assert.True(overlapB >= 4,
+            $"Seq B batched top-5 overlaps the single-user reference in only {overlapB}/5 slots (maxAbs={maxAbsB}).");
+        Assert.True(maxAbsB < 1.0f,
+            $"Seq B batched vs single-user logits diverged beyond tolerance: maxAbs={maxAbsB}.");
+    }
+
+    /// <summary>
+    /// A second batched decode step (positions advance by one) must still track the single-user
+    /// continuation — catches a per-sequence cache-append / position-indexing bug that a single
+    /// decode step would miss (the first step's KV is reused, a second token is appended).
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_BatchForwardMulti_TwoDecodeSteps_MatchSingleUser()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim);
+
+        using var fwd = NewFwd(model, gpu, hp);
+
+        // Single-user reference: two greedy decode steps for each prompt.
+        fwd.ResetCache();
+        int a0 = Argmax(fwd.Prefill(PromptA));
+        int a1 = Argmax(fwd.Forward(a0, PromptA.Length));
+        float[] refA = fwd.Forward(a1, PromptA.Length + 1).ToArray();
+
+        fwd.ResetCache();
+        int b0 = Argmax(fwd.Prefill(PromptB));
+        int b1 = Argmax(fwd.Forward(b0, PromptB.Length));
+        float[] refB = fwd.Forward(b1, PromptB.Length + 1).ToArray();
+
+        // Batched: prefill, then two decode steps; sample greedily between steps to follow
+        // the same trajectory as the single-user reference.
+        using var cacheA = fwd.CreateCache();
+        using var cacheB = fwd.CreateCache();
+        fwd.PrefillWithCache(PromptA, cacheA);
+        fwd.PrefillWithCache(PromptB, cacheB);
+
+        var step1 = fwd.BatchForwardMulti([a0, b0], [PromptA.Length, PromptB.Length], [cacheA, cacheB]);
+        int ba1 = Argmax(step1[0]);
+        int bb1 = Argmax(step1[1]);
+        Assert.Equal(a1, ba1);
+        Assert.Equal(b1, bb1);
+
+        var step2 = fwd.BatchForwardMulti([ba1, bb1], [PromptA.Length + 1, PromptB.Length + 1], [cacheA, cacheB]);
+
+        var (maxAbsA, overlapA) = Compare(refA, step2[0]);
+        Assert.Equal(Argmax(refA), Argmax(step2[0]));
+        Assert.True(overlapA >= 4, $"Seq A 2nd-step top-5 overlap {overlapA}/5 (maxAbs={maxAbsA}).");
+        Assert.True(maxAbsA < 1.0f, $"Seq A 2nd-step maxAbs={maxAbsA}.");
+
+        var (maxAbsB, overlapB) = Compare(refB, step2[1]);
+        Assert.Equal(Argmax(refB), Argmax(step2[1]));
+        Assert.True(overlapB >= 4, $"Seq B 2nd-step top-5 overlap {overlapB}/5 (maxAbs={maxAbsB}).");
+        Assert.True(maxAbsB < 1.0f, $"Seq B 2nd-step maxAbs={maxAbsB}.");
+    }
+
+    /// <summary>
+    /// <see cref="CudaForwardPass.PrefillWithCache"/> into a per-sequence
+    /// <see cref="CudaSequenceKvCache"/> must produce the same final-token logits as the
+    /// single-user <see cref="CudaForwardPass.Prefill"/> into the owned cache — identical
+    /// kernels, only the cache pointers differ, so this should be near bit-identical.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_PrefillWithCache_MatchesSingleUserPrefill()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim);
+
+        using var fwd = NewFwd(model, gpu, hp);
+
+        fwd.ResetCache();
+        float[] reference = fwd.Prefill(PromptA).ToArray();
+
+        using var cache = fwd.CreateCache();
+        float[] viaCache = fwd.PrefillWithCache(PromptA, cache).ToArray();
+
+        Assert.Equal(reference.Length, viaCache.Length);
+        Assert.Equal(Argmax(reference), Argmax(viaCache));
+        float maxAbs = 0f;
+        for (int i = 0; i < reference.Length; i++)
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(reference[i] - viaCache[i]));
+        Assert.True(maxAbs < 1e-2f,
+            $"PrefillWithCache (per-sequence cache) diverged from single-user Prefill: maxAbs={maxAbs}.");
+
+        // The cache's logical length must equal the prompt length after prefill.
+        Assert.Equal(PromptA.Length, cache.Length);
+    }
+
+    /// <summary>
+    /// Chunked <see cref="CudaForwardPass.PrefillWithCache"/> (advancing <c>startPos</c>) into
+    /// one per-sequence cache must match a single whole-prompt prefill — the path the engine's
+    /// chunked admission drives. Validates that prior-chunk KV is read correctly by later chunks.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_PrefillWithCache_Chunked_MatchesFull()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim);
+
+        int[] prompt = { 9707, 11, 1879, 0, 358, 1079, 264, 4108, 1614, 13, 220, 17, 18, 19 };
+
+        using var fwd = NewFwd(model, gpu, hp);
+
+        using var refCache = fwd.CreateCache();
+        float[] reference = fwd.PrefillWithCache(prompt, refCache).ToArray();
+
+        using var cache = fwd.CreateCache();
+        float[] chunked = Array.Empty<float>();
+        const int chunk = 4;
+        for (int start = 0; start < prompt.Length; start += chunk)
+        {
+            int len = Math.Min(chunk, prompt.Length - start);
+            var segment = new ArraySegment<int>(prompt, start, len);
+            chunked = fwd.PrefillWithCache(segment, cache, startPos: start).ToArray();
+        }
+
+        Assert.Equal(prompt.Length, cache.Length);
+        Assert.Equal(Argmax(reference), Argmax(chunked));
+        var (maxAbs, overlap) = Compare(reference, chunked);
+        Assert.True(overlap >= 4, $"Chunked-vs-full top-5 overlap {overlap}/5 (maxAbs={maxAbs}).");
+        Assert.True(maxAbs < 1.0f, $"Chunked-vs-full prefill maxAbs={maxAbs}.");
+    }
+
+    /// <summary>Empty token list and empty batch are rejected / no-op, matching the CPU path.</summary>
+    [Fact]
+    public void Qwen3_8B_BatchForwardMulti_EmptyBatch_ReturnsEmpty()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        using var fwd = NewFwd(model, gpu, hp);
+
+        Assert.Empty(fwd.BatchForwardMulti([], [], []));
+
+        using var cache = fwd.CreateCache();
+        Assert.Throws<ArgumentException>(() => fwd.PrefillWithCache([], cache));
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics;
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #190: aggregate decode-throughput measurement for CUDA continuous batching. Compares
+/// the single-user per-token <see cref="CudaForwardPass.Forward"/> loop against batched
+/// <see cref="CudaForwardPass.BatchForwardMulti"/> at several batch sizes on Qwen3-8B Q4_K_M —
+/// the whole point of the feature is that batched decode amortizes weight reads across N
+/// sequences, so aggregate t/s should climb well above the single-user baseline (~75 t/s on a
+/// 4070 Ti). Surfaces numbers, asserts no threshold (mirrors <see cref="CudaTurboQuantBench"/>).
+///
+/// Opt-in (so it never runs in the normal suite) and silent-skip without CUDA/model:
+///   $env:SHARPI_BENCH_BATCH=1; dotnet test tests/SharpInference.Tests.ForwardPass -c Release `
+///     --filter "FullyQualifiedName~CudaBatchedDecodeBench" --logger "console;verbosity=normal"
+/// </summary>
+public sealed class CudaBatchedDecodeBench
+{
+    private const string ModelFile = "Qwen3-8B-Q4_K_M.gguf";
+    private readonly ITestOutputHelper _out;
+    public CudaBatchedDecodeBench(ITestOutputHelper outHelper) { _out = outHelper; }
+
+    private void Log(string line) { _out.WriteLine(line); Console.Error.WriteLine(line); }
+
+    private static bool BenchEnabled => Environment.GetEnvironmentVariable("SHARPI_BENCH_BATCH") == "1";
+
+    private static readonly int[] Prompt =
+        { 9707, 11, 1879, 0, 358, 1079, 264, 4108, 1614, 13, 220, 17, 18, 19, 20, 21,
+          22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 };
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absolute = { $@"E:\models\{ModelFile}", $@"C:\p\sharpi\models\{ModelFile}" };
+        foreach (var p in absolute)
+            if (File.Exists(p)) return p;
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0; float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    [Fact]
+    public void Decode_Throughput_SingleUser_vs_Batched()
+    {
+        if (!BenchEnabled) return;
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        // Pin SnapKV off: at this context VRAM auto-SnapKV would otherwise engage and (correctly)
+        // disable batching — but the point of this bench is to measure the batched decode path.
+        var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0");
+        CudaForwardPass fwdTmp;
+        try { fwdTmp = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048); }
+        finally { Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap); }
+        using var fwd = fwdTmp;
+
+        const int decodeSteps = 128;
+        const int warmup = 8;
+
+        // ── Single-user baseline (per-token Forward, CUDA graphs on by default) ──
+        fwd.ResetCache();
+        int tok = Argmax(fwd.Prefill(Prompt));
+        int pos = Prompt.Length;
+        for (int i = 0; i < warmup; i++) { tok = Argmax(fwd.Forward(tok, pos)); pos++; }
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < decodeSteps; i++) { tok = Argmax(fwd.Forward(tok, pos)); pos++; }
+        sw.Stop();
+        double singleTps = decodeSteps / sw.Elapsed.TotalSeconds;
+        Log($"[bench-190] single-user Forward: {singleTps:F1} t/s ({decodeSteps} steps in {sw.Elapsed.TotalMilliseconds:F0} ms)");
+
+        // ── Batched BatchForwardMulti at N ∈ {1,2,4,8} (CreateCache disables graphs) ──
+        foreach (int n in new[] { 1, 2, 4, 8 })
+        {
+            var caches = new CudaSequenceKvCache[n];
+            try
+            {
+                var toks = new int[n];
+                var poss = new int[n];
+                for (int s = 0; s < n; s++)
+                {
+                    caches[s] = fwd.CreateCache();
+                    toks[s] = Argmax(fwd.PrefillWithCache(Prompt, caches[s]));
+                    poss[s] = Prompt.Length;
+                }
+
+                for (int i = 0; i < warmup; i++)
+                {
+                    var lg = fwd.BatchForwardMulti(toks, poss, caches);
+                    for (int s = 0; s < n; s++) { toks[s] = Argmax(lg[s]); poss[s]++; }
+                }
+                var sw2 = Stopwatch.StartNew();
+                for (int i = 0; i < decodeSteps; i++)
+                {
+                    var lg = fwd.BatchForwardMulti(toks, poss, caches);
+                    for (int s = 0; s < n; s++) { toks[s] = Argmax(lg[s]); poss[s]++; }
+                }
+                sw2.Stop();
+                double aggTps = (double)n * decodeSteps / sw2.Elapsed.TotalSeconds;
+                double perSeq = (double)decodeSteps / sw2.Elapsed.TotalSeconds;
+                Log($"[bench-190] batched N={n}: aggregate {aggTps:F1} t/s ({perSeq:F1} t/s/seq), " +
+                    $"{aggTps / singleTps:F2}× single-user");
+            }
+            finally
+            {
+                foreach (var c in caches) c?.Dispose();
+            }
+        }
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -375,6 +375,125 @@ public sealed class CudaForwardPassKvDtypeTests
     public void Gemma4_12B_Q8ChunkedPrefill_MatchesFp32()
         => AssertKvChunkedPrefillParity("gemma-4-12b-it-qat-q4_0.gguf", "q8_0", maxAbsCeiling: 45.0f);
 
+    // ── Issue #191: narrowed-KV GREEDY decode coherence (template-correct) ───
+    // The parity tests above teacher-force the narrowed dtype onto fp32's trajectory, so
+    // they never let bf16/q8_0 pick their OWN greedy tokens — exactly the path a real 12 GB
+    // user hits (#185 auto-narrows to bf16 by default) and the one #188 found degenerate on
+    // a synthetic OOD prompt. These decode the narrowed path GREEDILY on a TEMPLATE-CORRECT
+    // prompt (turn-structured, healthy top-logit margin per the 'prompt must match chat
+    // template' lesson) and assert coherence (≥2 distinct, non-EOS, finite). The fp32
+    // synthetic-prompt tests in Gemma4Cuda12BForwardPassTests stay as the trunk-math guards.
+
+    // Gemma 4 turn format: <bos> is added by the tokenizer (add_bos=true); the control tokens
+    // encode as singletons. An open-ended instruction elicits a multi-token answer (a factual
+    // prompt makes the 12B-IT emit a 1-token <end_of_turn>, which is why the fp32 guard uses a
+    // synthetic prompt instead — see Gemma4Cuda12BForwardPassTests).
+    private const string Gemma4TemplatePrompt =
+        "<start_of_turn>user\nWrite a short sentence about the ocean.<end_of_turn>\n<start_of_turn>model\n";
+
+    // Qwen3 ChatML. Thinking is left on (the template auto-opens <think>), which only makes the
+    // continuation longer/more varied — fine for a coherence check.
+    private const string Qwen3TemplatePrompt =
+        "<|im_start|>user\nWrite a short sentence about the ocean.<|im_end|>\n<|im_start|>assistant\n";
+
+    private static int ReadEosId(string path)
+    {
+        using var model = GgufModel.Open(path);
+        return GgufTokenizer.FromGgufModel(model).EosTokenId;
+    }
+
+    /// <summary>
+    /// Prefill a template-correct prompt and GREEDILY decode (the narrowed path picks its own
+    /// tokens — not teacher-forced) on the given KV dtype, asserting the decode is coherent:
+    /// all logits finite, the first generated token is not EOS, and ≥2 distinct tokens over the
+    /// run (an all-one-token repetition or all-EOS collapse — the #188 failure mode — fails).
+    /// </summary>
+    private static void AssertGreedyCoherence(
+        string filename, string kvDtype, string prompt, int ctx = 2048, bool batchedPrefill = false)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(filename);
+        if (path is null) return;
+
+        int eosId = ReadEosId(path);
+        const int steps = 6;
+        var (logits, argmax) = RunPrefillDecode(
+            gpu, path, kvDtype, prompt, steps, ctx, forced: null, batchedPrefill: batchedPrefill);
+
+        for (int p = 0; p <= steps; p++)
+            for (int i = 0; i < logits[p].Length; i++)
+                Assert.True(float.IsFinite(logits[p][i]),
+                    $"{filename} {kvDtype}: non-finite logit at pos {p}, idx {i} — a narrowed-KV (SWA-ring / k_eq_v) bug.");
+
+        Assert.True(argmax[0] != eosId,
+            $"{filename} {kvDtype}: first greedy token was EOS — the template-correct prompt should have a real " +
+            "continuation, so this means the narrowed greedy path collapsed.");
+
+        var seen = new HashSet<int>(argmax);
+        Assert.True(seen.Count >= 2,
+            $"{filename} {kvDtype}: greedy decode produced only {seen.Count} distinct token(s) " +
+            $"([{string.Join(",", argmax)}]) — narrowed-KV greedy decode is degenerate.");
+    }
+
+    /// <summary>Qwen3-8B Q4_K (non-SWA dense) bf16 KV: greedy decode stays coherent.</summary>
+    [Fact]
+    public void Qwen3_8B_Bf16Kv_GreedyDecode_Coherent()
+        => AssertGreedyCoherence("Qwen3-8B-Q4_K_M.gguf", "bf16", Qwen3TemplatePrompt);
+
+    /// <summary>Qwen3-8B Q4_K q8_0 KV: greedy decode stays coherent.</summary>
+    [Fact]
+    public void Qwen3_8B_Q8Kv_GreedyDecode_Coherent()
+        => AssertGreedyCoherence("Qwen3-8B-Q4_K_M.gguf", "q8_0", Qwen3TemplatePrompt);
+
+    /// <summary>
+    /// Gemma 4 12B QAT bf16 KV: the headline 12 GB-card config (auto-narrows to bf16 by
+    /// default). The fp32 synthetic-prompt guard can't run bf16 greedily — this is the only
+    /// coverage that the default narrowed dtype decodes coherently on a real prompt.
+    /// </summary>
+    [Fact]
+    public void Gemma4_12B_Bf16Kv_GreedyDecode_Coherent()
+        => AssertGreedyCoherence("gemma-4-12b-it-qat-q4_0.gguf", "bf16", Gemma4TemplatePrompt);
+
+    /// <summary>Gemma 4 12B QAT q8_0 KV: greedy decode stays coherent.</summary>
+    [Fact]
+    public void Gemma4_12B_Q8Kv_GreedyDecode_Coherent()
+        => AssertGreedyCoherence("gemma-4-12b-it-qat-q4_0.gguf", "q8_0", Gemma4TemplatePrompt);
+
+    /// <summary>
+    /// Issue #166 (latent half): bf16 KV with the SWA ring WRAPPED, then a GREEDY decode. E4B
+    /// has sliding_window=512, so the ring is min(ctx, 512+4096=4608); a >4608-token prefill
+    /// wraps it (the batched bf16 append overwrites earlier slots), and the subsequent greedy
+    /// decode keeps writing wrapped slots via the single-token bf16 append — the decode path
+    /// the existing chunked-prefill parity test only exercises teacher-forced. A wrapped-ring
+    /// OOB read/write would surface as NaN or a degenerate single-token collapse here.
+    /// </summary>
+    [Fact]
+    public void Gemma4_E4B_Bf16Kv_GreedyDecodePastSwaRingWrap_Coherent()
+    {
+        // AssertGreedyCoherence creates its own backend; just gate the prompt build here.
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath("gemma-4-E4B-it-Q8_0.gguf");
+        if (path is null) return;
+
+        // Build a >4608-token prompt so the 512-window SWA ring (4608 slots) actually wraps.
+        string prompt;
+        using (var model = GgufModel.Open(path))
+        {
+            var tok = GgufTokenizer.FromGgufModel(model);
+            var sb = new System.Text.StringBuilder();
+            const string seed = "The quick brown fox jumps over the lazy dog. " +
+                                "Sphinx of black quartz, judge my vow. " +
+                                "Pack my box with five dozen liquor jugs. ";
+            while (tok.Encode(sb.ToString()).Count < 5000) sb.Append(seed);
+            prompt = sb.ToString();
+        }
+
+        // ctx 6144 > ring (4608) so the wrap is real; batched prefill drives the chunked
+        // append, then RunPrefillDecode greedily decodes past the wrap.
+        AssertGreedyCoherence("gemma-4-E4B-it-Q8_0.gguf", "bf16", prompt, ctx: 6144, batchedPrefill: true);
+    }
+
     // ── Issue #185 item 1: auto-narrow KV dtype decision ─────────────────────
     // The decision is factored into the pure CudaForwardPass.ResolveKvDType /
     // EstimateKvCacheBytes / Q8KvGeometrySupported helpers so it's unit-testable

--- a/tests/SharpInference.Tests.ForwardPass/SimdKernelsDequantCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SimdKernelsDequantCacheTests.cs
@@ -1,0 +1,58 @@
+using SharpInference.Core;
+using SharpInference.Cpu;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #189: the dequant-once weight cache routes BLAS-path batched matmuls through
+/// <see cref="SimdKernels.MatMulBatchedF32"/> with a pre-dequantized F32 weight instead of
+/// <see cref="SimdKernels.MatMulBatched"/> (which dequantizes every call). The substitution
+/// must be bit-for-bit identical: same F32 weights feed the same SGEMM. This kernel-level
+/// test proves that without needing a model file.
+/// </summary>
+public sealed unsafe class SimdKernelsDequantCacheTests
+{
+    [Fact]
+    public void MatMulBatchedF32_EqualsMatMulBatched_OnBlasPath_BitIdentical()
+    {
+        // The cache only diverts the OpenBLAS SGEMM path; below the threshold both fall back
+        // to fused MatVec, which is a *different* (register-dequant) kernel — out of scope here.
+        if (!SimdKernels.BlasAvailable) return;
+
+        const int rows = 96, cols = 160;
+        int batch = SimdKernels.MinBatchForBlas + 8; // ensure the SGEMM path is taken
+        var rng = new Random(20260610);
+
+        // bf16 weights are trivially constructible and dequantize exactly (zero-extend the
+        // mantissa), so MatMulBatched's internal Dequantize.ToFloat32 yields exactly wF32.
+        var wBf16 = new ushort[rows * cols];
+        var wF32 = new float[rows * cols];
+        for (int i = 0; i < wBf16.Length; i++)
+        {
+            float f = (float)(rng.NextDouble() * 2 - 1);
+            ushort bf = (ushort)(BitConverter.SingleToUInt32Bits(f) >> 16);
+            wBf16[i] = bf;
+            wF32[i] = BitConverter.UInt32BitsToSingle((uint)bf << 16);
+        }
+
+        var input = new float[batch * cols];
+        for (int i = 0; i < input.Length; i++)
+            input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var outPerCallDequant = new float[batch * rows];
+        var outCachedF32 = new float[batch * rows];
+
+        fixed (ushort* wp = wBf16)
+        fixed (float* wf = wF32)
+        fixed (float* ip = input)
+        fixed (float* o1 = outPerCallDequant)
+        fixed (float* o2 = outCachedF32)
+        {
+            SimdKernels.MatMulBatched(o1, (byte*)wp, ip, batch, rows, cols, DType.BFloat16);
+            SimdKernels.MatMulBatchedF32(o2, wf, ip, batch, rows, cols);
+        }
+
+        for (int i = 0; i < outPerCallDequant.Length; i++)
+            Assert.Equal(outPerCallDequant[i], outCachedF32[i]);
+    }
+}


### PR DESCRIPTION
## Summary

Completes the `feat/183-followups-189-191-190` branch. The headline change is **#190 CUDA dense continuous batching**: `CudaForwardPass` now implements `IBatchedForwardPass`, so `ContinuousBatchingEngine` can drive **CUDA** dense serving (per-sequence GPU KV caches + a true batched decode that amortizes weight reads across the batch), not just the CPU path. Also folds in the remaining #183 follow-ups already on the branch (#189 dequant cache, #191 narrowed-KV coherence tests, the #190 batched-forward abstraction).

## #190 — CUDA dense continuous batching (new)

`CudaForwardPass : IForwardPass, IBatchedForwardPass`, scoped to the **dense** path.

- **`CreateCache`** → `CudaSequenceKvCache`: NumLayers full-context K/V pairs at the active KV dtype (with OOM cleanup). Disables CUDA graphs for the instance — the per-token decode graph bakes owned-cache device pointers, which a per-sequence rebind would invalidate.
- **Cache rebind**: `_gpuKCache`/`_gpuVCache` made mutable; `_ownedKCache`/`_ownedVCache` are the real allocation home (and the only arrays `Dispose` frees). `PrefillWithCache` = `BindCache` → existing batched-trunk `Prefill` → writeback `cache.Length` → `RestoreOwned` in a finally.
- **`BatchForwardMulti`** — *true* batched decode (not a rebind+`Forward` loop): batched embed → per layer {batched RmsNorm + batched QKV/O/FFN **GEMM-N**, with **per-sequence** RoPE / QK-norm / KV-append / single-query attention against each sequence's own cache} → batched final norm + one batched output GEMM. Mirrors the dense `RunDeviceRegion` ordering exactly (QK-norm before RoPE, #157), so it's argmax-stable vs the single-user loop.
- **`PrefillPackedMulti`** — per-sequence loop for now (cross-prompt packing is a follow-up).
- **`SupportsContinuousBatching`** — a single gate shared by the loader and the runtime guard so they can't diverge: dense-only, excludes MoE / Gemma-4 (per-layer head_dim) / TurboQuant / active SnapKV / final-logit softcap / non-GEMM-N-batchable Q4_0 weights. `KvBytesPerToken` is block-aware (`DTypeInfo.ByteSize`) so q8_0 KV doesn't throw.
- **Loader** (`InferenceEngineLoader`): the CUDA full-offload branch returns `cfwd.SupportsContinuousBatching`; engine construction is wrapped in the same dispose-on-throw guard as `BuildForwardPass`.

### Throughput (Qwen3-8B Q4_K_M, RTX 4070 Ti)

| batch N | aggregate t/s | × single-user (75 t/s) |
|--------:|--------------:|-----------------------:|
| 1 | 70 | 0.92× |
| 2 | 88 | 1.17× |
| 4 | 99 | **1.32×** |
| 8 | 106 | **1.41×** |

The GEMM-N matvec (grid Y = nTok) reads each weight tile once *per token-block*, so the win is launch-overhead amortization + L2 weight reuse. A/B against the compute-bound MMQ/GEMM path (`SHARPI_BATCH_DECODE_GEMM=1`) showed it is **worse** for small-N decode (N=4: 57 vs 99 t/s) — its fixed per-step costs (int8 activation conversion + Q6_K output-weight fp16 dequant every step) only amortize at the N=4096 prefill scale. So GEMM-N is the default; the toggle is kept for very high concurrency (curves converge near N=8).

## #183 follow-ups (from `ab6a398`, already on the branch)

- **#189** dequant-once CPU weight cache for the BLAS prefill path (bit-identical).
- **#191** narrowed-KV coherence tests.
- **#190** the backend-agnostic `IBatchedForwardPass` / `ISequenceKvCache` abstraction + CPU wiring (this PR adds the CUDA implementer).

## Review

An adversarial multi-agent review of the diff caught and fixed: a **blocker** (`KvBytesPerToken` threw `ArgumentException` for q8_0 KV → block-aware `ByteSize`), a `CreateCache` OOM partial-allocation leak, the non-Gemma Q4_0 gate gap (GEMM-N has no Q4_0 kernel → would crash at first decode), a latent final-logit-softcap divergence, and an int-overflow guard on the host logits buffer. The single-gate `SupportsContinuousBatching` resolves the loader-vs-runtime divergence those findings flagged.

## Testing (RTX 4070 Ti)

- **New** `CudaBatchForwardMultiTests` (5): batched N=2 / two decode steps / prefill-with-cache / chunked prefill — each vs single-user `Forward`/`Prefill` (argmax + top-5 + maxAbs<1.0). `CudaBatchedDecodeBench` (`SHARPI_BENCH_BATCH=1`) surfaces the throughput table above.
- **No regression**: Qwen3 dense prefill 7/7, full KV-dtype suite (bf16/q8_0 + Gemma-4 aliased-KV), CPU `ContinuousBatchingTests` 13/13, Server 103/103, CUDA SnapKV 3/3. Full-solution Release build clean (0 warnings, TreatWarningsAsErrors).

## Notes

- At long context (ctx ≳ 2048) VRAM auto-SnapKV engages and (correctly) routes the model to the single-user engine. To use batched CUDA serving at long context, run with `SHARPI_SNAPKV_BUDGET=0` or `--kv-type bf16`.
- Follow-ups: cross-prompt packed prefill (`PrefillPackedMulti` is sequential today); MoE / Gemma-4 / TQ / SnapKV batched serving remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
