### PR TITLE
perf(cuda): #201 q6k scale-word WS decode + opt-in Q4_K decode MMQ (N=8: 246 -> 317 t/s)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -183,6 +183,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private readonly nint[] _matvecQ6KWsKernels    = new nint[CudaWsKernels.Variants.Length];
     private readonly nint[] _matvecQ80WsKernels    = new nint[CudaWsKernels.Variants.Length];
     private readonly nint[] _matvecQ80WsSoaKernels = new nint[CudaWsKernels.Variants.Length];
+    // #201: scale-word Q6_K WS variant + Q4_K decode MMQ (BN=16 int8 mma).
+    private readonly nint[] _matvecQ6KWsSwKernels    = new nint[CudaWsKernels.Variants.Length];
+    private nint _mmqQ4kSoaActsN16Kernel;
     // Issue #141: compute-bound prefill GEMM — dequant Q8_0 weight + convert
     // activations to fp16, then one cublasGemmEx (weight read once per batch).
     private nint   _dequantQ80F16Kernel;
@@ -415,6 +418,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// </summary>
     public bool ActSoaCpaEnabled { get; set; } =
         Environment.GetEnvironmentVariable("SHARPI_ACT_SOA_CPA") == "1";
+
+    /// <summary>
+    /// Issue #201: decode the Q6_K WS per-super-block scale/d tail (bytes 192..209)
+    /// via five aligned word loads + funnel-shift extracts (<c>llm_matvec_q6k_ws_sw_n*</c>)
+    /// instead of 10 dependent byte-gather loads. Same bytes, same chain —
+    /// bit-identical (CudaMatMulBatchedWsTests verify against N sequential MatMul
+    /// calls); cuts the LSU instruction count and the gather latency the serial walk
+    /// stalls on. <c>SHARPI_BATCH_DECODE_WS_V2=0</c> restores the #194 byte-gather
+    /// kernel. Settable so tests can A/B both generations on one backend.
+    /// </summary>
+    public bool WsV2Enabled { get; set; } =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_WS_V2") != "0";
 
     /// <summary>Total VRAM on the active CUDA device, in bytes. Queried once at backend creation.</summary>
     public ulong VramBytes
@@ -2010,11 +2025,12 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         }
 
         // F32-input kernels: same (rows+7)/8 × 256-thread geometry as the GEMM-N
-        // dispatch, minus the token grid dimension.
+        // dispatch, minus the token grid dimension. #201: Q6_K defaults to the
+        // scale-word variant (bit-identical, word-loaded scale/d tail).
         bool q80Soa = weightDType == DType.Q8_0 && _soaHandles.ContainsKey(matrix.Handle);
         nint kernel = weightDType switch
         {
-            DType.Q6_K => _matvecQ6KWsKernels[variant],
+            DType.Q6_K => WsV2Enabled ? _matvecQ6KWsSwKernels[variant] : _matvecQ6KWsKernels[variant],
             DType.Q5_K => _matvecQ5KWsKernels[variant],
             DType.Q8_0 => q80Soa ? _matvecQ80WsSoaKernels[variant] : _matvecQ80WsKernels[variant],
             _          => _matvecF32WsKernels[variant],
@@ -2045,16 +2061,16 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
 
         int subBlocks = cols / 32;                          // per token
         long totalSub = (long)subBlocks * nTok;
-        nuint q81Bytes = (nuint)(totalSub * 36L);
-        EnsureQ81BatchBuf(q81Bytes);
+        if ((long)cols * nTok > int.MaxValue)
+            throw new InvalidOperationException(
+                $"MatMulBatchedWeightStationary: cols*nTok ({(long)cols * nTok}) exceeds int range.");
+        int qN = (int)((long)cols * nTok);
+
+        EnsureQ81BatchBuf((nuint)(totalSub * 36L));
 
         {
             nint qInPtr  = xPtr;
             nint qOutPtr = _q81BatchBuf;
-            int  qN      = (int)((long)cols * nTok);
-            if ((long)cols * nTok > int.MaxValue)
-                throw new InvalidOperationException(
-                    $"MatMulBatchedWeightStationary: cols*nTok ({(long)cols * nTok}) exceeds int range.");
             nint* args = stackalloc nint[3]
             {
                 (nint)(&qInPtr), (nint)(&qOutPtr), (nint)(&qN)
@@ -2078,6 +2094,87 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             int rm = NvrtcInterop.LaunchKernel(kernel, (uint)rows, 1, 1,
                                                32, 8, 1, 0, _stream, args, null);
             if (rm != 0) throw new InvalidOperationException($"cuLaunchKernel(matvec_q4k_ws{(soa ? "_soa" : "")}) failed: {rm}");
+        }
+    }
+
+    /// <summary>
+    /// Issue #201: int8 tensor-core batched-decode matmul (<c>SHARPI_BATCH_DECODE_MMQ=1</c>).
+    /// The bit-exact WS matvecs are frozen into a lane geometry that saturates the
+    /// L1TEX/LSU pipe ~3× above the weight-streaming floor at N=8 (see
+    /// <see cref="CudaWsKernels"/>); this path relaxes the contract to <b>argmax-stable</b>
+    /// — the contract the prefill MMQ holds — and runs a BN=16 decode tile of the
+    /// prefill MMQ instead: SoA Q8_1 activations + one m16n8k32 s8 mma per warp per
+    /// K-block, each weight byte read from HBM exactly once per step.
+    ///
+    /// <para>Eligibility: Q4_K with a #156 SoA-repacked weight (the decode default),
+    /// cols % 256 == 0, N ≥ 5, and rows ≥ 2048. Below 2048 rows the (rows/64)-block
+    /// grid starves the GPU (K/V-projection shapes), and below N=5 the BN=16 mma tile
+    /// runs mostly predicated-off — measured on Qwen3-8B @ 4070 Ti: N=2 123 vs the
+    /// bit-exact WS path's 139 t/s, N=4 a wash, N=8 317 vs 248. Everything else falls
+    /// back to <see cref="MatMulBatchedWeightStationary"/>, so a mixed-dtype trunk
+    /// (Qwen3-8B carries Q6_K attn_v/ffn_down halves) routes per tensor.</para>
+    /// </summary>
+    public void MatMulBatchedDecodeMmq(Tensor outputAll, Tensor matrix, Tensor inputAll,
+                                       int nTok, DType weightDType)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available on this system.");
+        if (nTok <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nTok), nTok, "nTok must be > 0.");
+        if (outputAll.ElementCount % nTok != 0 || inputAll.ElementCount % nTok != 0)
+            throw new ArgumentException(
+                $"MatMulBatchedDecodeMmq: outputAll ({outputAll.ElementCount}) and inputAll " +
+                $"({inputAll.ElementCount}) element counts must be divisible by nTok ({nTok}).");
+
+        int rows = (int)(outputAll.ElementCount / nTok);
+        int cols = (int)(inputAll.ElementCount / nTok);
+        if (weightDType != DType.Q4_K || !_soaQ4kHandles.ContainsKey(matrix.Handle)
+            || (cols & 0xff) != 0 || nTok < 5 || rows < 2048)
+        {
+            MatMulBatchedWeightStationary(outputAll, matrix, inputAll, nTok, weightDType);
+            return;
+        }
+
+        nint wPtr = GetDevPtr(matrix);
+        nint xPtr = GetDevPtr(inputAll);
+        nint yPtr = GetDevPtr(outputAll);
+
+        int subBlocks = cols / 32;
+        long totalSub = (long)subBlocks * nTok;
+        if ((long)cols * nTok > int.MaxValue)
+            throw new InvalidOperationException(
+                $"MatMulBatchedDecodeMmq: cols*nTok ({(long)cols * nTok}) exceeds int range.");
+        int qN = (int)((long)cols * nTok);
+
+        // Quantize activations f32 → SoA Q8_1 ([qs: totalSub*32 B][ds: totalSub*4 B],
+        // the same producer the prefill SoA-acts MMQ uses).
+        EnsureQ81BatchSoaBuf((nuint)(totalSub * 36L));
+        nint qsPtr = _q81BatchSoaBuf;
+        nint dsPtr = _q81BatchSoaBuf + (nint)(totalSub * 32L);
+        {
+            nint qInPtr = xPtr;
+            nint* args = stackalloc nint[4]
+            {
+                (nint)(&qInPtr), (nint)(&qsPtr), (nint)(&dsPtr), (nint)(&qN)
+            };
+            int rq = NvrtcInterop.LaunchKernel(
+                _quantizeQ81SoaKernel, (uint)totalSub, 1, 1,
+                32, 1, 1, 0, _stream, args, null);
+            if (rq != 0) throw new InvalidOperationException($"cuLaunchKernel(quantize_q8_1_soa decode-mmq) failed: {rq}");
+        }
+
+        {
+            int pRows = rows, pCols = cols, pN = nTok;
+            nint* args = stackalloc nint[7]
+            {
+                (nint)(&wPtr), (nint)(&qsPtr), (nint)(&dsPtr), (nint)(&yPtr),
+                (nint)(&pRows), (nint)(&pCols), (nint)(&pN)
+            };
+            uint gx = (uint)((rows + 63) / 64), gy = (uint)((nTok + 15) / 16);
+            int rm = NvrtcInterop.LaunchKernel(_mmqQ4kSoaActsN16Kernel, gx, gy, 1,
+                                               256, 1, 1, 0, _stream, args, null);
+            if (rm != 0) throw new InvalidOperationException($"cuLaunchKernel(mmq_q4k_soa_acts_n16) failed: {rm}");
         }
     }
 
@@ -5744,16 +5841,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _kvAppendRaggedKernel, _kvAppendRaggedBf16Kernel, _kvAppendRaggedQ8Kernel,
             _attentionRaggedKernel, _attentionRaggedBf16Kernel, _attentionRaggedQ8Kernel,
             _addBiasRowsKernel,
+            _mmqQ4kSoaActsN16Kernel,   // #201
         ];
         foreach (nint k in kernels)
         {
             if (k != nint.Zero)
                 NvrtcInterop.FuncGetAttribute(out _, NvrtcInterop.CU_FUNC_ATTRIBUTE_NUM_REGS, k);
         }
-        // #194: weight-stationary batched-decode matvec variants.
+        // #194/#201: weight-stationary batched-decode matvec variants.
         ReadOnlySpan<nint[]> wsKernelSets = [
             _matvecF32WsKernels, _matvecQ4KWsKernels, _matvecQ4KWsSoaKernels,
             _matvecQ5KWsKernels, _matvecQ6KWsKernels, _matvecQ80WsKernels, _matvecQ80WsSoaKernels,
+            _matvecQ6KWsSwKernels,
         ];
         foreach (nint[] set in wsKernelSets)
             foreach (nint k in set)
@@ -5833,7 +5932,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _matvecQ6KWsKernels[v]    = GetKernelFunc($"llm_matvec_q6k_ws_n{nt}");
             _matvecQ80WsKernels[v]    = GetKernelFunc($"llm_matvec_q8_0_ws_n{nt}");
             _matvecQ80WsSoaKernels[v] = GetKernelFunc($"llm_matvec_q8_0_ws_soa_n{nt}");
+            _matvecQ6KWsSwKernels[v]    = GetKernelFunc($"llm_matvec_q6k_ws_sw_n{nt}");      // #201
         }
+        _mmqQ4kSoaActsN16Kernel = GetKernelFunc("llm_mmq_q4k_soa_acts_n16");   // #201
         _dequantQ80F16Kernel   = GetKernelFunc("llm_dequant_q8_0_to_f16");
         _dequantQ4KF16Kernel   = GetKernelFunc("llm_dequant_q4k_to_f16");
         _dequantQ4KF16SoaKernel = GetKernelFunc("llm_dequant_q4k_to_f16_soa");

--- a/src/SharpInference.Cuda/CudaWsKernels.cs
+++ b/src/SharpInference.Cuda/CudaWsKernels.cs
@@ -26,6 +26,21 @@ namespace SharpInference.Cuda;
 /// bit-identical to the GEMM-N path and to <c>n_tok</c> sequential matvecs
 /// (CudaMatMulBatchedWsTests enforce this). Only the loop nest changes: weight outer,
 /// token inner.</para>
+///
+/// <para><b>#201:</b> <c>llm_matvec_q6k_ws_sw_n*</c> (scale-word) replaces the Q6_K
+/// kernel's 10 dependent per-super-block scale/d byte-gather loads with five aligned
+/// word loads + funnel-shift extracts — same bytes, same chain, bit-identical; it
+/// attacks the gather latency the serial walk stalls on. Two sibling #201 attempts
+/// were measured and REMOVED — re-read the issue before re-trying them: token-warp
+/// (one warp per (row, token), bit-exact by construction) loses everywhere because
+/// the NT× weight-decode replication outweighs the occupancy win (N=8 aggregate
+/// 243→239 even routed only to the grid-starved attn_v shape, 243→182 routed to
+/// ffn_down too); SoA-Q8_1-activation reads (xs) genuinely cut the LSU/L1TEX load
+/// (94.7% → 82%) but the second activation-region pointer costs 7 registers in the
+/// NT-unrolled token loop (48 → 55) and the occupancy loss (80% → 63%) nets −5 t/s
+/// (forcing 48 via launch bounds spills: −36 t/s). The bit-identity contract freezes
+/// the lane geometry, so the remaining q4k headroom belongs to the argmax-stable
+/// decode MMQ (<c>SHARPI_BATCH_DECODE_MMQ=1</c>), not to load-shape tweaks.</para>
 /// </summary>
 internal static class CudaWsKernels
 {
@@ -33,14 +48,16 @@ internal static class CudaWsKernels
     /// matters: dispatch indexes kernel-handle arrays by position.</summary>
     internal static readonly int[] Variants = [2, 4, 8, 16];
 
-    /// <summary>All weight-stationary kernels, one instantiation per variant.</summary>
+    /// <summary>All weight-stationary kernels (one instantiation per variant) plus the
+    /// once-only #201 decode-MMQ kernel.</summary>
     public static string Source { get; } = Build();
 
     private static string Build()
     {
-        var sb = new System.Text.StringBuilder(Template.Length * Variants.Length);
+        var sb = new System.Text.StringBuilder(Template.Length * Variants.Length + DecodeMmq.Length);
         foreach (int nt in Variants)
             sb.Append(Template.Replace("__NT__", nt.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        sb.Append(DecodeMmq);
         return sb.ToString();
     }
 
@@ -596,5 +613,283 @@ extern ""C"" __global__ void llm_matvec_q4k_ws_soa_n__NT__(
         output_all[(long)lane * (long)rows + row] = s;
     }
 }
+
+// ── #201 Q6_K scale-word (sw) variant ──────────────────────────────────────
+// Identical geometry (8 rows/block × 32 lanes, token loop inside) and identical
+// reduction chain to llm_matvec_q6k_ws_n*, but the per-super-block scale/d
+// decode loads the 18-byte tail [scales[16] ‖ fp16 d] (bytes 192..209) as five
+// aligned words + funnel-shift extracts instead of 10 separate byte-gather
+// loads (8 × sharpi_int8_at + 2 d bytes). Same bytes → same int8 / fp16 values
+// → bit-identical; the serial super-block walk #201 profiled as latency-bound
+// (ffn_down 48% pipe / 19% DRAM) gets 5 independent LDGs instead of a 10-deep
+// gather burst, and the LSU issues ~30% fewer weight-load instructions.
+extern ""C"" __global__ void llm_matvec_q6k_ws_sw_n__NT__(
+    const unsigned int* __restrict__ weights,
+    const float* __restrict__ input_all,   // [n_tok][cols]
+    float* __restrict__ output_all,        // [n_tok][rows]
+    int rows, int cols, int n_tok)
+{
+    const int NT = __NT__;
+    const int N_ROWS = 8;
+    const int THREADS_PER_ROW = 32;
+    unsigned int tid = threadIdx.x;
+    int row_in_wg = (int)tid / THREADS_PER_ROW;
+    int lane = (int)tid & (THREADS_PER_ROW - 1);
+    int row = (int)blockIdx.x * N_ROWS + row_in_wg;
+    if (row >= rows) return;
+
+    int num_blocks = cols >> 8;
+    long row_base_bytes = (long)row * (long)num_blocks * 210L;
+
+    float acc[NT];
+    #pragma unroll
+    for (int t = 0; t < NT; t++) acc[t] = 0.f;
+
+    // Scale-byte select: original lanes read byte 192 + 2k + isc, isc = lane>>4.
+    unsigned int isc8 = ((unsigned int)lane >> 4) * 8u;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long b0 = row_base_bytes + (long)block * 210L;
+
+        // b0 is always even (210-byte stride from an even base), so the tail
+        // starts at word offset 0 or 2 and five aligned words cover all 18 bytes.
+        // The word covering byte 209 spills ≤2 bytes into the next block — the
+        // same word sharpi_byte_at(b0+209) already reads in the #194 kernel.
+        long sc_word = (b0 + 192) >> 2;
+        unsigned int sw0 = weights[sc_word];
+        unsigned int sw1 = weights[sc_word + 1];
+        unsigned int sw2 = weights[sc_word + 2];
+        unsigned int sw3 = weights[sc_word + 3];
+        unsigned int sw4 = weights[sc_word + 4];
+        unsigned int s01, s23, s45, s67, d_bits;
+        if (((unsigned int)b0 & 3u) != 0u) {   // warp-uniform (b0 is per-block)
+            s01 = __funnelshift_r(sw0, sw1, 16);
+            s23 = __funnelshift_r(sw1, sw2, 16);
+            s45 = __funnelshift_r(sw2, sw3, 16);
+            s67 = __funnelshift_r(sw3, sw4, 16);
+            d_bits = sw4 >> 16;
+        } else {
+            s01 = sw0; s23 = sw1; s45 = sw2; s67 = sw3;
+            d_bits = sw4 & 0xffffu;
+        }
+        float d = sharpi_fp16_to_fp32(d_bits);
+
+        // Same byte, same sign-widening as sharpi_int8_at(weights, b0+192+2k+isc).
+        int v0 = (int)((s01 >> (isc8      )) & 0xFFu); v0 = v0 >= 128 ? v0 - 256 : v0;
+        int v1 = (int)((s01 >> (isc8 + 16u)) & 0xFFu); v1 = v1 >= 128 ? v1 - 256 : v1;
+        int v2 = (int)((s23 >> (isc8      )) & 0xFFu); v2 = v2 >= 128 ? v2 - 256 : v2;
+        int v3 = (int)((s23 >> (isc8 + 16u)) & 0xFFu); v3 = v3 >= 128 ? v3 - 256 : v3;
+        int v4 = (int)((s45 >> (isc8      )) & 0xFFu); v4 = v4 >= 128 ? v4 - 256 : v4;
+        int v5 = (int)((s45 >> (isc8 + 16u)) & 0xFFu); v5 = v5 >= 128 ? v5 - 256 : v5;
+        int v6 = (int)((s67 >> (isc8      )) & 0xFFu); v6 = v6 >= 128 ? v6 - 256 : v6;
+        int v7 = (int)((s67 >> (isc8 + 16u)) & 0xFFu); v7 = v7 >= 128 ? v7 - 256 : v7;
+
+        float sc0 = d * (float)v0;
+        float sc1 = d * (float)v1;
+        float sc2 = d * (float)v2;
+        float sc3 = d * (float)v3;
+        float sc4 = d * (float)v4;
+        float sc5 = d * (float)v5;
+        float sc6 = d * (float)v6;
+        float sc7 = d * (float)v7;
+
+        unsigned int ql0 = sharpi_byte_at(weights, b0 +   0 + lane);
+        unsigned int ql1 = sharpi_byte_at(weights, b0 +  32 + lane);
+        unsigned int ql2 = sharpi_byte_at(weights, b0 +  64 + lane);
+        unsigned int ql3 = sharpi_byte_at(weights, b0 +  96 + lane);
+        unsigned int qh0 = sharpi_byte_at(weights, b0 + 128 + lane);
+        unsigned int qh1 = sharpi_byte_at(weights, b0 + 160 + lane);
+
+        float w0 = sc0 * (float)((int)((ql0 & 0xFu)        | (((qh0 >> 0) & 3u) << 4)) - 32);
+        float w1 = sc1 * (float)((int)((ql1 & 0xFu)        | (((qh0 >> 2) & 3u) << 4)) - 32);
+        float w2 = sc2 * (float)((int)(((ql0 >> 4) & 0xFu) | (((qh0 >> 4) & 3u) << 4)) - 32);
+        float w3 = sc3 * (float)((int)(((ql1 >> 4) & 0xFu) | (((qh0 >> 6) & 3u) << 4)) - 32);
+        float w4 = sc4 * (float)((int)((ql2 & 0xFu)        | (((qh1 >> 0) & 3u) << 4)) - 32);
+        float w5 = sc5 * (float)((int)((ql3 & 0xFu)        | (((qh1 >> 2) & 3u) << 4)) - 32);
+        float w6 = sc6 * (float)((int)(((ql2 >> 4) & 0xFu) | (((qh1 >> 4) & 3u) << 4)) - 32);
+        float w7 = sc7 * (float)((int)(((ql3 >> 4) & 0xFu) | (((qh1 >> 6) & 3u) << 4)) - 32);
+
+        int base_elem = block * 256;
+        #pragma unroll
+        for (int t = 0; t < NT; t++)
+            if (t < n_tok) {
+                const float* input = input_all + (long)t * (long)cols;
+                acc[t] += w0 * input[base_elem +       lane];
+                acc[t] += w1 * input[base_elem +  32 + lane];
+                acc[t] += w2 * input[base_elem +  64 + lane];
+                acc[t] += w3 * input[base_elem +  96 + lane];
+                acc[t] += w4 * input[base_elem + 128 + lane];
+                acc[t] += w5 * input[base_elem + 160 + lane];
+                acc[t] += w6 * input[base_elem + 192 + lane];
+                acc[t] += w7 * input[base_elem + 224 + lane];
+            }
+    }
+
+    #pragma unroll
+    for (int t = 0; t < NT; t++)
+        if (t < n_tok) {
+            float result = sharpi_warp_reduce_sum(acc[t]);
+            if (lane == 0) output_all[(long)t * (long)rows + row] = result;
+        }
+}
+";
+
+    /// <summary>
+    /// #201 decode MMQ (<c>SHARPI_BATCH_DECODE_MMQ=1</c>): the bit-exact WS kernels
+    /// are frozen into a lane geometry whose token loop costs ~30 L1TEX wavefront-heavy
+    /// load instructions per 36-word super-block at NT=8 (~3× the weight-streaming
+    /// floor, #201). This kernel relaxes the contract to argmax-stable — the same
+    /// contract the prefill MMQ holds — and re-tiles <c>llm_mmq_q4k_soa_acts</c> for
+    /// decode batch sizes: BN drops 128 → 16, so grid.y == 1 for N ≤ 16 and each
+    /// weight byte is read from HBM exactly once per step (true weight-stationary)
+    /// while the m16n8k32 int8 mma replaces the per-token dp4a chains. Identical
+    /// K-order accumulation and {d,s} fixup math to the prefill kernel — only the
+    /// tile shape changes (one n-tile per warp, scalar acc0..3 instead of acc[8][4]).
+    /// </summary>
+    private const string DecodeMmq = @"
+// ── #201 decode MMQ: Q4_K SoA weights × SoA Q8_1 activations, BN=16 ─────────
+// grid = (ceil(rows/64), ceil(n_tok/16)), block = 256 (8 warps: 4 row-strips ×
+// 2 token-strips). The K-step is one 256-element SUPER-block: the block stages
+// the raw tile (64×32 quant words + 64 scale tails + 16×64 act words + 16×8
+// act {d,s}) with linear fully-coalesced copies, then runs 8 m16n8k32 s8 mma
+// per warp between one barrier pair — nibble/scale decode happens at
+// fragment-read time from shared. A sub-block-sized K-step (one mma per
+// barrier pair) was measured 1.4-1.7× SLOWER than the WS matvec it replaces:
+// ~50 cycles of mma cannot hide the next tile's global-load latency, so the
+// loop serializes at one latency epoch per 32 elements. The super-block step
+// issues ~14 independent loads per thread per epoch and amortizes it 8×.
+// Argmax-stable, not bit-exact: both operands int8-quantized, min-bias via the
+// fp16 s = d·Σq field (same contract and K-order as the prefill MMQ).
+#define MMQ_BM 64
+#define MMQ_BN 16
+extern ""C"" __global__ void __launch_bounds__(256) llm_mmq_q4k_soa_acts_n16(
+    const unsigned int*  __restrict__ weights,   // SoA [Q][S][D]
+    const unsigned int*  __restrict__ y_qs,      // SoA Q8_1 quants [n_tok × sub_total × 32 B]
+    const unsigned int*  __restrict__ y_ds,      // SoA Q8_1 scales [n_tok × sub_total] {d,s}
+    float* __restrict__ output,                  // [n_tok × rows] fp32
+    int rows, int cols, int n_tok)
+{
+    // Row strides padded +1 word: an unpadded 32/64-word stride would land all 8
+    // grp-lanes of a fragment read on one shared bank (8-way conflict).
+    __shared__ unsigned int sWq[MMQ_BM * 33];    // raw quant words   [row][32+1]
+    __shared__ unsigned int sWs[MMQ_BM * 4];     // raw 16-B sc|mn    [row][4]
+    __shared__ unsigned int sWd[MMQ_BM];         // raw {d,dmin}      [row]
+    __shared__ unsigned int sYq[MMQ_BN * 65];    // raw act words     [tok][64+1]
+    __shared__ unsigned int sYd[MMQ_BN * 8];     // raw act {d,s}     [tok][8]
+
+    int row_block = (int)blockIdx.x * MMQ_BM;
+    int tok_block = (int)blockIdx.y * MMQ_BN;
+    int nb_super  = cols >> 8;
+    int sub_total = cols >> 5;
+    long total_sb = (long)rows * nb_super;
+
+    const unsigned int*  qReg = weights;
+    const unsigned char* sReg = (const unsigned char*)weights + total_sb * 128L;
+    const unsigned int*  dReg = (const unsigned int*)(sReg + total_sb * 16L);
+
+    int tid  = (int)threadIdx.x;
+    int warp = tid >> 5;
+    int lane = tid & 31;
+    int grp  = lane >> 2;
+    int tig  = lane & 3;
+    int wr   = warp & 3;
+    int wc   = warp >> 2;
+    int mrow0 = wr * 16;
+    int ncol0 = wc * 8;
+
+    float acc0 = 0.f, acc1 = 0.f, acc2 = 0.f, acc3 = 0.f;
+
+    int rowA = row_block + mrow0 + grp;
+    int rowB = rowA + 8;
+    int tokC0 = tok_block + ncol0 + tig * 2;
+    int tokC1 = tokC0 + 1;
+
+    for (int ksb = 0; ksb < nb_super; ksb++) {
+        // Stage the raw super-block tile. All copies are linear in shared and
+        // 128-B-coalesced in global (one row / token segment per warp-instruction).
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {            // 64 rows × 32 quant words
+            int k = tid + j * 256;
+            int r = row_block + (k >> 5);
+            sWq[(k >> 5) * 33 + (k & 31)] =
+                (r < rows) ? qReg[((long)r * nb_super + ksb) * 32L + (k & 31)] : 0u;
+        }
+        {                                        // 64 rows × 4 scale words (16 B sc|mn)
+            int r = row_block + (tid >> 2);
+            sWs[tid] = (r < rows)
+                ? reinterpret_cast<const unsigned int*>(sReg)[((long)r * nb_super + ksb) * 4L + (tid & 3)]
+                : 0u;
+        }
+        if (tid < MMQ_BM) {                      // 64 rows × {d,dmin}
+            int r = row_block + tid;
+            sWd[tid] = (r < rows) ? dReg[(long)r * nb_super + ksb] : 0u;
+        }
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {            // 16 tokens × 64 act words (256 B)
+            int k = tid + j * 256;
+            int t = tok_block + (k >> 6);
+            sYq[(k >> 6) * 65 + (k & 63)] =
+                (t < n_tok) ? y_qs[((long)t * sub_total + ksb * 8) * 8L + (k & 63)] : 0u;
+        }
+        if (tid < MMQ_BN * 8) {                  // 16 tokens × 8 act {d,s}
+            int t = tok_block + (tid >> 3);
+            sYd[tid] = (t < n_tok) ? y_ds[(long)t * sub_total + ksb * 8 + (tid & 7)] : 0u;
+        }
+        __syncthreads();
+
+        // 8 sub-blocks per super-block: same per-sub-block fixup math and K-order
+        // as llm_mmq_q4k_soa_acts; nibble polarity and scale bytes decode here.
+        const unsigned char* sWsB = reinterpret_cast<const unsigned char*>(sWs);
+        #pragma unroll
+        for (int sb = 0; sb < 8; sb++) {
+            int chk = sb >> 1, pol = sb & 1;
+            unsigned int wa0 = sWq[(mrow0 + grp) * 33     + chk * 8 + tig];
+            unsigned int wa1 = sWq[(mrow0 + grp + 8) * 33 + chk * 8 + tig];
+            unsigned int wa2 = sWq[(mrow0 + grp) * 33     + chk * 8 + tig + 4];
+            unsigned int wa3 = sWq[(mrow0 + grp + 8) * 33 + chk * 8 + tig + 4];
+            int a0 = (int)(pol ? ((wa0 >> 4) & 0x0F0F0F0Fu) : (wa0 & 0x0F0F0F0Fu));
+            int a1 = (int)(pol ? ((wa1 >> 4) & 0x0F0F0F0Fu) : (wa1 & 0x0F0F0F0Fu));
+            int a2 = (int)(pol ? ((wa2 >> 4) & 0x0F0F0F0Fu) : (wa2 & 0x0F0F0F0Fu));
+            int a3 = (int)(pol ? ((wa3 >> 4) & 0x0F0F0F0Fu) : (wa3 & 0x0F0F0F0Fu));
+
+            unsigned int ddA = sWd[mrow0 + grp];
+            unsigned int ddB = sWd[mrow0 + grp + 8];
+            float dwA = sharpi_fp16_to_fp32(ddA & 0xffffu) * (float)sWsB[(mrow0 + grp) * 16 + sb];
+            float dmA = sharpi_fp16_to_fp32(ddA >> 16)     * (float)sWsB[(mrow0 + grp) * 16 + 8 + sb];
+            float dwB = sharpi_fp16_to_fp32(ddB & 0xffffu) * (float)sWsB[(mrow0 + grp + 8) * 16 + sb];
+            float dmB = sharpi_fp16_to_fp32(ddB >> 16)     * (float)sWsB[(mrow0 + grp + 8) * 16 + 8 + sb];
+
+            int b0 = (int)sYq[(ncol0 + grp) * 65 + sb * 8 + tig];
+            int b1 = (int)sYq[(ncol0 + grp) * 65 + sb * 8 + tig + 4];
+            unsigned int dy0 = sYd[(ncol0 + tig * 2) * 8 + sb];
+            unsigned int dy1 = sYd[(ncol0 + tig * 2 + 1) * 8 + sb];
+            float dC0 = sharpi_fp16_to_fp32(dy0 & 0xffffu), sC0 = sharpi_fp16_to_fp32(dy0 >> 16);
+            float dC1 = sharpi_fp16_to_fp32(dy1 & 0xffffu), sC1 = sharpi_fp16_to_fp32(dy1 >> 16);
+
+            int c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+            asm(
+              ""mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 ""
+              ""{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};""
+              : ""+r""(c0), ""+r""(c1), ""+r""(c2), ""+r""(c3)
+              : ""r""(a0), ""r""(a1), ""r""(a2), ""r""(a3), ""r""(b0), ""r""(b1));
+            acc0 += (float)c0 * dwA * dC0 - dmA * sC0;
+            acc1 += (float)c1 * dwA * dC1 - dmA * sC1;
+            acc2 += (float)c2 * dwB * dC0 - dmB * sC0;
+            acc3 += (float)c3 * dwB * dC1 - dmB * sC1;
+        }
+        __syncthreads();
+    }
+
+    if (rowA < rows) {
+        if (tokC0 < n_tok) output[(long)tokC0 * rows + rowA] = acc0;
+        if (tokC1 < n_tok) output[(long)tokC1 * rows + rowA] = acc1;
+    }
+    if (rowB < rows) {
+        if (tokC0 < n_tok) output[(long)tokC0 * rows + rowB] = acc2;
+        if (tokC1 < n_tok) output[(long)tokC1 * rows + rowB] = acc3;
+    }
+}
+#undef MMQ_BM
+#undef MMQ_BN
 ";
 }

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -369,6 +369,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_GEMM") == "1";
     private readonly bool _batchDecodeWeightStationary =
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_WS") != "0";
+    // SHARPI_BATCH_DECODE_MMQ=1 (#201, opt-in): int8 tensor-core decode matmuls for the
+    // big Q4_K-SoA shapes (BN=16 mma tile, weight read once per step) — argmax-stable,
+    // not bit-exact; small/non-Q4_K shapes fall back to weight-stationary per tensor
+    // inside the backend. The bit-exact WS matvecs are L1TEX-bound ~3× above the weight
+    // floor at N=8 and their lane geometry is frozen by the bit-identity contract, so
+    // this toggle is where the remaining batched-decode headroom lives.
+    private readonly bool _batchDecodeMmq =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ") == "1";
 
     // Ragged-batched per-sequence attention ops (issue #197). Default on: the per-layer
     // QK-norm/RoPE/KV-append/attention launches collapse from O(N) per-sequence calls
@@ -3179,13 +3187,17 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// <summary>One batched-decode matmul. Default: the weight-stationary small-N matvec
     /// (#194 — weight HBM read amortized across the batch, bit-identical reduction to the
     /// GEMM-N matvec; N=1 / N&gt;16 delegate to GEMM-N inside the backend).
-    /// SHARPI_BATCH_DECODE_WS=0: the #190 GEMM-N matvec. SHARPI_BATCH_DECODE_GEMM=1: the
-    /// compute-bound GEMM/MMQ path (the same routing <see cref="GpuMatMulBatchedCore"/> uses
-    /// for prefill) — argmax-stable only, kept as the A/B toggle for very high concurrency.</summary>
+    /// SHARPI_BATCH_DECODE_WS=0: the #190 GEMM-N matvec. SHARPI_BATCH_DECODE_MMQ=1: the
+    /// #201 int8 tensor-core decode tile for big Q4_K-SoA shapes (argmax-stable, WS
+    /// fallback per tensor). SHARPI_BATCH_DECODE_GEMM=1: the compute-bound GEMM/MMQ path
+    /// (the same routing <see cref="GpuMatMulBatchedCore"/> uses for prefill) —
+    /// argmax-stable only, kept as the A/B toggle for very high concurrency.</summary>
     private void BatchDecodeMatMul(Tensor outAll, Tensor weights, Tensor inAll, int n)
     {
         if (_batchDecodeComputeBound)
             GpuMatMulBatchedCore(outAll, weights, inAll, n);
+        else if (_batchDecodeMmq)
+            _gpu.MatMulBatchedDecodeMmq(outAll, weights, inAll, n, WDType(weights));
         else if (_batchDecodeWeightStationary)
             _gpu.MatMulBatchedWeightStationary(outAll, weights, inAll, n, WDType(weights));
         else

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
@@ -156,6 +156,67 @@ public sealed class CudaBatchForwardMultiTests
     }
 
     /// <summary>
+    /// #201 oracle for the opt-in decode MMQ (<c>SHARPI_BATCH_DECODE_MMQ=1</c>): the int8
+    /// tensor-core decode tile is argmax-stable, not bit-exact, so a batched decode step
+    /// must still reproduce the single-user argmax/top-5 within the same cross-path
+    /// tolerance the GEMM toggle holds. Uses the same 2-sequence shape as the headline
+    /// #190 oracle; the env var is pinned around construction (the flag is read once).
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_BatchForwardMulti_DecodeMmq_MatchesSingleUser()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        var prevMmq = Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ");
+        Environment.SetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ", "1");
+        CudaForwardPass fwdTmp;
+        try { fwdTmp = NewFwd(model, gpu, hp); }
+        finally { Environment.SetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ", prevMmq); }
+        using var fwd = fwdTmp;
+
+        // Single-user reference (per-token matvecs — unaffected by the MMQ toggle).
+        fwd.ResetCache();
+        int tokA = Argmax(fwd.Prefill(PromptA));
+        float[] refLogitsA = fwd.Forward(tokA, PromptA.Length).ToArray();
+
+        fwd.ResetCache();
+        int tokB = Argmax(fwd.Prefill(PromptB));
+        float[] refLogitsB = fwd.Forward(tokB, PromptB.Length).ToArray();
+
+        using var cacheA = fwd.CreateCache();
+        using var cacheB = fwd.CreateCache();
+        fwd.PrefillWithCache(PromptA, cacheA);
+        fwd.PrefillWithCache(PromptB, cacheB);
+
+        var batch = fwd.BatchForwardMulti(
+            [tokA, tokB],
+            [PromptA.Length, PromptB.Length],
+            [cacheA, cacheB]);
+
+        Assert.Equal(2, batch.Length);
+
+        var (maxAbsA, overlapA) = Compare(refLogitsA, batch[0]);
+        Assert.Equal(Argmax(refLogitsA), Argmax(batch[0]));
+        Assert.True(overlapA >= 4,
+            $"Seq A MMQ-decode top-5 overlaps the single-user reference in only {overlapA}/5 slots (maxAbs={maxAbsA}).");
+        Assert.True(maxAbsA < 1.0f,
+            $"Seq A MMQ-decode vs single-user logits diverged beyond tolerance: maxAbs={maxAbsA}.");
+
+        var (maxAbsB, overlapB) = Compare(refLogitsB, batch[1]);
+        Assert.Equal(Argmax(refLogitsB), Argmax(batch[1]));
+        Assert.True(overlapB >= 4,
+            $"Seq B MMQ-decode top-5 overlaps the single-user reference in only {overlapB}/5 slots (maxAbs={maxAbsB}).");
+        Assert.True(maxAbsB < 1.0f,
+            $"Seq B MMQ-decode vs single-user logits diverged beyond tolerance: maxAbs={maxAbsB}.");
+    }
+
+    /// <summary>
     /// A second batched decode step (positions advance by one) must still track the single-user
     /// continuation — catches a per-sequence cache-append / position-indexing bug that a single
     /// decode step would miss (the first step's KV is reused, a second token is appended).

--- a/tests/SharpInference.Tests.ForwardPass/CudaDecodeMmqTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDecodeMmqTests.cs
@@ -26,7 +26,7 @@ public sealed unsafe class CudaDecodeMmqTests
     }
 
     private static ushort HalfToUshort(Half h) =>
-        BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+        BitConverter.HalfToUInt16Bits(h);
 
     private static byte[] BuildQ4KMatrix(int rows, int cols, Random rng)
     {

--- a/tests/SharpInference.Tests.ForwardPass/CudaDecodeMmqTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDecodeMmqTests.cs
@@ -1,0 +1,137 @@
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #201: parity for the int8 tensor-core batched-decode matmul
+/// (<see cref="CudaBackend.MatMulBatchedDecodeMmq"/>, kernel
+/// <c>llm_mmq_q4k_soa_acts_n16</c> — the BN=16 decode tile of the prefill MMQ).
+/// Same contract as the prefill MMQ (argmax-stable, both operands int8-quantized):
+/// the output tracks the fp32 CPU reference (<see cref="SimdKernels.DotQ4K"/>) to a
+/// per-batch-RMS tolerance. Batch sizes cover the partial token tile (n_tok &lt; 16),
+/// the second grid.y tile (n_tok &gt; 16), and the row guards; the ineligible-shape
+/// case pins the weight-stationary fallback.
+///
+/// Silent no-op on hosts without CUDA, matching the other Cuda* test files.
+/// </summary>
+public sealed unsafe class CudaDecodeMmqTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static ushort HalfToUshort(Half h) =>
+        BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+
+    private static byte[] BuildQ4KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 144;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 144;
+                float d = (float)(rng.NextDouble() * 0.04 + 0.005);
+                float dmin = (float)(rng.NextDouble() * 0.02 + 0.002);
+                ushort dHalf = HalfToUshort((Half)d);
+                ushort dmHalf = HalfToUshort((Half)dmin);
+                bytes[off + 0] = (byte)(dHalf & 0xFF);
+                bytes[off + 1] = (byte)(dHalf >> 8);
+                bytes[off + 2] = (byte)(dmHalf & 0xFF);
+                bytes[off + 3] = (byte)(dmHalf >> 8);
+                for (int i = 4; i < 144; i++)
+                    bytes[off + i] = (byte)rng.Next(256);
+            }
+        return bytes;
+    }
+
+    private static void RunCase(CudaBackend gpu, Tensor gpuW, byte[] weightBytes,
+                                int rows, int cols, int nTok, Random rng)
+    {
+        var acts = new float[nTok * cols];
+        for (int i = 0; i < acts.Length; i++)
+            acts[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        int bytesPerRow = (cols / 256) * 144;
+        var cpuOut = new float[nTok * rows];
+        fixed (byte* wPtr = weightBytes)
+        fixed (float* aPtr = acts)
+        {
+            for (int t = 0; t < nTok; t++)
+                for (int r = 0; r < rows; r++)
+                    cpuOut[t * rows + r] = SimdKernels.DotQ4K(wPtr + r * bytesPerRow, aPtr + t * cols, cols);
+        }
+
+        var gpuX = gpu.Upload(acts, TensorShape.D1(acts.Length));
+        var gpuY = gpu.Allocate(TensorShape.D1((long)nTok * rows));
+
+        gpu.MatMulBatchedDecodeMmq(gpuY, gpuW, gpuX, nTok, DType.Q4_K);
+        gpu.Synchronize();
+
+        var gpuOut = new float[nTok * rows];
+        gpu.Download(gpuY, gpuOut);
+        gpu.Free(gpuX);
+        gpu.Free(gpuY);
+
+        double sumSq = 0;
+        for (int i = 0; i < cpuOut.Length; i++) sumSq += (double)cpuOut[i] * cpuOut[i];
+        float refRms = (float)Math.Sqrt(sumSq / cpuOut.Length);
+
+        int mismatches = 0;
+        float maxAbs = 0;
+        for (int i = 0; i < cpuOut.Length; i++)
+        {
+            float diff = MathF.Abs(gpuOut[i] - cpuOut[i]);
+            maxAbs = MathF.Max(maxAbs, diff);
+            if (diff > 0.03f * refRms) mismatches++;
+        }
+        Assert.True(mismatches <= cpuOut.Length / 100 + 1,
+            $"Decode MMQ rows={rows} cols={cols} nTok={nTok} drifted from fp32 reference: " +
+            $"{mismatches}/{cpuOut.Length} beyond 3% of RMS ({refRms:E3}), maxAbs={maxAbs:E3}.");
+    }
+
+    [Fact]
+    public void DecodeMmq_Q4K_Soa_TracksCpuReference()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        // rows ≥ 2048 (eligible) with non-multiple-of-64 coverage via the second case;
+        // batch sizes cover partial token tiles (2, 5, 11), the full tile (16), and the
+        // grid.y = 2 round-up (17).
+        foreach ((int rows, int cols) in new[] { (2048, 512), (2112, 256) })
+        {
+            var rng = new Random(20260610 + rows * 13 + cols * 5);
+            byte[] weightBytes = BuildQ4KMatrix(rows, cols, rng);
+            var gpuWAos = gpu.UploadRaw(weightBytes, TensorShape.D1(weightBytes.Length), DType.Q4_K);
+            var gpuW = gpu.RepackQ4KSoa(gpuWAos, rows, cols);
+            foreach (int nTok in new[] { 2, 5, 8, 11, 16, 17 })
+                RunCase(gpu, gpuW, weightBytes, rows, cols, nTok, rng);
+            gpu.Free(gpuW);
+        }
+    }
+
+    /// <summary>Ineligible shapes (rows &lt; 2048 here) must take the weight-stationary
+    /// fallback — same fp32-tracking contract holds trivially (the WS path is bit-exact
+    /// to the per-token matvec).</summary>
+    [Fact]
+    public void DecodeMmq_SmallRows_FallsBackToWeightStationary()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int rows = 1024, cols = 512;
+        var rng = new Random(20260610 + 7);
+        byte[] weightBytes = BuildQ4KMatrix(rows, cols, rng);
+        var gpuWAos = gpu.UploadRaw(weightBytes, TensorShape.D1(weightBytes.Length), DType.Q4_K);
+        var gpuW = gpu.RepackQ4KSoa(gpuWAos, rows, cols);
+        RunCase(gpu, gpuW, weightBytes, rows, cols, 8, rng);
+        gpu.Free(gpuW);
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/CudaMatMulBatchedWsTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaMatMulBatchedWsTests.cs
@@ -276,6 +276,40 @@ public sealed unsafe class CudaMatMulBatchedWsTests
         gpu.Free(gpuW);
     }
 
+    /// <summary>
+    /// #201 kill-switch coverage. The default-on Q6_K sweep above routes through the
+    /// scale-word kernel (<c>llm_matvec_q6k_ws_sw_n*</c>), so this pins the
+    /// SHARPI_BATCH_DECODE_WS_V2=0 fallback — the #194 byte-gather kernel — to the
+    /// same bit-identity contract against sequential MatMul across all capacity
+    /// variants, plus the sw path explicitly (independent of the dispatch default).
+    /// The 210-byte Q6_K block stride makes the scale-word tail alternate between 0-
+    /// and 2-byte word misalignment per super-block, so the multi-block cols=1024
+    /// shape exercises both funnel-shift paths.
+    /// </summary>
+    [Fact]
+    public void Ws_Q6K_V2KillSwitch_BitwiseMatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int rows = 64, cols = 1024;
+        var rng = new Random(20260610 + 201);
+        byte[] q6 = BuildQ6KMatrix(rows, cols, rng);
+        var gpuQ6 = gpu.UploadRaw(q6, TensorShape.D1(q6.Length), DType.Q6_K);
+
+        // SHARPI_BATCH_DECODE_WS_V2=0: the #194 byte-gather kernel.
+        gpu.WsV2Enabled = false;
+        foreach (int nTok in new[] { 2, 5, 8, 16 })
+            RunCase(gpu, gpuQ6, DType.Q6_K, "Q6_K-v2off", rows, cols, nTok, rng);
+
+        // Default: the #201 scale-word kernel.
+        gpu.WsV2Enabled = true;
+        foreach (int nTok in new[] { 2, 5, 8, 16 })
+            RunCase(gpu, gpuQ6, DType.Q6_K, "Q6_K-sw", rows, cols, nTok, rng);
+
+        gpu.Free(gpuQ6);
+    }
+
     [Fact]
     public void Ws_F32_BitwiseMatchesSequential()
     {


### PR DESCRIPTION
## Summary

Implements #201. Qwen3-8B Q4_K_M on RTX 4070 Ti, aggregate batched-decode t/s (single-user 75.6 unchanged):

| config | N=1 | N=2 | N=4 | N=8 |
|---|--:|--:|--:|--:|
| before (#197 / PR #200) | 68.8 | 128.8 | 207.5 | 246.1 |
| **default (bit-exact)** | 68.8 | **138.8** | 208.9 | 248.2 |
| **`SHARPI_BATCH_DECODE_MMQ=1`** | 68.8 | 138.9 | 208.6 | **317.4** (4.2× single-user) |

### 1. `llm_matvec_q6k_ws_sw_n*` — Q6_K scale-word decode (default on, bit-exact)

The Q6_K WS serial walk was latency-bound on its per-super-block scale/d decode: 10 dependent byte-gather loads. The sw kernel loads the 18-byte tail (bytes 192..209) as **five aligned words + funnel-shift extracts** — same bytes, same chain, **bit-identical** to N sequential `MatMul` calls (`CudaMatMulBatchedWsTests` enforce it). N=8 per-shape: ffn_down 5.14→4.79, lm-head 2.84→2.65, attn_v 0.80→0.75 ms/step. Most of the win shows at N=2 (+7.8% aggregate). Kill-switch `SHARPI_BATCH_DECODE_WS_V2=0`.

### 2. `llm_mmq_q4k_soa_acts_n16` — decode MMQ (opt-in, argmax-stable)

85% of the N=8 step was the two WS matvec families at ~3.3× the weight-streaming floor, and per ncu the q4k kernel is **L1TEX-wavefront-bound by its lane geometry, which the bit-identity contract freezes** (see dead ends below). The opt-in path relaxes to the argmax-stable contract (same as the prefill MMQ / `SHARPI_BATCH_DECODE_GEMM` toggle) and re-tiles the prefill MMQ to BN=16: SoA Q8_1 activations, one m16n8k32 s8 mma per warp per sub-block, each weight byte read from HBM **once per step**.

The K-step matters: a first cut with one sub-block (32 elems) per barrier pair measured **1.4–1.7× slower than the WS matvec** — one mma (~50 cycles) cannot hide a staging-load latency epoch. The shipped kernel stages one **256-element super-block** per barrier pair (raw quants, linear coalesced copies, nibble/scale decode at fragment-read time, +1-word padded strides against 8-way bank conflicts): gate/up 11.6→6.9 ms/step (1.7× floor), Q/O 6.5→4.5.

Per-tensor dispatch falls back to bit-exact WS for Q6_K, rows<2048 (grid-starved K/V shapes), and N<5 (BN=16 tile mostly predicated off: N=2 measured 123 vs 139 t/s).

### Measured dead ends (implemented, profiled, removed)

- **Token-warp WS geometry** (bit-exact by construction, one warp per (row, token)): loses everywhere — NT× weight-decode replication outweighs the occupancy win (N=8: 243→239 routed only to the grid-starved attn_v shape; →182 incl. ffn_down). The issue's "8 warps striding super-blocks" idea is bit-incompatible with the per-token `llm_matvec_q6k` serial chain, so token-warp was the only bit-exact geometry available — and it doesn't pay.
- **SoA-Q8_1-activation WS reads (xs)**: genuinely cut L1TEX 94.7→82%, but the second activation-region pointer costs 7 registers in the NT-unrolled token loop (48→55 → occupancy 80→63%): net −5 t/s; pinning 48 regs via launch bounds spills (−36 t/s).

### Validation

- `CudaMatMulBatchedWsTests`: bit-identity vs N sequential `MatMul` (batch sizes 1,2,3,4,5,8,11,16,17; all dtypes; `WS_V2` kill-switch both ways) — green.
- `CudaDecodeMmqTests` (new): fp32-CPU-reference tolerance for the n16 kernel incl. partial tile / grid.y=2 / WS-fallback shapes — green.
- New `BatchForwardMulti` MMQ argmax/top-5 e2e oracle vs single-user; `CudaBatchForwardMultiTests`, `CudaRaggedDecodeKernelTests`, `ContinuousBatchingTests` — 39 tests green.
- A/B sanity unchanged: `SHARPI_BATCH_DECODE_WS=0` → 89.9/103.9/112.3 (was 90/104/113); `SHARPI_BATCH_DECODE_RAGGED=0` → ~199 @ N=8.

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)