### PR TITLE
perf(engine): TierPlanner KV pricing (#220) + CPU-MoE execution mode for CudaHybridForwardPass (#215)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -447,7 +447,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                     var hwProfile = HardwareProfile.Detect(cuda);
                     AnsiConsole.MarkupLine($"[dim]Hardware: {hwProfile.Summary()}[/]");
                     var placement = TierPlanner.Plan(model, hp, hwProfile, settings.TurboQuant,
-                        requestedCtxSize: ctxSize);
+                        requestedCtxSize: ctxSize, kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
                     cudaGpuLayers = placement.GpuLayers;
 
                     // Gemma 4 KV-share constraint: the shared-KV source layers (E4B:
@@ -487,7 +487,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 {
                     var hwProfile = HardwareProfile.Detect(cuda);
                     var placement = TierPlanner.Plan(model, hp, hwProfile, settings.TurboQuant,
-                        requestedCtxSize: ctxSize);
+                        requestedCtxSize: ctxSize, kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
                     if (nGpuLayers != -1)
                         placement = placement with { GpuLayers = cudaGpuLayers, CpuLayers = hp.NumLayers - cudaGpuLayers };
 

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -442,6 +442,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 // a model bigger than VRAM (e.g. Qwen3-Coder 30B-A3B in 12 GB) would
                 // attempt full-offload via CudaForwardPass and silently OOM.
                 int cudaGpuLayers;
+                bool moeAutoNeedsHybrid = false;
                 if (nGpuLayers == -1)
                 {
                     var hwProfile = HardwareProfile.Detect(cuda);
@@ -476,13 +477,29 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                             cudaGpuLayers = hp.NumLayers;
                         }
                     }
+
+                    // Issue #215: a MoE model whose routed experts can't all stay resident must use the
+                    // hybrid path (which streams experts via SLRU or runs them on CPU), even though the
+                    // planner places the whole attention trunk on GPU (GpuLayers == NumLayers). Without
+                    // this, auto (-g -1) falls through to full-offload CudaForwardPass and thrashes/OOMs —
+                    // the very case TierPlanner was added to avoid.
+                    moeAutoNeedsHybrid = hp.IsMoE
+                        && cudaGpuLayers == hp.NumLayers
+                        && placement.MoeRoutedExpertBytes > placement.ExpertCacheBudgetBytes;
+                    if (moeAutoNeedsHybrid)
+                    {
+                        AnsiConsole.MarkupLine(
+                            $"[dim]MoE routed experts ({placement.MoeRoutedExpertBytes / (1024.0 * 1024):F0} MB) " +
+                            $"exceed the GPU expert-cache budget ({placement.ExpertCacheBudgetBytes / (1024.0 * 1024):F0} MB); " +
+                            $"using the hybrid path (CPU-MoE / SLRU streaming) instead of full offload.[/]");
+                    }
                 }
                 else
                 {
                     cudaGpuLayers = nGpuLayers;
                 }
 
-                bool wantHybrid = cudaGpuLayers > 0 && cudaGpuLayers < hp.NumLayers;
+                bool wantHybrid = (cudaGpuLayers > 0 && cudaGpuLayers < hp.NumLayers) || moeAutoNeedsHybrid;
                 if (wantHybrid)
                 {
                     var hwProfile = HardwareProfile.Detect(cuda);

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -286,6 +286,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     };
 
     /// <summary>
+    /// Resolves the configured KV-cache dtype from the SHARPI_KV_DTYPE environment variable
+    /// (fp32 default, bf16, q8_0), reusing the same parser the constructor uses. Exposed so
+    /// the layer planner / loader can price the KV budget at the dtype the forward pass will
+    /// actually allocate, instead of assuming fp32. Throws on an invalid value (same contract
+    /// as the constructor) so a typo can't silently mis-budget.
+    /// </summary>
+    public static DType ResolveConfiguredKvDType() =>
+        ParseKvDType(Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE"));
+
+    /// <summary>
     /// Issue #141: route Q8_0 trunk matmuls in the batched prefill through the
     /// compute-bound cuBLAS GEMM (<see cref="CudaBackend.MatMulBatchedGemm"/>)
     /// instead of the memory-bound matvec GEMM-N. Default on
@@ -3978,13 +3988,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// <c>NumLayers × kvDim × maxCtx</c> formula otherwise; KV-share layers (Gemma 4 tail)
     /// alias the source and allocate nothing. Used by the auto-narrow heuristic (#185) to
     /// compare the fp32 / bf16 / q8_0 footprints against <see cref="EstimateAvailableKvVram"/>.
+    /// <paramref name="gpuLayers"/> (default -1 = all) scopes the sum to the first N
+    /// GPU-resident layers, used by TierPlanner to price the GPU KV budget for a candidate split.
     /// </summary>
-    internal static long EstimateKvCacheBytes(ModelHyperparams hp, int maxCtx, DType kvDType)
+    internal static long EstimateKvCacheBytes(ModelHyperparams hp, int maxCtx, DType kvDType, int gpuLayers = -1)
     {
         bool perLayerKv = hp.LayerHeadDim is not null;
         int swaWindow = hp.SlidingWindowSize > 0 ? hp.SlidingWindowSize : maxCtx;
         long total = 0;
-        for (int i = 0; i < hp.NumLayers; i++)
+        int layerCount = gpuLayers < 0 ? hp.NumLayers : Math.Min(gpuLayers, hp.NumLayers);
+        for (int i = 0; i < layerCount; i++)
         {
             if (hp.KvSourceLayer is { } ksl && ksl[i] >= 0) continue; // aliased — no own pages
             int layerHd = perLayerKv ? hp.LayerHeadDim![i] : hp.HeadDim;

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -60,6 +60,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     private readonly float*[] _cpuQNorm, _cpuKNorm;
     private readonly CpuWeightRef[]? _cpuWGateInp, _cpuWGateShexp, _cpuWUpShexp, _cpuWDownShexp;
     private readonly CpuWeightRef[]? _cpuWGateExps, _cpuWUpExps, _cpuWDownExps;
+    // CPU-MoE mode: routed experts for the GPU-TRUNK layers (0.._nGpuLayers-1) run on the
+    // CPU from mmap instead of streaming through the SLRU cache. Index i maps directly to
+    // model layer i. Sized _nGpuLayers and populated only when _cpuMoe is true; null otherwise.
+    private readonly CpuWeightRef[]? _cpuMoeGateInp, _cpuMoeGateExps, _cpuMoeUpExps, _cpuMoeDownExps;
     private readonly CpuWeightRef _cpuEmbedding, _cpuOutputWeight, _cpuOutputNorm;
     private readonly float* _cpuRouterLogits;
     private readonly float* _cpuSharedOut;
@@ -152,6 +156,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // Null when not MoE or there are no GPU layers. Loads are synchronous on miss
     // (no prefetcher): the GDN path established this is fast enough for k=8 decode.
     private readonly CudaExpertSlotManager? _expertSlotManager;
+
+    // CPU-MoE auto-select (mirror of CudaHybridGdnForwardPass). When the expert-cache
+    // budget can hold fewer than ~half the GPU-trunk experts, routed-expert MoE runs on
+    // the CPU (mmap) instead of streaming through the SLRU cache. Decided in the ctor
+    // before the GPU upload loop. SHARPI_CPU_MOE=0|1 overrides. Always false for non-MoE.
+    private readonly bool _cpuMoe;
 
     // ── Issue #123: batched-trunk prompt prefill ──────────────────────────────
     // Gate (default ON). When set, Prefill dispatches the supported configs to the
@@ -275,6 +285,39 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         _tqFp32Window = enableTq ? Math.Min(tqFp32Window, _maxSeqLen) : 0;
         _tqBlockBytes = enableTq ? TurboQuantOps.BlockSize(tqBits, _headDim) : 0;
         _gpuRouterBuf = _isMoE && _nGpuLayers > 0 ? new float[hp.NumExperts] : null;
+
+        // ── Auto-detect CPU-MoE vs GPU SLRU MoE ─────────────────────────────────
+        // Mirrors CudaHybridGdnForwardPass: SLRU only pays off when most experts fit in
+        // VRAM. Predict the slot count from the planner's expert-cache budget (VRAM left
+        // after trunk + KV) before uploading any MoE weights. Route MoE through CPU when
+        // fewer than ~half of all GPU-trunk experts can be cached on the GPU.
+        if (_isMoE)
+        {
+            string? cpuMoeOverride = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+            if (cpuMoeOverride == "1")
+            {
+                _cpuMoe = true;
+            }
+            else if (cpuMoeOverride == "0")
+            {
+                _cpuMoe = false;
+            }
+            else
+            {
+                long perExpert = PerExpertBytes();
+                long budget = placement.ExpertCacheBudgetBytes;
+                int predictedSlots = perExpert > 0 ? (int)(budget / perExpert) : 0;
+                int totalExperts = _nGpuLayers * hp.NumExperts;
+                double ratio = totalExperts > 0 ? (double)predictedSlots / totalExperts : 1.0;
+                _cpuMoe = ratio < 0.5;
+                Console.Error.WriteLine(
+                    $"[CudaHybridForwardPass] MoE auto-select: expert-cache capacity ≈ {predictedSlots}/{totalExperts} ({ratio:P0}) → {(_cpuMoe ? "CPU" : "GPU SLRU")} MoE.  Override with SHARPI_CPU_MOE=0|1.");
+            }
+        }
+        else
+        {
+            _cpuMoe = false;
+        }
 
         Console.Error.WriteLine($"[HybridForwardPass] {placement.Summary()}{(enableTq ? $" [TQ{tqBits}]" : "")}");
 
@@ -421,7 +464,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 _gpuPostFfwNorm[i]  = UploadWeight($"blk.{i}.post_ffw_norm.weight");
             if (_isMoE)
             {
-                _gpuWGateInp![i]  = UploadWeight($"blk.{i}.ffn_gate_inp.weight");
+                // CPU-MoE: the router (ffn_gate_inp) runs on the CPU in the compute-half,
+                // so leave _gpuWGateInp[i] default/null here. GPU-SLRU mode uploads it.
+                if (!_cpuMoe)
+                    _gpuWGateInp![i]  = UploadWeight($"blk.{i}.ffn_gate_inp.weight");
                 // Routed experts are NOT uploaded here — they stream through the
                 // CudaExpertSlotManager SLRU cache (created after this loop). The router
                 // and shared expert stay resident since they run on every token.
@@ -501,7 +547,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // fits — so there is no new OOM risk; the budget term only *shrinks* capacity
         // when VRAM is tight (e.g. the user forced extra GPU layers via -g), enabling
         // streaming instead of an OOM.
-        if (_isMoE && _nGpuLayers > 0)
+        if (_isMoE && _nGpuLayers > 0 && _cpuMoe)
+        {
+            Console.Error.WriteLine(
+                "[CudaHybridForwardPass] CPU-MoE mode: routed experts for the GPU-trunk layers " +
+                "run on the CPU from mmap; no SLRU expert cache is allocated.");
+        }
+        if (_isMoE && _nGpuLayers > 0 && !_cpuMoe)
         {
             long perExpert = PerExpertBytes();
             long reserve = 512L << 20; // 512 MiB headroom for transient per-GEMM scratch
@@ -539,6 +591,24 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                     break;
             }
             _expertSlotManager = new CudaExpertSlotManager(gpu, model, hp, plan.Slots, _gpuWeightDTypes);
+        }
+
+        // CPU-MoE: resolve the GPU-trunk layers' routed-expert weights as CPU mmap views.
+        // These layers (0.._nGpuLayers-1) keep attention + shared expert on the GPU but run
+        // the router + routed FFN on the CPU. Index i maps directly to model layer i.
+        if (_isMoE && _cpuMoe)
+        {
+            _cpuMoeGateInp  = new CpuWeightRef[_nGpuLayers];
+            _cpuMoeGateExps = new CpuWeightRef[_nGpuLayers];
+            _cpuMoeUpExps   = new CpuWeightRef[_nGpuLayers];
+            _cpuMoeDownExps = new CpuWeightRef[_nGpuLayers];
+            for (int i = 0; i < _nGpuLayers; i++)
+            {
+                _cpuMoeGateInp[i]  = ResolveCpuWeight($"blk.{i}.ffn_gate_inp.weight");
+                _cpuMoeGateExps[i] = ResolveCpuWeight($"blk.{i}.ffn_gate_exps.weight");
+                _cpuMoeUpExps[i]   = ResolveCpuWeight($"blk.{i}.ffn_up_exps.weight");
+                _cpuMoeDownExps[i] = ResolveCpuWeight($"blk.{i}.ffn_down_exps.weight");
+            }
         }
 
         // ── Resolve CPU weights (layers nGpuLayers..numLayers-1) ──
@@ -1318,8 +1388,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         {
             _gpu.CopyDeviceRegion(_gpuNormBuf, 0, normAll, (long)t * _embDim * sizeof(float),
                                   (long)_embDim * sizeof(float));
-            if (_isMoE) GpuMoeFfn(i);
-            else        GpuDenseFfn(i);
+            if (_isMoE)
+            {
+                if (_cpuMoe) GpuTrunkCpuMoeFfn(i);
+                else         GpuMoeFfn(i);
+            }
+            else GpuDenseFfn(i);
 
             _gpu.CopyDeviceRegion(_gpuResidual, 0, blockOut, (long)t * _embDim * sizeof(float),
                                   (long)_embDim * sizeof(float));
@@ -1471,7 +1545,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         _gpu.RecordBarrier();
 
         if (_isMoE)
-            GpuMoeFfn(i);
+        {
+            if (_cpuMoe) GpuTrunkCpuMoeFfn(i);
+            else         GpuMoeFfn(i);
+        }
         else
             GpuDenseFfn(i);
         _gpu.RecordBarrier();
@@ -2276,51 +2353,56 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         SimdKernels.AddInPlace(_cpuHidden, _pleY, _embDim);
     }
 
-    private void CpuMoeFfn(int ci)
+    // Router + routed-expert FFN on the CPU. Reads `normIn` ([_embDim]), writes the routed
+    // MoE output into `hiddenOut` ([_embDim], cleared first). Does NOT include the shared
+    // expert (callers add it). Bit-identical to the inlined loop it replaces.
+    private void CpuMoeRouted(CpuWeightRef gateInp, CpuWeightRef gateExps,
+        CpuWeightRef upExps, CpuWeightRef downExps, float* normIn, float* hiddenOut)
     {
         int numExperts = _hp.NumExperts;
-        int numActive = _hp.NumActiveExperts;
+        int numActive  = _hp.NumActiveExperts;
 
-        SimdKernels.MatVec(_cpuRouterLogits, _cpuWGateInp![ci].DataPtr, _cpuNormBuf, numExperts, _embDim, _cpuWGateInp[ci].DType);
-        if (_hp.UseSigmoidGating)
-            SimdKernels.SigmoidInPlace(_cpuRouterLogits, numExperts);
-        else
-            SimdKernels.SoftmaxInPlace(_cpuRouterLogits, numExperts);
+        SimdKernels.MatVec(_cpuRouterLogits, gateInp.DataPtr, normIn, numExperts, _embDim, gateInp.DType);
+        if (_hp.UseSigmoidGating) SimdKernels.SigmoidInPlace(_cpuRouterLogits, numExperts);
+        else                      SimdKernels.SoftmaxInPlace(_cpuRouterLogits, numExperts);
 
-        Span<int> selectedExperts = stackalloc int[numActive];
-        Span<float> expertWeights = stackalloc float[numActive];
+        Span<int>   selectedExperts = stackalloc int[numActive];
+        Span<float> expertWeights   = stackalloc float[numActive];
         SelectTopK(_cpuRouterLogits, numExperts, numActive, selectedExperts, expertWeights,
             normalize: _hp.NormalizeMoeTopKWeights);
 
-        if (_hasSharedExpert)
-        {
-            SimdKernels.MatVec(_cpuExpertGate, _cpuWGateShexp![ci].DataPtr, _cpuNormBuf, _expertDim, _embDim, _cpuWGateShexp[ci].DType);
-            SimdKernels.MatVec(_cpuExpertUp, _cpuWUpShexp![ci].DataPtr, _cpuNormBuf, _expertDim, _embDim, _cpuWUpShexp[ci].DType);
-            SimdKernels.SiLuMul(_cpuExpertGate, _cpuExpertUp, _expertDim);
-            SimdKernels.MatVec(_cpuSharedOut, _cpuWDownShexp![ci].DataPtr, _cpuExpertGate, _embDim, _expertDim, _cpuWDownShexp[ci].DType);
-        }
-
-        new Span<float>(_cpuHidden, _embDim).Clear();
+        new Span<float>(hiddenOut, _embDim).Clear();
 
         for (int k = 0; k < numActive; k++)
         {
             int expertIdx = selectedExperts[k];
-            float weight = expertWeights[k];
+            float weight  = expertWeights[k];
 
-            ExpertMatVec(_cpuExpertGate, _cpuWGateExps![ci], expertIdx, _expertDim, _embDim, _cpuNormBuf);
-            ExpertMatVec(_cpuExpertUp, _cpuWUpExps![ci], expertIdx, _expertDim, _embDim, _cpuNormBuf);
+            ExpertMatVec(_cpuExpertGate, gateExps, expertIdx, _expertDim, _embDim, normIn);
+            ExpertMatVec(_cpuExpertUp,   upExps,   expertIdx, _expertDim, _embDim, normIn);
 
             if (_hp.UseSigmoidGating)
             {
                 SimdKernels.ScaleInPlace(_cpuExpertGate, weight, _expertDim);
-                SimdKernels.ScaleInPlace(_cpuExpertUp, weight, _expertDim);
+                SimdKernels.ScaleInPlace(_cpuExpertUp,   weight, _expertDim);
                 weight = 1.0f;
             }
 
             SimdKernels.SiLuMul(_cpuExpertGate, _cpuExpertUp, _expertDim);
-            ExpertMatVecDown(_cpuHidden, _cpuWDownExps![ci], expertIdx, _embDim, _expertDim, _cpuExpertGate, weight);
+            ExpertMatVecDown(hiddenOut, downExps, expertIdx, _embDim, _expertDim, _cpuExpertGate, weight);
         }
+    }
 
+    private void CpuMoeFfn(int ci)
+    {
+        if (_hasSharedExpert)
+        {
+            SimdKernels.MatVec(_cpuExpertGate, _cpuWGateShexp![ci].DataPtr, _cpuNormBuf, _expertDim, _embDim, _cpuWGateShexp[ci].DType);
+            SimdKernels.MatVec(_cpuExpertUp,   _cpuWUpShexp![ci].DataPtr,   _cpuNormBuf, _expertDim, _embDim, _cpuWUpShexp[ci].DType);
+            SimdKernels.SiLuMul(_cpuExpertGate, _cpuExpertUp, _expertDim);
+            SimdKernels.MatVec(_cpuSharedOut, _cpuWDownShexp![ci].DataPtr, _cpuExpertGate, _embDim, _expertDim, _cpuWDownShexp[ci].DType);
+        }
+        CpuMoeRouted(_cpuWGateInp![ci], _cpuWGateExps![ci], _cpuWUpExps![ci], _cpuWDownExps![ci], _cpuNormBuf, _cpuHidden);
         if (_hasSharedExpert)
             SimdKernels.AddInPlace(_cpuHidden, _cpuSharedOut, _embDim);
     }
@@ -2802,6 +2884,34 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             _gpu.AddInPlace(_gpuHidden, _gpuMoeSharedOut!);
     }
 
+    // CPU-MoE trunk path (issue #215): the GPU computes attention/norms (already done by the
+    // caller, leaving the post-FFN-norm hidden in _gpuNormBuf) plus the shared expert; the
+    // routed experts run on the CPU. Mirrors CudaHybridGdnForwardPass's CPU-MoE per-layer
+    // path. Writes the MoE output into _gpuHidden (no residual add — the caller does that),
+    // exactly like GpuMoeFfn.
+    private void GpuTrunkCpuMoeFfn(int layer)
+    {
+        // Shared expert on the GPU first, overlapping the CPU routed work below. (Targets
+        // Qwen3-Coder / OLMoE have no shared expert, so this branch is dead there; kept for
+        // qwen2moe-class models.)
+        if (_hasSharedExpert)
+        {
+            GpuMatMul(_gpuFfnGate, _gpuWGateShexp![layer], _gpuNormBuf);
+            GpuMatMul(_gpuFfnUp,   _gpuWUpShexp![layer],   _gpuNormBuf);
+            _gpu.SiLuMul(_gpuFfnGate, _gpuFfnUp);
+            GpuMatMul(_gpuMoeSharedOut!, _gpuWDownShexp![layer], _gpuFfnGate);
+        }
+
+        // Download the normed hidden, run router + routed experts on the CPU, upload back.
+        _gpu.Download(_gpuNormBuf, (nint)_cpuNormBuf, _embDim);
+        CpuMoeRouted(_cpuMoeGateInp![layer], _cpuMoeGateExps![layer],
+                     _cpuMoeUpExps![layer], _cpuMoeDownExps![layer], _cpuNormBuf, _cpuHidden);
+        _gpu.UploadInto(_gpuHidden, (nint)_cpuHidden, _embDim);
+
+        if (_hasSharedExpert)
+            _gpu.AddInPlace(_gpuHidden, _gpuMoeSharedOut!);
+    }
+
     // Routed-expert weights are uploaded lazily by CudaExpertSlotManager on cache
     // miss, not eagerly here. (The shared expert and router stay resident.)
 
@@ -2948,7 +3058,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             _gpu.Free(_gpuWo[i]);
             if (_isMoE)
             {
-                _gpu.Free(_gpuWGateInp![i]);
+                // _gpuWGateInp[i] is null on CPU-MoE layers (router runs on CPU; not uploaded).
+                if (_gpuWGateInp![i] is not null) _gpu.Free(_gpuWGateInp[i]);
                 // Routed-expert tensors are owned by _expertSlotManager (freed in its Dispose).
                 if (_hasSharedExpert)
                 {

--- a/src/SharpInference.Engine/TierPlanner.cs
+++ b/src/SharpInference.Engine/TierPlanner.cs
@@ -14,13 +14,21 @@ public static class TierPlanner
     /// </summary>
     public static LayerPlacement Plan(GgufModel model, ModelHyperparams hp,
         HardwareProfile hardware, bool turboQuant = false, int tqBits = 3,
-        int requestedCtxSize = 0, int tqFp32Window = 256)
+        int requestedCtxSize = 0, int tqFp32Window = 256, DType kvDtype = DType.Float32)
     {
         if (hardware.VramBytes <= 0)
             return new LayerPlacement(0, hp.NumLayers, 0, 0, requestedCtxSize > 0 ? requestedCtxSize : hp.ContextLength);
 
         long vramTotal = hardware.VramBytes;
         int headDim = hp.HeadDim;
+
+        // Gemma-4-class models have per-layer KV shape (SWA window-rings, KV-share
+        // aliasing, per-layer head_dim / kv-heads). Their KV footprint is a piecewise
+        // function of context, so price it via the runtime allocator's own helper
+        // (CudaForwardPass.EstimateKvCacheBytes) rather than the flat per-token formula —
+        // the two can't drift. Uniform-attention models keep the flat formula.
+        bool perLayerKvShape = hp.LayerHeadDim is not null
+            || hp.IsSwaLayer is not null || hp.KvSourceLayer is not null;
 
         // Reserve for Vulkan overhead + scratch buffers
         long scratchBytes = (long)(hp.EmbeddingDim * 3 + hp.NumHeads * headDim
@@ -96,9 +104,16 @@ public static class TierPlanner
         }
         else if (gpuLayers > 0 && vramBudget > 0)
         {
-            long kvBytesPerToken = 2L * gpuLayers * hp.NumKvHeads * headDim * sizeof(float);
-            gpuCtxSize = (int)(vramBudget / kvBytesPerToken);
-            gpuCtxSize = Math.Clamp(gpuCtxSize, 512, autoCtxCap);
+            if (perLayerKvShape)
+            {
+                gpuCtxSize = SolveGpuCtxForPerLayerKv(hp, autoCtxCap, vramBudget, kvDtype, gpuLayers);
+            }
+            else
+            {
+                long kvBytesPerToken = 2L * gpuLayers * DTypeInfo.ByteSize((long)hp.NumKvHeads * headDim, kvDtype);
+                gpuCtxSize = (int)(vramBudget / kvBytesPerToken);
+                gpuCtxSize = Math.Clamp(gpuCtxSize, 512, autoCtxCap);
+            }
         }
         else
         {
@@ -119,18 +134,56 @@ public static class TierPlanner
             long tqPositions = Math.Max(0, gpuCtxSize - fp32Window);
             gpuKvBytes = fp32WindowBytes + tqBytesPerToken * tqPositions;
         }
+        else if (perLayerKvShape)
+        {
+            gpuKvBytes = CudaForwardPass.EstimateKvCacheBytes(hp, gpuCtxSize, kvDtype, gpuLayers);
+        }
         else
         {
-            long kvBytesPerToken = 2L * gpuLayers * hp.NumKvHeads * headDim * sizeof(float);
+            long kvBytesPerToken = 2L * gpuLayers * DTypeInfo.ByteSize((long)hp.NumKvHeads * headDim, kvDtype);
             gpuKvBytes = kvBytesPerToken * gpuCtxSize;
         }
+
+        // Issue #215: for MoE models the routed experts are NOT charged against the trunk
+        // weight budget (excluded in MeasureLayerBytes); the VRAM left after trunk weights
+        // and KV is the budget the SLRU routed-expert cache can use (or, when too small,
+        // the signal to route MoE to CPU). Diagnostic only — the runtime SLRU/CPU-MoE
+        // decision is made later from actual free VRAM. Zero for dense models.
+        long expertCacheBudget = hp.IsMoE ? Math.Max(0, vramBudget - gpuKvBytes) : 0;
 
         return new LayerPlacement(
             gpuLayers,
             hp.NumLayers - gpuLayers,
             gpuWeightBytes,
             gpuKvBytes,
-            gpuCtxSize);
+            gpuCtxSize,
+            expertCacheBudget);
+    }
+
+    // For per-layer-KV models (Gemma 4: SWA window-rings, KV-share aliasing, per-layer
+    // head_dim / kv-heads) KV bytes are piecewise in context — SWA layers saturate at
+    // their window ring — so the flat divide the uniform path uses would mis-solve the
+    // context. Binary-search the largest context whose true allocation (the same
+    // CudaForwardPass.EstimateKvCacheBytes the forward pass allocates from) fits the
+    // budget. The function is monotonic non-decreasing in context, so an upper-bound
+    // search converges; the floor (512) mirrors the uniform path's Math.Clamp lower bound.
+    internal static int SolveGpuCtxForPerLayerKv(
+        ModelHyperparams hp, int autoCtxCap, long vramBudget, DType kvDtype, int gpuLayers)
+    {
+        const int floorCtx = 512;
+        if (autoCtxCap <= floorCtx ||
+            CudaForwardPass.EstimateKvCacheBytes(hp, floorCtx, kvDtype, gpuLayers) > vramBudget)
+            return Math.Min(floorCtx, autoCtxCap);
+        int lo = floorCtx, hi = autoCtxCap;
+        while (lo < hi)
+        {
+            int mid = lo + (hi - lo + 1) / 2;
+            if (CudaForwardPass.EstimateKvCacheBytes(hp, mid, kvDtype, gpuLayers) <= vramBudget)
+                lo = mid;
+            else
+                hi = mid - 1;
+        }
+        return lo;
     }
 
     private static long MeasureTensorBytes(GgufModel model, string name)
@@ -162,12 +215,18 @@ public static class TierPlanner
     private static long MeasureLayerBytes(GgufModel model, ModelHyperparams hp, int layer)
     {
         long total = 0;
+        // Issue #215: routed experts (ffn_gate_exps / ffn_up_exps / ffn_down_exps) are
+        // NOT eagerly resident per layer — the runtime streams them via the SLRU slot
+        // manager or runs them on CPU. Charging them against the trunk weight budget
+        // makes the greedy packer over-charge MoE layers and stop placing trunk layers
+        // far too early. Measure MoE layers as trunk-only (attn + norms + router + shared
+        // expert) and exclude the routed experts here. ffn_gate_inp (the router) IS
+        // eagerly resident, so it stays.
         string[] suffixes = hp.IsMoE
             ?
             [
                 "attn_norm.weight", "attn_q.weight", "attn_k.weight", "attn_v.weight",
-                "attn_output.weight", "ffn_norm.weight", "ffn_gate_inp.weight",
-                "ffn_gate_exps.weight", "ffn_up_exps.weight", "ffn_down_exps.weight"
+                "attn_output.weight", "ffn_norm.weight", "ffn_gate_inp.weight"
             ]
             :
             [
@@ -235,18 +294,26 @@ public static class TierPlanner
     }
 }
 
-/// <summary>Result of tier placement analysis.</summary>
+/// <summary>
+/// Result of tier placement analysis.
+/// <paramref name="ExpertCacheBudgetBytes"/> is the VRAM left over after trunk weights
+/// and KV for the SLRU routed-expert cache (MoE only; 0 for dense — issue #215).
+/// </summary>
 public sealed record LayerPlacement(
     int GpuLayers,
     int CpuLayers,
     long GpuWeightBytes,
     long GpuKvBytes,
-    int RecommendedCtxSize)
+    int RecommendedCtxSize,
+    long ExpertCacheBudgetBytes = 0)
 {
     public string Summary()
     {
         double gpuWeightMB = GpuWeightBytes / (1024.0 * 1024);
         double gpuKvMB = GpuKvBytes / (1024.0 * 1024);
-        return $"GPU: {GpuLayers} layers ({gpuWeightMB:F0} MB weights, {gpuKvMB:F0} MB KV), CPU: {CpuLayers} layers, ctx: {RecommendedCtxSize}";
+        string moe = ExpertCacheBudgetBytes > 0
+            ? $", expert-cache budget: {ExpertCacheBudgetBytes / (1024.0 * 1024):F0} MB"
+            : "";
+        return $"GPU: {GpuLayers} layers ({gpuWeightMB:F0} MB weights, {gpuKvMB:F0} MB KV), CPU: {CpuLayers} layers, ctx: {RecommendedCtxSize}{moe}";
     }
 }

--- a/src/SharpInference.Engine/TierPlanner.cs
+++ b/src/SharpInference.Engine/TierPlanner.cs
@@ -151,13 +151,29 @@ public static class TierPlanner
         // decision is made later from actual free VRAM. Zero for dense models.
         long expertCacheBudget = hp.IsMoE ? Math.Max(0, vramBudget - gpuKvBytes) : 0;
 
+        // Issue #215: the full-residency GPU cost of every routed expert (gate/up/down _exps
+        // across all layers). Compared against ExpertCacheBudgetBytes by the CLI to decide
+        // whether full-GPU MoE is viable or the model must use the hybrid path (SLRU streaming
+        // or CPU-MoE). Zero for dense models.
+        long moeRoutedExpertBytes = 0;
+        if (hp.IsMoE)
+        {
+            for (int i = 0; i < hp.NumLayers; i++)
+            {
+                moeRoutedExpertBytes += MeasureGpuTensorBytes(model, $"blk.{i}.ffn_gate_exps.weight");
+                moeRoutedExpertBytes += MeasureGpuTensorBytes(model, $"blk.{i}.ffn_up_exps.weight");
+                moeRoutedExpertBytes += MeasureGpuTensorBytes(model, $"blk.{i}.ffn_down_exps.weight");
+            }
+        }
+
         return new LayerPlacement(
             gpuLayers,
             hp.NumLayers - gpuLayers,
             gpuWeightBytes,
             gpuKvBytes,
             gpuCtxSize,
-            expertCacheBudget);
+            expertCacheBudget,
+            moeRoutedExpertBytes);
     }
 
     // For per-layer-KV models (Gemma 4: SWA window-rings, KV-share aliasing, per-layer
@@ -298,6 +314,9 @@ public static class TierPlanner
 /// Result of tier placement analysis.
 /// <paramref name="ExpertCacheBudgetBytes"/> is the VRAM left over after trunk weights
 /// and KV for the SLRU routed-expert cache (MoE only; 0 for dense — issue #215).
+/// <paramref name="MoeRoutedExpertBytes"/> is the full-residency GPU cost of all routed
+/// experts; when it exceeds <paramref name="ExpertCacheBudgetBytes"/> the model can't keep
+/// every expert resident and must use the hybrid path (MoE only; 0 for dense — issue #215).
 /// </summary>
 public sealed record LayerPlacement(
     int GpuLayers,
@@ -305,14 +324,16 @@ public sealed record LayerPlacement(
     long GpuWeightBytes,
     long GpuKvBytes,
     int RecommendedCtxSize,
-    long ExpertCacheBudgetBytes = 0)
+    long ExpertCacheBudgetBytes = 0,
+    long MoeRoutedExpertBytes = 0)
 {
     public string Summary()
     {
         double gpuWeightMB = GpuWeightBytes / (1024.0 * 1024);
         double gpuKvMB = GpuKvBytes / (1024.0 * 1024);
         string moe = ExpertCacheBudgetBytes > 0
-            ? $", expert-cache budget: {ExpertCacheBudgetBytes / (1024.0 * 1024):F0} MB"
+            ? $", expert-cache budget: {ExpertCacheBudgetBytes / (1024.0 * 1024):F0} MB" +
+              $" (routed experts: {MoeRoutedExpertBytes / (1024.0 * 1024):F0} MB)"
             : "";
         return $"GPU: {GpuLayers} layers ({gpuWeightMB:F0} MB weights, {gpuKvMB:F0} MB KV), CPU: {CpuLayers} layers, ctx: {RecommendedCtxSize}{moe}";
     }

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -210,7 +210,8 @@ public static class InferenceEngineLoader
             // full-offload / hybrid / CPU based on what we got back.
             var hwProfile = HardwareProfile.Detect(cuda);
             int gpuLayers = nGpuLayers == -1
-                ? TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize).GpuLayers
+                ? TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize,
+                    kvDtype: CudaForwardPass.ResolveConfiguredKvDType()).GpuLayers
                 : nGpuLayers;
             if (nGpuLayers == -1)
                 gpuLayers = ClampGemma4KvShareBoundary(hp, gpuLayers);
@@ -235,7 +236,8 @@ public static class InferenceEngineLoader
                 return (cfwd, cfwd.SupportsContinuousBatching);
             }
 
-            var planForHybrid = TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize)
+            var planForHybrid = TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize,
+                    kvDtype: CudaForwardPass.ResolveConfiguredKvDType())
                 with { GpuLayers = gpuLayers, CpuLayers = hp.NumLayers - gpuLayers };
             var chfwd = new CudaHybridForwardPass(model, cuda, hp, planForHybrid, turboQuant);
             owned.Add(chfwd);

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -699,6 +699,125 @@ public sealed class CudaForwardPassKvDtypeTests
         Assert.Equal(expected, bytes);
     }
 
+    // ── Issues #220 / #215: gpuLayers scoping + per-layer-KV ctx solver ──────
+    // EstimateKvCacheBytes gained a final gpuLayers param: when < 0 it sums ALL
+    // layers (old behavior); when >= 0 it sums only the first gpuLayers (clamped to
+    // NumLayers). TierPlanner.SolveGpuCtxForPerLayerKv binary-searches the largest
+    // context whose scoped KV allocation fits the VRAM budget — the #220 contract is
+    // that the chosen context never UNDER-reserves (the true allocation must fit).
+
+    /// <summary>
+    /// gpuLayers scopes the sum to the first N layers. On a flat/uniform model every
+    /// layer is identical, so the first 2 of 4 is exactly half of all 4; -1 / NumLayers /
+    /// an over-cap value / the no-arg default all mean "all layers"; 0 means nothing.
+    /// </summary>
+    [Fact]
+    public void EstimateKvCacheBytes_GpuLayersScoping_SumsOnlyFirstN()
+    {
+        var hp = FlatHp(numLayers: 4, numKvHeads: 8, headDim: 128);
+        const int ctx = 2048;
+
+        long all = CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.Float32, gpuLayers: 4);
+        long firstTwo = CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.Float32, gpuLayers: 2);
+        Assert.Equal(all / 2, firstTwo);            // uniform model → first 2 == 2/4 of all 4
+
+        // -1 (default), == NumLayers, and an over-cap value (clamped to NumLayers) all mean "all".
+        Assert.Equal(all, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.Float32, gpuLayers: -1));
+        Assert.Equal(all, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.Float32, gpuLayers: 100));
+        Assert.Equal(all, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.Float32)); // no-arg == -1
+
+        // gpuLayers 0 → no layers summed.
+        Assert.Equal(0L, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.Float32, gpuLayers: 0));
+    }
+
+    /// <summary>
+    /// gpuLayers scoping over the gemma4 per-layer shape: the scoped prefix still honors
+    /// SWA-ring capping and KV-share aliasing. layer0 = global, layer1 = SWA, layer2 aliases
+    /// layer0 (allocates nothing). So gpuLayers 1 = layer0 only; gpuLayers 2 = layer0+layer1;
+    /// gpuLayers 3 (== all) is identical to 2 because the aliased tail contributes 0.
+    /// </summary>
+    [Fact]
+    public void EstimateKvCacheBytes_GpuLayersScoping_Gemma4_SkipsAliasedAndScopes()
+    {
+        const int ctx = 65536;
+        const int window = 1024;
+        var hp = Gemma4ShapedHp(
+            layerHeadDim: [256, 256, 256],
+            layerKvHeads: [8, 8, 8],
+            isSwa: [false, true, false],
+            kvSource: [-1, -1, 0],   // layer 2 aliases layer 0 → no own pages
+            slidingWindow: window);
+
+        int swaRing = SwaRingSizeForTest(ctx, window);
+        long kvDim = 8L * 256;                          // 2048
+        long globalBuf = RoundUpPow2(kvDim * ctx * 2);  // bf16 = 2 B/elem
+        long swaBuf = RoundUpPow2(kvDim * swaRing * 2);
+
+        long expected1 = 2 * globalBuf;                 // layer0 only (K+V)
+        long expected2 = 2 * globalBuf + 2 * swaBuf;    // layer0 + layer1 (SWA)
+        // layer2 is aliased → 0, so all (3) == first 2.
+        Assert.Equal(expected1, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.BFloat16, gpuLayers: 1));
+        Assert.Equal(expected2, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.BFloat16, gpuLayers: 2));
+        Assert.Equal(expected2, CudaForwardPass.EstimateKvCacheBytes(hp, ctx, DType.BFloat16, gpuLayers: 3));
+    }
+
+    /// <summary>
+    /// SolveGpuCtxForPerLayerKv returns the LARGEST context whose scoped KV allocation fits
+    /// the budget (#220). Sizing the budget to exactly a reference context's footprint, the
+    /// solver must (a) fit — never under-reserve, (b) return at least that reference context
+    /// (it fits), and (c) be maximal — the next context up overflows the budget (unless the
+    /// auto cap is hit first).
+    /// </summary>
+    [Fact]
+    public void SolveGpuCtxForPerLayerKv_ReturnsLargestFittingContext()
+    {
+        const int gpuLayers = 3;
+        const int autoCtxCap = 32768;
+        const int refCtx = 8192;
+        var dtype = DType.BFloat16;
+        var hp = Gemma4ShapedHp(
+            layerHeadDim: [256, 256, 256],
+            layerKvHeads: [8, 8, 8],
+            isSwa: [false, true, false],
+            kvSource: [-1, -1, 0],
+            slidingWindow: 1024);
+
+        long budget = CudaForwardPass.EstimateKvCacheBytes(hp, refCtx, dtype, gpuLayers);
+        int got = TierPlanner.SolveGpuCtxForPerLayerKv(hp, autoCtxCap, budget, dtype, gpuLayers);
+
+        Assert.True(CudaForwardPass.EstimateKvCacheBytes(hp, got, dtype, gpuLayers) <= budget,
+            $"solved ctx {got} over-reserves vs budget {budget} — would OOM at runtime (#220).");
+        Assert.True(got >= refCtx,
+            $"solved ctx {got} below the reference {refCtx}, which fits exactly — not maximal.");
+        Assert.True(got == autoCtxCap ||
+            CudaForwardPass.EstimateKvCacheBytes(hp, got + 1, dtype, gpuLayers) > budget,
+            $"ctx {got + 1} also fits budget {budget} — solver did not return the LARGEST fitting context.");
+    }
+
+    /// <summary>
+    /// SolveGpuCtxForPerLayerKv floors at 512: a budget too small for even 512-ctx returns
+    /// the floor (the alloc then fails loudly rather than silently picking a smaller, unusable
+    /// context), and an autoCtxCap below the floor clamps to the cap (Math.Min(512, cap)).
+    /// </summary>
+    [Fact]
+    public void SolveGpuCtxForPerLayerKv_BudgetBelowFloor_ReturnsFloor()
+    {
+        var dtype = DType.BFloat16;
+        var hp = Gemma4ShapedHp(
+            layerHeadDim: [256, 256, 256],
+            layerKvHeads: [8, 8, 8],
+            isSwa: [false, true, false],
+            kvSource: [-1, -1, 0],
+            slidingWindow: 1024);
+
+        // 1 byte can't hold even a 512-ctx cache → floor (512).
+        Assert.Equal(512, TierPlanner.SolveGpuCtxForPerLayerKv(hp, autoCtxCap: 32768, vramBudget: 1, dtype, gpuLayers: 3));
+
+        // autoCtxCap below the floor → clamp to the cap (Math.Min(512, cap)), even with a huge budget.
+        Assert.Equal(256, TierPlanner.SolveGpuCtxForPerLayerKv(
+            hp, autoCtxCap: 256, vramBudget: long.MaxValue, dtype, gpuLayers: 3));
+    }
+
     /// <summary>
     /// Q8KvGeometrySupported returns false when ANY single (non-aliased) layer violates the
     /// %32 rule — not just when all do. A mixed set with one bad layer must fail, matching

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridForwardPassCpuMoeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridForwardPassCpuMoeTests.cs
@@ -1,0 +1,186 @@
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Cross-backend correctness coverage for the CPU-MoE execution mode of
+/// <see cref="CudaHybridForwardPass"/> (SHARPI_CPU_MOE=1). In that mode the GPU runs
+/// attention/norms (+ shared expert if present) for the trunk layers, the post-FFN-norm
+/// hidden is downloaded to the CPU, the MoE router + routed experts run on the CPU via
+/// SimdKernels (shared with the CPU-tail path through <c>CpuMoeRouted</c>), and the
+/// result is uploaded back to the GPU.
+///
+/// Parity philosophy: we do NOT assert strict greedy/argmax equality. Q4_K matvec
+/// quantizes activations to Q8_1, and MoE router top-K is sensitive to that drift — the
+/// GPU-attention upstream can legitimately flip an expert near the K/K+1 boundary even
+/// when everything is wired correctly (see <see cref="CudaMoeTests"/>). Instead, per the
+/// project's cross-backend parity guidance, we use the CPU <see cref="ForwardPass"/> as
+/// the INDEPENDENT reference and assert at the logit level via top-5 vocab overlap. On a
+/// short in-distribution prompt a correctly-wired CPU-MoE path overlaps heavily with the
+/// pure-CPU reference; an overlap collapse signals a real wiring bug, not quant noise.
+/// </summary>
+public sealed class CudaHybridForwardPassCpuMoeTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); } catch { return null; }
+    }
+
+    private static string? FindMoEModelPath()
+    {
+        // Smallest first — OLMoE is the fast, no-shared-expert MoE preferred for this test.
+        string[] candidates =
+        {
+            "models\\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf",
+            "models\\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        };
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            foreach (var c in candidates)
+            {
+                var p = Path.Combine(dir, c);
+                if (File.Exists(p)) return p;
+            }
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    private static int[] TopK(float[] logits, int k)
+    {
+        var idx = new int[logits.Length];
+        for (int i = 0; i < idx.Length; i++) idx[i] = i;
+        Array.Sort(idx, (a, b) => logits[b].CompareTo(logits[a]));
+        var top = new int[k];
+        Array.Copy(idx, top, k);
+        return top;
+    }
+
+    /// <summary>
+    /// Runs the CPU-MoE hybrid (GPU attention + CPU routed experts) against the
+    /// independent pure-CPU <see cref="ForwardPass"/> on a short coherent prompt.
+    /// Asserts the hybrid output is well-formed (finite, non-degenerate range, ≥2
+    /// distinct argmax over a 5-token greedy decode) and that the hybrid's top-5
+    /// vocab logits overlap the CPU reference's top-5 by ≥3. Strict argmax parity is
+    /// deliberately NOT required: Q4_K activation quant can flip the router top-K near
+    /// the boundary; top-5 overlap validates the CPU-MoE wiring without flakiness.
+    /// </summary>
+    [Fact]
+    public void CudaHybridForwardPass_CpuMoeMode_MatchesCpuReference()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return; // silent skip — no CUDA
+
+        var path = FindMoEModelPath();
+        if (path is null) return; // silent skip — no MoE model on disk
+
+        var prev = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+        Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            Assert.True(hp.IsMoE, "Expected hp.IsMoE for the MoE model under test.");
+
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+            // GpuLayers = NumLayers is the "user wants GPU" hint; with SHARPI_CPU_MOE=1
+            // the routed-expert FFN is forced onto the CPU regardless of the cut point.
+            var placement = new LayerPlacement(
+                GpuLayers: hp.NumLayers,
+                CpuLayers: 0,
+                GpuWeightBytes: 0,
+                GpuKvBytes: 0,
+                RecommendedCtxSize: Math.Min(hp.ContextLength, 2048));
+
+            using var hybrid = new CudaHybridForwardPass(model, gpu, hp, placement);
+
+            // Independent reference: pure-CPU forward pass over the same model handle.
+            using var cpuBackend = new CpuBackend();
+            using var cpu = new SharpInference.Engine.ForwardPass(model, cpuBackend, hp);
+
+            var prompt = "The capital of France is";
+            var tokens = tokenizer.Encode(prompt);
+            Assert.NotEmpty(tokens);
+
+            var hybridLogits = hybrid.Prefill(tokens).ToArray();
+            var cpuLogits = cpu.Prefill(tokens).ToArray();
+            Assert.Equal(cpuLogits.Length, hybridLogits.Length);
+
+            // Well-formedness on the hybrid prefill logits.
+            float min = float.MaxValue, max = float.MinValue;
+            for (int i = 0; i < hybridLogits.Length; i++)
+            {
+                float v = hybridLogits[i];
+                Assert.True(float.IsFinite(v), $"Non-finite hybrid logit at vocab idx {i}: {v}");
+                if (v < min) min = v;
+                if (v > max) max = v;
+            }
+            Assert.True(max - min > 0.1f,
+                $"Hybrid logit range too tight ({min:F3}..{max:F3}); the CPU-MoE FFN is " +
+                "likely returning a near-zero hidden state.");
+
+            // Anti-garble: greedy decode 5 tokens on the hybrid; ≥2 distinct argmaxes.
+            ReadOnlySpan<float> dl = hybridLogits;
+            var decoded = new List<int>(5);
+            for (int i = 0; i < 5; i++)
+            {
+                int next = Sampler.Greedy(dl);
+                decoded.Add(next);
+                dl = hybrid.Forward(next, tokens.Count + i);
+            }
+            int distinct = decoded.Distinct().Count();
+            Assert.True(distinct >= 2,
+                $"Hybrid greedy decode produced only {distinct} distinct token(s) across 5 steps " +
+                $"({string.Join(",", decoded)}); the CPU-MoE FFN may be stuck in a degenerate loop.");
+
+            // Cross-backend top-5 overlap against the independent CPU reference.
+            int hybridArgmax = Argmax(hybridLogits);
+            int cpuArgmax = Argmax(cpuLogits);
+            int[] hybridTop5 = TopK(hybridLogits, 5);
+            int[] cpuTop5 = TopK(cpuLogits, 5);
+            int overlap = 0;
+            foreach (var t in hybridTop5)
+                if (Array.IndexOf(cpuTop5, t) >= 0) overlap++;
+
+            float maxAbs = 0f;
+            for (int i = 0; i < cpuLogits.Length; i++)
+                maxAbs = Math.Max(maxAbs, Math.Abs(cpuLogits[i] - hybridLogits[i]));
+
+            // Diagnostic line (visible with `dotnet test --logger "console;verbosity=detailed"`).
+            Console.WriteLine(
+                $"[CpuMoeMode] overlap={overlap}/5 top1Match={hybridArgmax == cpuArgmax} " +
+                $"maxAbsLogitDiff={maxAbs:F4} hybridArgmax={hybridArgmax} cpuArgmax={cpuArgmax} " +
+                $"hybridTop5=[{string.Join(",", hybridTop5)}] cpuTop5=[{string.Join(",", cpuTop5)}]");
+
+            Assert.True(overlap >= 3,
+                $"CPU-MoE hybrid top-5 overlaps the CPU reference by only {overlap}/5 " +
+                $"(maxAbsLogitDiff={maxAbs:F4}, top1Match={hybridArgmax == cpuArgmax}): " +
+                $"hybrid top5=[{string.Join(",", hybridTop5)}] (argmax {hybridArgmax}), " +
+                $"cpu top5=[{string.Join(",", cpuTop5)}] (argmax {cpuArgmax}). " +
+                "An overlap collapse on an in-distribution prompt signals a real CPU-MoE " +
+                "wiring bug (router/expert weight loading or the upload/download round-trip), " +
+                "not the documented Q4_K router-boundary drift.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prev);
+        }
+    }
+}


### PR DESCRIPTION
Two commits closing **#220** and the compute-half of **#215**.

## #220 — TierPlanner prices KV at real dtype + per-layer shape
The layer planner priced GPU KV with a flat `2·gpuLayers·NumKvHeads·HeadDim·sizeof(float)·ctx` formula — wrong for Gemma-4-class models (SWA window-rings, KV-share aliasing, per-layer head_dim/kv-heads) and blind to narrowed KV dtypes (bf16/q8_0). It also charged every routed MoE expert against the trunk weight budget even though the runtime streams them lazily via the SLRU slot manager (or runs them on CPU), so the greedy packer stopped placing trunk layers far too early.

- Reuse the runtime allocator's own `CudaForwardPass.EstimateKvCacheBytes` (now gpuLayers-scoped) for per-layer-shape models, with a monotonic binary search (`SolveGpuCtxForPerLayerKv`) for the inverse context solve — planner and allocator can no longer drift. Uniform models keep the flat formula, dtype-scaled via `DTypeInfo.ByteSize` (byte-identical at fp32).
- New `kvDtype` param on `Plan`, threaded through the CUDA dense/hybrid call sites only (Vulkan/GDN/bench stay fp32).
- `MeasureLayerBytes` excludes routed experts (`ffn_*_exps`) for MoE; leftover VRAM after trunk+KV reported as `LayerPlacement.ExpertCacheBudgetBytes`.

## #215 — CPU-MoE execution mode for CudaHybridForwardPass (compute-half)
`CudaHybridForwardPass` (pure-attention MoE hybrid — Qwen3-Coder-30B-A3B, OLMoE, qwen2moe-class) gains a CPU-MoE mode mirroring the GDN sibling: GPU runs attention/norms (+shared expert when present), the post-FFN-norm hidden is downloaded, the MoE router + routed experts run on the CPU, result uploaded back. At a 12 GB profile the SLRU expert cache is only ~13% resident on Qwen3-Coder-30B, so miss-driven PCIe traffic dominates the GPU-SLRU path; running routed experts on the CPU is faster (the #100 precedent).

- New `_cpuMoe` auto-router (`SHARPI_CPU_MOE=0|1` override, else `predictedSlots/totalExperts < 0.5`), predicted from the planner's `ExpertCacheBudgetBytes`.
- `GpuTrunkCpuMoeFfn`: GPU shexp kick → `Download` → `CpuMoeRouted` (factored out of the existing `CpuMoeFfn` — no new dot kernel) → `UploadInto` → GPU shexp add. Dispatched in both decode and per-token prefill.
- Fixes a `-g -1` auto-select regression the #215 planner-half introduced: excluding routed experts from the trunk budget made `TierPlanner` return `GpuLayers == NumLayers` for big MoE, so the CLI `wantHybrid` gate went false and Qwen3-Coder-30B fell through to full-offload `CudaForwardPass` (the silent-OOM/thrash case TierPlanner exists to avoid). New `LayerPlacement.MoeRoutedExpertBytes`; RunCommand routes auto MoE to hybrid when that exceeds the expert-cache budget. OLMoE (experts fit) stays full-GPU.

## Validation
- `CudaHybridForwardPass_CpuMoeMode_MatchesCpuReference`: top-5 logit overlap vs the independent CPU `ForwardPass` (strict argmax parity is unreliable for CUDA MoE — Q4_K activation quant flips the router top-K near the boundary). OLMoE: 4/5 overlap, top-1 match, maxAbs 1.61.
- `CudaForwardPassKvDtypeTests`: gpuLayers scoping + binary-search contract (fits / never under-reserves / ≥ reference / maximal / floors at 512).
- A/B on Qwen3-Coder-30B-A3B @ 12 GB: decode 18.6→25.0 t/s (1.34×), prefill 14.2→20.8 t/s (1.46×).
- Full Release build clean under `TreatWarningsAsErrors`; forward-pass + planner tests green.

## Follow-ups (separate issues)
The #215 commit message lists "batched CPU-MoE prefill / Q8_K-input routed kernels" as follow-ups. These were **investigated this session and measured to regress** the Q4_K targets (the per-token sequential core is the optimum); issues will be filed documenting the negative results so they aren't re-attempted blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)