### PR TITLE
perf(cuda): #194 weight-stationary batched-decode matmul — N=8 aggregate 106 -> 183 t/s

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -173,6 +173,16 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _matvecQ5KGemmNKernel;
     private nint   _matvecQ6KGemmNKernel;
     private nint   _matvecQ80GemmNKernel;
+    // Issue #194: weight-stationary small-N batched-decode matvecs — token loop inside
+    // the block so each weight read is amortized across the batch. One handle per
+    // compile-time batch capacity (CudaWsKernels.Variants: 2/4/8/16), indexed by position.
+    private readonly nint[] _matvecF32WsKernels    = new nint[CudaWsKernels.Variants.Length];
+    private readonly nint[] _matvecQ4KWsKernels    = new nint[CudaWsKernels.Variants.Length];
+    private readonly nint[] _matvecQ4KWsSoaKernels = new nint[CudaWsKernels.Variants.Length];
+    private readonly nint[] _matvecQ5KWsKernels    = new nint[CudaWsKernels.Variants.Length];
+    private readonly nint[] _matvecQ6KWsKernels    = new nint[CudaWsKernels.Variants.Length];
+    private readonly nint[] _matvecQ80WsKernels    = new nint[CudaWsKernels.Variants.Length];
+    private readonly nint[] _matvecQ80WsSoaKernels = new nint[CudaWsKernels.Variants.Length];
     // Issue #141: compute-bound prefill GEMM — dequant Q8_0 weight + convert
     // activations to fp16, then one cublasGemmEx (weight read once per batch).
     private nint   _dequantQ80F16Kernel;
@@ -1920,6 +1930,141 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     {
         var dtype = _tensorDTypes.GetValueOrDefault(matrix.Handle, matrix.DType);
         MatMulBatched(outputAll, matrix, inputAll, nTok, dtype);
+    }
+
+    /// <summary>
+    /// Weight-stationary batched matvec for small-N decode (issue #194). Same contract
+    /// and token-major layout as <see cref="MatMulBatched(Tensor,Tensor,Tensor,int,DType)"/>,
+    /// but the token loop runs <b>inside</b> the thread block: each weight element is read
+    /// from HBM once and applied to all <paramref name="nTok"/> activation rows, so the
+    /// weight read — the dominant cost of batched decode — is amortized N× instead of
+    /// re-streamed per token (the GEMM-N grid puts the token on <c>blockIdx.y</c> and only
+    /// gets L2 reuse; #190 measured ~1.4× aggregate at N=8 from that).
+    ///
+    /// <para><b>Bit-exact:</b> each (row, token) pair runs the identical per-element
+    /// reduction chain as the GEMM-N kernel (same loads, same product association, same
+    /// warp/shared reduce order — see <see cref="CudaWsKernels"/>), so output is
+    /// bit-identical to <see cref="MatMulBatched(Tensor,Tensor,Tensor,int,DType)"/> and to
+    /// <paramref name="nTok"/> sequential <see cref="MatMul(Tensor,Tensor,Tensor,DType)"/>
+    /// calls. Callers that need the byte-parity guarantee should still call
+    /// <see cref="MatMulBatched(Tensor,Tensor,Tensor,int,DType)"/> — its contract is the
+    /// documented one; this entry point only promises argmax-stability.</para>
+    ///
+    /// <para>Kernels are stamped per compile-time batch capacity (2/4/8/16; smallest ≥
+    /// <paramref name="nTok"/> wins) so the per-token accumulators stay register-resident.
+    /// <c>nTok == 1</c> and <c>nTok &gt; 16</c> delegate to the GEMM-N path (no weight
+    /// reuse to gain at N=1; capacities above 16 spill registers — large N belongs to the
+    /// compute-bound MMQ/GEMM prefill path). Supports the same dtypes as the GEMM-N matvec:
+    /// Q4_K (AoS + #156 SoA, via per-token Q8_1 quantize + dp4a), Q5_K, Q6_K, Q8_0
+    /// (AoS + #149 SoA), and Float32; anything else delegates (and throws) there too.</para>
+    /// </summary>
+    public void MatMulBatchedWeightStationary(Tensor outputAll, Tensor matrix, Tensor inputAll,
+                                              int nTok, DType weightDType)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available on this system.");
+        if (nTok <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nTok), nTok, "nTok must be > 0.");
+        if (outputAll.ElementCount % nTok != 0 || inputAll.ElementCount % nTok != 0)
+            throw new ArgumentException(
+                $"MatMulBatchedWeightStationary: outputAll ({outputAll.ElementCount}) and inputAll " +
+                $"({inputAll.ElementCount}) element counts must be divisible by nTok ({nTok}).");
+
+        int maxCapacity = CudaWsKernels.Variants[^1];
+        if (nTok == 1 || nTok > maxCapacity ||
+            weightDType is not (DType.Q4_K or DType.Q5_K or DType.Q6_K or DType.Q8_0 or DType.Float32))
+        {
+            MatMulBatched(outputAll, matrix, inputAll, nTok, weightDType);
+            return;
+        }
+
+        int variant = 0;
+        while (CudaWsKernels.Variants[variant] < nTok) variant++;
+
+        int rows = (int)(outputAll.ElementCount / nTok);
+        int cols = (int)(inputAll.ElementCount / nTok);
+        nint wPtr = GetDevPtr(matrix);
+        nint xPtr = GetDevPtr(inputAll);
+        nint yPtr = GetDevPtr(outputAll);
+
+        if (weightDType == DType.Q4_K)
+        {
+            DispatchMatVecQ4KWs(wPtr, xPtr, yPtr, rows, cols, nTok, variant,
+                                soa: _soaQ4kHandles.ContainsKey(matrix.Handle));
+            return;
+        }
+
+        // F32-input kernels: same (rows+7)/8 × 256-thread geometry as the GEMM-N
+        // dispatch, minus the token grid dimension.
+        bool q80Soa = weightDType == DType.Q8_0 && _soaHandles.ContainsKey(matrix.Handle);
+        nint kernel = weightDType switch
+        {
+            DType.Q6_K => _matvecQ6KWsKernels[variant],
+            DType.Q5_K => _matvecQ5KWsKernels[variant],
+            DType.Q8_0 => q80Soa ? _matvecQ80WsSoaKernels[variant] : _matvecQ80WsKernels[variant],
+            _          => _matvecF32WsKernels[variant],
+        };
+        int pRows = rows, pCols = cols, pN = nTok;
+        nint* args = stackalloc nint[6]
+        {
+            (nint)(&wPtr), (nint)(&xPtr), (nint)(&yPtr),
+            (nint)(&pRows), (nint)(&pCols), (nint)(&pN)
+        };
+        uint gridX = (uint)((rows + 7) / 8);
+        int r = NvrtcInterop.LaunchKernel(kernel, gridX, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(matvec_ws) failed: {r}");
+    }
+
+    /// <summary>
+    /// Q4_K weight-stationary launch (#194): quantize all <paramref name="nTok"/> inputs to
+    /// contiguous Q8_1 (identical to <see cref="DispatchMatVecQ4KBatched"/> — per-token
+    /// quantization is unchanged, only the matvec geometry differs), then one
+    /// grid = rows, block = 32 × MATVEC_Q4K_NWARPS launch with the token loop inside.
+    /// </summary>
+    private void DispatchMatVecQ4KWs(nint wPtr, nint xPtr, nint yPtr,
+                                     int rows, int cols, int nTok, int variant, bool soa)
+    {
+        if ((cols & 0xff) != 0)
+            throw new InvalidOperationException(
+                $"CUDA matvec_q4k_ws requires cols % 256 == 0 (got {cols}).");
+
+        int subBlocks = cols / 32;                          // per token
+        long totalSub = (long)subBlocks * nTok;
+        nuint q81Bytes = (nuint)(totalSub * 36L);
+        EnsureQ81BatchBuf(q81Bytes);
+
+        {
+            nint qInPtr  = xPtr;
+            nint qOutPtr = _q81BatchBuf;
+            int  qN      = (int)((long)cols * nTok);
+            if ((long)cols * nTok > int.MaxValue)
+                throw new InvalidOperationException(
+                    $"MatMulBatchedWeightStationary: cols*nTok ({(long)cols * nTok}) exceeds int range.");
+            nint* args = stackalloc nint[3]
+            {
+                (nint)(&qInPtr), (nint)(&qOutPtr), (nint)(&qN)
+            };
+            int rq = NvrtcInterop.LaunchKernel(
+                _quantizeQ81Kernel, (uint)totalSub, 1, 1,
+                32, 1, 1, 0, _stream, args, null);
+            if (rq != 0) throw new InvalidOperationException($"cuLaunchKernel(quantize_q8_1 ws) failed: {rq}");
+        }
+
+        {
+            nint q81Ptr = _q81BatchBuf;
+            int  pRows  = rows, pCols = cols, pN = nTok;
+            nint* args = stackalloc nint[6]
+            {
+                (nint)(&wPtr), (nint)(&q81Ptr), (nint)(&yPtr),
+                (nint)(&pRows), (nint)(&pCols), (nint)(&pN)
+            };
+            // grid = rows; block = 32 × MATVEC_Q4K_NWARPS(8) = 256 threads (token loop inside).
+            nint kernel = soa ? _matvecQ4KWsSoaKernels[variant] : _matvecQ4KWsKernels[variant];
+            int rm = NvrtcInterop.LaunchKernel(kernel, (uint)rows, 1, 1,
+                                               32, 8, 1, 0, _stream, args, null);
+            if (rm != 0) throw new InvalidOperationException($"cuLaunchKernel(matvec_q4k_ws{(soa ? "_soa" : "")}) failed: {rm}");
+        }
     }
 
     /// <summary>
@@ -5127,8 +5272,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         t_primaryCtxBoundOnThisThread = true;
     }
 
-    /// <summary>Combined CUDA source for image + text kernels — one NVRTC compilation.</summary>
-    private static string CombinedKernelSource => CudaKernels.Source + "\n" + CudaTextKernels.Source;
+    /// <summary>Combined CUDA source for image + text + weight-stationary kernels — one
+    /// NVRTC compilation (the cubin cache key hashes this, so adding a source invalidates it).</summary>
+    private static string CombinedKernelSource =>
+        CudaKernels.Source + "\n" + CudaTextKernels.Source + "\n" + CudaWsKernels.Source;
 
     private void CompileAndLoadKernels()
     {
@@ -5353,6 +5500,17 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             if (k != nint.Zero)
                 NvrtcInterop.FuncGetAttribute(out _, NvrtcInterop.CU_FUNC_ATTRIBUTE_NUM_REGS, k);
         }
+        // #194: weight-stationary batched-decode matvec variants.
+        ReadOnlySpan<nint[]> wsKernelSets = [
+            _matvecF32WsKernels, _matvecQ4KWsKernels, _matvecQ4KWsSoaKernels,
+            _matvecQ5KWsKernels, _matvecQ6KWsKernels, _matvecQ80WsKernels, _matvecQ80WsSoaKernels,
+        ];
+        foreach (nint[] set in wsKernelSets)
+            foreach (nint k in set)
+            {
+                if (k != nint.Zero)
+                    NvrtcInterop.FuncGetAttribute(out _, NvrtcInterop.CU_FUNC_ATTRIBUTE_NUM_REGS, k);
+            }
     }
 
     private void LoadKernelFunctions()
@@ -5415,6 +5573,17 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _matvecQ5KGemmNKernel  = GetKernelFunc("llm_matvec_q5k_gemm_n");
         _matvecQ6KGemmNKernel  = GetKernelFunc("llm_matvec_q6k_gemm_n");
         _matvecQ80GemmNKernel  = GetKernelFunc("llm_matvec_q8_0_gemm_n");
+        for (int v = 0; v < CudaWsKernels.Variants.Length; v++)   // #194
+        {
+            int nt = CudaWsKernels.Variants[v];
+            _matvecF32WsKernels[v]    = GetKernelFunc($"llm_matvec_f32_ws_n{nt}");
+            _matvecQ4KWsKernels[v]    = GetKernelFunc($"llm_matvec_q4k_ws_n{nt}");
+            _matvecQ4KWsSoaKernels[v] = GetKernelFunc($"llm_matvec_q4k_ws_soa_n{nt}");
+            _matvecQ5KWsKernels[v]    = GetKernelFunc($"llm_matvec_q5k_ws_n{nt}");
+            _matvecQ6KWsKernels[v]    = GetKernelFunc($"llm_matvec_q6k_ws_n{nt}");
+            _matvecQ80WsKernels[v]    = GetKernelFunc($"llm_matvec_q8_0_ws_n{nt}");
+            _matvecQ80WsSoaKernels[v] = GetKernelFunc($"llm_matvec_q8_0_ws_soa_n{nt}");
+        }
         _dequantQ80F16Kernel   = GetKernelFunc("llm_dequant_q8_0_to_f16");
         _dequantQ4KF16Kernel   = GetKernelFunc("llm_dequant_q4k_to_f16");
         _dequantQ4KF16SoaKernel = GetKernelFunc("llm_dequant_q4k_to_f16_soa");

--- a/src/SharpInference.Cuda/CudaWsKernels.cs
+++ b/src/SharpInference.Cuda/CudaWsKernels.cs
@@ -1,0 +1,600 @@
+namespace SharpInference.Cuda;
+
+/// <summary>
+/// Weight-stationary batched-decode matvec kernels (issue #194), appended to the
+/// NVRTC compilation after <see cref="CudaTextKernels"/> (whose <c>sharpi_*</c>
+/// helpers and <c>MATVEC_Q4K_NWARPS</c> they reuse).
+///
+/// <para>The GEMM-N matvecs (<c>llm_matvec_*_gemm_n</c>) put the token on the grid
+/// (one block-row group per token), so each weight tile is re-streamed from HBM once
+/// per token — at decode batch sizes the win over sequential matvecs is launch-count
+/// and L2 reuse only (#190 measured ~1.4× at N=8). These variants drop the token grid
+/// dimension instead: each thread block loads a weight element once and applies it to
+/// all <c>n_tok</c> activation rows, amortizing the weight HBM read N× — the dominant
+/// cost of small-N batched decode.</para>
+///
+/// <para>Each kernel body is stamped once per compile-time batch capacity
+/// (<see cref="Variants"/>; dispatch picks the smallest ≥ <c>n_tok</c>) so the
+/// per-token accumulator array indexes resolve at compile time and stays
+/// register-resident. Tokens beyond <c>n_tok</c> are guarded off — the guard is
+/// block-uniform, so there is no intra-warp divergence.</para>
+///
+/// <para><b>Bit-exact:</b> each surviving (row, token) pair runs the identical
+/// per-element reduction chain as the matching <c>llm_matvec_*_gemm_n</c> kernel —
+/// same loads, same product association (token-invariant factors are hoisted only at
+/// existing left-fold boundaries), same warp/shared reduce order — so the output is
+/// bit-identical to the GEMM-N path and to <c>n_tok</c> sequential matvecs
+/// (CudaMatMulBatchedWsTests enforce this). Only the loop nest changes: weight outer,
+/// token inner.</para>
+/// </summary>
+internal static class CudaWsKernels
+{
+    /// <summary>Compile-time batch capacities stamped for each kernel body. Order
+    /// matters: dispatch indexes kernel-handle arrays by position.</summary>
+    internal static readonly int[] Variants = [2, 4, 8, 16];
+
+    /// <summary>All weight-stationary kernels, one instantiation per variant.</summary>
+    public static string Source { get; } = Build();
+
+    private static string Build()
+    {
+        var sb = new System.Text.StringBuilder(Template.Length * Variants.Length);
+        foreach (int nt in Variants)
+            sb.Append(Template.Replace("__NT__", nt.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        return sb.ToString();
+    }
+
+    private const string Template = @"
+// ── Weight-stationary batched matvecs, batch capacity __NT__ (issue #194) ──
+
+// F32: grid = ceil(rows/8), block = 256 (8 rows × 32 lanes). Same geometry as
+// llm_matvec_f32_gemm_n minus the token grid dimension; each weight element is
+// loaded once and applied to all n_tok activations.
+extern ""C"" __global__ void llm_matvec_f32_ws_n__NT__(
+    const float* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols]
+    float* __restrict__ output_all,        // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    if (row >= rows) return;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    long base = (long)row * (long)cols;
+    for (int i = lane; i < cols; i += THREADS_PER_ROW) {
+        float w = weights[base + i];
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok)
+                acc[t] += w * input_all[(long)t * (long)cols + i];
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok) {
+            float result = sharpi_warp_reduce_sum(acc[t]);
+            if (lane == 0) output_all[(long)t * (long)rows + row] = result;
+        }
+}
+
+// Q8_0 (interleaved AoS blocks): hoists the token-invariant d*q — the same
+// left-fold llm_matvec_q8_0_gemm_n's  d * (float)q * x  contracts to.
+extern ""C"" __global__ void llm_matvec_q8_0_ws_n__NT__(
+    const unsigned int* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols]
+    float* __restrict__ output_all,        // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 5;
+    long row_base_bytes = (long)row * (long)num_blocks * 34L;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long b0 = row_base_bytes + (long)block * 34L;
+        unsigned int dlo = sharpi_byte_at(weights, b0 + 0);
+        unsigned int dhi = sharpi_byte_at(weights, b0 + 1);
+        float d = sharpi_fp16_to_fp32(dlo | (dhi << 8));
+        int q = sharpi_int8_at(weights, b0 + 2 + (long)lane);
+        float dq = d * (float)q;
+        int elem = block * 32 + lane;
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok)
+                acc[t] += dq * input_all[(long)t * (long)cols + elem];
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok) {
+            float result = sharpi_warp_reduce_sum(acc[t]);
+            if (lane == 0) output_all[(long)t * (long)rows + row] = result;
+        }
+}
+
+// Q8_0 SoA (#149 layout): identical reduction, aligned SoA weight reads.
+extern ""C"" __global__ void llm_matvec_q8_0_ws_soa_n__NT__(
+    const unsigned int* __restrict__ weights,
+    const float* __restrict__ input_all,
+    float* __restrict__ output_all,
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 5;
+    long qrow = (long)row * cols;
+    const unsigned short* scales = (const unsigned short*)((const char*)weights + (long)rows * cols);
+    long srow = (long)row * num_blocks;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    for (int block = 0; block < num_blocks; block++) {
+        float d = sharpi_fp16_to_fp32(scales[srow + block]);
+        int q = sharpi_int8_at(weights, qrow + (long)block * 32 + lane);
+        float dq = d * (float)q;
+        int elem = block * 32 + lane;
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok)
+                acc[t] += dq * input_all[(long)t * (long)cols + elem];
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok) {
+            float result = sharpi_warp_reduce_sum(acc[t]);
+            if (lane == 0) output_all[(long)t * (long)rows + row] = result;
+        }
+}
+
+// Q6_K: hoists the 8 token-invariant dequantized weight values per 256-block —
+// the same (scX * decode) left-fold llm_matvec_q6k_gemm_n contracts to before
+// the activation multiply.
+extern ""C"" __global__ void llm_matvec_q6k_ws_n__NT__(
+    const unsigned int* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols]
+    float* __restrict__ output_all,        // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 8;
+    long row_base_bytes = (long)row * (long)num_blocks * 210L;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long b0 = row_base_bytes + (long)block * 210L;
+
+        unsigned int dlo = (weights[(b0 + 208) >> 2] >> (((b0 + 208) & 3) * 8)) & 0xFFu;
+        unsigned int dhi = (weights[(b0 + 209) >> 2] >> (((b0 + 209) & 3) * 8)) & 0xFFu;
+        float d = sharpi_fp16_to_fp32(dlo | (dhi << 8));
+
+        long isc = (long)(lane >> 4);
+
+        float sc0 = d * (float)sharpi_int8_at(weights, b0 + 192 + isc);
+        float sc1 = d * (float)sharpi_int8_at(weights, b0 + 194 + isc);
+        float sc2 = d * (float)sharpi_int8_at(weights, b0 + 196 + isc);
+        float sc3 = d * (float)sharpi_int8_at(weights, b0 + 198 + isc);
+        float sc4 = d * (float)sharpi_int8_at(weights, b0 + 200 + isc);
+        float sc5 = d * (float)sharpi_int8_at(weights, b0 + 202 + isc);
+        float sc6 = d * (float)sharpi_int8_at(weights, b0 + 204 + isc);
+        float sc7 = d * (float)sharpi_int8_at(weights, b0 + 206 + isc);
+
+        unsigned int ql0 = sharpi_byte_at(weights, b0 +   0 + lane);
+        unsigned int ql1 = sharpi_byte_at(weights, b0 +  32 + lane);
+        unsigned int ql2 = sharpi_byte_at(weights, b0 +  64 + lane);
+        unsigned int ql3 = sharpi_byte_at(weights, b0 +  96 + lane);
+        unsigned int qh0 = sharpi_byte_at(weights, b0 + 128 + lane);
+        unsigned int qh1 = sharpi_byte_at(weights, b0 + 160 + lane);
+
+        float w0 = sc0 * (float)((int)((ql0 & 0xFu)        | (((qh0 >> 0) & 3u) << 4)) - 32);
+        float w1 = sc1 * (float)((int)((ql1 & 0xFu)        | (((qh0 >> 2) & 3u) << 4)) - 32);
+        float w2 = sc2 * (float)((int)(((ql0 >> 4) & 0xFu) | (((qh0 >> 4) & 3u) << 4)) - 32);
+        float w3 = sc3 * (float)((int)(((ql1 >> 4) & 0xFu) | (((qh0 >> 6) & 3u) << 4)) - 32);
+        float w4 = sc4 * (float)((int)((ql2 & 0xFu)        | (((qh1 >> 0) & 3u) << 4)) - 32);
+        float w5 = sc5 * (float)((int)((ql3 & 0xFu)        | (((qh1 >> 2) & 3u) << 4)) - 32);
+        float w6 = sc6 * (float)((int)(((ql2 >> 4) & 0xFu) | (((qh1 >> 4) & 3u) << 4)) - 32);
+        float w7 = sc7 * (float)((int)(((ql3 >> 4) & 0xFu) | (((qh1 >> 6) & 3u) << 4)) - 32);
+
+        int base_elem = block * 256;
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok) {
+                const float* input = input_all + (long)t * (long)cols;
+                acc[t] += w0 * input[base_elem +       lane];
+                acc[t] += w1 * input[base_elem +  32 + lane];
+                acc[t] += w2 * input[base_elem +  64 + lane];
+                acc[t] += w3 * input[base_elem +  96 + lane];
+                acc[t] += w4 * input[base_elem + 128 + lane];
+                acc[t] += w5 * input[base_elem + 160 + lane];
+                acc[t] += w6 * input[base_elem + 192 + lane];
+                acc[t] += w7 * input[base_elem + 224 + lane];
+            }
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok) {
+            float result = sharpi_warp_reduce_sum(acc[t]);
+            if (lane == 0) output_all[(long)t * (long)rows + row] = result;
+        }
+}
+
+// Q5_K: hoists the token-invariant (d1*q - dm1) per element pair — the same
+// fma llm_matvec_q5k_gemm_n contracts to before the activation multiply.
+extern ""C"" __global__ void llm_matvec_q5k_ws_n__NT__(
+    const unsigned int* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols]
+    float* __restrict__ output_all,        // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 8;
+    long row_base_bytes = (long)row * (long)num_blocks * 176L;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long b0 = row_base_bytes + (long)block * 176L;
+
+        unsigned int dword0 = __ldg(&weights[b0 >> 2]);
+        float d    = sharpi_fp16_to_fp32(dword0 & 0xffffu);
+        float dmin = sharpi_fp16_to_fp32(dword0 >> 16);
+
+        unsigned int qh_byte = sharpi_byte_at(weights, b0 + 16 + lane);
+
+        int base_elem = block * 256;
+
+        #pragma unroll
+        for (int chunk = 0; chunk < 4; chunk++) {
+            unsigned int sc_lo_byte, sc_hi_byte;
+            unsigned int sc1, m1, sc2, m2;
+            int j_lo = chunk * 2;
+            int j_hi = j_lo + 1;
+            if (j_lo < 4) {
+                sc_lo_byte = sharpi_byte_at(weights, b0 + 4 + j_lo);
+                sc_hi_byte = sharpi_byte_at(weights, b0 + 4 + j_lo + 4);
+                sc1 = sc_lo_byte & 63u;
+                m1  = sc_hi_byte & 63u;
+                unsigned int sc_lo2 = sharpi_byte_at(weights, b0 + 4 + j_hi);
+                unsigned int sc_hi2 = sharpi_byte_at(weights, b0 + 4 + j_hi + 4);
+                sc2 = sc_lo2 & 63u;
+                m2  = sc_hi2 & 63u;
+            } else {
+                unsigned int a_lo = sharpi_byte_at(weights, b0 + 4 + j_lo + 4);
+                unsigned int b_lo = sharpi_byte_at(weights, b0 + 4 + j_lo - 4);
+                unsigned int c_lo = sharpi_byte_at(weights, b0 + 4 + j_lo);
+                sc1 = (a_lo & 0xFu) | (((b_lo >> 6) & 3u) << 4);
+                m1  = ((a_lo >> 4) & 0xFu) | (((c_lo >> 6) & 3u) << 4);
+
+                unsigned int a_hi = sharpi_byte_at(weights, b0 + 4 + j_hi + 4);
+                unsigned int b_hi = sharpi_byte_at(weights, b0 + 4 + j_hi - 4);
+                unsigned int c_hi = sharpi_byte_at(weights, b0 + 4 + j_hi);
+                sc2 = (a_hi & 0xFu) | (((b_hi >> 6) & 3u) << 4);
+                m2  = ((a_hi >> 4) & 0xFu) | (((c_hi >> 6) & 3u) << 4);
+            }
+
+            float d1  = d * (float)sc1;
+            float dm1 = dmin * (float)m1;
+            float d2  = d * (float)sc2;
+            float dm2 = dmin * (float)m2;
+
+            unsigned int u1 = 1u << (2 * chunk);
+            unsigned int u2 = u1 << 1;
+
+            unsigned int ql_byte = sharpi_byte_at(weights, b0 + 48 + chunk * 32 + lane);
+            unsigned int low4 = ql_byte & 0xFu;
+            unsigned int hi4  = (ql_byte >> 4) & 0xFu;
+
+            int hLo = (qh_byte & u1) != 0u ? 16 : 0;
+            int hHi = (qh_byte & u2) != 0u ? 16 : 0;
+
+            int elem_lo = base_elem + chunk * 64 + lane;
+            int elem_hi = elem_lo + 32;
+
+            float w_lo = d1 * (float)((int)low4 + hLo) - dm1;
+            float w_hi = d2 * (float)((int)hi4  + hHi) - dm2;
+
+            #pragma unroll
+            for (int t = 0; t < NT; t++)
+                if (t < n_tok) {
+                    const float* input = input_all + (long)t * (long)cols;
+                    acc[t] += w_lo * input[elem_lo];
+                    acc[t] += w_hi * input[elem_hi];
+                }
+        }
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok) {
+            float result = sharpi_warp_reduce_sum(acc[t]);
+            if (lane == 0) output_all[(long)t * (long)rows + row] = result;
+        }
+}
+
+// Q4_K (interleaved AoS, dp4a over Q8_1 activations): grid = rows, block =
+// 32 × MATVEC_Q4K_NWARPS — llm_matvec_q4k_gemm_n minus the token grid dimension.
+// The weight words and the hoisted scale products (super_d*sc, super_dmin*mn —
+// the same left-fold the GEMM-N coef_* computes) are loaded once per block
+// iteration and applied to all n_tok Q8_1 activation rows.
+extern ""C"" __global__ void llm_matvec_q4k_ws_n__NT__(
+    const unsigned int* __restrict__ weights,
+    const unsigned char* __restrict__ y_q81_all,  // [n_tok][num_blocks*8*36] bytes
+    float* __restrict__ output_all,               // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    int row     = (int)blockIdx.x;
+    int warp_id = (int)threadIdx.y;
+    int lane    = (int)threadIdx.x;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 8;
+    long word_row_base = (long)row * (long)num_blocks * 36L;
+    // q81 row stride = (cols/32) sub-blocks × 36 bytes = num_blocks*8*36.
+    long tok_stride = (long)num_blocks * 8L * 36L;
+
+    int chunk    = lane >> 3;
+    int byte_off = (lane & 7) * 4;
+    int q4_offset = 4 + chunk * 8 + (lane & 7);
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    for (int block = warp_id; block < num_blocks; block += MATVEC_Q4K_NWARPS) {
+        long word_base = word_row_base + (long)block * 36L;
+
+        unsigned int w0  = __ldg(&weights[word_base]);
+        unsigned int sm0 = __ldg(&weights[word_base + 1]);
+        unsigned int sm1 = __ldg(&weights[word_base + 2]);
+        unsigned int sm2 = __ldg(&weights[word_base + 3]);
+        float super_d    = sharpi_fp16_to_fp32(w0 & 0xffffu);
+        float super_dmin = sharpi_fp16_to_fp32(w0 >> 16);
+
+        unsigned int sc_lo, mn_lo, sc_hi, mn_hi;
+        switch (chunk) {
+            case 0:
+                sc_lo = (sm0)       & 63u; mn_lo = (sm1)       & 63u;
+                sc_hi = (sm0 >>  8) & 63u; mn_hi = (sm1 >>  8) & 63u;
+                break;
+            case 1:
+                sc_lo = (sm0 >> 16) & 63u; mn_lo = (sm1 >> 16) & 63u;
+                sc_hi = (sm0 >> 24) & 63u; mn_hi = (sm1 >> 24) & 63u;
+                break;
+            case 2:
+                sc_lo = (sm2        & 0xFu) | (((sm0 >>  6) & 3u) << 4);
+                mn_lo = ((sm2 >>  4) & 0xFu) | (((sm1 >>  6) & 3u) << 4);
+                sc_hi = ((sm2 >>  8) & 0xFu) | (((sm0 >> 14) & 3u) << 4);
+                mn_hi = ((sm2 >> 12) & 0xFu) | (((sm1 >> 14) & 3u) << 4);
+                break;
+            default:
+                sc_lo = ((sm2 >> 16) & 0xFu) | (((sm0 >> 22) & 3u) << 4);
+                mn_lo = ((sm2 >> 20) & 0xFu) | (((sm1 >> 22) & 3u) << 4);
+                sc_hi = ((sm2 >> 24) & 0xFu) | (((sm0 >> 30) & 3u) << 4);
+                mn_hi = ((sm2 >> 28) & 0xFu) | (((sm1 >> 30) & 3u) << 4);
+                break;
+        }
+
+        unsigned int wq    = __ldg(&weights[word_base + q4_offset]);
+        unsigned int wq_lo = wq & 0x0F0F0F0Fu;
+        unsigned int wq_hi = (wq >> 4) & 0x0F0F0F0Fu;
+
+        float sd_sc_lo = super_d    * (float)sc_lo;
+        float sm_mn_lo = super_dmin * (float)mn_lo;
+        float sd_sc_hi = super_d    * (float)sc_hi;
+        float sm_mn_hi = super_dmin * (float)mn_hi;
+
+        long q81_base_lo = (long)(block * 8 + chunk * 2)     * 36L;
+        long q81_base_hi = (long)(block * 8 + chunk * 2 + 1) * 36L;
+
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok) {
+                const unsigned char* y_q81 = y_q81_all + (long)t * tok_stride;
+
+                unsigned int d_bits_lo = __ldg(reinterpret_cast<const unsigned int*>(y_q81 + q81_base_lo)) & 0xffffu;
+                unsigned int d_bits_hi = __ldg(reinterpret_cast<const unsigned int*>(y_q81 + q81_base_hi)) & 0xffffu;
+                float d8_lo = sharpi_fp16_to_fp32(d_bits_lo);
+                float d8_hi = sharpi_fp16_to_fp32(d_bits_hi);
+
+                int act_lo = *reinterpret_cast<const int*>(y_q81 + q81_base_lo + 4 + byte_off);
+                int act_hi = *reinterpret_cast<const int*>(y_q81 + q81_base_hi + 4 + byte_off);
+
+                int dot_lo   = __dp4a((int)wq_lo, act_lo, 0);
+                int dot_hi   = __dp4a((int)wq_hi, act_hi, 0);
+                int sum_lo   = __dp4a((int)0x01010101, act_lo, 0);
+                int sum_hi   = __dp4a((int)0x01010101, act_hi, 0);
+
+                float coef_d_lo = sd_sc_lo * d8_lo;
+                float coef_m_lo = sm_mn_lo * d8_lo;
+                float coef_d_hi = sd_sc_hi * d8_hi;
+                float coef_m_hi = sm_mn_hi * d8_hi;
+                acc[t] += coef_d_lo * (float)dot_lo - coef_m_lo * (float)sum_lo;
+                acc[t] += coef_d_hi * (float)dot_hi - coef_m_hi * (float)sum_hi;
+            }
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok)
+            acc[t] = sharpi_warp_reduce_sum(acc[t]);
+
+    __shared__ float warp_acc[NT * MATVEC_Q4K_NWARPS];
+    if (lane == 0) {
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok)
+                warp_acc[t * MATVEC_Q4K_NWARPS + warp_id] = acc[t];
+    }
+    __syncthreads();
+
+    // Warp 0, lane t finishes token t (n_tok <= 16 < 32): the w=0..7 partial-sum
+    // order matches the GEMM-N kernel's warp_id loop exactly; tokens are independent.
+    if (warp_id == 0 && lane < n_tok) {
+        float s = 0.f;
+        #pragma unroll
+        for (int w = 0; w < MATVEC_Q4K_NWARPS; w++)
+            s += warp_acc[lane * MATVEC_Q4K_NWARPS + w];
+        output_all[(long)lane * (long)rows + row] = s;
+    }
+}
+
+// Q4_K over the scale-pre-unpacked SoA weight (#156): identical reduction to
+// llm_matvec_q4k_ws_n__NT__, only the weight decode reads the SoA regions.
+extern ""C"" __global__ void llm_matvec_q4k_ws_soa_n__NT__(
+    const unsigned int* __restrict__ weights,     // SoA: [Q][S][D]
+    const unsigned char* __restrict__ y_q81_all,  // [n_tok][num_blocks*8*36] bytes
+    float* __restrict__ output_all,               // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    int row     = (int)blockIdx.x;
+    int warp_id = (int)threadIdx.y;
+    int lane    = (int)threadIdx.x;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 8;
+    long totalSub  = (long)rows * num_blocks;
+    const unsigned char* qReg = (const unsigned char*)weights;
+    const unsigned char* sReg = qReg + totalSub * 128L;
+    const unsigned int*  dReg = (const unsigned int*)(sReg + totalSub * 16L);
+
+    long tok_stride = (long)num_blocks * 8L * 36L;
+
+    int chunk    = lane >> 3;
+    int byte_off = (lane & 7) * 4;
+    int q_word_in_block = chunk * 8 + (lane & 7);
+
+    long row_blk_base = (long)row * num_blocks;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    for (int block = warp_id; block < num_blocks; block += MATVEC_Q4K_NWARPS) {
+        long sb = row_blk_base + block;
+
+        unsigned int dd  = __ldg(&dReg[sb]);
+        float super_d    = sharpi_fp16_to_fp32(dd & 0xffffu);
+        float super_dmin = sharpi_fp16_to_fp32(dd >> 16);
+
+        const unsigned char* sblk = sReg + sb * 16L;
+        unsigned int sc_lo = sblk[2 * chunk];
+        unsigned int sc_hi = sblk[2 * chunk + 1];
+        unsigned int mn_lo = sblk[8 + 2 * chunk];
+        unsigned int mn_hi = sblk[8 + 2 * chunk + 1];
+
+        unsigned int wq    = __ldg(&weights[sb * 32L + q_word_in_block]);
+        unsigned int wq_lo = wq & 0x0F0F0F0Fu;
+        unsigned int wq_hi = (wq >> 4) & 0x0F0F0F0Fu;
+
+        float sd_sc_lo = super_d    * (float)sc_lo;
+        float sm_mn_lo = super_dmin * (float)mn_lo;
+        float sd_sc_hi = super_d    * (float)sc_hi;
+        float sm_mn_hi = super_dmin * (float)mn_hi;
+
+        long q81_base_lo = (long)(block * 8 + chunk * 2)     * 36L;
+        long q81_base_hi = (long)(block * 8 + chunk * 2 + 1) * 36L;
+
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok) {
+                const unsigned char* y_q81 = y_q81_all + (long)t * tok_stride;
+
+                unsigned int d_bits_lo = __ldg(reinterpret_cast<const unsigned int*>(y_q81 + q81_base_lo)) & 0xffffu;
+                unsigned int d_bits_hi = __ldg(reinterpret_cast<const unsigned int*>(y_q81 + q81_base_hi)) & 0xffffu;
+                float d8_lo = sharpi_fp16_to_fp32(d_bits_lo);
+                float d8_hi = sharpi_fp16_to_fp32(d_bits_hi);
+
+                int act_lo = *reinterpret_cast<const int*>(y_q81 + q81_base_lo + 4 + byte_off);
+                int act_hi = *reinterpret_cast<const int*>(y_q81 + q81_base_hi + 4 + byte_off);
+
+                int dot_lo   = __dp4a((int)wq_lo, act_lo, 0);
+                int dot_hi   = __dp4a((int)wq_hi, act_hi, 0);
+                int sum_lo   = __dp4a((int)0x01010101, act_lo, 0);
+                int sum_hi   = __dp4a((int)0x01010101, act_hi, 0);
+
+                float coef_d_lo = sd_sc_lo * d8_lo;
+                float coef_m_lo = sm_mn_lo * d8_lo;
+                float coef_d_hi = sd_sc_hi * d8_hi;
+                float coef_m_hi = sm_mn_hi * d8_hi;
+                acc[t] += coef_d_lo * (float)dot_lo - coef_m_lo * (float)sum_lo;
+                acc[t] += coef_d_hi * (float)dot_hi - coef_m_hi * (float)sum_hi;
+            }
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok)
+            acc[t] = sharpi_warp_reduce_sum(acc[t]);
+
+    __shared__ float warp_acc[NT * MATVEC_Q4K_NWARPS];
+    if (lane == 0) {
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok)
+                warp_acc[t * MATVEC_Q4K_NWARPS + warp_id] = acc[t];
+    }
+    __syncthreads();
+
+    if (warp_id == 0 && lane < n_tok) {
+        float s = 0.f;
+        #pragma unroll
+        for (int w = 0; w < MATVEC_Q4K_NWARPS; w++)
+            s += warp_acc[lane * MATVEC_Q4K_NWARPS + w];
+        output_all[(long)lane * (long)rows + row] = s;
+    }
+}
+";
+}

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -350,21 +350,25 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private float[]? _decodeLogitsHost;
     private int _decodeLogitsCapacity;
 
-    // Batched-decode matmul path (issue #190). false (default): the GEMM-N matvec
-    // (_gpu.MatMulBatched) — bit-closest to the per-token decode oracle. It reads each weight
-    // tile once PER token-block (grid Y = nTok), so it amortizes launch overhead + L2 weight
-    // reuse, not the weight HBM reads. true (SHARPI_BATCH_DECODE_GEMM=1): the compute-bound
-    // GEMM/MMQ path (GpuMatMulBatchedCore) that reads each weight ONCE per batch — argmax-stable,
-    // not bit-exact (same contract the prefill batched trunk holds).
+    // Batched-decode matmul path (issue #190/#194). Default: the weight-stationary matvec
+    // (_gpu.MatMulBatchedWeightStationary) — token loop inside the block, so each weight HBM
+    // read is amortized across the batch AND the per-(row,token) reduction chain is identical
+    // to the GEMM-N matvec (bit-identical to the per-token decode oracle's kernels).
+    // SHARPI_BATCH_DECODE_WS=0 falls back to the #190 GEMM-N matvec (_gpu.MatMulBatched, grid
+    // Y = nTok: launch-overhead + L2 reuse only — the A/B baseline WS replaced).
+    // SHARPI_BATCH_DECODE_GEMM=1 routes the compute-bound GEMM/MMQ path (GpuMatMulBatchedCore)
+    // — argmax-stable, not bit-exact (same contract the prefill batched trunk holds).
     //
     // Measured on Qwen3-8B Q4_K_M @ 4070 Ti (aggregate t/s, single-user Forward = 75): GEMM-N
     // beats compute-bound at every realistic decode batch — N=1 70 vs 15, N=4 99 vs 57, N=8 106
     // vs 98 — because the compute-bound kernels carry large per-step fixed costs (int8 activation
     // conversion + the Q6_K output-weight fp16 dequant every step) that only amortize at the
-    // N=4096 scale prefill runs at. So GEMM-N is the default; the toggle is kept for very high
-    // concurrency (the curves converge near N=8, so compute-bound may overtake at N≳16).
+    // N=4096 scale prefill runs at. Weight-stationary keeps GEMM-N's near-zero fixed costs and
+    // adds the weight-read amortization GEMM-N lacks (#194).
     private readonly bool _batchDecodeComputeBound =
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_GEMM") == "1";
+    private readonly bool _batchDecodeWeightStationary =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_WS") != "0";
 
     // Empty (no-aliasing) layer set shared by every dense per-sequence cache CreateCache
     // hands out — dense models never share KV across layers (that's the Gemma 4 tail,
@@ -3147,14 +3151,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private static IReadOnlyList<int> AsList(ReadOnlyMemory<int> mem) =>
         MemoryMarshal.TryGetArray(mem, out ArraySegment<int> seg) ? seg : mem.ToArray();
 
-    /// <summary>One batched-decode matmul, routed by <see cref="_batchDecodeComputeBound"/>:
-    /// the GEMM-N matvec (default) or the compute-bound GEMM/MMQ path that amortizes the weight
-    /// HBM read across the batch (the same routing <see cref="GpuMatMulBatchedCore"/> uses for
-    /// prefill).</summary>
+    /// <summary>One batched-decode matmul. Default: the weight-stationary small-N matvec
+    /// (#194 — weight HBM read amortized across the batch, bit-identical reduction to the
+    /// GEMM-N matvec; N=1 / N&gt;16 delegate to GEMM-N inside the backend).
+    /// SHARPI_BATCH_DECODE_WS=0: the #190 GEMM-N matvec. SHARPI_BATCH_DECODE_GEMM=1: the
+    /// compute-bound GEMM/MMQ path (the same routing <see cref="GpuMatMulBatchedCore"/> uses
+    /// for prefill) — argmax-stable only, kept as the A/B toggle for very high concurrency.</summary>
     private void BatchDecodeMatMul(Tensor outAll, Tensor weights, Tensor inAll, int n)
     {
         if (_batchDecodeComputeBound)
             GpuMatMulBatchedCore(outAll, weights, inAll, n);
+        else if (_batchDecodeWeightStationary)
+            _gpu.MatMulBatchedWeightStationary(outAll, weights, inAll, n, WDType(weights));
         else
             _gpu.MatMulBatched(outAll, weights, inAll, n, WDType(weights));
     }
@@ -3227,9 +3235,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                 _gpu.CopyDevice(_bpResidual!, _bpHidden!);
                 _gpu.RmsNormBatched(_bpNorm!, _bpHidden!, _wAttnNorm[layer], N, embDim, _hp.RmsNormEps);
 
-                // Batched QKV. Default GEMM-N matvec (bit-closest to the per-token oracle);
-                // SHARPI_BATCH_DECODE_GEMM=1 routes the compute-bound GEMM/MMQ that amortizes
-                // the weight HBM read across the batch (argmax-stable, see BatchDecodeMatMul).
+                // Batched QKV. Default weight-stationary matvec (#194: weight read amortized
+                // across the batch, bit-identical reduction to the per-token oracle's kernels);
+                // SHARPI_BATCH_DECODE_WS=0 / SHARPI_BATCH_DECODE_GEMM=1 select the #190
+                // GEMM-N / compute-bound GEMM-MMQ alternatives (see BatchDecodeMatMul).
                 BatchDecodeMatMul(_bpQ!, _wq[layer], _bpNorm!, N);
                 BatchDecodeMatMul(_bpK!, _wk[layer], _bpNorm!, N);
                 BatchDecodeMatMul(_bpV!, _wv[layer]!, _bpNorm!, N);

--- a/tests/SharpInference.Tests.ForwardPass/CudaMatMulBatchedWsTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaMatMulBatchedWsTests.cs
@@ -1,0 +1,296 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #194 bit-exactness tests for <see cref="CudaBackend.MatMulBatchedWeightStationary"/>.
+/// The weight-stationary kernels keep the per-(row, token) reduction chain of the GEMM-N
+/// matvec and only move the token loop inside the thread block, so the output must be
+/// <b>bit-identical</b> to N sequential <see cref="CudaBackend.MatMul"/> calls — the
+/// independent per-token reference, NOT the GEMM-N path the kernels were derived from
+/// (a path validated only against the path built to mirror it isn't validated).
+///
+/// Batch sizes exercise every compile-time capacity variant (2/4/8/16) including
+/// non-capacity sizes that round up with predicated-off tokens (3, 5, 11), the N=1 and
+/// N&gt;16 delegates to the GEMM-N path, and rows not divisible by the 8-row block group.
+///
+/// Silently skips on hosts without CUDA, mirroring the other Cuda* test files.
+/// </summary>
+public sealed unsafe class CudaMatMulBatchedWsTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static ushort HalfToUshort(Half h) =>
+        BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+
+    private static void AssertBitIdentical(string label, int rows, int nTok,
+                                           float[] batched, float[][] reference)
+    {
+        for (int t = 0; t < nTok; t++)
+            for (int r = 0; r < rows; r++)
+            {
+                float bat = batched[(long)t * rows + r];
+                float refv = reference[t][r];
+                if (BitConverter.SingleToInt32Bits(bat) != BitConverter.SingleToInt32Bits(refv))
+                    Assert.Fail(
+                        $"{label}: token {t} row {r} WS={bat} (0x{BitConverter.SingleToInt32Bits(bat):X8}) " +
+                        $"!= sequential GEMV={refv} (0x{BitConverter.SingleToInt32Bits(refv):X8}). " +
+                        "MatMulBatchedWeightStationary must be bit-identical to N sequential MatMul calls.");
+            }
+    }
+
+    /// <summary>Run WS over [nTok × cols] random inputs and compare to nTok sequential
+    /// per-token MatMul calls against the same weight tensor, bit-for-bit.</summary>
+    private static void RunCase(CudaBackend gpu, Tensor gpuW, DType dtype, string label,
+                                int rows, int cols, int nTok, Random rng)
+    {
+        var inAll = new float[(long)nTok * cols];
+        for (int i = 0; i < inAll.Length; i++) inAll[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var gpuInAll = gpu.Upload(inAll, TensorShape.D1((long)nTok * cols));
+        var gpuOutAll = gpu.Allocate(TensorShape.D1((long)nTok * rows));
+
+        gpu.MatMulBatchedWeightStationary(gpuOutAll, gpuW, gpuInAll, nTok, dtype);
+        gpu.Synchronize();
+        var batched = new float[(long)nTok * rows];
+        gpu.Download(gpuOutAll, batched);
+
+        var reference = new float[nTok][];
+        for (int t = 0; t < nTok; t++)
+        {
+            var inT = new float[cols];
+            Array.Copy(inAll, (long)t * cols, inT, 0, cols);
+            var gpuInT = gpu.Upload(inT, TensorShape.D1(cols));
+            var gpuRefT = gpu.Allocate(TensorShape.D1(rows));
+            gpu.MatMul(gpuRefT, gpuW, gpuInT, dtype);
+            gpu.Synchronize();
+            reference[t] = new float[rows];
+            gpu.Download(gpuRefT, reference[t]);
+            gpu.Free(gpuInT); gpu.Free(gpuRefT);
+        }
+
+        gpu.Free(gpuInAll); gpu.Free(gpuOutAll);
+
+        AssertBitIdentical($"{label} rows={rows} cols={cols} nTok={nTok}", rows, nTok, batched, reference);
+    }
+
+    // Batch sizes covering each capacity variant, the round-up predication, and the
+    // N=1 / N>16 GEMM-N delegates.
+    private static readonly int[] BatchSizes = { 1, 2, 3, 4, 5, 8, 11, 16, 17 };
+
+    /// Q4_K layout: 144 bytes per 256-element super-block (matches the GGUF path).
+    private static byte[] BuildQ4KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 144;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 144;
+                float d    = (float)(rng.NextDouble() * 0.05 + 0.005);
+                float dmin = (float)(rng.NextDouble() * 0.03 + 0.005);
+                ushort dh = HalfToUshort((Half)d), dmh = HalfToUshort((Half)dmin);
+                bytes[off + 0] = (byte)(dh & 0xFF); bytes[off + 1] = (byte)(dh >> 8);
+                bytes[off + 2] = (byte)(dmh & 0xFF); bytes[off + 3] = (byte)(dmh >> 8);
+                for (int i = 0; i < 12;  i++) bytes[off +   4 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 128; i++) bytes[off +  16 + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void Ws_Q4K_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols) in new[] { (33, 512), (64, 1024) })
+        {
+            var rng = new Random(20260610 + rows * 31 + cols * 7);
+            byte[] weights = BuildQ4KMatrix(rows, cols, rng);
+            var gpuW = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q4_K);
+            foreach (int nTok in BatchSizes)
+                RunCase(gpu, gpuW, DType.Q4_K, "Q4_K", rows, cols, nTok, rng);
+            gpu.Free(gpuW);
+        }
+    }
+
+    [Fact]
+    public void Ws_Q4K_Soa_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int rows = 33, cols = 512;
+        var rng = new Random(20260610 + 156);
+        byte[] weights = BuildQ4KMatrix(rows, cols, rng);
+        var gpuWAos = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q4_K);
+        // Repack marks the new handle; both the WS dispatch and the sequential
+        // MatMul reference auto-route to their SoA readers.
+        var gpuW = gpu.RepackQ4KSoa(gpuWAos, rows, cols);
+        foreach (int nTok in BatchSizes)
+            RunCase(gpu, gpuW, DType.Q4_K, "Q4_K-SoA", rows, cols, nTok, rng);
+        gpu.Free(gpuW);
+    }
+
+    /// Q6_K layout: 210 bytes per 256-element super-block.
+    private static byte[] BuildQ6KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 210;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 210;
+                for (int i = 0; i < 128; i++) bytes[off + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 64;  i++) bytes[off + 128 + i] = (byte)rng.Next(256);
+                for (int i = 0; i < 16;  i++) bytes[off + 192 + i] = (byte)(rng.Next(33) - 16);
+                float d = (float)(rng.NextDouble() * 0.05 + 0.005);
+                ushort dh = HalfToUshort((Half)d);
+                bytes[off + 208] = (byte)(dh & 0xFF);
+                bytes[off + 209] = (byte)(dh >> 8);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void Ws_Q6K_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols) in new[] { (33, 512), (64, 1024) })
+        {
+            var rng = new Random(20260610 + rows * 37 + cols * 11);
+            byte[] weights = BuildQ6KMatrix(rows, cols, rng);
+            var gpuW = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q6_K);
+            foreach (int nTok in BatchSizes)
+                RunCase(gpu, gpuW, DType.Q6_K, "Q6_K", rows, cols, nTok, rng);
+            gpu.Free(gpuW);
+        }
+    }
+
+    /// Q5_K layout: 176 bytes per 256-element super-block
+    /// ([d:fp16][dmin:fp16][scales:12][qh:32][ql:128]).
+    private static byte[] BuildQ5KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 176;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 176;
+                float d = (float)(rng.NextDouble() * 0.05 + 0.005);
+                float dmin = (float)(rng.NextDouble() * 0.02);
+                ushort dh = HalfToUshort((Half)d);
+                ushort dmh = HalfToUshort((Half)dmin);
+                bytes[off + 0] = (byte)(dh & 0xFF);
+                bytes[off + 1] = (byte)(dh >> 8);
+                bytes[off + 2] = (byte)(dmh & 0xFF);
+                bytes[off + 3] = (byte)(dmh >> 8);
+                for (int i = 4; i < 176; i++) bytes[off + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void Ws_Q5K_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols) in new[] { (33, 512), (64, 1024) })
+        {
+            var rng = new Random(20260610 + rows * 41 + cols * 13);
+            byte[] weights = BuildQ5KMatrix(rows, cols, rng);
+            var gpuW = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q5_K);
+            foreach (int nTok in BatchSizes)
+                RunCase(gpu, gpuW, DType.Q5_K, "Q5_K", rows, cols, nTok, rng);
+            gpu.Free(gpuW);
+        }
+    }
+
+    /// Q8_0 layout: 34 bytes per 32-element block ([d:fp16][32×int8]).
+    private static byte[] BuildQ80Matrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 32;
+        int bytesPerRow = blocksPerRow * 34;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 34;
+                float d = (float)(rng.NextDouble() * 0.05 + 0.005);
+                ushort dh = HalfToUshort((Half)d);
+                bytes[off + 0] = (byte)(dh & 0xFF);
+                bytes[off + 1] = (byte)(dh >> 8);
+                for (int i = 0; i < 32; i++) bytes[off + 2 + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void Ws_Q8_0_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        // The WS kernels are fp32; pin the sequential MatMul reference to the fp32
+        // kernel too (the default dp4a path quantizes the activation to int8 —
+        // argmax-stable, not bit-exact). Issue #142.
+        gpu.Q80Dp4aEnabled = false;
+
+        foreach ((int rows, int cols) in new[] { (33, 512), (64, 1024) })
+        {
+            var rng = new Random(20260610 + rows * 17 + cols * 5);
+            byte[] weights = BuildQ80Matrix(rows, cols, rng);
+            var gpuW = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q8_0);
+            foreach (int nTok in BatchSizes)
+                RunCase(gpu, gpuW, DType.Q8_0, "Q8_0", rows, cols, nTok, rng);
+            gpu.Free(gpuW);
+        }
+    }
+
+    [Fact]
+    public void Ws_Q8_0_Soa_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        gpu.Q80Dp4aEnabled = false;
+
+        const int rows = 33, cols = 512;
+        var rng = new Random(20260610 + 149);
+        byte[] weights = BuildQ80Matrix(rows, cols, rng);
+        var gpuWAos = gpu.UploadRaw(weights, TensorShape.D1(weights.Length), DType.Q8_0);
+        var gpuW = gpu.RepackQ8_0Soa(gpuWAos, rows, cols);
+        foreach (int nTok in BatchSizes)
+            RunCase(gpu, gpuW, DType.Q8_0, "Q8_0-SoA", rows, cols, nTok, rng);
+        gpu.Free(gpuW);
+    }
+
+    [Fact]
+    public void Ws_F32_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        foreach ((int rows, int cols) in new[] { (33, 500), (64, 1024) })
+        {
+            var rng = new Random(20260610 + rows * 13 + cols * 3);
+            var weights = new float[(long)rows * cols];
+            for (int i = 0; i < weights.Length; i++) weights[i] = (float)(rng.NextDouble() * 2 - 1);
+            var gpuW = gpu.Upload(weights, TensorShape.D1((long)rows * cols));
+            foreach (int nTok in BatchSizes)
+                RunCase(gpu, gpuW, DType.Float32, "F32", rows, cols, nTok, rng);
+            gpu.Free(gpuW);
+        }
+    }
+}


### PR DESCRIPTION
## Context

#190 batched decode routed its trunk + output matmuls through the GEMM-N matvec (`CudaBackend.MatMulBatched`, grid Y = token), which re-streams every weight tile from HBM once per token — the batch win was launch overhead + L2 reuse only, capping aggregate throughput at ~1.4× single-user at N=8. The compute-bound MMQ/GEMM alternative is worse at decode batch sizes (fixed per-step costs only amortize at prefill scale). Closes #194.

## What

- **`CudaWsKernels`** (new): weight-stationary small-N matvec kernels — the token loop runs **inside** the thread block, so each weight read serves all N activation rows. Bodies for F32 / Q4_K (AoS + #156 SoA, dp4a over Q8_1) / Q5_K / Q6_K / Q8_0 (AoS + #149 SoA), stamped per compile-time batch capacity (2/4/8/16) so per-token accumulators stay register-resident; excess tokens are predicated off (block-uniform, no divergence).
- **`CudaBackend.MatMulBatchedWeightStationary`**: same contract/token-major layout as `MatMulBatched`; N=1, N>16, and non-batchable dtypes delegate to the GEMM-N path. `MatMulBatched` itself (the GDN/MTP byte-parity surface) and all prefill paths (`PrefillBatchedTrunk` / `GpuMatMulBatchedCore`) are untouched.
- **`CudaForwardPass.BatchDecodeMatMul`**: weight-stationary is the new default; `SHARPI_BATCH_DECODE_WS=0` restores the #190 GEMM-N matvec, `SHARPI_BATCH_DECODE_GEMM=1` still routes the compute-bound A/B path. Env-only toggles, same tier as `SHARPI_BATCH_DECODE_GEMM` — no CLI/server-options surface (no operator trade-off: bit-identical output, strictly faster at every measured N).

**Bit-exact, not just argmax-stable**: each (row, token) pair keeps the GEMM-N kernel's exact reduction chain — token-invariant factors are hoisted only at existing left-fold boundaries (`super_d*sc` like the N2 dual kernels, `d*q` for Q8_0, `sc*(dec-32)` for Q6_K, `d1*q-dm1` for Q5_K) — so output is bit-identical to N sequential per-token matvecs.

## Measured (Qwen3-8B Q4_K_M, RTX 4070 Ti, aggregate decode t/s, single-user = 75)

| N | before (#190) | after | × single-user |
|--:|--:|--:|--:|
| 1 | 69.8 | 69.7 | 0.92× (delegates to GEMM-N) |
| 2 | 88.7 | **123.4** | 1.17× → **1.64×** |
| 4 | 99.6 | **169.4** | 1.32× → **2.25×** |
| 8 | 105.9 | **182.7** | 1.41× → **2.42×** |

`SHARPI_BATCH_DECODE_WS=0` reproduces the old 89/100/106 exactly — the whole delta is the new kernels.

## Validation

- **`CudaMatMulBatchedWsTests`** (new, 7/7): bit-exactness oracle vs **sequential per-token `MatMul`** (the independent reference, not the GEMM-N path the kernels mirror) — every dtype + SoA layout, batch sizes 1–17 covering each capacity variant, round-up predication, and both delegates; rows not divisible by the 8-row block group.
- `CudaBatchForwardMultiTests` 5/5 (batched N=2 / two-step / prefill-with-cache / chunked vs single-user Forward, argmax + top-5 + maxAbs<1.0).
- `Qwen3CudaBatchedPrefillTests` 7/7, `ContinuousBatchingTests` 13/13, `CudaMatMulBatchedTests` 15/15 (GEMM-N regression).

## Follow-ups

- #197 — batch the per-sequence attention/RoPE/KV-append loop (the remaining N=8 flattening; ~1.7K launches per decode step).
- #198 — N>16 routing above WS capacity (silent GEMM-N fallback; sub-batch split / NT=32 / compute-bound crossover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)