### PR TITLE
perf(tokenizer): O(n²) → O(n log n) SPM encode + per-request perf trace

### DIFF
--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -5,7 +5,7 @@
     Downloads from HuggingFace to the models/ directory. Skips if already present.
     Supports: smollm2, qwen3-8b, olmoe-1b-7b, llama31-70b, qwen3-coder-30b-a3b, qwen36-35b-a3b,
               qwen36-27b-mtp, qwen36-27b-mtp-q5, qwen36-35b-a3b-mtp, carnice-35b-a3b-mtp,
-              gemma4-12b-qat, gemma4-12b-q4km,
+              gemma4-12b-qat, gemma4-12b-q4km, gemma4-e4b-qat,
               llama4-scout, z-image-turbo, z-image-turbo-q8, realesrgan-x4
 .PARAMETER Model
     Which model to download. Default: downloads all text models (skips large image models).
@@ -23,6 +23,7 @@
     .\download-model.ps1 -Model carnice-35b-a3b-mtp -DestDir E:\models  # Carnice (Qwen3.6-35B-A3B-MTP, agentic/tool-calling) APEX-MTP I-Compact (17.3 GB)
     .\download-model.ps1 -Model gemma4-12b-qat -DestDir E:\models  # Gemma 4 12B-it QAT q4_0 (~7.0 GB) — issue #124 PRIMARY (official quantization-aware-trained)
     .\download-model.ps1 -Model gemma4-12b-q4km -DestDir E:\models # Gemma 4 12B-it Q4_K_M (~7.3 GB) — issue #124 fallback / K-quant cross-check
+    .\download-model.ps1 -Model gemma4-e4b-qat -DestDir E:\models  # Gemma 4 E4B-it QAT q4_0 (~5.15 GB) — fast small Gemma (~1.6× decode vs Q8_0)
     .\download-model.ps1 -Model llama4-scout            # Llama 4 Scout Q4_K_M (60.9 GB, 2 shards)
     .\download-model.ps1 -Model z-image-turbo           # Z-Image-Turbo Q5_K_M + abliterated encoder (~8.5 GB)
     .\download-model.ps1 -Model z-image-turbo-q8        # Z-Image-Turbo Q8_0 + abliterated encoder Q8_0 (~12 GB)
@@ -31,7 +32,7 @@
 param(
     [ValidateSet("smollm2", "qwen3-8b", "qwen3-0.6b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
                  "qwen36-27b-mtp", "qwen36-27b-mtp-q5", "qwen36-35b-a3b-mtp", "carnice-35b-a3b-mtp",
-                 "gemma4-12b-qat", "gemma4-12b-q4km",
+                 "gemma4-12b-qat", "gemma4-12b-q4km", "gemma4-e4b-qat",
                  "llama4-scout", "z-image-turbo", "z-image-turbo-q8", "realesrgan-x4")]
     [string]$Model,
     [string]$DestDir
@@ -143,6 +144,18 @@ $Models = @{
         Size  = "~7.0 GB"
         SizeGB = 7.0
         Phase = "issue #124 (PRIMARY — QAT q4_0, dense no-PLE path)"
+    }
+    # Gemma 4 E4B-it — Google's official QAT q4_0 weights for the small (effective-4B)
+    # Gemma 4. ~5.15 GB vs the 8.19 GB Q8_0: ~1.6× fewer bytes/token → ~1.6× faster
+    # decode at near-identical quality (QAT). Same dense gemma4 arch (PLE + 5:1 SWA).
+    # Filename is upstream's `gemma-4-E4B_q4_0-it.gguf` (note the underscore — not the
+    # `-it-qat-q4_0` pattern of the 12B). The repo also ships an mmproj (vision) we skip.
+    "gemma4-e4b-qat" = @{
+        Files = @("gemma-4-E4B_q4_0-it.gguf")
+        Urls  = @("https://huggingface.co/google/gemma-4-E4B-it-qat-q4_0-gguf/resolve/main/gemma-4-E4B_q4_0-it.gguf")
+        Size  = "~5.15 GB"
+        SizeGB = 5.15
+        Phase = "Gemma 4 E4B QAT q4_0 (fast small Gemma — ~1.6× decode vs Q8_0)"
     }
     # Community K-quant of the (non-QAT) instruct weights — the Q4_K_M fallback /
     # cross-check next to the QAT q4_0 primary. Exercises the K-quant path so both

--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -435,18 +435,40 @@ public sealed class GgufTokenizer : ITokenizer
         var en = System.Globalization.StringInfo.GetTextElementEnumerator(text);
         while (en.MoveNext()) pieces.Add((string)en.Current);
 
-        int n = pieces.Count;
-        if (n == 0) return [];
+        var merged = SpmMergePieces(pieces, _spmMerges!);
 
-        // Symbol doubly-linked list over a flat slot array (llama.cpp llm_tokenizer_spm).
-        // The previous implementation rescanned every adjacent pair to find the single
-        // best merge and applied one merge per pass — O(n²), which made a 40k-token prompt
-        // take minutes to tokenize (the dominant server-request latency). This replaces it
-        // with a min-heap of merge candidates: O(n log n), bit-identical token output.
-        //
-        // Slots are never reused and a symbol's text only ever grows via merges, so a slot's
-        // current string Length uniquely identifies its state — used as an O(1) staleness
-        // check to discard queued candidates whose operands have since been merged away.
+        var ids = new List<int>(merged.Count);
+        foreach (var piece in merged)
+        {
+            if (_vocab.TryGetValue(piece, out int id))
+                ids.Add(id);
+            else if (UnknownTokenId >= 0)
+                ids.Add(UnknownTokenId);
+        }
+        return ids;
+    }
+
+    /// <summary>
+    /// Core SentencePiece merge: given starting symbols (one per code point) and a
+    /// bigram→rank merge table, repeatedly apply the lowest-rank adjacent merge (leftmost on
+    /// a rank tie) until none apply, returning the surviving pieces in order. Matches
+    /// llama.cpp's <c>llm_tokenizer_spm</c>.
+    ///
+    /// <para>O(n log n) via a min-heap of merge candidates over a symbol doubly-linked list.
+    /// The previous implementation rescanned every adjacent pair to find the single best merge
+    /// and applied one merge per pass — O(n²) — which made a 40k-token prompt take minutes to
+    /// tokenize (the dominant server-request latency). Slots are never reused and a symbol's
+    /// text only ever grows via merges, so a slot's current Length uniquely identifies its
+    /// state — used as an O(1) staleness check to discard queued candidates whose operands
+    /// have since merged away. <c>internal</c> so the parity tests can exercise it directly
+    /// with a synthetic merge table (no model file needed).</para>
+    /// </summary>
+    internal static List<string> SpmMergePieces(
+        List<string> pieces, IReadOnlyDictionary<(string, string), int> merges)
+    {
+        int n = pieces.Count;
+        if (n == 0) return pieces;
+
         var sym = new string?[n];
         var prev = new int[n];
         var next = new int[n];
@@ -465,7 +487,7 @@ public sealed class GgufTokenizer : ITokenizer
         {
             if (l < 0 || r < 0) return;
             if (sym[l] is not { } ls || sym[r] is not { } rs) return;
-            if (_spmMerges!.TryGetValue((ls, rs), out int rank))
+            if (merges.TryGetValue((ls, rs), out int rank))
                 pq.Enqueue((l, r, ls.Length, rs.Length), ((long)rank << 32) | (uint)l);
         }
 
@@ -493,16 +515,10 @@ public sealed class GgufTokenizer : ITokenizer
 
         // Walk the surviving symbols in order (slot 0 is always the live head — nothing
         // precedes it, so it is never removed as a right operand).
-        var ids = new List<int>();
+        var result = new List<string>();
         for (int s = 0; s >= 0; s = next[s])
-        {
-            if (sym[s] is not { } piece) continue;
-            if (_vocab.TryGetValue(piece, out int id))
-                ids.Add(id);
-            else if (UnknownTokenId >= 0)
-                ids.Add(UnknownTokenId);
-        }
-        return ids;
+            if (sym[s] is { } piece) result.Add(piece);
+        return result;
     }
 
     /// <summary>

--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -430,30 +430,73 @@ public sealed class GgufTokenizer : ITokenizer
     /// </summary>
     private IReadOnlyList<int> EncodeSpm(string text)
     {
+        // Split into Unicode text elements (code points / graphemes), each a start symbol.
         var pieces = new List<string>(text.Length);
         var en = System.Globalization.StringInfo.GetTextElementEnumerator(text);
         while (en.MoveNext()) pieces.Add((string)en.Current);
 
-        while (true)
+        int n = pieces.Count;
+        if (n == 0) return [];
+
+        // Symbol doubly-linked list over a flat slot array (llama.cpp llm_tokenizer_spm).
+        // The previous implementation rescanned every adjacent pair to find the single
+        // best merge and applied one merge per pass — O(n²), which made a 40k-token prompt
+        // take minutes to tokenize (the dominant server-request latency). This replaces it
+        // with a min-heap of merge candidates: O(n log n), bit-identical token output.
+        //
+        // Slots are never reused and a symbol's text only ever grows via merges, so a slot's
+        // current string Length uniquely identifies its state — used as an O(1) staleness
+        // check to discard queued candidates whose operands have since been merged away.
+        var sym = new string?[n];
+        var prev = new int[n];
+        var next = new int[n];
+        for (int i = 0; i < n; i++)
         {
-            int bestIdx = -1;
-            int bestPriority = int.MaxValue;
-            for (int i = 0; i < pieces.Count - 1; i++)
-            {
-                if (_spmMerges!.TryGetValue((pieces[i], pieces[i + 1]), out int pri) && pri < bestPriority)
-                {
-                    bestPriority = pri;
-                    bestIdx = i;
-                }
-            }
-            if (bestIdx < 0) break;
-            pieces[bestIdx] = pieces[bestIdx] + pieces[bestIdx + 1];
-            pieces.RemoveAt(bestIdx + 1);
+            sym[i] = pieces[i];
+            prev[i] = i - 1;
+            next[i] = i + 1 < n ? i + 1 : -1;
         }
 
-        var ids = new List<int>(pieces.Count);
-        foreach (var piece in pieces)
+        // Priority packs merge rank (primary, lower wins — the merges-file order) with the
+        // left slot index (secondary, so ties resolve leftmost, matching the old linear scan).
+        var pq = new PriorityQueue<(int l, int r, int llen, int rlen), long>();
+
+        void TryAdd(int l, int r)
         {
+            if (l < 0 || r < 0) return;
+            if (sym[l] is not { } ls || sym[r] is not { } rs) return;
+            if (_spmMerges!.TryGetValue((ls, rs), out int rank))
+                pq.Enqueue((l, r, ls.Length, rs.Length), ((long)rank << 32) | (uint)l);
+        }
+
+        for (int i = 0; i + 1 < n; i++) TryAdd(i, i + 1);
+
+        while (pq.Count > 0)
+        {
+            var (l, r, llen, rlen) = pq.Dequeue();
+            // Skip a stale candidate: either operand already consumed (null) or grown (len
+            // changed), so this queued pair no longer reflects the current adjacency.
+            if (sym[l] is not { } ls || sym[r] is not { } rs || ls.Length != llen || rs.Length != rlen)
+                continue;
+
+            // Merge r into l and unlink r from the chain.
+            sym[l] = ls + rs;
+            sym[r] = null;
+            int nn = next[r];
+            next[l] = nn;
+            if (nn >= 0) prev[nn] = l;
+
+            // Re-evaluate the two adjacencies created around the merged symbol.
+            TryAdd(prev[l], l);
+            TryAdd(l, nn);
+        }
+
+        // Walk the surviving symbols in order (slot 0 is always the live head — nothing
+        // precedes it, so it is never removed as a right operand).
+        var ids = new List<int>();
+        for (int s = 0; s >= 0; s = next[s])
+        {
+            if (sym[s] is not { } piece) continue;
             if (_vocab.TryGetValue(piece, out int id))
                 ids.Add(id);
             else if (UnknownTokenId >= 0)

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 using SharpInference.Core;
 
 namespace SharpInference.Engine;
@@ -52,6 +54,14 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     // pass is leaked rather than freed (see DisposeCore). Overridable by tests via
     // InternalsVisibleTo to exercise the timeout path without a 10s wait.
     internal TimeSpan _disposeDrainTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Optional logger for per-request diagnostics. Set by the DI registration from the host's
+    /// <see cref="ILoggerFactory"/>; null in non-hosted use (CLI, tests) — calls are no-ops then.
+    /// The per-request perf trace is emitted at <see cref="LogLevel.Debug"/>, so it's off unless
+    /// the host enables Debug for this category (e.g. <c>"SharpInference.Engine": "Debug"</c>).
+    /// </summary>
+    public ILogger? Logger { get; set; }
 
     public string ModelId { get; }
 
@@ -275,9 +285,19 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
             // Run the blocking CPU generation on a thread-pool thread.
             var genTask = Task.Run(() =>
             {
+                // Per-request perf trace (issue: server feels slow on big agentic prompts).
+                // Splits encode / prefill / decode so a huge-prompt request shows where the
+                // wall time went. Emitted via ILogger at Debug, so enable
+                // "SharpInference.Engine": "Debug" in the host's Logging:LogLevel to see it.
+                var swReq = Stopwatch.StartNew();
+                bool logReq = Logger?.IsEnabled(LogLevel.Debug) == true;
+                int promptTokenCount = 0, reusedTokens = 0, decodeTokens = 0;
+                long encodeMs = 0, prefillMs = 0, ttftMs = -1;
                 try
                 {
                     var tokens = _tokenizer.Encode(prompt).ToArray();
+                    promptTokenCount = tokens.Length;
+                    encodeMs = swReq.ElapsedMilliseconds;
                     var rng = new Random();
                     System.Collections.Immutable.ImmutableArray<int> stopIds =
                         sp.StopTokenIds is { } userStops ? [.. userStops] : _tokenizer.EogTokenIds;
@@ -420,6 +440,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     {
                         // Issue #22 observability: account reused tokens regardless of
                         // mechanism (attention partial-rewind or GDN snapshot).
+                        reusedTokens = prefixLen;
                         Interlocked.Add(ref _prefillTokensReused, prefixLen);
                     }
 
@@ -443,6 +464,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     // Reused by the MTP path below for PrefillMtp(suffixTokens, prefixLen).
                     int[] suffixTokens = prefixLen > 0 ? tokens[prefixLen..] : tokens;
 
+                    long prefillStartMs = swReq.ElapsedMilliseconds;
                     ReadOnlySpan<float> logits;
                     if (useCanonicalSnapshot)
                     {
@@ -465,6 +487,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         else
                             logits = _fwd.Forward(tokens[^1], tokens.Length - 1);
                     }
+                    prefillMs = swReq.ElapsedMilliseconds - prefillStartMs;
 
                     if (useMtp)
                     {
@@ -485,6 +508,8 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
 
                         mtpDec.Decode(sp.MaxNewTokens, stopIds.AsSpan(), tok =>
                         {
+                            if (ttftMs < 0) ttftMs = swReq.ElapsedMilliseconds;
+                            decodeTokens++;
                             fullSeq.Add(tok);
                             var bytes = _tokenizer.DecodeBytes(tok);
                             var chunk = textDecMtp.Append(bytes);
@@ -567,6 +592,8 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         // Issue #21: chat-continuation prompts for turn N+1 typically extend
                         // turn N's full transcript, not just turn N's prompt.
                         fullSeq.Add(next);
+                        if (ttftMs < 0) ttftMs = swReq.ElapsedMilliseconds;
+                        decodeTokens++;
 
                         if (stopIds.Contains(next)) break;
 
@@ -642,6 +669,26 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 catch (Exception ex)
                 {
                     channel.Writer.TryComplete(ex);
+                }
+                finally
+                {
+                    if (logReq)
+                    {
+                        long totalMs = swReq.ElapsedMilliseconds;
+                        int newTokens = promptTokenCount - reusedTokens;
+                        double prefTps = prefillMs > 0 ? newTokens * 1000.0 / prefillMs : 0;
+                        // Decode wall = everything after the first token landed. total-ttft
+                        // also folds in the end-of-decode snapshot, a negligible tail.
+                        double decTps = (ttftMs >= 0 && totalMs > ttftMs)
+                            ? decodeTokens * 1000.0 / (totalMs - ttftMs) : 0;
+                        Logger!.LogDebug(
+                            "request prompt={PromptTokens}tok (reused={ReusedTokens} new={NewTokens}) " +
+                            "encode={EncodeMs}ms prefill={PrefillMs}ms ({PrefillTps:F0} tok/s) " +
+                            "ttft={TtftMs}ms decode={DecodeTokens}tok ({DecodeTps:F0} tok/s) total={TotalMs}ms",
+                            promptTokenCount, reusedTokens, newTokens,
+                            encodeMs, prefillMs, prefTps,
+                            ttftMs >= 0 ? ttftMs : totalMs, decodeTokens, decTps, totalMs);
+                    }
                 }
             }, ct);
 

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -290,7 +290,10 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 // wall time went. Emitted via ILogger at Debug, so enable
                 // "SharpInference.Engine": "Debug" in the host's Logging:LogLevel to see it.
                 var swReq = Stopwatch.StartNew();
-                bool logReq = Logger?.IsEnabled(LogLevel.Debug) == true;
+                // Capture the logger once: Logger has a public setter, so reading it twice
+                // (IsEnabled check here, LogDebug in the finally) could race a concurrent set.
+                var logger = Logger;
+                bool logReq = logger?.IsEnabled(LogLevel.Debug) == true;
                 int promptTokenCount = 0, reusedTokens = 0, decodeTokens = 0;
                 long encodeMs = 0, prefillMs = 0, ttftMs = -1;
                 try
@@ -681,7 +684,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         // also folds in the end-of-decode snapshot, a negligible tail.
                         double decTps = (ttftMs >= 0 && totalMs > ttftMs)
                             ? decodeTokens * 1000.0 / (totalMs - ttftMs) : 0;
-                        Logger!.LogDebug(
+                        logger!.LogDebug(
                             "request prompt={PromptTokens}tok (reused={ReusedTokens} new={NewTokens}) " +
                             "encode={EncodeMs}ms prefill={PrefillMs}ms ({PrefillTps:F0} tok/s) " +
                             "ttft={TtftMs}ms decode={DecodeTokens}tok ({DecodeTps:F0} tok/s) total={TotalMs}ms",

--- a/src/SharpInference.Engine/SharpInference.Engine.csproj
+++ b/src/SharpInference.Engine/SharpInference.Engine.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Logging abstractions only (no provider): lets the engine emit ILogger diagnostics
+         (per-request perf trace) that the host's configured logging pipeline renders. -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SharpInference.Core\SharpInference.Core.csproj" />
     <ProjectReference Include="..\SharpInference.Cpu\SharpInference.Cpu.csproj" />
     <ProjectReference Include="..\SharpInference.Vulkan\SharpInference.Vulkan.csproj" />

--- a/src/SharpInference.Server/ServiceCollectionExtensions.cs
+++ b/src/SharpInference.Server/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpInference.Engine;
 
@@ -47,6 +48,11 @@ public static class ServiceCollectionExtensions
         {
             var opts = sp.GetRequiredService<IOptions<SharpInferenceServerOptions>>().Value;
             var loaded = (opts.EngineFactory ?? (s => InferenceEngineLoader.Load(opts)))(sp);
+
+            // Hand the single-user engine the host's logger so its per-request perf trace
+            // (Debug level) flows through the configured logging pipeline rather than stderr.
+            if (loaded.Engine is InferenceEngine ie)
+                ie.Logger = sp.GetService<ILoggerFactory>()?.CreateLogger("SharpInference.Engine");
 
             // Reconfigure the renderer with the model's actual arch + Jinja template now
             // that we have them. Done here rather than as a separate DI registration so

--- a/tests/SharpInference.Tests.Core/SpmMergeTests.cs
+++ b/tests/SharpInference.Tests.Core/SpmMergeTests.cs
@@ -1,0 +1,132 @@
+using SharpInference.Core;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Parity tests for <see cref="GgufTokenizer.SpmMergePieces"/> — the O(n log n) priority-queue
+/// SentencePiece merge that replaced an O(n²) greedy loop. These run with no model file: they
+/// feed synthetic merge tables and assert the new algorithm is byte-identical to a reference
+/// implementation of the old behaviour (the exact greedy loop that shipped before), which is the
+/// contract the rewrite must preserve.
+/// </summary>
+public sealed class SpmMergeTests
+{
+    /// <summary>
+    /// Reference (oracle): the original O(n²) algorithm verbatim — repeatedly find the
+    /// lowest-rank adjacent merge (leftmost on a tie) and apply it. The fast path must match
+    /// this exactly for every input.
+    /// </summary>
+    private static List<string> NaiveMerge(List<string> input, IReadOnlyDictionary<(string, string), int> merges)
+    {
+        var pieces = new List<string>(input);
+        while (true)
+        {
+            int bestIdx = -1;
+            int bestPriority = int.MaxValue;
+            for (int i = 0; i < pieces.Count - 1; i++)
+            {
+                if (merges.TryGetValue((pieces[i], pieces[i + 1]), out int pri) && pri < bestPriority)
+                {
+                    bestPriority = pri;
+                    bestIdx = i;
+                }
+            }
+            if (bestIdx < 0) break;
+            pieces[bestIdx] = pieces[bestIdx] + pieces[bestIdx + 1];
+            pieces.RemoveAt(bestIdx + 1);
+        }
+        return pieces;
+    }
+
+    [Fact]
+    public void EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(GgufTokenizer.SpmMergePieces([], new Dictionary<(string, string), int>()));
+    }
+
+    [Fact]
+    public void SingleSymbol_Unchanged()
+    {
+        Assert.Equal(["a"], GgufTokenizer.SpmMergePieces(["a"], new Dictionary<(string, string), int>()));
+    }
+
+    [Fact]
+    public void NoApplicableMerges_Unchanged()
+    {
+        var merges = new Dictionary<(string, string), int> { [("x", "y")] = 0 };
+        Assert.Equal(["a", "b", "c"], GgufTokenizer.SpmMergePieces(["a", "b", "c"], merges));
+    }
+
+    [Fact]
+    public void HighestPriorityMergeAppliedFirst_ThenCascades()
+    {
+        // Ranks: (b,c)=0 fires before (a,b)=1. After "bc" forms, (a,"bc") isn't a merge,
+        // so the result is ["a","bc"] — not ["ab","c"]. Exercises priority ordering.
+        var merges = new Dictionary<(string, string), int> { [("a", "b")] = 1, [("b", "c")] = 0 };
+        Assert.Equal(["a", "bc"], GgufTokenizer.SpmMergePieces(["a", "b", "c"], merges));
+    }
+
+    [Fact]
+    public void RepeatedBigram_MergesLeftmostFirst()
+    {
+        // Two (a,a) candidates share rank 0; leftmost must win — matching the old scan.
+        var merges = new Dictionary<(string, string), int> { [("a", "a")] = 0, [("aa", "a")] = 5 };
+        // leftmost (a,a)->"aa" gives ["aa","a"], then ("aa","a")=5 -> "aaa".
+        Assert.Equal(["aaa"], GgufTokenizer.SpmMergePieces(["a", "a", "a"], merges));
+    }
+
+    [Fact]
+    public void MultiCharOperandMerges_Cascade()
+    {
+        // a+b -> ab (rank 0), then ab+c -> abc (rank 1).
+        var merges = new Dictionary<(string, string), int> { [("a", "b")] = 0, [("ab", "c")] = 1 };
+        Assert.Equal(["abc"], GgufTokenizer.SpmMergePieces(["a", "b", "c"], merges));
+    }
+
+    /// <summary>
+    /// Fuzz: thousands of random (input, merge-table) pairs over a tiny alphabet — including
+    /// multi-char operands, cascading merges, and duplicate bigrams with shared ranks — must
+    /// produce identical output to the reference greedy algorithm.
+    /// </summary>
+    [Fact]
+    public void FastPath_MatchesNaive_AcrossRandomInputs()
+    {
+        var rng = new Random(20260611);
+        string[] alphabet = ["a", "b", "c"];
+
+        // Candidate merge operands: all 1- to 3-char strings over the alphabet, so the table
+        // can express multi-level merges (e.g. "ab"+"c").
+        var operands = new List<string>(alphabet);
+        foreach (var x in alphabet)
+            foreach (var y in alphabet)
+            {
+                operands.Add(x + y);
+                foreach (var z in alphabet) operands.Add(x + y + z);
+            }
+
+        for (int iter = 0; iter < 5000; iter++)
+        {
+            // Random merge table: shuffle a random subset of (left,right) operand pairs and
+            // assign each a unique rank (its position) — mirrors a real merges file's ordering.
+            int pairCount = rng.Next(1, 40);
+            var pairs = new List<(string, string)>(pairCount);
+            for (int k = 0; k < pairCount; k++)
+                pairs.Add((operands[rng.Next(operands.Count)], operands[rng.Next(operands.Count)]));
+            var merges = new Dictionary<(string, string), int>();
+            int rank = 0;
+            foreach (var p in pairs) merges[p] = rank++; // later dup keys overwrite — fine, still a valid table
+
+            // Random input of single symbols (the real entry shape: one code point per piece).
+            int len = rng.Next(0, 30);
+            var input = new List<string>(len);
+            for (int k = 0; k < len; k++) input.Add(alphabet[rng.Next(alphabet.Length)]);
+
+            var expected = NaiveMerge(input, merges);
+            var actual = GgufTokenizer.SpmMergePieces(new List<string>(input), merges);
+
+            Assert.True(expected.SequenceEqual(actual),
+                $"mismatch on input=[{string.Join(",", input)}] " +
+                $"expected=[{string.Join(",", expected)}] actual=[{string.Join(",", actual)}]");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the real cause of "the server feels slow" under agentic clients (Claude Code): the **SPM tokenizer was O(n²)**, so big system prompts took tens of seconds to *tokenize* before any compute. Adds a per-request perf trace (via `ILogger`) that made the diagnosis possible and surfaces the remaining levers.

### 1. `perf(tokenizer)`: O(n²) → O(n log n) SPM encode
`GgufTokenizer.EncodeSpm` rescanned all adjacent pairs to find one best merge, applied it (O(n) `RemoveAt`), and repeated — O(n²) over the whole prompt. Replaced with llama.cpp's priority-queue approach (symbol linked-list + min-heap, O(1) staleness check via monotonic length). **Bit-identical output** (134 Tests.Core pass, incl. tokenizer parity).

| | before | after |
|---|---|---|
| encode 7,826-tok prompt | 30,832 ms | **61 ms** |
| encode 23,678-tok Claude Code prompt | ~90 s | **107 ms** |
| first request (real Claude Code) | minutes | **~44 s** (now real prefill+decode, not tokenize) |

### 2. `feat(server)`: per-request perf trace via `ILogger`
Debug-level structured log splitting encode / prefill / decode with throughput + prefix-reuse:
```
request prompt=23678tok (reused=0 new=23678) encode=107ms prefill=27755ms (853 tok/s) ttft=27958ms decode=185tok (12 tok/s) total=44033ms
```
`InferenceEngine` gets an `ILogger` wired from the host's `ILoggerFactory`; Engine takes a `Microsoft.Extensions.Logging.Abstractions` ref (abstractions only, AOT-safe). Off unless `"SharpInference.Engine": "Debug"` is enabled. Null logger (CLI/tests) = no-op.

### 3. `chore(scripts)`: `gemma4-e4b-qat` download entry (#211)

## Follow-ups surfaced by the trace
- **#212** — prefix-cache gets 0 reuse under agentic clients (single-slot KV evicted by interleaved auxiliary requests). Biggest remaining multi-turn win (~28s/turn).
- **#213** — decode degrades at long context with q8_0 KV (12 vs 65 tok/s).
- **#211** — Gemma 4 E4B QAT q4_0 loader gap (the download entry above is for this).

## Test plan
- [x] Tests.Core (134) green — tokenizer parity holds
- [ ] Tests.ForwardPass / Tests.Server green (running)
- [x] Live: 23,678-token Claude Code request, encode 107ms, coherent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
