### PR TITLE
perf(cuda): batched-trunk prefill for CPU-resident embedding (#218)

### DIFF
--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -182,8 +182,16 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // Test observable (issue #123): set by Prefill to whether the last call dispatched the
     // batched-trunk path (true) or fell back to the per-token loop (false). Lets the parity
     // oracles assert the batched path actually ran instead of passing vacuously when the
-    // config is gated out (e.g. CPU-resident embedding / non-batchable dtype on a given box).
+    // config is gated out (e.g. non-batchable dtype on a given box).
     internal bool LastPrefillWasBatched;
+
+    // Issue #218 test/bench hook: force the low-VRAM "fixed weights on CPU" config
+    // (embedding + output table CPU-resident, _gpuEmbedding/_gpuOutputWeight null) even on a
+    // box where ShouldKeepFixedWeightsOnCpu would keep them on the GPU. Lets the batched-CPU-
+    // embed prefill path (#218) be exercised and A/B-benched on a model whose embedding fits in
+    // VRAM. Read once in the constructor; OR'd into cpuEmbeddingOutputOnly. Default off.
+    internal static bool ForceCpuResidentEmbedding =
+        Environment.GetEnvironmentVariable("SHARPI_FORCE_CPU_EMBED") == "1";
 
     // Device scratch for the batched attention trunk, allocated lazily by
     // EnsureBatchedTrunkScratch(N) and sized to the largest N seen so far. The
@@ -201,6 +209,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // Pinned host buffer for the batched GPU→CPU hidden transfer [N × embDim].
     private Tensor? _pinnedHiddenAll;
     private int _pinnedHiddenAllN;
+    // Issue #218: dedicated pinned host buffer for the batched CPU→GPU embedding upload
+    // [N × embDim], used only when the embedding is CPU-resident (_gpuEmbedding is null).
+    // Distinct from _pinnedHidden/_pinnedHiddenAll so the embed staging never races the
+    // per-token hidden transfer; the whole block is CPU-written then uploaded in one async
+    // H2D, so there is no per-token write-after-read on a shared buffer.
+    private Tensor? _pinnedEmbedAll;
+    private int _pinnedEmbedAllN;
 
     // Non-transactional fault latch (mirror of CudaHybridGdnForwardPass._faulted):
     // set at batched-prefill entry, cleared only after the KV/position counters have
@@ -276,7 +291,7 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_isGemma4Like)
             Gemma4ValidateHybridSplit(hp, _nGpuLayers);
 
-        bool cpuEmbeddingOutputOnly = ShouldKeepFixedWeightsOnCpu(
+        bool cpuEmbeddingOutputOnly = ForceCpuResidentEmbedding || ShouldKeepFixedWeightsOnCpu(
             model.FindTensor("token_embd.weight")!.Value,
             model.FindTensor("output.weight"));
         _tqEnabled = enableTq;
@@ -1078,19 +1093,18 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     /// (per-layer head_dim / dual-RoPE / PLE), TurboQuant-KV, non-NEOX RoPE (the only
     /// batched RoPE kernel is NEOX), and L2 QK-norm (no batched HeadNormPure) all fall
     /// back to the per-token <see cref="Forward"/> loop. Qwen3-Coder-30B (NEOX, learned
-    /// QK-norm, no attn-bias, MoE, GPU-resident embedding) is supported.
+    /// QK-norm, no attn-bias, MoE) is supported with either embedding placement.
     /// <para>
-    /// CPU-resident embedding (<c>_gpuEmbedding is null</c>, a low-VRAM config) is gated
-    /// OUT: the batched embed loop would have to drain the stream between tokens to avoid
-    /// a write-after-read race on the shared <c>_pinnedHidden</c> staging buffer (the
-    /// per-token <see cref="Forward"/> path is safe only because it syncs once per token).
-    /// Rather than ship that uncovered path, fall back to the bit-exact per-token loop.
+    /// CPU-resident embedding (<c>_gpuEmbedding is null</c>, the low-VRAM / 12 GB-default
+    /// config) is supported as of issue #218: the embed step dequantizes all N rows into a
+    /// dedicated pinned staging block and uploads them in one async H2D, so there is no
+    /// per-token write-after-read on a shared buffer (which is why <c>_gpuEmbedding is not
+    /// null</c> is no longer required here). See <see cref="PrefillBatchedTrunk"/> step 1.
     /// </para>
     /// </summary>
     private bool IsBatchedPrefillSupported =>
         !_isGemma4Like
         && !_tqEnabled
-        && _gpuEmbedding is not null
         && _hp.IsNeoxRope
         && !(_hasQkNorm && _hp.UseL2QkNorm)
         && !_hasAttnBias
@@ -1172,6 +1186,17 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         return _pinnedHiddenAll;
     }
 
+    // Issue #218: exact-size pinned staging for the batched CPU→GPU embedding upload, so
+    // CopyDevice(stream, pinnedEmbed) has equal element counts on both sides (n × embDim).
+    private Tensor EnsurePinnedEmbedAll(int n)
+    {
+        if (_pinnedEmbedAll is { } p && _pinnedEmbedAllN == n) return p;
+        if (_pinnedEmbedAll is { } old) { _gpu.Free(old); _pinnedEmbedAll = null; }
+        _pinnedEmbedAll = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
+        _pinnedEmbedAllN = n;
+        return _pinnedEmbedAll;
+    }
+
     /// <summary>
     /// Batched-trunk prompt prefill for the pure-attention hybrid path (issue #123).
     /// The attention trunk of the <c>_nGpuLayers</c> GPU layers runs as batched launches
@@ -1207,19 +1232,31 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         _faulted = true;
 
         // 1. Embed every token into the residual-stream buffer [N × embDim].
-        //    Only the GPU-resident-embedding path runs here: CPU-resident embedding is
-        //    gated out of the batched path (IsBatchedPrefillSupported requires
-        //    _gpuEmbedding is not null) because reusing the shared _pinnedHidden staging
-        //    buffer across tokens without a per-token drain would race the async copy.
-        if (_gpuEmbedding is null)
-            throw new InvalidOperationException(
-                "Batched-trunk prefill requires a GPU-resident embedding (gated by IsBatchedPrefillSupported).");
-        for (int i = 0; i < N; i++)
+        if (_gpuEmbedding is not null)
         {
-            if (_embIsQuantized) _gpu.EmbedLookupQ4K(_gpuEmbedding, _gpuHidden, tokens[i], embDim);
-            else                 _gpu.EmbedLookup(_gpuEmbedding, _gpuHidden, tokens[i], embDim);
-            _gpu.CopyDeviceRegion(stream, (long)i * embDim * sizeof(float),
-                                  _gpuHidden, 0, (long)embDim * sizeof(float));
+            // GPU-resident embedding: look each row up on the GPU and scatter into the stream.
+            for (int i = 0; i < N; i++)
+            {
+                if (_embIsQuantized) _gpu.EmbedLookupQ4K(_gpuEmbedding, _gpuHidden, tokens[i], embDim);
+                else                 _gpu.EmbedLookup(_gpuEmbedding, _gpuHidden, tokens[i], embDim);
+                _gpu.CopyDeviceRegion(stream, (long)i * embDim * sizeof(float),
+                                      _gpuHidden, 0, (long)embDim * sizeof(float));
+            }
+        }
+        else
+        {
+            // Issue #218: CPU-resident embedding (low-VRAM config). Dequantize all N rows on
+            // the CPU into a dedicated pinned block [N × embDim] (the SAME per-row dequant as
+            // CpuEmbedToken → byte-identical to the per-token Forward path), then upload the
+            // whole block in ONE async H2D into the stream. The block is fully CPU-written
+            // before the single copy is enqueued, so there is no per-token write-after-read
+            // on a shared staging buffer — the hazard that gated this config out pre-#218.
+            var pinnedEmbed = EnsurePinnedEmbedAll(N);
+            float* host = _gpu.MapPinned(pinnedEmbed);
+            for (int i = 0; i < N; i++)
+                CpuEmbedToken(tokens[i], host + (long)i * embDim);
+            _gpu.UnmapPinned(pinnedEmbed);
+            _gpu.CopyDevice(stream, pinnedEmbed);   // pinned host → device stream (UVA H2D, N × embDim)
         }
 
         // 2. GPU layers: batched attention trunk + per-token FFN/MoE.
@@ -3048,6 +3085,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // Issue #123: batched-trunk prefill scratch.
         FreeBatchedTrunkScratch();
         if (_pinnedHiddenAll is { } pha) { _gpu.Free(pha); _pinnedHiddenAll = null; }
+        // Issue #218: batched CPU-embed staging buffer.
+        if (_pinnedEmbedAll is { } pea) { _gpu.Free(pea); _pinnedEmbedAll = null; }
 
         for (int i = 0; i < _nGpuLayers; i++)
         {

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -286,6 +286,99 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
     }
 
     /// <summary>
+    /// Issue #218 × #162: the combination that actually SHIPS by default on a 12 GB box —
+    /// CPU-resident embedding (#218) AND compute-routed attention projections
+    /// (<see cref="CudaHybridForwardPass.HybridPrefillComputeEnabled"/> default-on). The
+    /// bit-parity oracles pin compute routing off and the #162 oracle above runs GPU-embed, so
+    /// this exact pairing was previously asserted only by inference (the embed step and the
+    /// MMQ/GEMM routing are independent). This forces both and asserts the compute-routed batched
+    /// prefill stays <b>argmax-stable</b> vs the byte-exact matvec batching (shared top-5 + loose
+    /// fp tolerance) under the CPU-embed staging — the same contract as the GPU-embed variant.
+    /// </summary>
+    [Fact]
+    public void BatchedPrefill_CpuEmbedding_ComputeRouting_ArgmaxStableVsMatvec_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevCompute = CudaHybridForwardPass.HybridPrefillComputeEnabled;
+        bool prevForce = CudaHybridForwardPass.ForceCpuResidentEmbedding;
+        try
+        {
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = true;
+
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var placement = PlanCoder(model, hp, gpu, ctx);
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts! " +
+                "The five boxing wizards jump quickly.");
+            Assert.True(tokens.Count >= 8, $"Prompt tokenized to only {tokens.Count} tokens.");
+
+            float[] Run(bool compute)
+            {
+                CudaHybridForwardPass.BatchedPrefillEnabled = true;
+                CudaHybridForwardPass.HybridPrefillComputeEnabled = compute;
+                using var fwd = TryConstruct(model, gpu, hp, placement);
+                if (fwd is null) return Array.Empty<float>();
+                var logits = fwd.Prefill(tokens).ToArray();
+                Assert.True(fwd.LastPrefillWasBatched,
+                    "Batched arm fell back to per-token — the comparison would be vacuous.");
+                return logits;
+            }
+
+            float[] matvec  = Run(false);   // byte-exact GEMM-N matvec, CPU embed
+            float[] compute = Run(true);    // default-on MMQ/GEMM compute routing, CPU embed
+            if (matvec.Length == 0 || compute.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(matvec.Length, compute.Length);
+
+            float maxAbs = 0f;
+            for (int i = 0; i < matvec.Length; i++)
+                maxAbs = MathF.Max(maxAbs, MathF.Abs(matvec[i] - compute[i]));
+
+            static HashSet<int> Top5(float[] v)
+            {
+                var idx = new int[v.Length];
+                for (int i = 0; i < idx.Length; i++) idx[i] = i;
+                Array.Sort(idx, (a, b) => v[b].CompareTo(v[a]));
+                var set = new HashSet<int>();
+                for (int i = 0; i < 5 && i < idx.Length; i++) set.Add(idx[i]);
+                return set;
+            }
+            var matvecTop = Top5(matvec);
+            var computeTop = Top5(compute);
+            int overlap = 0;
+            foreach (var t in computeTop) if (matvecTop.Contains(t)) overlap++;
+            Assert.True(overlap >= 4,
+                $"CPU-embed compute-routing top-5 overlaps the byte-exact matvec in only {overlap}/5 slots " +
+                $"(maxAbs={maxAbs:E2}).");
+            Assert.True(maxAbs < 3.0f,
+                $"CPU-embed compute-routing vs matvec logits diverged beyond fp tolerance: maxAbs={maxAbs:E2}.");
+            _out.WriteLine($"OK cpu-embed compute-routing argmax-stable: N={tokens.Count} " +
+                $"greedy={Sampler.Greedy(matvec)} maxAbs={maxAbs:E2}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.HybridPrefillComputeEnabled = prevCompute;
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = prevForce;
+        }
+    }
+
+    /// <summary>
     /// Multi-chunk parity: prefill the prompt in two segments (<c>[0,k)</c> then
     /// <c>[k,N)</c> with <c>startPos=k</c>) and assert the final-token logits are
     /// bit-identical. Exercises <c>startPos &gt; 0</c>, cross-chunk KV continuity, and

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -647,6 +647,80 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// Issue #123 with CPU layers &gt; 0 on the GPU-resident-embedding path. The natural-placement
+    /// GPU-embed oracles above run 48 GPU / 0 CPU on a 12 GB card (CPU-MoE), so the per-token
+    /// CPU-layer download loop (<c>PrefillBatchedTrunk</c> step 3) is never exercised there. This
+    /// SYNTHESIZES a half/half split (overriding <see cref="LayerPlacement.GpuLayers"/>/<c>CpuLayers</c>)
+    /// so the GPU attention trunk, the GPU→CPU N-row transfer, and the per-token CPU-layer loop all
+    /// run with a GPU-resident embedding. Mirror of
+    /// <see cref="BatchedPrefill_CpuEmbedding_CpuLayersSplit_BitwiseMatchesSequential_Coder"/> with
+    /// the embedding left on the GPU. The synthetic split only uses LESS GPU VRAM than the full plan,
+    /// so it cannot OOM where the others construct. Final-token logits must be bit-identical to the
+    /// sequential per-token Forward loop.
+    /// </summary>
+    [Fact]
+    public void BatchedPrefill_GpuEmbedding_CpuLayersSplit_BitwiseMatchesSequential_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var planned = PlanCoder(model, hp, gpu, ctx);
+            // Force a cross-tier split so CpuLayers > 0 (the planner gives 48/0 here via CPU-MoE).
+            int gpuLayers = hp.NumLayers / 2;
+            var split = planned with { GpuLayers = gpuLayers, CpuLayers = hp.NumLayers - gpuLayers };
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts!");
+            Assert.True(tokens.Count >= 8, $"Prompt tokenized to only {tokens.Count} tokens.");
+
+            float[] Run(bool batched)
+            {
+                CudaHybridForwardPass.BatchedPrefillEnabled = batched;
+                using var fwd = TryConstruct(model, gpu, hp, split);
+                if (fwd is null) return Array.Empty<float>();
+                var logits = fwd.Prefill(tokens).ToArray();
+                if (batched)
+                    Assert.True(fwd.LastPrefillWasBatched,
+                        "Batched arm fell back to the per-token path — the parity check would be vacuous. " +
+                        $"GpuLayers={split.GpuLayers} CpuLayers={split.CpuLayers}.");
+                return logits;
+            }
+
+            float[] seq = Run(false);
+            float[] bat = Run(true);
+            if (seq.Length == 0 || bat.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(seq.Length, bat.Length);
+            int firstDiff = FirstBitDiff(seq, bat);
+            Assert.True(firstDiff < 0,
+                $"GPU-embed + CpuLayers>0 batched prefill diverges from sequential at index {firstDiff} " +
+                $"(GpuLayers={split.GpuLayers} CpuLayers={split.CpuLayers}). The batched GPU attention trunk " +
+                "and the per-token CPU-layer download loop must together be bit-identical to the sequential loop.");
+            Assert.Equal(Sampler.Greedy(seq), Sampler.Greedy(bat));
+            _out.WriteLine($"OK gpu-embed CpuLayers>0 N={tokens.Count} split={split.GpuLayers}/{split.CpuLayers} greedy={Sampler.Greedy(seq)}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+        }
+    }
+
     // Construction is the ONLY place allowed to skip (a box without the VRAM to host this
     // 30 GB MoE model under the planned split). A failure INSIDE Prefill must propagate
     // and fail the test — that is exactly the regression these oracles exist to catch.

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -12,11 +12,17 @@ namespace SharpInference.Tests.ForwardPass;
 /// used by Qwen3-Coder-30B-A3B). The batched path
 /// (<c>CudaHybridForwardPass.PrefillBatchedTrunk</c>) batches the attention trunk
 /// of the GPU layers over the N prompt tokens; the FFN/MoE stage stays per-token,
-/// and the CPU layers (Coder-30B splits ~29 GPU + 19 CPU on a 12 GB card) run per
-/// token over the N hidden rows. It must produce bit-identical final-token logits
-/// to the sequential per-token <see cref="CudaHybridForwardPass.Forward"/> loop
-/// (the deterministic reference), toggling only
-/// <see cref="CudaHybridForwardPass.BatchedPrefillEnabled"/>.
+/// and any CPU layers run per token over the N hidden rows. It must produce
+/// bit-identical final-token logits to the sequential per-token
+/// <see cref="CudaHybridForwardPass.Forward"/> loop (the deterministic reference),
+/// toggling only <see cref="CudaHybridForwardPass.BatchedPrefillEnabled"/>.
+///
+/// NOTE: on a 12 GB card the current planner places Coder-30B as 48 GPU / 0 CPU
+/// layers (CPU-MoE handles the routed experts; all attention trunks fit on GPU), so
+/// these natural-placement oracles exercise the all-GPU-layer branch. The CpuLayers&gt;0
+/// branch is covered deterministically by
+/// <see cref="BatchedPrefill_CpuEmbedding_CpuLayersSplit_BitwiseMatchesSequential_Coder"/>
+/// via a synthesized split.
 ///
 /// Skipped silently when CUDA is unavailable, the model isn't on disk, or
 /// construction OOMs — but a failure INSIDE Prefill must FAIL, not skip.
@@ -114,8 +120,9 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
     /// <summary>
     /// Single-chunk parity: the batched-trunk path must produce final-token logits
     /// bit-identical to the sequential per-token Forward loop. Exercises the batched
-    /// GPU attention trunk + per-token MoE FFN + the GPU→CPU N-row transfer + per-token
-    /// CPU layers (Coder-30B splits across both tiers on a 12 GB card).
+    /// GPU attention trunk + per-token MoE FFN (on this box Coder-30B places all 48 layers
+    /// on GPU with CPU-MoE, so the GPU→CPU N-row transfer + per-token CPU-layer loop are
+    /// covered by the synthesized-split oracle, not here).
     /// </summary>
     [Fact]
     public void BatchedPrefill_BitwiseMatchesSequential_Coder()

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -411,6 +411,235 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// Issue #218: batched-trunk prefill with a CPU-resident embedding (the low-VRAM / 12 GB
+    /// default config). <see cref="CudaHybridForwardPass.ForceCpuResidentEmbedding"/> forces the
+    /// embedding + output table onto the CPU (<c>_gpuEmbedding/_gpuOutputWeight</c> null) even
+    /// though Coder-30B's Q4_K embedding fits in VRAM, so the batched path's CPU-embed staging
+    /// (one pinned [N × embDim] block → single async H2D) and the <c>_gpuOutputWeight is null</c>
+    /// CPU output branches are exercised. Final-token logits must be bit-identical to the
+    /// sequential per-token <see cref="CudaHybridForwardPass.Forward"/> loop under the SAME
+    /// (forced-CPU-embed) config — only <see cref="CudaHybridForwardPass.BatchedPrefillEnabled"/>
+    /// toggles. Pre-#218 the batched arm would have fallen back to per-token (gated out); the
+    /// <c>LastPrefillWasBatched</c> assertion guards against a vacuous pass.
+    /// </summary>
+    [Fact]
+    public void BatchedPrefill_CpuEmbedding_BitwiseMatchesSequential_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevForce = CudaHybridForwardPass.ForceCpuResidentEmbedding;
+        try
+        {
+            // Forcing embedding+output to CPU only FREES VRAM, so the planned GPU layers still
+            // fit — no new OOM risk vs the GPU-embed oracle's split.
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = true;
+
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var placement = PlanCoder(model, hp, gpu, ctx);
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts! " +
+                "The five boxing wizards jump quickly.");
+            Assert.True(tokens.Count >= 8, $"Prompt tokenized to only {tokens.Count} tokens.");
+
+            float[] Run(bool batched)
+            {
+                CudaHybridForwardPass.BatchedPrefillEnabled = batched;
+                using var fwd = TryConstruct(model, gpu, hp, placement);
+                if (fwd is null) return Array.Empty<float>();
+                var logits = fwd.Prefill(tokens).ToArray();
+                if (batched)
+                    Assert.True(fwd.LastPrefillWasBatched,
+                        "Batched arm fell back to the per-token path — the parity check would be vacuous. " +
+                        "The CPU-resident-embedding gate (#218) must not block the batched path. " +
+                        $"GpuLayers={placement.GpuLayers} CpuLayers={placement.CpuLayers}.");
+                return logits;
+            }
+
+            float[] seq = Run(false);
+            float[] bat = Run(true);
+            if (seq.Length == 0 || bat.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(seq.Length, bat.Length);
+            int firstDiff = FirstBitDiff(seq, bat);
+            Assert.True(firstDiff < 0,
+                $"CPU-embed batched-trunk prefill diverges from sequential at index {firstDiff} " +
+                $"(seq={(firstDiff >= 0 ? seq[firstDiff] : 0)} bat={(firstDiff >= 0 ? bat[firstDiff] : 0)}). " +
+                "The batched CPU-embed staging upload must be bit-identical to the per-token CpuEmbedToken loop.");
+            Assert.Equal(Sampler.Greedy(seq), Sampler.Greedy(bat));
+            _out.WriteLine($"OK cpu-embed single-chunk N={tokens.Count} greedy={Sampler.Greedy(seq)}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = prevForce;
+        }
+    }
+
+    /// <summary>
+    /// Issue #218 multi-chunk: prefill in two segments (<c>[0,k)</c> then <c>[k,N)</c> with
+    /// <c>startPos=k</c>) on the forced CPU-resident-embedding config. Exercises the batched
+    /// CPU-embed upload across <c>startPos &gt; 0</c>, the exact-size pinned-embed buffer reuse
+    /// between two chunks of different length, and cross-chunk KV continuity. Final-token logits
+    /// must be bit-identical to the sequential per-token Forward loop under the same config.
+    /// </summary>
+    [Fact]
+    public void BatchedPrefill_CpuEmbedding_MultiChunk_BitwiseMatchesSequential_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevForce = CudaHybridForwardPass.ForceCpuResidentEmbedding;
+        try
+        {
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = true;
+
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var placement = PlanCoder(model, hp, gpu, ctx);
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts! " +
+                "The five boxing wizards jump quickly. Sphinx of black quartz, judge my vow.");
+            int N = tokens.Count;
+            Assert.True(N >= 12, $"Prompt tokenized to only {N} tokens.");
+            int k1 = N / 3;
+
+            float[] RunTwoChunks(bool batched)
+            {
+                CudaHybridForwardPass.BatchedPrefillEnabled = batched;
+                using var fwd = TryConstruct(model, gpu, hp, placement);
+                if (fwd is null) return Array.Empty<float>();
+                fwd.Prefill(tokens.Take(k1).ToList(), 0);
+                var logits = fwd.Prefill(tokens.Skip(k1).ToList(), k1).ToArray();
+                if (batched)
+                    Assert.True(fwd.LastPrefillWasBatched,
+                        "Batched arm fell back to the per-token path — the parity check would be vacuous. " +
+                        $"GpuLayers={placement.GpuLayers} CpuLayers={placement.CpuLayers}.");
+                return logits;
+            }
+
+            float[] seq = RunTwoChunks(false);
+            float[] bat = RunTwoChunks(true);
+            if (seq.Length == 0 || bat.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(seq.Length, bat.Length);
+            int firstDiff = FirstBitDiff(seq, bat);
+            Assert.True(firstDiff < 0,
+                $"Multi-chunk CPU-embed batched prefill diverges from sequential at index {firstDiff} " +
+                $"(N={N}, split at {k1}). Cross-chunk KV continuity, the startPos>0 path, or the " +
+                "exact-size pinned-embed buffer reuse is not bit-identical to the sequential loop.");
+            Assert.Equal(Sampler.Greedy(seq), Sampler.Greedy(bat));
+            _out.WriteLine($"OK cpu-embed multi-chunk N={N} split={k1} greedy={Sampler.Greedy(seq)}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = prevForce;
+        }
+    }
+
+    /// <summary>
+    /// Issue #218 with CPU layers &gt; 0. On a 12 GB card the current planner gives Coder-30B
+    /// 48 GPU / 0 CPU layers (CPU-MoE handles the routed experts), so the natural-placement
+    /// oracles above exercise the all-GPU-layer branch. This test SYNTHESIZES a half/half split
+    /// (overriding <see cref="LayerPlacement.GpuLayers"/>/<c>CpuLayers</c>) so the batched
+    /// CPU-embed staging (step 1) and the per-token CPU-layer download loop (step 3) run
+    /// together — the combination the planner won't produce on this box. The synthetic split
+    /// only uses LESS GPU VRAM than the full plan, so it cannot OOM where the others construct.
+    /// Final-token logits must be bit-identical to the sequential per-token Forward loop.
+    /// </summary>
+    [Fact]
+    public void BatchedPrefill_CpuEmbedding_CpuLayersSplit_BitwiseMatchesSequential_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevForce = CudaHybridForwardPass.ForceCpuResidentEmbedding;
+        try
+        {
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = true;
+
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var planned = PlanCoder(model, hp, gpu, ctx);
+            // Force a cross-tier split so CpuLayers > 0 (the planner gives 48/0 here via CPU-MoE).
+            int gpuLayers = hp.NumLayers / 2;
+            var split = planned with { GpuLayers = gpuLayers, CpuLayers = hp.NumLayers - gpuLayers };
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts!");
+            Assert.True(tokens.Count >= 8, $"Prompt tokenized to only {tokens.Count} tokens.");
+
+            float[] Run(bool batched)
+            {
+                CudaHybridForwardPass.BatchedPrefillEnabled = batched;
+                using var fwd = TryConstruct(model, gpu, hp, split);
+                if (fwd is null) return Array.Empty<float>();
+                var logits = fwd.Prefill(tokens).ToArray();
+                if (batched)
+                    Assert.True(fwd.LastPrefillWasBatched,
+                        "Batched arm fell back to the per-token path — the parity check would be vacuous. " +
+                        $"GpuLayers={split.GpuLayers} CpuLayers={split.CpuLayers}.");
+                return logits;
+            }
+
+            float[] seq = Run(false);
+            float[] bat = Run(true);
+            if (seq.Length == 0 || bat.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(seq.Length, bat.Length);
+            int firstDiff = FirstBitDiff(seq, bat);
+            Assert.True(firstDiff < 0,
+                $"CPU-embed + CpuLayers>0 batched prefill diverges from sequential at index {firstDiff} " +
+                $"(GpuLayers={split.GpuLayers} CpuLayers={split.CpuLayers}). The batched CPU-embed staging " +
+                "and the per-token CPU-layer download loop must together be bit-identical to the sequential loop.");
+            Assert.Equal(Sampler.Greedy(seq), Sampler.Greedy(bat));
+            _out.WriteLine($"OK cpu-embed CpuLayers>0 N={tokens.Count} split={split.GpuLayers}/{split.CpuLayers} greedy={Sampler.Greedy(seq)}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.ForceCpuResidentEmbedding = prevForce;
+        }
+    }
+
     // Construction is the ONLY place allowed to skip (a box without the VRAM to host this
     // 30 GB MoE model under the planned split). A failure INSIDE Prefill must propagate
     // and fail the test — that is exactly the regression these oracles exist to catch.


### PR DESCRIPTION
## Summary

Closes #218. The #123 batched-trunk prefill in `CudaHybridForwardPass` was gated out when the embedding table is CPU-resident (`_gpuEmbedding is null`) — **exactly the low-VRAM / 12 GB-default config** the tier planner produces. Those models fell back to the per-token `Forward` loop and paid the pinned map/copy/unmap + `EndRecordAndSubmit` launch cascade **per prompt token**, while a 16 GB+ card got the batched path for free.

The gate existed to avoid a write-after-read hazard: a naive batched embed loop reusing the shared `_pinnedHidden` buffer would race each token's CPU write against the prior token's still-in-flight async H2D read.

## Fix

When the embedding is CPU-resident, dequantize **all N rows** on the CPU (same `CpuEmbedToken` per-row dequant → byte-identical to the per-token path) into a **dedicated** pinned block `_pinnedEmbedAll` `[N × embDim]`, then upload the whole block in **one** async H2D (`CopyDevice`, UVA pinned→device) into the batched trunk's stream. All CPU writes complete before the single copy is enqueued, so the WAR hazard is removed by construction — no per-token drains.

- Dropped `_gpuEmbedding is not null` from `IsBatchedPrefillSupported`; every other gate (Gemma4-like, TurboQuant, non-NEOX RoPE, L2 QK-norm, attn-bias, non-batchable trunk dtypes) is unchanged.
- The `_faulted` latch + bit-exactness contract hold.
- Test/bench hook `ForceCpuResidentEmbedding` (env `SHARPI_FORCE_CPU_EMBED=1`) forces the CPU-resident config even where the embedding would fit in VRAM.

## Perf

Qwen3-Coder-30B-A3B Q4_K_M, RTX 4070 Ti 12 GB, 48 GPU / CPU-MoE, N=512 prefill:

| Config | tok/s |
|---|---|
| CPU-embed, batched-OFF (pre-#218 fallback) | 18.5 |
| **CPU-embed, batched-ON (#218)** | **25.1** (1.35×) |
| GPU-embed, batched-ON (what 16 GB+ got free) | 24.9 |

#218 lands the 12 GB config at **101% of the GPU-embed batched throughput** — i.e. it now matches what 16 GB+ got for free. The 1.35× ceiling here is the per-token CPU-MoE (identical in both arms); #218 collapses the embed + attention-launch cascade onto the GPU-embed curve.

## Tests (`Tests.ForwardPass` / `CudaHybridBatchedPrefillTests`)

New bit-parity oracles, all bit-identical to the sequential `Forward` loop:
- `BatchedPrefill_CpuEmbedding_BitwiseMatchesSequential_Coder` — single-chunk
- `BatchedPrefill_CpuEmbedding_MultiChunk_BitwiseMatchesSequential_Coder` — `startPos>0` + pinned-buffer reuse
- `BatchedPrefill_CpuEmbedding_CpuLayersSplit_BitwiseMatchesSequential_Coder` — synthesized `CpuLayers>0` split (the planner gives 48/0 here, so this deterministically exercises the CPU-embed staging + per-token CPU-layer loop together)
- `BatchedPrefill_GpuEmbedding_CpuLayersSplit_BitwiseMatchesSequential_Coder` — closes a pre-existing #123 gap: GPU-embed + `CpuLayers>0` had no committed guard on this box

Also fixed stale `~29 GPU + 19 CPU` split comments (the planner gives 48/0 via CPU-MoE). Existing GPU-embed oracles unchanged; full class 9/9 green. Solution builds clean under TreatWarningsAsErrors (Debug + Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)