### PR TITLE
perf(cuda): #197 ragged-batched decode attention/RoPE/KV-append

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -281,6 +281,20 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _fullSeqAttentionBf16Kernel;
     private nint   _fullSeqAttentionGlobalKernel;
     private nint   _fullSeqAttentionGlobalBf16Kernel;
+
+    // Issue #197: ragged-batched decode kernels — one launch covers all N sequences'
+    // RoPE / KV-append / single-query attention at per-sequence positions against N
+    // distinct per-sequence caches (positions + cache pointer tables ride in by-value
+    // struct kernel parameters; see CudaRaggedKernels).
+    private nint   _ropeNeoxRaggedKernel;
+    private nint   _ropeInterleavedRaggedKernel;
+    private nint   _kvAppendRaggedKernel;
+    private nint   _kvAppendRaggedBf16Kernel;
+    private nint   _kvAppendRaggedQ8Kernel;
+    private nint   _attentionRaggedKernel;
+    private nint   _attentionRaggedBf16Kernel;
+    private nint   _attentionRaggedQ8Kernel;
+    private nint   _addBiasRowsKernel;
     // Issue #141 (attention): memory-efficient flash-attention prefill (shared K/V
     // tiles reused across a query tile + online softmax) replacing the scalar
     // full_seq / swa_batched kernels' O(n²) global K/V re-reads.
@@ -3558,6 +3572,236 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         }
     }
 
+    // ── Ragged-batched decode ops (issue #197) ─────────────────────────────
+    //
+    // One launch per op covers all N decode sequences: row t of the [N × dim]
+    // activation buffer is processed at positions[t] against kCaches[t]/vCaches[t].
+    // Per-sequence positions and cache base pointers ride in by-value struct kernel
+    // parameters (capacity 16; larger batches chunk into ceil(N/16) launches), so
+    // there is no device-side table, no host→device upload, and no sync on the hot
+    // path. These methods issue direct launches only — batched decode never captures
+    // a CUDA graph (CudaForwardPass.CreateCache disables graphs), so no Track*Node.
+
+    /// <summary>Sequences per ragged launch — the by-value struct parameter capacity.</summary>
+    private const int RaggedChunk = CudaRaggedKernels.ChunkCapacity;
+
+    /// <summary>
+    /// Ragged-batched RoPE (issue #197): row <c>t</c> of <paramref name="xAll"/>
+    /// (<c>[N × numHeads*headDim]</c>) rotates at <c>positions[t]</c>. Per row
+    /// bit-identical to the per-token <see cref="RoPE"/> at that position. Unlike the
+    /// <c>*_batched</c> prefill RoPE kernels (consecutive <c>basePos+t</c>), every row
+    /// carries its own arbitrary position — the batched-decode contract.
+    /// </summary>
+    public void RoPEBatchedRagged(Tensor xAll, ReadOnlySpan<int> positions,
+        int numHeads, int headDim, float ropeTheta = 10000f, bool neox = false)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        int nTok = positions.Length;
+        if (nTok == 0) return;
+        if ((long)nTok * numHeads * headDim > xAll.ElementCount)
+            throw new ArgumentException(
+                $"RoPEBatchedRagged: x has {xAll.ElementCount} elements; need {(long)nTok * numHeads * headDim}.");
+
+        int totalPairs = numHeads * (headDim / 2);
+        uint gridX = (uint)((totalPairs + 255) / 256);
+        nint kernel = neox ? _ropeNeoxRaggedKernel : _ropeInterleavedRaggedKernel;
+        long rowBytes = (long)numHeads * headDim * sizeof(float);
+        nint xBase = GetDevPtr(xAll);
+
+        int* pos = stackalloc int[RaggedChunk];
+        nint xPtr = 0;
+        int  pNH = numHeads, pHD = headDim, pNT = 0;
+        float pT = ropeTheta;
+        nint* args = stackalloc nint[6]
+        {
+            (nint)(&xPtr), (nint)(&pNH), (nint)(&pHD), (nint)pos, (nint)(&pT), (nint)(&pNT)
+        };
+        for (int s = 0; s < nTok; s += RaggedChunk)
+        {
+            int n = Math.Min(RaggedChunk, nTok - s);
+            for (int t = 0; t < n; t++) pos[t] = positions[s + t];
+            xPtr = xBase + (nint)((long)s * rowBytes);
+            pNT = n;
+            int r = NvrtcInterop.LaunchKernel(kernel, gridX, (uint)n, 1, 256, 1, 1, 0, _stream, args, null);
+            if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rope_ragged) failed: {r}");
+        }
+    }
+
+    /// <summary>
+    /// Ragged-batched KV append (issue #197): row <c>t</c> of the fp32
+    /// <paramref name="kInputAll"/>/<paramref name="vInputAll"/> (<c>[N × kvDim]</c>)
+    /// is stored into <c>kCaches[t]</c>/<c>vCaches[t]</c> at slot
+    /// <c>positions[t] % maxSeqLen</c>. Per sequence bit-identical to the matching
+    /// per-token append (<see cref="KvAppend"/> / <see cref="KvAppendBf16"/> /
+    /// <see cref="KvAppendQ8_0"/> per <paramref name="kvDType"/>).
+    /// </summary>
+    public void KvAppendBatchedRagged(
+        Tensor kInputAll, Tensor vInputAll,
+        ReadOnlySpan<Tensor> kCaches, ReadOnlySpan<Tensor> vCaches,
+        ReadOnlySpan<int> positions, int kvDim, int maxSeqLen, DType kvDType = DType.Float32)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        int nTok = positions.Length;
+        if (nTok == 0) return;
+        if (kCaches.Length != nTok || vCaches.Length != nTok)
+            throw new ArgumentException("KvAppendBatchedRagged: kCaches/vCaches/positions lengths must match.");
+        nint kernel = kvDType switch
+        {
+            DType.Float32  => _kvAppendRaggedKernel,
+            DType.BFloat16 => _kvAppendRaggedBf16Kernel,
+            DType.Q8_0     => _kvAppendRaggedQ8Kernel,
+            _ => throw new NotSupportedException($"KvAppendBatchedRagged: unsupported KV dtype {kvDType}."),
+        };
+
+        uint gridX = (uint)((kvDim + 255) / 256);
+        long rowBytes = (long)kvDim * sizeof(float);
+        nint kBase = GetDevPtr(kInputAll);
+        nint vBase = GetDevPtr(vInputAll);
+
+        nint* kPtrs = stackalloc nint[RaggedChunk];
+        nint* vPtrs = stackalloc nint[RaggedChunk];
+        int*  pos   = stackalloc int[RaggedChunk];
+        nint kIn = 0, vIn = 0;
+        int  pKD = kvDim, pMSL = maxSeqLen, pNT = 0;
+        nint* args = stackalloc nint[8]
+        {
+            (nint)(&kIn), (nint)(&vIn), (nint)kPtrs, (nint)vPtrs, (nint)pos,
+            (nint)(&pKD), (nint)(&pMSL), (nint)(&pNT)
+        };
+        for (int s = 0; s < nTok; s += RaggedChunk)
+        {
+            int n = Math.Min(RaggedChunk, nTok - s);
+            for (int t = 0; t < n; t++)
+            {
+                kPtrs[t] = GetDevPtr(kCaches[s + t]);
+                vPtrs[t] = GetDevPtr(vCaches[s + t]);
+                pos[t]   = positions[s + t];
+            }
+            kIn = kBase + (nint)((long)s * rowBytes);
+            vIn = vBase + (nint)((long)s * rowBytes);
+            pNT = n;
+            int r = NvrtcInterop.LaunchKernel(kernel, gridX, (uint)n, 1, 256, 1, 1, 0, _stream, args, null);
+            if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kv_append_ragged) failed: {r}");
+        }
+    }
+
+    /// <summary>
+    /// Ragged-batched single-query attention (issue #197): query row <c>t</c> of
+    /// <paramref name="qAll"/> (<c>[N × numHeads*headDim]</c>) attends over
+    /// <c>kCaches[t]</c>/<c>vCaches[t]</c> positions <c>[0, positions[t] + 1)</c> into
+    /// row <c>t</c> of <paramref name="outputAll"/>. Grid is (numHeads, N): all N
+    /// sequences' attention blocks run concurrently in one launch. Each (head, sequence)
+    /// block keeps the per-token <see cref="Attention"/> kernel's exact reduction chain,
+    /// so per sequence the output is bit-identical to the sequential call.
+    ///
+    /// When every <c>positions[t] + 1 ≤ 4096</c> scores stay in shared memory and
+    /// <paramref name="scoresScratch"/> may be null; above that it must hold
+    /// <c>N × numHeads × maxSeqLen</c> floats (per-sequence rows of the per-token
+    /// kernel's <c>numHeads × maxSeqLen</c> layout).
+    /// </summary>
+    public void AttentionBatchedRagged(
+        Tensor qAll, ReadOnlySpan<Tensor> kCaches, ReadOnlySpan<Tensor> vCaches,
+        Tensor outputAll, Tensor? scoresScratch,
+        int numHeads, int numKvHeads, int headDim,
+        ReadOnlySpan<int> positions, int maxSeqLen, float attnScale = -1f, DType kvDType = DType.Float32)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        int nTok = positions.Length;
+        if (nTok == 0) return;
+        if (kCaches.Length != nTok || vCaches.Length != nTok)
+            throw new ArgumentException("AttentionBatchedRagged: kCaches/vCaches/positions lengths must match.");
+        nint kernel = kvDType switch
+        {
+            DType.Float32  => _attentionRaggedKernel,
+            DType.BFloat16 => _attentionRaggedBf16Kernel,
+            DType.Q8_0     => _attentionRaggedQ8Kernel,
+            _ => throw new NotSupportedException($"AttentionBatchedRagged: unsupported KV dtype {kvDType}."),
+        };
+
+        nint ssBase = scoresScratch is { } sv ? GetDevPtr(sv) : nint.Zero;
+        int maxLen = 0;
+        for (int i = 0; i < nTok; i++) maxLen = Math.Max(maxLen, positions[i] + 1);
+        if (maxLen > 4096)
+        {
+            // Fail loud, not corrupt: a too-small/absent scratch would make the kernel
+            // spill out of bounds (per-sequence rows, unlike the per-token kernel's
+            // single numHeads × maxSeqLen block).
+            if (scoresScratch is not { } scratch ||
+                scratch.ElementCount < (long)nTok * numHeads * maxSeqLen)
+                throw new ArgumentException(
+                    $"AttentionBatchedRagged: seqLen {maxLen} > 4096 requires a scores scratch of " +
+                    $"{nTok}×{numHeads}×{maxSeqLen} floats.");
+        }
+
+        long qRowBytes  = (long)numHeads * headDim * sizeof(float);
+        long ssRowBytes = (long)numHeads * maxSeqLen * sizeof(float);
+        nint qBase = GetDevPtr(qAll);
+        nint oBase = GetDevPtr(outputAll);
+
+        nint* kPtrs = stackalloc nint[RaggedChunk];
+        nint* vPtrs = stackalloc nint[RaggedChunk];
+        int*  pos   = stackalloc int[RaggedChunk];
+        nint qPtr = 0, oPtr = 0, ssPtr = 0;
+        int  pNH = numHeads, pNKV = numKvHeads, pHD = headDim, pMSL = maxSeqLen, pNT = 0;
+        float pScale = attnScale;
+        nint* args = stackalloc nint[12]
+        {
+            (nint)(&qPtr), (nint)kPtrs, (nint)vPtrs, (nint)(&oPtr), (nint)(&ssPtr),
+            (nint)(&pNH), (nint)(&pNKV), (nint)(&pHD),
+            (nint)pos, (nint)(&pMSL), (nint)(&pScale), (nint)(&pNT)
+        };
+        for (int s = 0; s < nTok; s += RaggedChunk)
+        {
+            int n = Math.Min(RaggedChunk, nTok - s);
+            for (int t = 0; t < n; t++)
+            {
+                kPtrs[t] = GetDevPtr(kCaches[s + t]);
+                vPtrs[t] = GetDevPtr(vCaches[s + t]);
+                pos[t]   = positions[s + t];
+            }
+            qPtr  = qBase + (nint)((long)s * qRowBytes);
+            oPtr  = oBase + (nint)((long)s * qRowBytes);
+            ssPtr = ssBase == nint.Zero ? nint.Zero : ssBase + (nint)((long)s * ssRowBytes);
+            pNT = n;
+            int r = NvrtcInterop.LaunchKernel(kernel, (uint)numHeads, (uint)n, 1, 256, 1, 1, 0, _stream, args, null);
+            if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(attention_ragged) failed: {r}");
+        }
+    }
+
+    /// <summary>
+    /// Broadcast bias add over <paramref name="nTok"/> rows (issue #197):
+    /// <c>xAll[t][i] += bias[i]</c>. Replaces N per-row <see cref="AddInPlace"/>
+    /// launches in the batched-decode attn-bias branch; one fp32 add per element,
+    /// bit-identical to the per-row calls.
+    /// </summary>
+    public void AddBiasBatched(Tensor xAll, Tensor bias, int dim, int nTok)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (nTok == 0) return;
+        if ((long)dim * nTok > xAll.ElementCount)
+            throw new ArgumentException(
+                $"AddBiasBatched: x has {xAll.ElementCount} elements; need {(long)dim * nTok}.");
+        if (bias.ElementCount < dim)
+            throw new ArgumentException(
+                $"AddBiasBatched: bias has {bias.ElementCount} elements; need {dim}.");
+
+        nint xPtr = GetDevPtr(xAll);
+        nint bPtr = GetDevPtr(bias);
+        int  pD = dim, pNT = nTok;
+        nint* args = stackalloc nint[4] { (nint)(&xPtr), (nint)(&bPtr), (nint)(&pD), (nint)(&pNT) };
+        uint gridX = (uint)((dim + 255) / 256);
+        int r = NvrtcInterop.LaunchKernel(_addBiasRowsKernel, gridX, (uint)nTok, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(add_bias_rows) failed: {r}");
+    }
+
     /// <summary>
     /// Sliding-window attention (Gemma 4 SWA layers). Iterates positions over
     /// <c>[max(0, position+1-windowSize), position+1)</c> instead of the full
@@ -5275,7 +5519,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// <summary>Combined CUDA source for image + text + weight-stationary kernels — one
     /// NVRTC compilation (the cubin cache key hashes this, so adding a source invalidates it).</summary>
     private static string CombinedKernelSource =>
-        CudaKernels.Source + "\n" + CudaTextKernels.Source + "\n" + CudaWsKernels.Source;
+        CudaKernels.Source + "\n" + CudaTextKernels.Source + "\n" + CudaWsKernels.Source +
+        "\n" + CudaRaggedKernels.Source;
 
     private void CompileAndLoadKernels()
     {
@@ -5494,6 +5739,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _kvAppendQ8Kernel, _kvAppendBatchedQ8Kernel,
             _attentionQ8Kernel, _attentionSwaQ8Kernel, _attentionSwaBatchedQ8Kernel,
             _fullSeqAttentionQ8Kernel, _fullSeqAttentionGlobalQ8Kernel,
+            // #197: ragged-batched decode kernels.
+            _ropeNeoxRaggedKernel, _ropeInterleavedRaggedKernel,
+            _kvAppendRaggedKernel, _kvAppendRaggedBf16Kernel, _kvAppendRaggedQ8Kernel,
+            _attentionRaggedKernel, _attentionRaggedBf16Kernel, _attentionRaggedQ8Kernel,
+            _addBiasRowsKernel,
         ];
         foreach (nint k in kernels)
         {
@@ -5672,6 +5922,17 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _fullSeqAttentionGlobalKernel      = GetKernelFunc("llm_full_seq_attention_global");
         _fullSeqAttentionGlobalBf16Kernel  = GetKernelFunc("llm_full_seq_attention_global_bf16");
         _fullSeqAttentionGlobalQ8Kernel    = GetKernelFunc("llm_full_seq_attention_global_q8_0");
+
+        // Issue #197: ragged-batched decode kernels.
+        _ropeNeoxRaggedKernel        = GetKernelFunc("llm_rope_neox_ragged");
+        _ropeInterleavedRaggedKernel = GetKernelFunc("llm_rope_interleaved_ragged");
+        _kvAppendRaggedKernel        = GetKernelFunc("llm_kv_append_ragged");
+        _kvAppendRaggedBf16Kernel    = GetKernelFunc("llm_kv_append_ragged_bf16");
+        _kvAppendRaggedQ8Kernel      = GetKernelFunc("llm_kv_append_ragged_q8_0");
+        _attentionRaggedKernel       = GetKernelFunc("llm_attention_ragged");
+        _attentionRaggedBf16Kernel   = GetKernelFunc("llm_attention_ragged_bf16");
+        _attentionRaggedQ8Kernel     = GetKernelFunc("llm_attention_ragged_q8_0");
+        _addBiasRowsKernel           = GetKernelFunc("llm_add_bias_rows");
     }
 
     /// <summary>

--- a/src/SharpInference.Cuda/CudaRaggedKernels.cs
+++ b/src/SharpInference.Cuda/CudaRaggedKernels.cs
@@ -1,0 +1,337 @@
+namespace SharpInference.Cuda;
+
+/// <summary>
+/// Ragged-batched decode kernels (issue #197), appended to the NVRTC compilation after
+/// <see cref="CudaTextKernels"/> / <see cref="CudaWsKernels"/> (whose <c>sharpi_*</c>
+/// helpers and <c>block_q8_0</c> they reuse).
+///
+/// <para>Batched decode (#190/#194) runs one token per sequence, each at its own position
+/// against its own per-sequence KV cache. After #194 made the matmuls weight-stationary,
+/// the residual per-step cost was the serial per-sequence block in
+/// <c>CudaForwardPass.BatchForwardMulti</c>: ~6 low-occupancy single-token launches per
+/// sequence per layer (QK-norm ×2, RoPE ×2, KV-append, single-query attention), the
+/// attention kernels running back-to-back instead of concurrently. These kernels take the
+/// whole batch in ONE launch: the sequence index rides on <c>blockIdx.y</c>, per-sequence
+/// positions arrive as a by-value array parameter, and the N distinct cache base pointers
+/// arrive as a by-value pointer-table parameter.</para>
+///
+/// <para><b>Parameter passing:</b> the positions array and the K/V cache pointer tables are
+/// plain struct kernel parameters (<c>sharpi_seq_pos</c> / <c>sharpi_seq_ptrs</c>, capacity
+/// <see cref="ChunkCapacity"/>). The driver copies kernel parameters with the launch
+/// command itself, so there is NO device-side table buffer, NO host→device upload, and NO
+/// synchronization on the hot path — the constraint #197 puts on the pointer table. Batches
+/// larger than the capacity are chunked into multiple launches by the
+/// <c>CudaBackend.*BatchedRagged</c> wrappers (launch count O(N/16), still ~O(1) at decode
+/// batch sizes). These kernels are never captured into CUDA graphs (batched decode issues
+/// direct launches only), so baking pointers into parameters is safe.</para>
+///
+/// <para><b>Bit-exact:</b> every kernel keeps the per-element / per-(head, position)
+/// computation chain of its single-sequence counterpart (<c>llm_rope_neox</c> /
+/// <c>llm_rope_interleaved</c> / <c>llm_kv_append*</c> / <c>llm_attention*</c>) — only the
+/// row/cache indirection differs — so each sequence's output is bit-identical to the
+/// matching sequential per-token call (CudaRaggedDecodeKernelTests enforce this against
+/// the independent per-token kernels).</para>
+/// </summary>
+internal static class CudaRaggedKernels
+{
+    /// <summary>Max sequences per launch — the capacity of the by-value struct parameters.
+    /// Matches the largest #194 weight-stationary capacity; the backend wrappers chunk
+    /// larger batches into ceil(N/16) launches.</summary>
+    internal const int ChunkCapacity = 16;
+
+    public static string Source { get; } = @"
+// ── Ragged-batch by-value parameter structs (issue #197) ───────────────────
+// Passed as plain kernel parameters: the driver snapshots them into the launch
+// command, so per-sequence positions / cache pointers need no device buffer and
+// no host->device copy. Capacity 16 per launch; the host chunks larger batches.
+typedef struct { const void* p[16]; } sharpi_seq_ptrs;
+typedef struct { int v[16]; } sharpi_seq_pos;
+
+// ── Ragged NEOX RoPE over n_tok rows at per-sequence positions ─────────────
+// Row t of x rotates at positions.v[t] (batched decode: every sequence sits at
+// its own position — unlike llm_rope_neox_*_batched's base_position + t prefill
+// contract). Per (pair, row) bit-identical to llm_rope_neox at that position.
+extern ""C"" __global__ void llm_rope_neox_ragged(
+    float* __restrict__ x,
+    int num_heads, int head_dim, sharpi_seq_pos positions, float theta, int n_tok)
+{
+    int pair_idx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int half_dim = head_dim / 2;
+    int total_pairs = num_heads * half_dim;
+    int token = (int)blockIdx.y;
+    if (pair_idx >= total_pairs || token >= n_tok) return;
+
+    int h = pair_idx / half_dim;
+    int i = pair_idx % half_dim;
+    int position = positions.v[token];
+
+    float freq = 1.0f / powf(theta, 2.0f * (float)i / (float)head_dim);
+    float angle = (float)position * freq;
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    long head_base = (long)token * (long)num_heads * (long)head_dim + (long)h * head_dim;
+    long a = head_base + i;
+    long b = head_base + i + half_dim;
+    float x0 = x[a];
+    float x1 = x[b];
+    x[a] = x0 * c - x1 * s;
+    x[b] = x0 * s + x1 * c;
+}
+
+// ── Ragged interleaved RoPE (GPT-NeoX-style pairs (2i, 2i+1)) ──────────────
+// Per (pair, row) bit-identical to llm_rope_interleaved at positions.v[t].
+extern ""C"" __global__ void llm_rope_interleaved_ragged(
+    float* __restrict__ x,
+    int num_heads, int head_dim, sharpi_seq_pos positions, float theta, int n_tok)
+{
+    int pair_idx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int half_dim = head_dim / 2;
+    int total_pairs = num_heads * half_dim;
+    int token = (int)blockIdx.y;
+    if (pair_idx >= total_pairs || token >= n_tok) return;
+
+    int h = pair_idx / half_dim;
+    int i = pair_idx % half_dim;
+    int position = positions.v[token];
+
+    float freq = 1.0f / powf(theta, 2.0f * (float)i / (float)head_dim);
+    float angle = (float)position * freq;
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    long base = (long)token * (long)num_heads * (long)head_dim + (long)h * head_dim + 2L * i;
+    float x0 = x[base];
+    float x1 = x[base + 1];
+    x[base]     = x0 * c - x1 * s;
+    x[base + 1] = x0 * s + x1 * c;
+}
+
+// ── Ragged KV append: row t of k/v_in_all → cache t at positions.v[t] ──────
+// N distinct caches per launch via the pointer table. Same ring-slot convention
+// as llm_kv_append (`position % max_seq_len`; identity for the full-context
+// dense caches batched decode uses). Pure copy — bit-identical trivially.
+extern ""C"" __global__ void llm_kv_append_ragged(
+    const float* __restrict__ k_in_all,
+    const float* __restrict__ v_in_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    sharpi_seq_pos positions,
+    int kv_dim, int max_seq_len, int n_tok)
+{
+    int i = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int token = (int)blockIdx.y;
+    if (i >= kv_dim || token >= n_tok) return;
+
+    float* k_cache = (float*)k_caches.p[token];
+    float* v_cache = (float*)v_caches.p[token];
+    long offset = (long)(positions.v[token] % max_seq_len) * (long)kv_dim + (long)i;
+    long in_off = (long)token * (long)kv_dim + (long)i;
+    k_cache[offset] = k_in_all[in_off];
+    v_cache[offset] = v_in_all[in_off];
+}
+
+// bf16-store variant: same fp32→bf16 conversion as llm_kv_append_bf16.
+extern ""C"" __global__ void llm_kv_append_ragged_bf16(
+    const float* __restrict__ k_in_all,
+    const float* __restrict__ v_in_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    sharpi_seq_pos positions,
+    int kv_dim, int max_seq_len, int n_tok)
+{
+    int i = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int token = (int)blockIdx.y;
+    if (i >= kv_dim || token >= n_tok) return;
+
+    unsigned short* k_cache = (unsigned short*)k_caches.p[token];
+    unsigned short* v_cache = (unsigned short*)v_caches.p[token];
+    long offset = (long)(positions.v[token] % max_seq_len) * (long)kv_dim + (long)i;
+    long in_off = (long)token * (long)kv_dim + (long)i;
+    k_cache[offset] = (unsigned short)sharpi_fp32_to_bf16(k_in_all[in_off]);
+    v_cache[offset] = (unsigned short)sharpi_fp32_to_bf16(v_in_all[in_off]);
+}
+
+// q8_0-store variant: identical warp-collaborative block quantization to
+// llm_kv_append_q8_0 (sharpi_q8_append_one — amax shuffle reduce, fp16 scale,
+// rintf clamp ±127). The token-uniform early return keeps every surviving
+// warp's 32 lanes intact for the shuffles, exactly as the per-token kernel.
+extern ""C"" __global__ void llm_kv_append_ragged_q8_0(
+    const float* __restrict__ k_in_all,
+    const float* __restrict__ v_in_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    sharpi_seq_pos positions,
+    int kv_dim, int max_seq_len, int n_tok)
+{
+    int token = (int)blockIdx.y;
+    if (token >= n_tok) return;   // block-uniform: no divergent lanes before shuffles
+
+    int i = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int lane = (int)(threadIdx.x & 31);
+    bool valid = (i < kv_dim);
+
+    block_q8_0* k_cache = (block_q8_0*)k_caches.p[token];
+    block_q8_0* v_cache = (block_q8_0*)v_caches.p[token];
+    long row   = (long)(positions.v[token] % max_seq_len);
+    long elem  = row * (long)kv_dim + (long)i;
+    long block = elem >> 5;
+    long in_off = (long)token * (long)kv_dim + (long)i;
+    sharpi_q8_append_one(valid ? k_in_all[in_off] : 0.f, valid, k_cache, block, lane);
+    sharpi_q8_append_one(valid ? v_in_all[in_off] : 0.f, valid, v_cache, block, lane);
+}
+
+// ── Ragged single-query attention over N distinct caches ───────────────────
+// grid = (num_heads, n_tok): all N sequences' single-query attentions run
+// concurrently in one launch instead of N back-to-back kernel calls. Each
+// (head, sequence) block runs the EXACT llm_attention_kv_impl computation —
+// same per-position score chain, same 256-thread shared-memory softmax
+// reductions, same sequential phase-3 V sum — against that sequence's own
+// cache over its own ragged length seq_len = positions.v[t] + 1, so per
+// sequence the output is bit-identical to the per-token llm_attention call.
+// Spill scratch (seq_len > 4096) is per-(sequence, head):
+// scores_scratch[((t*num_heads)+h) * max_seq_len].
+template<typename KV>
+__device__ void llm_attention_ragged_impl(
+    const float* __restrict__ q_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    float* __restrict__ out_all,
+    float* __restrict__ scores_scratch,
+    int num_heads, int num_kv_heads, int head_dim,
+    sharpi_seq_pos positions, int max_seq_len, float attn_scale, int n_tok)
+{
+    const int MAX_STORED_SCORES = 4096;
+    __shared__ float shared_scores[MAX_STORED_SCORES];
+    __shared__ float sdata[256];
+
+    unsigned int tid = threadIdx.x;
+    unsigned int h = blockIdx.x;
+    int token = (int)blockIdx.y;
+    if ((int)h >= num_heads || token >= n_tok) return;
+
+    const KV* k_cache = (const KV*)k_caches.p[token];
+    const KV* v_cache = (const KV*)v_caches.p[token];
+    int seq_len = positions.v[token] + 1;
+
+    int kv_head = (int)h / (num_heads / num_kv_heads);
+    int kv_dim  = num_kv_heads * head_dim;
+    // attn_scale > 0 overrides (Gemma 4 passes 1.0); ≤0 uses 1/sqrt(head_dim).
+    float scale = (attn_scale > 0.f) ? attn_scale : rsqrtf((float)head_dim);
+    long q_off  = (long)token * (long)num_heads * (long)head_dim + (long)h * (long)head_dim;
+    long out_off = q_off;
+
+    bool use_shared = (seq_len <= MAX_STORED_SCORES);
+    float* head_scratch = scores_scratch
+        + ((long)token * (long)num_heads + (long)h) * (long)max_seq_len;
+
+    for (int t = (int)tid; t < seq_len; t += 256) {
+        float dot = 0.f;
+        long k_off = (long)t * (long)kv_dim + (long)kv_head * (long)head_dim;
+        for (int d = 0; d < head_dim; d++)
+            dot += q_all[q_off + d] * sharpi_kvload(k_cache, k_off + d);
+        float score = dot * scale;
+        if (use_shared) shared_scores[t] = score;
+        else            head_scratch[t]  = score;
+    }
+    if (use_shared) {
+        for (int t = seq_len + (int)tid; t < MAX_STORED_SCORES; t += 256)
+            shared_scores[t] = sharpi_neg_inf();
+    }
+    __syncthreads();
+
+    float local_max = sharpi_neg_inf();
+    for (int t = (int)tid; t < seq_len; t += 256) {
+        float s = use_shared ? shared_scores[t] : head_scratch[t];
+        local_max = fmaxf(local_max, s);
+    }
+    sdata[tid] = local_max;
+    __syncthreads();
+    for (unsigned int s = 128; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] = fmaxf(sdata[tid], sdata[tid + s]);
+        __syncthreads();
+    }
+    float max_val = sdata[0];
+    __syncthreads();
+
+    float local_sum = 0.f;
+    for (int t = (int)tid; t < seq_len; t += 256) {
+        float s = use_shared ? shared_scores[t] : head_scratch[t];
+        float e = __expf(s - max_val);
+        if (use_shared) shared_scores[t] = e;
+        else            head_scratch[t]  = e;
+        local_sum += e;
+    }
+    sdata[tid] = local_sum;
+    __syncthreads();
+    for (unsigned int s = 128; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+    float inv_sum = 1.0f / sdata[0];
+    __syncthreads();
+
+    for (int t = (int)tid; t < seq_len; t += 256) {
+        if (use_shared) shared_scores[t] *= inv_sum;
+        else            head_scratch[t]  *= inv_sum;
+    }
+    __syncthreads();
+
+    for (int d = (int)tid; d < head_dim; d += 256) {
+        float acc = 0.f;
+        for (int t = 0; t < seq_len; t++) {
+            float weight = use_shared ? shared_scores[t] : head_scratch[t];
+            long v_off = (long)t * (long)kv_dim + (long)kv_head * (long)head_dim;
+            acc += weight * sharpi_kvload(v_cache, v_off + d);
+        }
+        out_all[out_off + d] = acc;
+    }
+}
+
+extern ""C"" __global__ void llm_attention_ragged(
+    const float* __restrict__ q_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    float* __restrict__ out_all,
+    float* __restrict__ scores_scratch,
+    int num_heads, int num_kv_heads, int head_dim,
+    sharpi_seq_pos positions, int max_seq_len, float attn_scale, int n_tok)
+{
+    llm_attention_ragged_impl<float>(q_all, k_caches, v_caches, out_all, scores_scratch,
+        num_heads, num_kv_heads, head_dim, positions, max_seq_len, attn_scale, n_tok);
+}
+
+extern ""C"" __global__ void llm_attention_ragged_bf16(
+    const float* __restrict__ q_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    float* __restrict__ out_all,
+    float* __restrict__ scores_scratch,
+    int num_heads, int num_kv_heads, int head_dim,
+    sharpi_seq_pos positions, int max_seq_len, float attn_scale, int n_tok)
+{
+    llm_attention_ragged_impl<unsigned short>(q_all, k_caches, v_caches, out_all, scores_scratch,
+        num_heads, num_kv_heads, head_dim, positions, max_seq_len, attn_scale, n_tok);
+}
+
+extern ""C"" __global__ void llm_attention_ragged_q8_0(
+    const float* __restrict__ q_all,
+    sharpi_seq_ptrs k_caches, sharpi_seq_ptrs v_caches,
+    float* __restrict__ out_all,
+    float* __restrict__ scores_scratch,
+    int num_heads, int num_kv_heads, int head_dim,
+    sharpi_seq_pos positions, int max_seq_len, float attn_scale, int n_tok)
+{
+    llm_attention_ragged_impl<block_q8_0>(q_all, k_caches, v_caches, out_all, scores_scratch,
+        num_heads, num_kv_heads, head_dim, positions, max_seq_len, attn_scale, n_tok);
+}
+
+// ── Broadcast bias add over N rows: x_all[t][i] += bias[i] ─────────────────
+// Replaces N per-row llm_add launches in the attn-bias / O-bias decode branch.
+// One fp32 add per element — bit-identical to the per-row kernel trivially.
+extern ""C"" __global__ void llm_add_bias_rows(
+    float* __restrict__ x_all,
+    const float* __restrict__ bias,
+    int dim, int n_tok)
+{
+    int i = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int token = (int)blockIdx.y;
+    if (i >= dim || token >= n_tok) return;
+    x_all[(long)token * (long)dim + i] += bias[i];
+}
+";
+}

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -370,6 +370,31 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private readonly bool _batchDecodeWeightStationary =
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_WS") != "0";
 
+    // Ragged-batched per-sequence attention ops (issue #197). Default on: the per-layer
+    // QK-norm/RoPE/KV-append/attention launches collapse from O(N) per-sequence calls
+    // (~6·N low-occupancy single-token kernels per layer, the N attention blocks running
+    // back-to-back) to O(1) ragged kernels whose grid covers all N sequences at their own
+    // positions against their own caches (CudaBackend.*BatchedRagged). Bit-identical per
+    // sequence to the per-sequence loop (same kernels' reduction chains, batched grid).
+    // SHARPI_BATCH_DECODE_RAGGED=0 restores the #190 per-sequence loop.
+    private readonly bool _batchDecodeRagged =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_RAGGED") != "0";
+
+    // Per-batch-composition cache pointer table for the ragged kernels: [layer][seq]
+    // K/V cache tensors, rebuilt only when the caches array composition changes
+    // (sequence admitted/retired — compared by element identity). Avoids re-walking
+    // N caches × L layers on every decode step.
+    private CudaSequenceKvCache[]? _raggedSnapshot;
+    private Tensor[][]? _raggedKLayers;
+    private Tensor[][]? _raggedVLayers;
+
+    // Ragged attention spill scratch [N × numHeads × maxSeqLen] — the ragged kernel
+    // spills per-(sequence, head) score rows when a sequence's length exceeds the
+    // 4096-slot shared-memory fast path. Lazily allocated only when such a length
+    // actually occurs (43 MB at N=8 / 40K ctx — don't pay it for short decodes).
+    private Tensor? _raggedAttnScores;
+    private int _raggedAttnScoresCapacity;
+
     // Empty (no-aliasing) layer set shared by every dense per-sequence cache CreateCache
     // hands out — dense models never share KV across layers (that's the Gemma 4 tail,
     // excluded from batching), so nothing is ever skipped on CudaSequenceKvCache.Dispose.
@@ -3198,12 +3223,27 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         EnsureBatchedTrunkScratch(N);
         EnsureDecodeLogits(N);
 
-        // Per-sequence views into the batched Q/K/V/attnOut scratch. The offsets are fixed
-        // across layers (the batched buffers are reused each layer), so build them once and
-        // free them at the end rather than per-layer. _maxHeadDim == _headDim on the dense
-        // path, so the q/k/v/attn buffers are exactly N×qDim / N×kvDim with no padding stride.
-        // (The O-projection bias add needs per-row hidden views too, but only when _hasAttnBias
-        // — created inline in that rare branch so the common no-bias path allocates nothing extra.)
+        // Ragged path (#197, default): the per-layer QK-norm/RoPE/KV-append/attention run as
+        // O(1) ragged-batched launches over all N sequences. Build the [layer][seq] cache
+        // tensor table once per batch composition (identity-compared; steps within a stable
+        // batch reuse it) and grab the spill scratch only if some sequence is past the
+        // 4096-slot shared-memory fast path.
+        bool ragged = _batchDecodeRagged;
+        Tensor? raggedScores = null;
+        if (ragged)
+        {
+            EnsureRaggedCacheTable(caches);
+            raggedScores = EnsureRaggedAttnScores(N, positions);
+        }
+
+        // Per-sequence views into the batched Q/K/V/attnOut scratch — only the legacy
+        // per-sequence loop (SHARPI_BATCH_DECODE_RAGGED=0) needs them; the ragged kernels
+        // index rows internally. The offsets are fixed across layers (the batched buffers
+        // are reused each layer), so build them once and free them at the end rather than
+        // per-layer. _maxHeadDim == _headDim on the dense path, so the q/k/v/attn buffers
+        // are exactly N×qDim / N×kvDim with no padding stride. (The O-projection bias add
+        // needs per-row hidden views too, but only when _hasAttnBias — created inline in
+        // that rare branch so the common no-bias path allocates nothing extra.)
         // Allocated INSIDE the try so a mid-loop View throw still frees the views taken so far.
         var qViews = new Tensor[N];
         var kViews = new Tensor[N];
@@ -3211,13 +3251,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         var aViews = new Tensor[N];
         try
         {
-            for (int n = 0; n < N; n++)
-            {
-                qViews[n] = _gpu.View(_bpQ!, (long)n * qDim, qDim);
-                kViews[n] = _gpu.View(_bpK!, (long)n * kvDim, kvDim);
-                vViews[n] = _gpu.View(_bpV!, (long)n * kvDim, kvDim);
-                aViews[n] = _gpu.View(_bpAttnOut!, (long)n * qDim, qDim);
-            }
+            if (!ragged)
+                for (int n = 0; n < N; n++)
+                {
+                    qViews[n] = _gpu.View(_bpQ!, (long)n * qDim, qDim);
+                    kViews[n] = _gpu.View(_bpK!, (long)n * kvDim, kvDim);
+                    vViews[n] = _gpu.View(_bpV!, (long)n * kvDim, kvDim);
+                    aViews[n] = _gpu.View(_bpAttnOut!, (long)n * qDim, qDim);
+                }
 
             // 1. Embed each sequence's current token into the batched hidden buffer. (No
             //    embedding scale: the dense per-token Forward oracle applies none — that
@@ -3245,10 +3286,47 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
 
                 bool useRoPE = _hp.NoRopeLayerStep == 0 || (layer + 1) % _hp.NoRopeLayerStep != 0;
 
-                // Per-sequence: bias → QK-norm/RoPE (same order as RunDeviceRegion, #157) →
-                // KV append into that sequence's own cache → single-query attention over its
-                // [0, pos+1). _kvEvictedCount is 0 (SnapKV is rejected for batching), so the
-                // physical slot is simply pos.
+                if (ragged)
+                {
+                    // Ragged-batched (#197): same op sequence as the per-sequence loop below
+                    // (bias → QK-norm/RoPE, #157 order → KV append → attention), each op one
+                    // launch whose grid covers all N rows at positions[n] against caches[n].
+                    // Every kernel keeps its per-token counterpart's reduction chain, so per
+                    // sequence this is bit-identical to the loop it replaces. _kvEvictedCount
+                    // is 0 (SnapKV is rejected for batching), so the physical slot is pos.
+                    if (_hasAttnBias)
+                    {
+                        _gpu.AddBiasBatched(_bpQ!, _bq![layer], qDim, N);
+                        _gpu.AddBiasBatched(_bpK!, _bk![layer], kvDim, N);
+                        _gpu.AddBiasBatched(_bpV!, _bv![layer], kvDim, N);
+                    }
+
+                    if (_hasQkNorm && !_hp.UseL2QkNorm)
+                        _gpu.HeadNormQkBatched(_bpQ!, _wqNorm![layer], _bpK!, _wkNorm![layer],
+                            _numHeads, _numKvHeads, _headDim, N, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                    if (useRoPE)
+                    {
+                        _gpu.RoPEBatchedRagged(_bpQ!, positions, _numHeads, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                        _gpu.RoPEBatchedRagged(_bpK!, positions, _numKvHeads, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                    }
+                    if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
+                    {
+                        _gpu.HeadNormPureBatched(_bpQ!, _numHeads, _headDim, N, _hp.RmsNormEps);
+                        _gpu.HeadNormPureBatched(_bpK!, _numKvHeads, _headDim, N, _hp.RmsNormEps);
+                    }
+
+                    _gpu.KvAppendBatchedRagged(_bpK!, _bpV!, _raggedKLayers![layer], _raggedVLayers![layer],
+                        positions, kvDim, _maxSeqLen, _kvDType);
+                    _gpu.AttentionBatchedRagged(_bpQ!, _raggedKLayers[layer], _raggedVLayers[layer],
+                        _bpAttnOut!, raggedScores,
+                        _numHeads, _numKvHeads, _headDim, positions, _maxSeqLen, _attnScale, _kvDType);
+                    // caches[n].Length is advanced once after the pass completes (below).
+                }
+                else
+                // Per-sequence (#190, SHARPI_BATCH_DECODE_RAGGED=0): bias → QK-norm/RoPE (same
+                // order as RunDeviceRegion, #157) → KV append into that sequence's own cache →
+                // single-query attention over its [0, pos+1). _kvEvictedCount is 0 (SnapKV is
+                // rejected for batching), so the physical slot is simply pos.
                 for (int n = 0; n < N; n++)
                 {
                     int pos = positions[n];
@@ -3285,17 +3363,23 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                     // here — a mid-pass throw then leaves the logical length unadvanced.
                 }
 
-                // Batched O-projection + residual. The attn-output bias is per-row, so it needs
-                // a per-sequence hidden view; created inline here (rare branch) to keep the
-                // common no-bias decode path free of unused per-row views.
+                // Batched O-projection + residual. The attn-output bias is per-row; the ragged
+                // path adds it in one broadcast launch, the legacy loop via per-sequence hidden
+                // views created inline here (rare branch) to keep the common no-bias decode
+                // path free of unused per-row views.
                 BatchDecodeMatMul(_bpHidden!, _wo[layer], _bpAttnOut!, N);
                 if (_hasAttnBias)
-                    for (int n = 0; n < N; n++)
-                    {
-                        var hv = _gpu.View(_bpHidden!, (long)n * embDim, embDim);
-                        _gpu.AddInPlace(hv, _bo![layer]);
-                        _gpu.Free(hv);
-                    }
+                {
+                    if (ragged)
+                        _gpu.AddBiasBatched(_bpHidden!, _bo![layer], embDim, N);
+                    else
+                        for (int n = 0; n < N; n++)
+                        {
+                            var hv = _gpu.View(_bpHidden!, (long)n * embDim, embDim);
+                            _gpu.AddInPlace(hv, _bo![layer]);
+                            _gpu.Free(hv);
+                        }
+                }
                 _gpu.AddInPlace(_bpHidden!, _bpResidual!);
 
                 // FFN (dense SwiGLU), batched across N.
@@ -3358,6 +3442,63 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         _decodeLogitsAll = _gpu.Allocate(TensorShape.D1(total));
         _decodeLogitsHost = new float[(int)total];
         _decodeLogitsCapacity = n;
+    }
+
+    /// <summary>
+    /// (Re)build the ragged kernels' [layer][seq] K/V cache tensor table when the batch
+    /// composition changed (issue #197). Compared by element identity: a stable batch
+    /// reuses the table across decode steps; any admit/retire (different object at any
+    /// slot, or different length) rebuilds it. The snapshot is a defensive clone so a
+    /// caller mutating its array between steps can't alias the comparison.
+    /// </summary>
+    private void EnsureRaggedCacheTable(CudaSequenceKvCache[] caches)
+    {
+        if (_raggedSnapshot is { } snap && snap.Length == caches.Length)
+        {
+            bool same = true;
+            for (int i = 0; i < caches.Length; i++)
+                if (!ReferenceEquals(snap[i], caches[i])) { same = false; break; }
+            if (same) return;
+        }
+
+        int layers = _hp.NumLayers, count = caches.Length;
+        var k = new Tensor[layers][];
+        var v = new Tensor[layers][];
+        for (int l = 0; l < layers; l++)
+        {
+            k[l] = new Tensor[count];
+            v[l] = new Tensor[count];
+            for (int n = 0; n < count; n++)
+            {
+                k[l][n] = caches[n].K[l];
+                v[l][n] = caches[n].V[l];
+            }
+        }
+        _raggedKLayers = k;
+        _raggedVLayers = v;
+        _raggedSnapshot = (CudaSequenceKvCache[])caches.Clone();
+    }
+
+    /// <summary>
+    /// Spill scratch for the ragged attention kernel (issue #197): null while every
+    /// sequence fits the kernel's 4096-slot shared-memory score path (the common case —
+    /// the kernel never dereferences the scratch then); otherwise an
+    /// [N × numHeads × maxSeqLen] buffer of per-(sequence, head) score rows, lazily
+    /// allocated and re-sized only when the decode batch capacity changes.
+    /// </summary>
+    private Tensor? EnsureRaggedAttnScores(int n, int[] positions)
+    {
+        int maxLen = 0;
+        for (int i = 0; i < positions.Length; i++) maxLen = Math.Max(maxLen, positions[i] + 1);
+        if (maxLen <= 4096) return null;
+
+        if (_raggedAttnScoresCapacity != n)
+        {
+            if (_raggedAttnScores is { } old) _gpu.Free(old);
+            _raggedAttnScores = _gpu.Allocate(TensorShape.D1((long)n * _numHeads * _maxSeqLen));
+            _raggedAttnScoresCapacity = n;
+        }
+        return _raggedAttnScores;
     }
 
     // Explicit IBatchedForwardPass surface: the engine holds caches as opaque
@@ -4010,6 +4151,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
 
         // Batched-decode logits scratch (issue #190; allocated only if batching ran).
         if (_decodeLogitsAll is { } dl) _gpu.Free(dl);
+        // Ragged attention spill scratch (issue #197; allocated only on a >4096-length
+        // batched decode). The [layer][seq] cache table holds borrowed tensor refs the
+        // per-sequence caches own — nothing to free there.
+        if (_raggedAttnScores is { } ras) _gpu.Free(ras);
 
         if (_tqEnabled)
         {

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
@@ -28,6 +28,19 @@ public sealed class CudaBatchedDecodeBench
 
     private static bool BenchEnabled => Environment.GetEnvironmentVariable("SHARPI_BENCH_BATCH") == "1";
 
+    // Profiler ergonomics (#197 follow-up): SHARPI_BENCH_BATCH_N="8" runs only those batch
+    // sizes (comma list; default 1,2,4,8), SHARPI_BENCH_SINGLE=0 skips the single-user
+    // baseline, and SHARPI_BENCH_STEPS shrinks the timed loop (ncu's launch interception
+    // makes the full 128-step loop crawl), so a capture contains exactly one configuration.
+    private static int[] BatchSizesToRun =>
+        (Environment.GetEnvironmentVariable("SHARPI_BENCH_BATCH_N") ?? "1,2,4,8")
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .Select(int.Parse).ToArray();
+    private static bool SingleUserEnabled =>
+        Environment.GetEnvironmentVariable("SHARPI_BENCH_SINGLE") != "0";
+    private static int DecodeSteps =>
+        int.TryParse(Environment.GetEnvironmentVariable("SHARPI_BENCH_STEPS"), out int s) && s > 0 ? s : 128;
+
     private static readonly int[] Prompt =
         { 9707, 11, 1879, 0, 358, 1079, 264, 4108, 1614, 13, 220, 17, 18, 19, 20, 21,
           22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 };
@@ -85,22 +98,26 @@ public sealed class CudaBatchedDecodeBench
         finally { Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap); }
         using var fwd = fwdTmp;
 
-        const int decodeSteps = 128;
+        int decodeSteps = DecodeSteps;
         const int warmup = 8;
 
         // ── Single-user baseline (per-token Forward, CUDA graphs on by default) ──
-        fwd.ResetCache();
-        int tok = Argmax(fwd.Prefill(Prompt));
-        int pos = Prompt.Length;
-        for (int i = 0; i < warmup; i++) { tok = Argmax(fwd.Forward(tok, pos)); pos++; }
-        var sw = Stopwatch.StartNew();
-        for (int i = 0; i < decodeSteps; i++) { tok = Argmax(fwd.Forward(tok, pos)); pos++; }
-        sw.Stop();
-        double singleTps = decodeSteps / sw.Elapsed.TotalSeconds;
-        Log($"[bench-190] single-user Forward: {singleTps:F1} t/s ({decodeSteps} steps in {sw.Elapsed.TotalMilliseconds:F0} ms)");
+        double singleTps = double.NaN;
+        if (SingleUserEnabled)
+        {
+            fwd.ResetCache();
+            int tok = Argmax(fwd.Prefill(Prompt));
+            int pos = Prompt.Length;
+            for (int i = 0; i < warmup; i++) { tok = Argmax(fwd.Forward(tok, pos)); pos++; }
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < decodeSteps; i++) { tok = Argmax(fwd.Forward(tok, pos)); pos++; }
+            sw.Stop();
+            singleTps = decodeSteps / sw.Elapsed.TotalSeconds;
+            Log($"[bench-190] single-user Forward: {singleTps:F1} t/s ({decodeSteps} steps in {sw.Elapsed.TotalMilliseconds:F0} ms)");
+        }
 
         // ── Batched BatchForwardMulti at N ∈ {1,2,4,8} (CreateCache disables graphs) ──
-        foreach (int n in new[] { 1, 2, 4, 8 })
+        foreach (int n in BatchSizesToRun)
         {
             var caches = new CudaSequenceKvCache[n];
             try

--- a/tests/SharpInference.Tests.ForwardPass/CudaRaggedDecodeKernelTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaRaggedDecodeKernelTests.cs
@@ -1,0 +1,416 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #197 bit-exactness tests for the ragged-batched decode kernels
+/// (<see cref="CudaBackend.RoPEBatchedRagged"/>, <see cref="CudaBackend.KvAppendBatchedRagged"/>,
+/// <see cref="CudaBackend.AttentionBatchedRagged"/>, <see cref="CudaBackend.AddBiasBatched"/>).
+/// The ragged kernels keep the per-element / per-(head, position) computation chain of their
+/// single-sequence counterparts and only batch the row/cache indirection onto the grid, so each
+/// sequence's result must be <b>bit-identical</b> to the matching sequential per-token kernel
+/// call — the independent per-token reference, NOT a path built to mirror the ragged one
+/// (a path validated only against its own mirror isn't validated).
+///
+/// Batch sizes cross the by-value struct parameter capacity (16) so the host-side chunking into
+/// multiple launches is exercised (17, 20), plus N=1 and odd sizes. Positions are deliberately
+/// ragged (every sequence at a different position). Cache buffers are compared only at the rows
+/// the appends wrote (allocations are not zero-initialized).
+///
+/// Silently skips on hosts without CUDA, mirroring the other Cuda* test files.
+/// </summary>
+public sealed class CudaRaggedDecodeKernelTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static readonly int[] BatchSizes = { 1, 2, 3, 5, 8, 16, 17, 20 };
+
+    private static float[] RandomFloats(int n, Random rng)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        return a;
+    }
+
+    /// <summary>Ragged positions: distinct, non-monotonic, includes 0.</summary>
+    private static int[] RaggedPositions(int n, int maxSeqLen, Random rng)
+    {
+        var pos = new int[n];
+        for (int i = 0; i < n; i++)
+            pos[i] = i == 0 ? 0 : rng.Next(maxSeqLen);
+        return pos;
+    }
+
+    private static void AssertBitIdentical(string label, float[] expected, float[] actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+            if (BitConverter.SingleToInt32Bits(expected[i]) != BitConverter.SingleToInt32Bits(actual[i]))
+                Assert.Fail(
+                    $"{label}: element {i} ragged={actual[i]} (0x{BitConverter.SingleToInt32Bits(actual[i]):X8}) " +
+                    $"!= sequential={expected[i]} (0x{BitConverter.SingleToInt32Bits(expected[i]):X8}). " +
+                    "Ragged kernels must be bit-identical to the sequential per-token kernels.");
+    }
+
+    // ── RoPE ────────────────────────────────────────────────────────────────
+
+    private void RopeCase(bool neox)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int numHeads = 8, headDim = 64;
+        int rowDim = numHeads * headDim;
+        const float theta = 1_000_000f;   // Qwen3's rope_theta scale
+
+        foreach (int n in BatchSizes)
+        {
+            var rng = new Random(197_001 + n);
+            int[] positions = RaggedPositions(n, 5000, rng);
+            float[] xAll = RandomFloats(n * rowDim, rng);
+
+            // Ragged: one call over all rows.
+            var gpuXAll = gpu.Upload(xAll, TensorShape.D1((long)n * rowDim));
+            gpu.RoPEBatchedRagged(gpuXAll, positions, numHeads, headDim, theta, neox);
+            gpu.Synchronize();
+            var ragged = new float[n * rowDim];
+            gpu.Download(gpuXAll, ragged);
+            gpu.Free(gpuXAll);
+
+            // Sequential per-token reference: each row through the independent RoPE kernel.
+            for (int t = 0; t < n; t++)
+            {
+                var row = new float[rowDim];
+                Array.Copy(xAll, (long)t * rowDim, row, 0, rowDim);
+                var gpuRow = gpu.Upload(row, TensorShape.D1(rowDim));
+                gpu.RoPE(gpuRow, positions[t], headDim, theta, neox);
+                gpu.Synchronize();
+                var expected = new float[rowDim];
+                gpu.Download(gpuRow, expected);
+                gpu.Free(gpuRow);
+
+                var actual = new float[rowDim];
+                Array.Copy(ragged, (long)t * rowDim, actual, 0, rowDim);
+                AssertBitIdentical($"RoPE(neox={neox}) N={n} seq={t} pos={positions[t]}", expected, actual);
+            }
+        }
+    }
+
+    [Fact]
+    public void Rope_Neox_Ragged_BitwiseMatchesSequential() => RopeCase(neox: true);
+
+    [Fact]
+    public void Rope_Interleaved_Ragged_BitwiseMatchesSequential() => RopeCase(neox: false);
+
+    // ── KV append ───────────────────────────────────────────────────────────
+
+    /// <summary>Bytes one cache row occupies for the given KV dtype (fp32/bf16/q8_0).</summary>
+    private static int RowBytes(int kvDim, DType dtype) => dtype switch
+    {
+        DType.Float32  => kvDim * 4,
+        DType.BFloat16 => kvDim * 2,
+        DType.Q8_0     => kvDim / 32 * 34,
+        _ => throw new ArgumentOutOfRangeException(nameof(dtype)),
+    };
+
+    /// <summary>Download a cache tensor's raw storage as uint words for bit comparison.</summary>
+    private static uint[] DownloadWords(CudaBackend gpu, Tensor cache, int totalBytes)
+    {
+        var f = new float[totalBytes / 4];
+        gpu.Download(cache, f);
+        var w = new uint[f.Length];
+        for (int i = 0; i < f.Length; i++) w[i] = (uint)BitConverter.SingleToInt32Bits(f[i]);
+        return w;
+    }
+
+    private void KvAppendCase(DType dtype)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int kvDim = 128, maxSeqLen = 64;
+        int rowBytes = RowBytes(kvDim, dtype);
+        int totalBytes = maxSeqLen * rowBytes;
+        int rowWords = rowBytes / 4;
+
+        foreach (int n in BatchSizes)
+        {
+            var rng = new Random(197_100 + n);
+            int[] positions = RaggedPositions(n, maxSeqLen, rng);
+            float[] kAll = RandomFloats(n * kvDim, rng);
+            float[] vAll = RandomFloats(n * kvDim, rng);
+
+            var refK = new Tensor[n]; var refV = new Tensor[n];
+            var ragK = new Tensor[n]; var ragV = new Tensor[n];
+            for (int t = 0; t < n; t++)
+            {
+                refK[t] = gpu.Allocate(TensorShape.D1(maxSeqLen * kvDim), dtype);
+                refV[t] = gpu.Allocate(TensorShape.D1(maxSeqLen * kvDim), dtype);
+                ragK[t] = gpu.Allocate(TensorShape.D1(maxSeqLen * kvDim), dtype);
+                ragV[t] = gpu.Allocate(TensorShape.D1(maxSeqLen * kvDim), dtype);
+            }
+            try
+            {
+                // Ragged: one call appends every row into its own cache pair.
+                var gpuKAll = gpu.Upload(kAll, TensorShape.D1((long)n * kvDim));
+                var gpuVAll = gpu.Upload(vAll, TensorShape.D1((long)n * kvDim));
+                gpu.KvAppendBatchedRagged(gpuKAll, gpuVAll, ragK, ragV, positions, kvDim, maxSeqLen, dtype);
+                gpu.Synchronize();
+                gpu.Free(gpuKAll); gpu.Free(gpuVAll);
+
+                // Sequential per-token reference appends into the independent cache set.
+                for (int t = 0; t < n; t++)
+                {
+                    var kRow = new float[kvDim]; var vRow = new float[kvDim];
+                    Array.Copy(kAll, (long)t * kvDim, kRow, 0, kvDim);
+                    Array.Copy(vAll, (long)t * kvDim, vRow, 0, kvDim);
+                    var gpuKRow = gpu.Upload(kRow, TensorShape.D1(kvDim));
+                    var gpuVRow = gpu.Upload(vRow, TensorShape.D1(kvDim));
+                    switch (dtype)
+                    {
+                        case DType.Float32:
+                            gpu.KvAppend(gpuKRow, gpuVRow, refK[t], refV[t], kvDim, positions[t], maxSeqLen);
+                            break;
+                        case DType.BFloat16:
+                            gpu.KvAppendBf16(gpuKRow, gpuVRow, refK[t], refV[t], kvDim, positions[t], maxSeqLen);
+                            break;
+                        default:
+                            gpu.KvAppendQ8_0(gpuKRow, gpuVRow, refK[t], refV[t], kvDim, positions[t], maxSeqLen);
+                            break;
+                    }
+                    gpu.Synchronize();
+                    gpu.Free(gpuKRow); gpu.Free(gpuVRow);
+                }
+
+                // Compare only the written row (allocations are not zeroed; untouched rows
+                // hold unrelated garbage that differs between the two allocation sets).
+                for (int t = 0; t < n; t++)
+                {
+                    int wordOff = positions[t] * rowWords;
+                    foreach ((Tensor reference, Tensor candidate, string which) in
+                             new[] { (refK[t], ragK[t], "K"), (refV[t], ragV[t], "V") })
+                    {
+                        uint[] expected = DownloadWords(gpu, reference, totalBytes);
+                        uint[] actual   = DownloadWords(gpu, candidate, totalBytes);
+                        for (int w = 0; w < rowWords; w++)
+                            if (expected[wordOff + w] != actual[wordOff + w])
+                                Assert.Fail(
+                                    $"KvAppend({dtype}) N={n} seq={t} pos={positions[t]} {which}: word {w} " +
+                                    $"ragged=0x{actual[wordOff + w]:X8} != sequential=0x{expected[wordOff + w]:X8}.");
+                    }
+                }
+            }
+            finally
+            {
+                for (int t = 0; t < n; t++)
+                {
+                    gpu.Free(refK[t]); gpu.Free(refV[t]);
+                    gpu.Free(ragK[t]); gpu.Free(ragV[t]);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void KvAppend_Ragged_F32_BitwiseMatchesSequential() => KvAppendCase(DType.Float32);
+
+    [Fact]
+    public void KvAppend_Ragged_Bf16_BitwiseMatchesSequential() => KvAppendCase(DType.BFloat16);
+
+    [Fact]
+    public void KvAppend_Ragged_Q8_0_BitwiseMatchesSequential() => KvAppendCase(DType.Q8_0);
+
+    // ── Single-query attention ──────────────────────────────────────────────
+
+    private static ushort HalfToUshort(Half h) => BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+
+    /// <summary>Upload a random cache of <paramref name="elems"/> KV elements in the given
+    /// dtype. The same tensor is read by both the ragged and the per-token kernels, so
+    /// contents only need to be valid for the dtype, not derived from appends.</summary>
+    private static Tensor UploadRandomCache(CudaBackend gpu, int elems, DType dtype, Random rng)
+    {
+        switch (dtype)
+        {
+            case DType.Float32:
+                return gpu.Upload(RandomFloats(elems, rng), TensorShape.D1(elems));
+            case DType.BFloat16:
+            {
+                var u = new ushort[elems];
+                for (int i = 0; i < elems; i++)
+                    u[i] = (ushort)((uint)BitConverter.SingleToInt32Bits(
+                        (float)(rng.NextDouble() * 2 - 1)) >> 16);
+                return gpu.UploadBf16(u, TensorShape.D1(elems));
+            }
+            default:
+            {
+                // block_q8_0: fp16 scale + 32 int8 quants per 32 elements.
+                int blocks = elems / 32;
+                var bytes = new byte[blocks * 34];
+                for (int b = 0; b < blocks; b++)
+                {
+                    int off = b * 34;
+                    ushort d = HalfToUshort((Half)(rng.NextDouble() * 0.05 + 0.005));
+                    bytes[off] = (byte)(d & 0xFF); bytes[off + 1] = (byte)(d >> 8);
+                    for (int i = 0; i < 32; i++) bytes[off + 2 + i] = (byte)rng.Next(256);
+                }
+                return gpu.UploadRaw(bytes, TensorShape.D1(bytes.Length), DType.Q8_0);
+            }
+        }
+    }
+
+    private void AttentionCase(DType dtype, int maxSeqLen, int[] seqLens, bool withScratch)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int numHeads = 8, numKvHeads = 2, headDim = 64;
+        int qDim = numHeads * headDim, kvDim = numKvHeads * headDim;
+        int n = seqLens.Length;
+        int cacheElems = maxSeqLen * kvDim;
+        var rng = new Random(197_200 + n + maxSeqLen);
+
+        var positions = new int[n];
+        for (int t = 0; t < n; t++) positions[t] = seqLens[t] - 1;
+
+        var kCaches = new Tensor[n]; var vCaches = new Tensor[n];
+        for (int t = 0; t < n; t++)
+        {
+            kCaches[t] = UploadRandomCache(gpu, cacheElems, dtype, rng);
+            vCaches[t] = UploadRandomCache(gpu, cacheElems, dtype, rng);
+        }
+        float[] qAll = RandomFloats(n * qDim, rng);
+        var gpuQAll = gpu.Upload(qAll, TensorShape.D1((long)n * qDim));
+        var gpuOutAll = gpu.Allocate(TensorShape.D1((long)n * qDim));
+        Tensor? raggedScratch = withScratch
+            ? gpu.Allocate(TensorShape.D1((long)n * numHeads * maxSeqLen)) : null;
+        Tensor? refScratch = withScratch
+            ? gpu.Allocate(TensorShape.D1((long)numHeads * maxSeqLen)) : null;
+
+        try
+        {
+            // Ragged: one launch, all sequences' single-query attentions concurrent.
+            gpu.AttentionBatchedRagged(gpuQAll, kCaches, vCaches, gpuOutAll, raggedScratch,
+                numHeads, numKvHeads, headDim, positions, maxSeqLen, -1f, dtype);
+            gpu.Synchronize();
+            var ragged = new float[n * qDim];
+            gpu.Download(gpuOutAll, ragged);
+
+            // Sequential per-token reference against the same caches.
+            for (int t = 0; t < n; t++)
+            {
+                var qRow = new float[qDim];
+                Array.Copy(qAll, (long)t * qDim, qRow, 0, qDim);
+                var gpuQRow = gpu.Upload(qRow, TensorShape.D1(qDim));
+                var gpuOutRow = gpu.Allocate(TensorShape.D1(qDim));
+                switch (dtype)
+                {
+                    case DType.Float32:
+                        gpu.Attention(gpuQRow, kCaches[t], vCaches[t], gpuOutRow, refScratch,
+                            numHeads, numKvHeads, headDim, seqLens[t], maxSeqLen);
+                        break;
+                    case DType.BFloat16:
+                        gpu.AttentionBf16(gpuQRow, kCaches[t], vCaches[t], gpuOutRow, refScratch,
+                            numHeads, numKvHeads, headDim, seqLens[t], maxSeqLen);
+                        break;
+                    default:
+                        gpu.AttentionQ8_0(gpuQRow, kCaches[t], vCaches[t], gpuOutRow, refScratch,
+                            numHeads, numKvHeads, headDim, seqLens[t], maxSeqLen);
+                        break;
+                }
+                gpu.Synchronize();
+                var expected = new float[qDim];
+                gpu.Download(gpuOutRow, expected);
+                gpu.Free(gpuQRow); gpu.Free(gpuOutRow);
+
+                var actual = new float[qDim];
+                Array.Copy(ragged, (long)t * qDim, actual, 0, qDim);
+                AssertBitIdentical(
+                    $"Attention({dtype}) N={n} seq={t} seqLen={seqLens[t]} maxSeq={maxSeqLen}",
+                    expected, actual);
+            }
+        }
+        finally
+        {
+            for (int t = 0; t < n; t++) { gpu.Free(kCaches[t]); gpu.Free(vCaches[t]); }
+            gpu.Free(gpuQAll); gpu.Free(gpuOutAll);
+            if (raggedScratch is { } rs) gpu.Free(rs);
+            if (refScratch is { } fs) gpu.Free(fs);
+        }
+    }
+
+    /// <summary>Ragged lengths under the 4096 shared-memory fast path, batch sizes crossing
+    /// the 16-sequence chunk boundary.</summary>
+    [Fact]
+    public void Attention_Ragged_F32_BitwiseMatchesSequential()
+    {
+        foreach (int n in new[] { 1, 3, 8, 17 })
+        {
+            var rng = new Random(197_300 + n);
+            var lens = new int[n];
+            for (int t = 0; t < n; t++) lens[t] = 1 + rng.Next(300);
+            AttentionCase(DType.Float32, maxSeqLen: 320, lens, withScratch: false);
+        }
+    }
+
+    /// <summary>seqLen &gt; 4096 forces the per-(sequence, head) spill-scratch rows — mixed
+    /// with short sequences so both paths run in one launch.</summary>
+    [Fact]
+    public void Attention_Ragged_F32_SpillPath_BitwiseMatchesSequential() =>
+        AttentionCase(DType.Float32, maxSeqLen: 4500, seqLens: [4400, 17, 4100], withScratch: true);
+
+    [Fact]
+    public void Attention_Ragged_Bf16_BitwiseMatchesSequential() =>
+        AttentionCase(DType.BFloat16, maxSeqLen: 320, seqLens: [200, 1, 64, 300, 7], withScratch: false);
+
+    [Fact]
+    public void Attention_Ragged_Q8_0_BitwiseMatchesSequential() =>
+        AttentionCase(DType.Q8_0, maxSeqLen: 320, seqLens: [200, 1, 64, 300, 7], withScratch: false);
+
+    // ── Broadcast bias add ──────────────────────────────────────────────────
+
+    [Fact]
+    public void AddBiasBatched_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int dim = 1234;
+        foreach (int n in new[] { 1, 5, 17 })
+        {
+            var rng = new Random(197_400 + n);
+            float[] xAll = RandomFloats(n * dim, rng);
+            float[] bias = RandomFloats(dim, rng);
+            var gpuBias = gpu.Upload(bias, TensorShape.D1(dim));
+
+            var gpuXAll = gpu.Upload(xAll, TensorShape.D1((long)n * dim));
+            gpu.AddBiasBatched(gpuXAll, gpuBias, dim, n);
+            gpu.Synchronize();
+            var ragged = new float[n * dim];
+            gpu.Download(gpuXAll, ragged);
+            gpu.Free(gpuXAll);
+
+            for (int t = 0; t < n; t++)
+            {
+                var row = new float[dim];
+                Array.Copy(xAll, (long)t * dim, row, 0, dim);
+                var gpuRow = gpu.Upload(row, TensorShape.D1(dim));
+                gpu.AddInPlace(gpuRow, gpuBias);
+                gpu.Synchronize();
+                var expected = new float[dim];
+                gpu.Download(gpuRow, expected);
+                gpu.Free(gpuRow);
+
+                var actual = new float[dim];
+                Array.Copy(ragged, (long)t * dim, actual, 0, dim);
+                AssertBitIdentical($"AddBiasBatched N={n} row={t}", expected, actual);
+            }
+            gpu.Free(gpuBias);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

After #194 (weight-stationary batched-decode matmuls), the residual per-step cost in `CudaForwardPass.BatchForwardMulti` was the serial per-sequence block: ~6 low-occupancy single-token launches per sequence per layer (QK-norm ×2, RoPE ×2, KV-append, single-query attention) — ~1.7K launches per decode step at N=8, with the N attention kernels running back-to-back instead of concurrently. This PR makes the per-layer launch count O(1) in N.

- **`CudaRaggedKernels`** — ragged RoPE (per-sequence positions array; the existing `*_batched` kernels assume one sequence at consecutive `basePos+t`), ragged KV-append + ragged single-query attention over **N distinct caches** at ragged lengths `pos[n]+1` (f32/bf16/q8_0 KV dtypes), and a broadcast bias-row add. Per-sequence positions and cache base pointers are passed as **by-value struct kernel parameters** (capacity 16, host chunks above that): the driver snapshots them with the launch command itself, so there is no device-side pointer table, no host→device upload, and no sync on the hot path. Batched decode never captures CUDA graphs (`CreateCache` disables them), so parameter-baked pointers are safe.
- **`CudaBackend`** — `RoPEBatchedRagged` / `KvAppendBatchedRagged` / `AttentionBatchedRagged` / `AddBiasBatched` chunking wrappers; the attention spill scratch becomes per-(sequence, head) rows `[N × numHeads × maxSeqLen]`, validated fail-loud.
- **`CudaForwardPass.BatchForwardMulti`** — ragged path default-on; the `[layer][seq]` cache tensor table rebuilds only when the batch composition changes (element identity), the spill scratch allocates only when a sequence exceeds the 4096-slot shared-memory fast path; QK-norm rides the existing `HeadNormQkBatched` (one launch for Q+K). **`SHARPI_BATCH_DECODE_RAGGED=0`** restores the #190 per-sequence loop.

Each ragged kernel keeps its per-token counterpart's exact per-(head, position) reduction chain — only the row/cache indirection is batched — so per sequence the output is **bit-identical** to the sequential kernels.

## Throughput (Qwen3-8B Q4_K_M, RTX 4070 Ti, single-user 75.7 t/s)

| N | #194 (ragged off) | ragged (this PR) | Δ | × single-user |
|--:|--:|--:|--:|--:|
| 1 | 69.8 | 69.2 | — | 0.91× |
| 2 | 123.1 | 128.8 | +4.6% | 1.70× |
| 4 | 169.2 | 207.5 | +22.6% | 2.74× |
| 8 | 188.5 | **246.1** | **+30.6%** | **3.25×** |

Acceptance met: N=8 well above 183 t/s, N=4 above 169. `SHARPI_BATCH_DECODE_WS=0` A/B intact (90/104/113 at N=2/4/8 — tracks the #190 GEMM-N curve; that path is matmul-bound so ragged attention moves it little).

## Validation

- **Kernel isolation** (`CudaRaggedDecodeKernelTests`, 10 tests): bit-exactness vs the **sequential per-token kernels** (the independent reference) — chunk-boundary batch sizes (17, 20), ragged positions, all three KV dtypes, q8_0 warp-collaborative append, and the >4096 spill-scratch path.
- **E2E parity**: `CudaBatchForwardMultiTests` 5/5 (argmax + top-5 + maxAbs<1.0 vs single-user `Forward`) and `ContinuousBatchingTests` 13/13 — green on the ragged path **and** with `SHARPI_BATCH_DECODE_RAGGED=0`.
- `CudaMatMulBatched*` suites (22 tests) still green.

Scope: dense batched decode only (the `SupportsContinuousBatching` gate). Per-token `Forward`, prefill paths, and `MatMulBatched` (GDN/MTP byte-parity surface) untouched. SnapKV remains excluded (`_kvEvictedCount == 0`, physical slot == pos).

Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)