### PR TITLE
perf(cuda): SWA-scoped KV-VRAM reserve — Gemma 4 q8 auto-context 30K→123K (#228)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -574,6 +574,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             // below never fires for an fp32-sized auto-context, since fp32 fits there by
             // construction).
             _maxSeqLen = EstimateMaxContext(model, gpu, hp, ResolveConfiguredKvDType());
+        // Invariant (#228): the resolved context never exceeds the model's own maximum, whether
+        // it came from an explicit -c or a VRAM-fit estimator. Each branch above already clamps
+        // to hp.ContextLength; this is the single chokepoint that guarantees it so no future
+        // path (or estimator change) can over-shoot the model max.
+        _maxSeqLen = Math.Min(_maxSeqLen, hp.ContextLength);
         // The KV-append/attention kernels index the cache at `pos % _maxSeqLen` (the ring
         // modulo, identity for full caches), so a zero context — e.g. a malformed GGUF with
         // context_length=0 reached via an explicit ctx-size — would be an in-kernel
@@ -3974,18 +3979,45 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             + hp.NumKvHeads * headDim * 2 + hp.NumHeads * headDim
             + hp.IntermediateDim * 2 + hp.VocabSize) * sizeof(float);
 
-        // Reserve at least 2 GiB (or a third of total) for the driver, the cuBLAS
-        // workspace, the Q8_1 quantization scratch, the pinned host buffer, the GPU
-        // buffer pool's per-bucket reuse list, and CUDA's framebuffer-and-context
-        // overhead. The previous max(vram/5, 1 GiB) left only ~24 MiB free on a
-        // 12 GiB card running Qwen3-8B; the driver then mapped late weight
-        // allocations (notably the 600 MiB lm-head) into system memory, where the
-        // matvec ran at ~22 GB/s over PCIe instead of ~400 GB/s in HBM and prefill
-        // collapsed from ~65 t/s to ~4 t/s.
-        long reserved = Math.Max(vramBytes / 3, 2L * 1024 * 1024 * 1024);
+        long reserved = KvVramReserveBytes(hp, vramBytes);
         long available = vramBytes - weightBytes - scratchBytes - reserved;
         if (available <= 0) available = 64L * 1024 * 1024;
         return available;
+    }
+
+    /// <summary>
+    /// VRAM held back from the KV budget for everything that isn't weights/scratch/KV: the CUDA
+    /// context/framebuffer, the cuBLAS workspace, the Q8_1 quantization scratch, the pinned host
+    /// buffer, the GPU buffer-pool reuse lists, and the transient prefill working set. Pure
+    /// (no GPU/GGUF) so it's unit-testable (cf. <see cref="ResolveKvDType"/>).
+    /// <para><b>Uniform / dense models</b> keep the proven <c>max(VRAM/3, 2 GiB)</c> reserve.
+    /// Their KV grows linearly to fill whatever budget is left, so the reserve is the only thing
+    /// bounding the cache size — and an earlier <c>max(VRAM/5, 1 GiB)</c> once left ~24 MiB free
+    /// on a 12 GiB card running Qwen3-8B, spilling the ~600 MiB lm-head to system RAM over PCIe
+    /// and collapsing prefill ~65→4 t/s (#185). This path is unchanged.</para>
+    /// <para><b>SWA / per-layer (Gemma 4) models</b> use a smaller, bounded reserve — a fixed
+    /// system allowance (NOT a fraction of total VRAM) plus one <see cref="PrefillBatchChunk"/>'s
+    /// activation working set. This is safe precisely because SWA KV <i>saturates</i>: past the
+    /// sliding-window ring only the few global layers grow, so the cache asymptotes to
+    /// <c>KV(modelMax)</c> and a larger budget cannot grow it to consume the headroom (the dense
+    /// failure mode). The old <c>VRAM/3</c> reserve over-reserved ~2.5 GB on a 12 GiB card and
+    /// pinned Gemma 4 12B q8_0 auto-context to ~30 K when the full 256 K fits (#228 / #220).</para>
+    /// </summary>
+    internal static long KvVramReserveBytes(ModelHyperparams hp, long vramBytes)
+    {
+        if (hp.IsSwaLayer is null)
+            return Math.Max(vramBytes / 3, 2L * 1024 * 1024 * 1024);
+
+        // Transient activations for one batched-prefill chunk (norm/qkv/attn/FFN buffers),
+        // sized to the model width — the only reserve term that scales with the model rather
+        // than the GPU. Generous (overlapping buffers) so the budget can't starve a real prefill.
+        long prefillWorkingSet = (long)PrefillBatchChunk *
+            (hp.EmbeddingDim * 4L + hp.IntermediateDim * 2L
+             + (long)hp.NumHeads * hp.HeadDim + 2L * hp.NumKvHeads * hp.HeadDim) * sizeof(float);
+        // Fixed system allowance (CUDA context/framebuffer + cuBLAS workspace + pinned + pool),
+        // floored at 2 GiB and rising to VRAM/6 on larger cards where those costs grow.
+        long systemReserve = Math.Max(2L * 1024 * 1024 * 1024, vramBytes / 6);
+        return systemReserve + prefillWorkingSet;
     }
 
     /// <summary>

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -4030,12 +4030,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         int maxHeadDim = hp.HeadDim;
         foreach (int hd in lhd) if (hd > maxHeadDim) maxHeadDim = hd;
         long perTokenFloats =
-            hp.EmbeddingDim * 4L                          // hidden + residual + norm + PleY
+            hp.EmbeddingDim * 3L                          // hidden + residual + norm
             + 2L * hp.NumHeads * maxHeadDim               // Q + AttnOut
             + 2L * hp.NumKvHeads * maxHeadDim             // K + V
             + hp.IntermediateDim * 2L;                    // FFN gate + up
-        if (hp.HasPerLayerTokenEmbd)
-            perTokenFloats += 2L * hp.NumLayers * hp.PerLayerEmbeddingWidth + hp.PerLayerEmbeddingWidth;
+        if (hp.HasPerLayerTokenEmbd)                      // PLE: proj/row stacks + gate + PleY
+            perTokenFloats += 2L * hp.NumLayers * hp.PerLayerEmbeddingWidth
+                            + hp.PerLayerEmbeddingWidth + hp.EmbeddingDim;
         long prefillWorkingSet = (long)PrefillBatchChunk * perTokenFloats * sizeof(float);
 
         // Fixed system allowance (CUDA context/framebuffer + cuBLAS workspace + pinned + pool),

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -4005,19 +4005,44 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// </summary>
     internal static long KvVramReserveBytes(ModelHyperparams hp, long vramBytes)
     {
-        if (hp.IsSwaLayer is null)
-            return Math.Max(vramBytes / 3, 2L * 1024 * 1024 * 1024);
+        long dense = Math.Max(vramBytes / 3, 2L * 1024 * 1024 * 1024);
 
-        // Transient activations for one batched-prefill chunk (norm/qkv/attn/FFN buffers),
-        // sized to the model width — the only reserve term that scales with the model rather
-        // than the GPU. Generous (overlapping buffers) so the budget can't starve a real prefill.
-        long prefillWorkingSet = (long)PrefillBatchChunk *
-            (hp.EmbeddingDim * 4L + hp.IntermediateDim * 2L
-             + (long)hp.NumHeads * hp.HeadDim + 2L * hp.NumKvHeads * hp.HeadDim) * sizeof(float);
+        // The smaller SWA reserve is sound ONLY where the KV cache actually saturates: a model
+        // with per-layer head_dim AND at least one real sliding-window layer (the exact regime
+        // SolveMaxCtxForKv prices with SwaRingSize). A model lacking either — no per-layer dims,
+        // or a Gemma-arch GGUF with an all-false SWA pattern — has linearly-growing KV like a
+        // dense model and MUST keep the dense reserve, or the smaller reserve would let KV grow
+        // into the spill cliff. (Guard kept in lockstep with SolveMaxCtxForKv's branch.)
+        if (hp.LayerHeadDim is not { } lhd || hp.IsSwaLayer is not { } swa)
+            return dense;
+        bool hasSwaLayer = false;
+        foreach (bool s in swa) if (s) { hasSwaLayer = true; break; }
+        if (!hasSwaLayer)
+            return dense;
+
+        // Faithful upper bound on one PrefillBatchChunk's transient activation buffers
+        // (EnsureBatchedTrunkScratch): hidden/residual/norm/PleY at embDim; Q + AttnOut at
+        // numHeads*maxHeadDim; K + V at numKvHeads*maxHeadDim; 2 FFN buffers at intermDim; and —
+        // for Gemma's per-layer token embedding — the stacked PLE proj/row buffers at
+        // NumLayers*pleWidth. These allocate lazily at the first long prefill and coexist with the
+        // (now larger) construction-time KV cache, so the reserve must hold room for them. Buffers
+        // use the WIDEST per-layer head_dim (global 512 on Gemma 4 12B), not the per-layer min.
+        int maxHeadDim = hp.HeadDim;
+        foreach (int hd in lhd) if (hd > maxHeadDim) maxHeadDim = hd;
+        long perTokenFloats =
+            hp.EmbeddingDim * 4L                          // hidden + residual + norm + PleY
+            + 2L * hp.NumHeads * maxHeadDim               // Q + AttnOut
+            + 2L * hp.NumKvHeads * maxHeadDim             // K + V
+            + hp.IntermediateDim * 2L;                    // FFN gate + up
+        if (hp.HasPerLayerTokenEmbd)
+            perTokenFloats += 2L * hp.NumLayers * hp.PerLayerEmbeddingWidth + hp.PerLayerEmbeddingWidth;
+        long prefillWorkingSet = (long)PrefillBatchChunk * perTokenFloats * sizeof(float);
+
         // Fixed system allowance (CUDA context/framebuffer + cuBLAS workspace + pinned + pool),
-        // floored at 2 GiB and rising to VRAM/6 on larger cards where those costs grow.
+        // floored at 2 GiB and rising to VRAM/6 on larger cards where those costs grow. Always
+        // ≤ the dense VRAM/3 reserve, so an SWA model can never reserve MORE than dense would.
         long systemReserve = Math.Max(2L * 1024 * 1024 * 1024, vramBytes / 6);
-        return systemReserve + prefillWorkingSet;
+        return Math.Min(dense, systemReserve + prefillWorkingSet);
     }
 
     /// <summary>

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -1009,6 +1009,71 @@ public sealed class CudaForwardPassKvDtypeTests
             $"ctx {got + 1} also fits — not the largest fitting context for the mixed-headdim shape.");
     }
 
+    // ── Issue #228: KvVramReserveBytes — bounded reserve for SWA, unchanged for dense ──
+    // The reserve held back from the KV budget. Dense models keep the proven
+    // max(VRAM/3, 2GB) (guards the #185 spill cliff — their KV fills any budget). SWA/Gemma
+    // models use a bounded system allowance + prefill working set, safe because SWA KV
+    // saturates past the ring (a bigger budget can't grow KV to eat the headroom).
+
+    /// <summary>Dense (no IsSwaLayer) keeps the exact max(VRAM/3, 2 GiB) reserve — unchanged.</summary>
+    [Fact]
+    public void KvVramReserveBytes_DenseModel_KeepsMaxVramThirdOr2GiB()
+    {
+        var hp = FlatHp(numLayers: 32, numKvHeads: 8, headDim: 128);   // IsSwaLayer == null
+        const long GiB = 1024L * 1024 * 1024;
+        // 12 GiB → VRAM/3 (4 GiB) wins the max.
+        Assert.Equal(4 * GiB, CudaForwardPass.KvVramReserveBytes(hp, 12 * GiB));
+        // 3 GiB → the 2 GiB floor wins.
+        Assert.Equal(2 * GiB, CudaForwardPass.KvVramReserveBytes(hp, 3 * GiB));
+        // 48 GiB → VRAM/3 (16 GiB) — the dense reserve scales with total VRAM (the #228 complaint,
+        // intentionally preserved for dense where KV grows linearly to fill the budget).
+        Assert.Equal(16 * GiB, CudaForwardPass.KvVramReserveBytes(hp, 48 * GiB));
+    }
+
+    /// <summary>
+    /// SWA/Gemma reserve is bounded BELOW the dense reserve at the same VRAM (the #228 win):
+    /// a fixed system allowance (≥ 2 GiB floor) plus a positive prefill working set, never the
+    /// VRAM/3 fraction. On a 12 GiB card it's well under the dense 4 GiB.
+    /// </summary>
+    [Fact]
+    public void KvVramReserveBytes_SwaModel_BoundedBelowDense()
+    {
+        const long GiB = 1024L * 1024 * 1024;
+        var swa = Gemma4ShapedHp(
+            layerHeadDim: [256, 256, 256],
+            layerKvHeads: [8, 8, 8],
+            isSwa: [false, true, false],
+            kvSource: [-1, -1, 0],
+            slidingWindow: 1024);
+        var dense = FlatHp(numLayers: 3, numKvHeads: 8, headDim: 256);
+
+        long swaReserve = CudaForwardPass.KvVramReserveBytes(swa, 12 * GiB);
+        long denseReserve = CudaForwardPass.KvVramReserveBytes(dense, 12 * GiB);
+
+        Assert.True(swaReserve > 2 * GiB, "SWA reserve must add a prefill working set on top of the 2 GiB floor.");
+        Assert.True(swaReserve < denseReserve,
+            $"SWA reserve ({swaReserve}) must be below the dense VRAM/3 reserve ({denseReserve}) — the #228 win.");
+        Assert.True(swaReserve < 4 * GiB, $"SWA reserve ({swaReserve}) should be well under the dense 4 GiB at 12 GiB VRAM.");
+    }
+
+    /// <summary>
+    /// The SWA reserve's working-set term scales with MODEL width (not just VRAM): a wider model
+    /// (larger intermediate dim) reserves more. Distinguishes it from a pure VRAM fraction.
+    /// </summary>
+    [Fact]
+    public void KvVramReserveBytes_SwaModel_ScalesWithModelWidth()
+    {
+        const long GiB = 1024L * 1024 * 1024;
+        var narrow = Gemma4ShapedHp([256, 256], [8, 8], [false, true], [-1, -1], 1024);
+        var wide = narrow with { IntermediateDim = narrow.IntermediateDim * 4 };
+
+        long narrowReserve = CudaForwardPass.KvVramReserveBytes(narrow, 12 * GiB);
+        long wideReserve = CudaForwardPass.KvVramReserveBytes(wide, 12 * GiB);
+        Assert.True(wideReserve > narrowReserve,
+            $"wider model (4× intermediate dim) should reserve more for its prefill working set " +
+            $"(narrow={narrowReserve} wide={wideReserve}).");
+    }
+
     /// <summary>
     /// Q8KvGeometrySupported returns false when ANY single (non-aliased) layer violates the
     /// %32 rule — not just when all do. A mixed set with one bad layer must fail, matching

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -1075,6 +1075,56 @@ public sealed class CudaForwardPassKvDtypeTests
     }
 
     /// <summary>
+    /// The system-allowance term is max(2 GiB, VRAM/6): the 2 GiB floor wins at ≤ 12 GiB, but
+    /// VRAM/6 takes over on larger cards. The working set is VRAM-independent, so the SWA reserve
+    /// delta between a 48 GiB and a 12 GiB card is exactly the VRAM/6 delta (8 − 2 = 6 GiB) —
+    /// pinning the only VRAM-scaling term (untested when every case uses 12 GiB → /6 == floor).
+    /// </summary>
+    [Fact]
+    public void KvVramReserveBytes_SwaModel_SystemReserveScalesOnLargeCard()
+    {
+        const long GiB = 1024L * 1024 * 1024;
+        var swa = Gemma4ShapedHp([256, 256, 256], [8, 8, 8], [false, true, false], [-1, -1, 0], 1024);
+        long at12 = CudaForwardPass.KvVramReserveBytes(swa, 12 * GiB);
+        long at48 = CudaForwardPass.KvVramReserveBytes(swa, 48 * GiB);
+        // Both below their respective dense caps (workset is tiny here), so neither clamps.
+        Assert.Equal(6 * GiB, at48 - at12);   // (48/6 − 12/6) GiB — the VRAM/6 term, isolated
+    }
+
+    /// <summary>
+    /// The prefill working set must count the buffers EnsureBatchedTrunkScratch actually
+    /// allocates: at the WIDEST per-layer head_dim (Gemma 4 12B's global 512, not the per-layer
+    /// min), and — for a per-layer-token-embedding (PLE) model — the stacked PLE proj/row buffers
+    /// (NumLayers × pleWidth). Dropping either (the original formula did both) under-reserves and
+    /// risks a prefill-time OOM (#231 review). Exact-value pin so a silently-dropped term fails.
+    /// </summary>
+    [Fact]
+    public void KvVramReserveBytes_SwaModel_CountsPleAndWidestHeadDim()
+    {
+        const long GiB = 1024L * 1024 * 1024;
+        // Mixed head_dim (256 SWA / 512 global) + PLE. NumHeads/NumKvHeads = 8 (Gemma4ShapedHp).
+        var hp = Gemma4ShapedHp([256, 512], [8, 8], [false, true], [-1, -1], 1024)
+            with { HasPerLayerTokenEmbd = true, PerLayerEmbeddingWidth = 256 };
+
+        const int chunk = 4096;          // PrefillBatchChunk
+        const int maxHeadDim = 512;      // widest per-layer head_dim
+        long perToken =
+            hp.EmbeddingDim * 4L                          // hidden+residual+norm+PleY
+            + 2L * hp.NumHeads * maxHeadDim               // Q + AttnOut (at maxHeadDim, not 256)
+            + 2L * hp.NumKvHeads * maxHeadDim             // K + V
+            + hp.IntermediateDim * 2L                     // FFN gate + up
+            + 2L * hp.NumLayers * hp.PerLayerEmbeddingWidth + hp.PerLayerEmbeddingWidth; // PLE stack
+        long expected = 2 * GiB + chunk * perToken * sizeof(float);   // systemReserve(2 GiB floor) + workset
+
+        Assert.Equal(expected, CudaForwardPass.KvVramReserveBytes(hp, 12 * GiB));
+
+        // And the PLE term is genuinely load-bearing: the same shape without PLE reserves strictly less.
+        var noPle = hp with { HasPerLayerTokenEmbd = false };
+        Assert.True(CudaForwardPass.KvVramReserveBytes(noPle, 12 * GiB) < expected,
+            "dropping the PLE table must lower the reserve — the PLE stack is part of the prefill working set.");
+    }
+
+    /// <summary>
     /// Q8KvGeometrySupported returns false when ANY single (non-aliased) layer violates the
     /// %32 rule — not just when all do. A mixed set with one bad layer must fail, matching
     /// the ctor's per-layer throw (else auto-narrow would pick q8_0 and then crash).


### PR DESCRIPTION
## Summary

Fixes #228. `CudaForwardPass.EstimateAvailableKvVram` reserved `max(VRAM/3, 2GB)` = **4 GiB** on a 12 GB card — the dominant term shrinking the KV budget and pinning Gemma 4 12B q8_0 auto-context to **~30K** when far more fits (the full 256K runs via `-c`).

The reserve is **load-bearing for dense models**: their KV grows linearly to fill any budget, and an earlier smaller reserve once left ~24 MiB free running Qwen3-8B, spilling the lm-head to system RAM over PCIe and collapsing prefill 65→4 t/s (#185). So it can't be cut globally.

## Fix

Factor the reserve into the pure, testable `CudaForwardPass.KvVramReserveBytes(hp, vram)` and **scope a smaller bounded reserve to SWA/per-layer (Gemma 4) models only**: a fixed system allowance (`max(2 GiB, VRAM/6)`, not `VRAM/3`) plus one `PrefillBatchChunk`'s activation working set. This is safe precisely because **SWA KV saturates** past the sliding-window ring (only the few global layers grow), so a larger budget can't grow KV to consume the headroom — the dense failure mode. Dense models keep `max(VRAM/3, 2GB)` **byte-for-byte unchanged**.

Also enforce the model-max ceiling at the single `_maxSeqLen` chokepoint (`Math.Min(_maxSeqLen, hp.ContextLength)`) so neither an explicit `-c` nor a calculated context can ever exceed the model's own max, regardless of estimator.

## Result (4070 Ti 12 GB, `gemma-4-12b-it-qat-q4_0`, `-g -1 --kv-type q8_0`)

| | master | branch |
|---|---|---|
| Gemma q8 auto-ctx | 30,840 | **123,361 (4×)** |
| Gemma real 5052-token prefill | — | **1312 t/s, no OOM/spill** (1290 MiB free held) |
| Qwen3-8B (dense) | 12080 bf16, 3474 MiB free | **identical** (byte-for-byte reserve) |
| explicit `-c 999999999` | — | **clamps to 262144** |

## Tests

3 GGUF-free `KvVramReserveBytes` unit tests: dense keeps `max(VRAM/3, 2GB)`; SWA bounded below dense; SWA scales with model width. 42/42 `CudaForwardPassKvDtypeTests` green (excl. the slow >4096 chunked, validated via the CLI 5K-token prefill above). Release build clean under TreatWarningsAsErrors + AOT analyzers.

## Safety A/B (the load-bearing check)

Qwen3-8B (the #185 cliff model) is **byte-identical** — dense reserve unchanged → no spill risk by construction. Gemma's real long-context prefill (5052 tokens, crossing the chunk + SWA-ring boundary) runs at 1312 t/s with no OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)