### PR TITLE
perf(cuda): honor --kv-type on CudaHybridForwardPass (layer-split MoE hybrid) (#230)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -4091,10 +4091,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// row, so a layer with kvDim % 32 != 0 cannot use q8_0 (the ctor would throw). The
     /// auto-narrow heuristic checks this before falling to q8_0 (#185).
     /// </summary>
-    internal static bool Q8KvGeometrySupported(ModelHyperparams hp)
+    /// <paramref name="gpuLayers"/> (default -1 = all layers) scopes the check to the first N
+    /// GPU-resident layers — used by CudaHybridForwardPass, where only those layers carry the
+    /// narrowed cache (CPU-offloaded layers always use fp32, so their geometry is irrelevant and
+    /// must not falsely reject q8). gpuLayers == 0 returns true (nothing narrowed).
+    internal static bool Q8KvGeometrySupported(ModelHyperparams hp, int gpuLayers = -1)
     {
         bool perLayerKv = hp.LayerHeadDim is not null;
-        for (int i = 0; i < hp.NumLayers; i++)
+        int layerCount = gpuLayers < 0 ? hp.NumLayers : Math.Min(gpuLayers, hp.NumLayers);
+        for (int i = 0; i < layerCount; i++)
         {
             if (hp.KvSourceLayer is { } ksl && ksl[i] >= 0) continue;
             int layerHd = perLayerKv ? hp.LayerHeadDim![i] : hp.HeadDim;

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -321,10 +321,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 $"SHARPI_KV_DTYPE={requestedKv} + TurboQuant is not supported (TQ owns the KV quantization). " +
                 "Use one or the other.");
         _kvDType = _tqEnabled ? DType.Float32 : requestedKv;
-        if (_kvDType == DType.Q8_0 && !CudaForwardPass.Q8KvGeometrySupported(hp))
+        // Only the GPU-resident layers carry the narrowed cache (CPU-offloaded layers keep fp32),
+        // so scope the q8 geometry check to them — checking all layers would falsely reject q8
+        // when only a CPU-tail layer is incompatible (and trivially passes when _nGpuLayers == 0).
+        if (_kvDType == DType.Q8_0 && !CudaForwardPass.Q8KvGeometrySupported(hp, _nGpuLayers))
             throw new NotSupportedException(
-                "SHARPI_KV_DTYPE=q8_0 requires every layer's kvDim (kvHeads × headDim) to be a multiple " +
-                "of 32 (the q8_0 block size); this model's geometry is incompatible. Use bf16 or fp32.");
+                "SHARPI_KV_DTYPE=q8_0 requires every GPU-resident layer's kvDim (kvHeads × headDim) to be a " +
+                "multiple of 32 (the q8_0 block size); this model's geometry is incompatible. Use bf16 or fp32.");
 
         _tqFp32Window = enableTq ? Math.Min(tqFp32Window, _maxSeqLen) : 0;
         _tqBlockBytes = enableTq ? TurboQuantOps.BlockSize(tqBits, _headDim) : 0;

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -189,6 +189,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // config is gated out (e.g. non-batchable dtype on a given box).
     internal bool LastPrefillWasBatched;
 
+    // Test observable (issue #230): the resolved GPU KV-cache dtype. Lets the parity oracle
+    // confirm --kv-type actually applied (the cache is genuinely narrowed) instead of passing
+    // vacuously if the env plumbing regressed and KV silently stayed fp32 (fp32-vs-fp32 is
+    // trivially argmax-stable).
+    internal DType KvCacheDType => _kvDType;
+
     // Issue #218 test/bench hook: force the low-VRAM "fixed weights on CPU" config
     // (embedding + output table CPU-resident, _gpuEmbedding/_gpuOutputWeight null) even on a
     // box where ShouldKeepFixedWeightsOnCpu would keep them on the GPU. Lets the batched-CPU-

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -85,6 +85,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     private readonly float[]? _gpuRouterBuf;
     private readonly bool _hasAttnBias, _hasQkNorm, _isMoE, _hasSharedExpert;
     private readonly bool _tqEnabled;
+    // GPU-resident KV-cache element dtype (#179/#230): fp32 (default), bf16 (½), or q8_0 (¼),
+    // resolved from SHARPI_KV_DTYPE. Applies to the GPU-trunk layers only — CPU-offloaded layers
+    // keep their own fp32 SimdKernels KV. Forced fp32 under TurboQuant (TQ owns its quantized ring).
+    private readonly DType _kvDType;
     private readonly int _tqFp32Window;
     private readonly int _tqBlockBytes;
     private int _gpuTqCompressedLen;
@@ -297,6 +301,25 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         _tqEnabled = enableTq;
         if (_tqEnabled && _headDim is not 128 and not 256)
             throw new NotSupportedException($"TurboQuant currently supports head dimensions 128 and 256; model head dim is {_headDim}.");
+
+        // KV-cache dtype (#230): honor SHARPI_KV_DTYPE on this layer-split hybrid path — it was
+        // silently ignored (KV always fp32), so --kv-type q8_0 was a no-op even though TierPlanner
+        // already prices the KV budget at the narrowed dtype (RunCommand passes ResolveConfiguredKvDType
+        // to TierPlanner.Plan). That left a plan/runtime mismatch: the planner reserved a smaller KV
+        // and a larger expert-cache budget while the runtime allocated the full fp32 cache. Narrowing
+        // applies to the GPU-trunk KV only; CPU layers keep their fp32 store. Reuses the dense path's
+        // narrowed append/attention kernels (#179) via the *Kv dispatch helpers below.
+        DType requestedKv = CudaForwardPass.ResolveConfiguredKvDType();
+        if (_tqEnabled && requestedKv != DType.Float32)
+            throw new NotSupportedException(
+                $"SHARPI_KV_DTYPE={requestedKv} + TurboQuant is not supported (TQ owns the KV quantization). " +
+                "Use one or the other.");
+        _kvDType = _tqEnabled ? DType.Float32 : requestedKv;
+        if (_kvDType == DType.Q8_0 && !CudaForwardPass.Q8KvGeometrySupported(hp))
+            throw new NotSupportedException(
+                "SHARPI_KV_DTYPE=q8_0 requires every layer's kvDim (kvHeads × headDim) to be a multiple " +
+                "of 32 (the q8_0 block size); this model's geometry is incompatible. Use bf16 or fp32.");
+
         _tqFp32Window = enableTq ? Math.Min(tqFp32Window, _maxSeqLen) : 0;
         _tqBlockBytes = enableTq ? TurboQuantOps.BlockSize(tqBits, _headDim) : 0;
         _gpuRouterBuf = _isMoE && _nGpuLayers > 0 ? new float[hp.NumExperts] : null;
@@ -334,7 +357,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             _cpuMoe = false;
         }
 
-        Console.Error.WriteLine($"[HybridForwardPass] {placement.Summary()}{(enableTq ? $" [TQ{tqBits}]" : "")}");
+        string kvTag = _kvDType switch { DType.BFloat16 => " [KV bf16]", DType.Q8_0 => " [KV q8_0]", _ => "" };
+        Console.Error.WriteLine($"[HybridForwardPass] {placement.Summary()}{(enableTq ? $" [TQ{tqBits}]" : "")}{kvTag}");
 
         bool vramTrace = Environment.GetEnvironmentVariable("SHARPI_TRACE_VRAM") == "1";
         void TraceVram(string label)
@@ -546,8 +570,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 int layerCtx = (_isGemma4Like && hp.IsSwaLayer is { } swa && swa[i] && hp.SlidingWindowSize > 0)
                     ? Math.Min(_maxSeqLen, hp.SlidingWindowSize)
                     : _maxSeqLen;
-                _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)layerCtx * layerKvDim));
-                _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)layerCtx * layerKvDim));
+                _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)layerCtx * layerKvDim), _kvDType);
+                _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)layerCtx * layerKvDim), _kvDType);
             }
             Console.Error.Write(".");
         }
@@ -1403,12 +1427,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // ── KV append + SDPA (batched). Shared-scores fast path when startPos+n ≤ 4096,
         //    wave-based global-scratch SDPA above (issue #118). Both bit-identical to the
         //    per-position KvAppend + Attention loop in GpuLayer.
-        _gpu.KvAppendBatched(kAll, vAll, _gpuKCache[i], _gpuVCache[i], kvDim, startPos, _maxSeqLen, n);
+        KvAppendBatchedKv(kAll, vAll, _gpuKCache[i], _gpuVCache[i], kvDim, startPos, _maxSeqLen, n);
         if (startPos + n <= 4096)
-            _gpu.AttentionBatched(qAll, _gpuKCache[i], _gpuVCache[i], attnOut,
+            AttentionBatchedKv(qAll, _gpuKCache[i], _gpuVCache[i], attnOut,
                 _numHeads, _numKvHeads, _headDim, startPos, _maxSeqLen, n);
         else
-            _gpu.AttentionBatchedWave(qAll, _gpuKCache[i], _gpuVCache[i], attnOut,
+            AttentionBatchedWaveKv(qAll, _gpuKCache[i], _gpuVCache[i], attnOut,
                 _numHeads, _numKvHeads, _headDim, startPos, _maxSeqLen, n);
 
         // ── Output projection (batched) → blockOut, then post-attn residual add.
@@ -1466,6 +1490,68 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // ================================================================
     //  GPU Layer (same pattern as GpuForwardPass)
     // ================================================================
+
+    // ── Narrowed-KV dispatch (#179/#230) ──────────────────────────────────────
+    // Route every GPU-trunk KV append/attention through the dtype the cache was allocated at
+    // (_kvDType). Mirrors CudaForwardPass's KvAppendKv/AttentionKv/AttentionSwaKv; fp32 is the
+    // unchanged default. The TQ path is excluded (forces _kvDType == fp32).
+    private void KvAppendKv(Tensor k, Tensor v, Tensor kCache, Tensor vCache, int kvDim, int position, int maxSeqLen)
+    {
+        if (_kvDType == DType.BFloat16) _gpu.KvAppendBf16(k, v, kCache, vCache, kvDim, position, maxSeqLen);
+        else if (_kvDType == DType.Q8_0) _gpu.KvAppendQ8_0(k, v, kCache, vCache, kvDim, position, maxSeqLen);
+        else _gpu.KvAppend(k, v, kCache, vCache, kvDim, position, maxSeqLen);
+    }
+
+    private void AttentionKv(Tensor q, Tensor kCache, Tensor vCache, Tensor output, Tensor? scoresScratch,
+                             int numHeads, int numKvHeads, int headDim, int seqLen, int maxSeqLen, float attnScale = -1f)
+    {
+        if (_kvDType == DType.BFloat16)
+            _gpu.AttentionBf16(q, kCache, vCache, output, scoresScratch, numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
+        else if (_kvDType == DType.Q8_0)
+            _gpu.AttentionQ8_0(q, kCache, vCache, output, scoresScratch, numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
+        else
+            _gpu.Attention(q, kCache, vCache, output, scoresScratch, numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
+    }
+
+    private void AttentionSwaKv(Tensor q, Tensor kCache, Tensor vCache, Tensor output, Tensor? scoresScratch,
+                                int position, int windowSize, int headDim, int numHeads, int numKvHeads, int maxSeqLen, float attnScale = -1f)
+    {
+        if (_kvDType == DType.BFloat16)
+            _gpu.AttentionSwaBf16(q, kCache, vCache, output, scoresScratch, position, windowSize, headDim, numHeads, numKvHeads, maxSeqLen, attnScale);
+        else if (_kvDType == DType.Q8_0)
+            _gpu.AttentionSwaQ8_0(q, kCache, vCache, output, scoresScratch, position, windowSize, headDim, numHeads, numKvHeads, maxSeqLen, attnScale);
+        else
+            _gpu.AttentionSwa(q, kCache, vCache, output, scoresScratch, position, windowSize, headDim, numHeads, numKvHeads, maxSeqLen, attnScale);
+    }
+
+    private void KvAppendBatchedKv(Tensor kAll, Tensor vAll, Tensor kCache, Tensor vCache, int kvDim, int startPos, int maxSeqLen, int nTok)
+    {
+        if (_kvDType == DType.BFloat16) _gpu.KvAppendBatchedBf16(kAll, vAll, kCache, vCache, kvDim, startPos, maxSeqLen, nTok);
+        else if (_kvDType == DType.Q8_0) _gpu.KvAppendBatchedQ8_0(kAll, vAll, kCache, vCache, kvDim, startPos, maxSeqLen, nTok);
+        else _gpu.KvAppendBatched(kAll, vAll, kCache, vCache, kvDim, startPos, maxSeqLen, nTok);
+    }
+
+    private void AttentionBatchedKv(Tensor qAll, Tensor kCache, Tensor vCache, Tensor outAll,
+                                    int numHeads, int numKvHeads, int headDim, int startPos, int maxSeqLen, int nTok)
+    {
+        if (_kvDType == DType.BFloat16)
+            _gpu.AttentionBatchedBf16(qAll, kCache, vCache, outAll, numHeads, numKvHeads, headDim, startPos, maxSeqLen, nTok);
+        else if (_kvDType == DType.Q8_0)
+            _gpu.AttentionBatchedQ8_0(qAll, kCache, vCache, outAll, numHeads, numKvHeads, headDim, startPos, maxSeqLen, nTok);
+        else
+            _gpu.AttentionBatched(qAll, kCache, vCache, outAll, numHeads, numKvHeads, headDim, startPos, maxSeqLen, nTok);
+    }
+
+    private void AttentionBatchedWaveKv(Tensor qAll, Tensor kCache, Tensor vCache, Tensor outAll,
+                                        int numHeads, int numKvHeads, int headDim, int startPos, int maxSeqLen, int nTok)
+    {
+        if (_kvDType == DType.BFloat16)
+            _gpu.AttentionBatchedWaveBf16(qAll, kCache, vCache, outAll, numHeads, numKvHeads, headDim, startPos, maxSeqLen, nTok);
+        else if (_kvDType == DType.Q8_0)
+            _gpu.AttentionBatchedWaveQ8_0(qAll, kCache, vCache, outAll, numHeads, numKvHeads, headDim, startPos, maxSeqLen, nTok);
+        else
+            _gpu.AttentionBatchedWave(qAll, kCache, vCache, outAll, numHeads, numKvHeads, headDim, startPos, maxSeqLen, nTok);
+    }
 
     private void GpuLayer(int i, int position)
     {
@@ -1554,11 +1640,11 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         }
         else
         {
-            _gpu.KvAppend(_gpuK, _gpuV, _gpuKCache[i], _gpuVCache[i],
+            KvAppendKv(_gpuK, _gpuV, _gpuKCache[i], _gpuVCache[i],
                 (_numKvHeads * _headDim), position, _maxSeqLen);
             _gpu.RecordBarrier();
 
-            _gpu.Attention(_gpuQ, _gpuKCache[i], _gpuVCache[i], _gpuAttnOut,
+            AttentionKv(_gpuQ, _gpuKCache[i], _gpuVCache[i], _gpuAttnOut,
                 _gpuAttnScoresScratch,
                 _numHeads, _numKvHeads, _headDim,
                 (position + 1), _maxSeqLen);
@@ -2012,7 +2098,7 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             int layerCtx = isSwa && _hp.SlidingWindowSize > 0
                 ? Math.Min(_maxSeqLen, _hp.SlidingWindowSize)
                 : _maxSeqLen;
-            _gpu.KvAppend(kView, vView, _gpuKCache[i], _gpuVCache[i], kvDimL, position, layerCtx);
+            KvAppendKv(kView, vView, _gpuKCache[i], _gpuVCache[i], kvDimL, position, layerCtx);
             _gpu.RecordBarrier();
         }
 
@@ -2024,14 +2110,14 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // Gemma 4: attention_scale = 1.0, passed explicitly (kernel skips its rsqrtf).
         if (isSwa)
         {
-            _gpu.AttentionSwa(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
+            AttentionSwaKv(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
                 _gpuAttnScoresScratch,
                 position, _hp.SlidingWindowSize, layerHd,
                 _numHeads, layerKv, effLayerCtx, attnScale: 1f);
         }
         else
         {
-            _gpu.Attention(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
+            AttentionKv(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
                 _gpuAttnScoresScratch,
                 _numHeads, layerKv, layerHd, position + 1, effLayerCtx, attnScale: 1f);
         }

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -1152,6 +1152,28 @@ public sealed class CudaForwardPassKvDtypeTests
         Assert.True(CudaForwardPass.Q8KvGeometrySupported(aliased));
     }
 
+    /// <summary>
+    /// #230/#232 review: the gpuLayers scope. CudaHybridForwardPass narrows only the GPU-resident
+    /// layers' KV (CPU-offloaded layers stay fp32), so the q8 geometry check must consider only the
+    /// first N layers — a bad-geometry CPU-tail layer must NOT reject q8 when the GPU layers are fine.
+    /// </summary>
+    [Fact]
+    public void Q8KvGeometry_GpuLayersScope_IgnoresCpuTailLayers()
+    {
+        // layer 0 OK (8×128=1024, %32==0); layer 1 BAD (1×52=52, %32==20).
+        var hp = Gemma4ShapedHp(
+            layerHeadDim: [128, 52],
+            layerKvHeads: [8, 1],
+            isSwa: [false, false],
+            kvSource: [-1, -1],
+            slidingWindow: 4096);
+
+        Assert.False(CudaForwardPass.Q8KvGeometrySupported(hp));              // all layers → bad layer 1 fails
+        Assert.False(CudaForwardPass.Q8KvGeometrySupported(hp, gpuLayers: 2)); // first 2 == all → still fails
+        Assert.True(CudaForwardPass.Q8KvGeometrySupported(hp, gpuLayers: 1));  // only layer 0 on GPU → OK
+        Assert.True(CudaForwardPass.Q8KvGeometrySupported(hp, gpuLayers: 0));  // nothing narrowed → trivially OK
+    }
+
     /// <summary>ResolveKvDType fit comparisons are inclusive (&lt;=): an exact-fit fp32/bf16 is kept, not narrowed past.</summary>
     [Fact]
     public void ResolveKvDType_FitBoundaryIsInclusive()

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
@@ -1,0 +1,138 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using SharpInference.Pipeline;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #230: narrowed KV (--kv-type bf16/q8_0, #179) on the layer-split pure-attention MoE
+/// hybrid (<see cref="CudaHybridForwardPass"/> — Qwen3-Coder-30B, OLMoE). It was previously
+/// silently ignored (KV always fp32) even though TierPlanner priced the budget at the narrowed
+/// dtype. These oracles teacher-force a narrowed-KV prefill+decode onto the fp32 trajectory (so
+/// the KV dtype is the only variable per position) and assert it stays <b>argmax-stable</b>:
+/// finite logits, fp32's top-1 inside the narrowed top-5, and a bounded logit max-abs gap. The
+/// store rounding is lossy, so token-exact equality is not asserted (mirrors the dense
+/// <see cref="CudaForwardPassKvDtypeTests"/> contract).
+///
+/// Skipped silently when CUDA is unavailable, the model isn't on disk, or construction OOMs.
+/// q8_0 is skipped for a model whose per-layer kvDim isn't a multiple of 32 (the geometry the
+/// ctor rejects). Compute-routing is pinned OFF so the batched prefill is deterministic per arm.
+/// </summary>
+public sealed class CudaHybridKvDtypeTests : IDisposable
+{
+    private readonly ITestOutputHelper _out;
+    private readonly bool _prevCompute = CudaHybridForwardPass.HybridPrefillComputeEnabled;
+
+    public CudaHybridKvDtypeTests(ITestOutputHelper o)
+    {
+        _out = o;
+        CudaHybridForwardPass.HybridPrefillComputeEnabled = false; // deterministic batched prefill
+    }
+    public void Dispose() => CudaHybridForwardPass.HybridPrefillComputeEnabled = _prevCompute;
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); } catch { return null; }
+    }
+
+    private static string? FirstExisting(params string[] c)
+    {
+        foreach (var p in c) if (File.Exists(p)) return p;
+        return null;
+    }
+
+    private static (float[][] logits, int[] argmax) RunPrefillDecode(
+        CudaBackend gpu, string path, string? kvDtype, string prompt, int steps, int ctx, int[]? forced)
+    {
+        var prev = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+        Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", kvDtype);
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int useCtx = Math.Min(hp.ContextLength, ctx);
+            var hw = HardwareProfile.Detect(gpu);
+            var placement = TierPlanner.Plan(model, hp, hw, turboQuant: false, requestedCtxSize: useCtx,
+                kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
+            using var fwd = new CudaHybridForwardPass(model, gpu, hp, placement);
+
+            var tokens = tokenizer.Encode(prompt).ToArray();
+            var perPos = new float[steps + 1][];
+            var argmax = new int[steps + 1];
+            var logits = fwd.Prefill(tokens).ToArray();
+            perPos[0] = logits; argmax[0] = Sampler.Greedy(logits);
+            for (int i = 0; i < steps; i++)
+            {
+                int fed = forced is not null ? forced[i] : argmax[i];
+                logits = fwd.Forward(fed, tokens.Length + i).ToArray();
+                perPos[i + 1] = logits; argmax[i + 1] = Sampler.Greedy(logits);
+            }
+            return (perPos, argmax);
+        }
+        finally { Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prev); }
+    }
+
+    private static HashSet<int> TopK(float[] v, int k)
+    {
+        var idx = new int[v.Length];
+        for (int i = 0; i < v.Length; i++) idx[i] = i;
+        Array.Sort(idx, (a, b) => v[b].CompareTo(v[a]));
+        var set = new HashSet<int>(k);
+        for (int i = 0; i < k && i < idx.Length; i++) set.Add(idx[i]);
+        return set;
+    }
+
+    private void AssertKvParity(string? path, string kvDtype, string prompt, float maxAbsTol)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) { _out.WriteLine("SKIP: no CUDA"); return; }
+        if (path is null) { _out.WriteLine("SKIP: model not on disk"); return; }
+
+        const int steps = 6, ctx = 2048;
+        float[][] f32, kv; int[] f32Argmax;
+        try
+        {
+            (f32, f32Argmax) = RunPrefillDecode(gpu, path, "fp32", prompt, steps, ctx, forced: null);
+            (kv, _) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: f32Argmax);
+        }
+        catch (InvalidOperationException) { _out.WriteLine("SKIP: construction OOM'd"); return; }
+        catch (NotSupportedException e)   { _out.WriteLine($"SKIP: {e.Message}"); return; } // e.g. q8 geometry
+
+        for (int p = 0; p <= steps; p++)
+        {
+            Assert.Equal(f32[p].Length, kv[p].Length);
+            float maxAbs = 0f;
+            for (int i = 0; i < f32[p].Length; i++)
+            {
+                Assert.True(float.IsFinite(kv[p][i]), $"{kvDtype}: non-finite logit at pos {p}, idx {i}.");
+                maxAbs = Math.Max(maxAbs, Math.Abs(f32[p][i] - kv[p][i]));
+            }
+            Assert.True(TopK(kv[p], 5).Contains(f32Argmax[p]),
+                $"{kvDtype}: fp32 top-1 ({f32Argmax[p]}) fell out of the {kvDtype} top-5 at pos {p} " +
+                $"(maxAbs {maxAbs:F3}) — the narrowed-KV hybrid path reordered the head of the distribution.");
+            Assert.True(maxAbs < maxAbsTol,
+                $"{kvDtype}: pos {p} vs fp32 logit max-abs {maxAbs:F3} exceeds the rounding budget ({maxAbsTol:F1}).");
+        }
+        _out.WriteLine($"OK {kvDtype} argmax-stable vs fp32 ({Path.GetFileName(path)})");
+    }
+
+    private const string Prompt = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs.";
+
+    private static string? OlmoePath() => FirstExisting(
+        @"C:\p\sharpi\models\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf",
+        @"E:\models\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf");
+
+    private static string? CoderPath() => FirstExisting(
+        @"C:\p\sharpi\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        @"E:\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf");
+
+    [Fact] public void OLMoE_Bf16Kv_ArgmaxStable() => AssertKvParity(OlmoePath(), "bf16", Prompt, maxAbsTol: 2.5f);
+    [Fact] public void OLMoE_Q8Kv_ArgmaxStable()  => AssertKvParity(OlmoePath(), "q8_0", Prompt, maxAbsTol: 3.5f);
+    [Fact] public void Coder30B_Bf16Kv_ArgmaxStable() => AssertKvParity(CoderPath(), "bf16", Prompt, maxAbsTol: 5.0f);
+    [Fact] public void Coder30B_Q8Kv_ArgmaxStable()  => AssertKvParity(CoderPath(), "q8_0", Prompt, maxAbsTol: 6.0f);
+}

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
@@ -61,6 +61,17 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
                 kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
             using var fwd = new CudaHybridForwardPass(model, gpu, hp, placement);
 
+            // Guard against a vacuous pass: confirm the requested dtype actually applied (the GPU
+            // KV is genuinely narrowed). If env plumbing regressed and KV silently stayed fp32,
+            // fp32-vs-fp32 would be trivially argmax-stable and hide the very bug #230 fixes.
+            DType expected = kvDtype switch
+            {
+                "bf16" => DType.BFloat16,
+                "q8_0" => DType.Q8_0,
+                _ => DType.Float32,
+            };
+            Assert.Equal(expected, fwd.KvCacheDType);
+
             var tokens = tokenizer.Encode(prompt).ToArray();
             var perPos = new float[steps + 1][];
             var argmax = new int[steps + 1];
@@ -87,13 +98,13 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
         return set;
     }
 
-    private void AssertKvParity(string? path, string kvDtype, string prompt, float maxAbsTol)
+    private void AssertKvParity(string? path, string kvDtype, string prompt, float maxAbsTol, int ctx = 2048)
     {
         using var gpu = TryCreate();
         if (gpu is null) { _out.WriteLine("SKIP: no CUDA"); return; }
         if (path is null) { _out.WriteLine("SKIP: model not on disk"); return; }
 
-        const int steps = 6, ctx = 2048;
+        const int steps = 6;
         float[][] f32, kv; int[] f32Argmax;
         try
         {
@@ -101,7 +112,8 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
             (kv, _) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: f32Argmax);
         }
         catch (InvalidOperationException) { _out.WriteLine("SKIP: construction OOM'd"); return; }
-        catch (NotSupportedException e)   { _out.WriteLine($"SKIP: {e.Message}"); return; } // e.g. q8 geometry
+        // NOTE: q8_0 is supported for both test models (kvDim % 32 == 0: OLMoE 16×128, Coder 4×128),
+        // so a NotSupportedException here is a real regression — let it FAIL, don't skip.
 
         for (int p = 0; p <= steps; p++)
         {
@@ -121,7 +133,79 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
         _out.WriteLine($"OK {kvDtype} argmax-stable vs fp32 ({Path.GetFileName(path)})");
     }
 
+    /// <summary>
+    /// Greedy (NOT teacher-forced) coherence on the narrowed-KV hybrid path — the narrowed run
+    /// picks its OWN tokens, so an #188-style degenerate collapse (all-EOS / single-token repeat)
+    /// that teacher-forcing would mask is caught here. Asserts finite logits, first token ≠ EOS,
+    /// and ≥2 distinct tokens over the run. (Separate from AssertKvParity, which teacher-forces.)
+    /// </summary>
+    private void AssertGreedyCoherence(string? path, string kvDtype, string userMessage, int ctx = 2048)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) { _out.WriteLine("SKIP: no CUDA"); return; }
+        if (path is null) { _out.WriteLine("SKIP: model not on disk"); return; }
+        // Render the model's OWN chat template (#230 review): a raw continuation prompt makes an
+        // instruct model collapse to a single token regardless of KV dtype (the 'prompt must match
+        // the chat template' trap), which would falsely flag the narrowed path. Falls back to the
+        // raw message when the GGUF carries no template.
+        int eosId; string prompt;
+        using (var m = GgufModel.Open(path))
+        {
+            var tok = GgufTokenizer.FromGgufModel(m);
+            eosId = tok.EosTokenId;
+            prompt = ApplyChatTemplate(tok, userMessage);
+        }
+
+        const int steps = 6;
+        int[] argmax; float[][] logits;
+        try { (logits, argmax) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: null); }
+        catch (InvalidOperationException) { _out.WriteLine("SKIP: construction OOM'd"); return; }
+
+        for (int p = 0; p <= steps; p++)
+            for (int i = 0; i < logits[p].Length; i++)
+                Assert.True(float.IsFinite(logits[p][i]), $"{kvDtype}: non-finite greedy logit at pos {p}, idx {i}.");
+        Assert.True(argmax[0] != eosId, $"{kvDtype}: first greedy token was EOS — narrowed-KV greedy decode collapsed.");
+        Assert.True(new HashSet<int>(argmax).Count >= 2,
+            $"{kvDtype}: greedy decode produced only 1 distinct token ([{string.Join(",", argmax)}]) — degenerate narrowed-KV decode.");
+        _out.WriteLine($"OK {kvDtype} greedy-coherent ({Path.GetFileName(path)})");
+    }
+
+    /// <summary>
+    /// Render the model's GGUF chat template (tokenizer.chat_template) around a single user turn
+    /// with add_generation_prompt, mirroring the CLI/server path. Returns the raw message when the
+    /// model carries no template. Used by the greedy-coherence tests so an instruct model sees a
+    /// template-correct prompt rather than a raw continuation it would degenerate on.
+    /// </summary>
+    private static string ApplyChatTemplate(GgufTokenizer tok, string userMessage)
+    {
+        if (tok.ChatTemplate is null) return userMessage;
+        var messages = JinjaChatTemplate.BuildMessages(userMessage, systemContent: null);
+        return tok.ChatTemplate.Render(new Dictionary<string, object?>
+        {
+            ["messages"] = messages,
+            ["add_generation_prompt"] = true,
+            ["tools"] = null,
+            ["enable_thinking"] = false,
+        });
+    }
+
     private const string Prompt = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs.";
+
+    /// <summary>Repeat a varied seed until the tokenizer emits ≥ <paramref name="approx"/> tokens (for the >4096 wave path).</summary>
+    private static string LongPrompt(string path, int approx)
+    {
+        using var model = GgufModel.Open(path);
+        var tok = GgufTokenizer.FromGgufModel(model);
+        const string seed = "The quick brown fox jumps over the lazy dog. Sphinx of black quartz, judge my vow. " +
+                            "Pack my box with five dozen liquor jugs. How razorback-jumping frogs can level six piqued gymnasts. ";
+        var sb = new System.Text.StringBuilder();
+        while (tok.Encode(sb.ToString()).Count < approx)
+        {
+            sb.Append(seed);
+            if (sb.Length > 400_000) break;
+        }
+        return sb.ToString();
+    }
 
     private static string? OlmoePath() => FirstExisting(
         @"C:\p\sharpi\models\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf",
@@ -135,4 +219,23 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
     [Fact] public void OLMoE_Q8Kv_ArgmaxStable()  => AssertKvParity(OlmoePath(), "q8_0", Prompt, maxAbsTol: 3.5f);
     [Fact] public void Coder30B_Bf16Kv_ArgmaxStable() => AssertKvParity(CoderPath(), "bf16", Prompt, maxAbsTol: 5.0f);
     [Fact] public void Coder30B_Q8Kv_ArgmaxStable()  => AssertKvParity(CoderPath(), "q8_0", Prompt, maxAbsTol: 6.0f);
+
+    /// <summary>
+    /// >4096 wave path (AttentionBatchedWaveQ8_0): a single Prefill of &gt;4096 tokens makes
+    /// PrefillBatchedTrunk take the wave SDPA branch under a narrowed cache. ctx 6144.
+    /// </summary>
+    [Fact]
+    public void Coder30B_Q8Kv_Wave_ArgmaxStable()
+    {
+        var path = CoderPath();
+        if (path is null || !CudaBackend.IsAvailable()) { _out.WriteLine("SKIP"); return; }
+        AssertKvParity(path, "q8_0", LongPrompt(path, 4600), maxAbsTol: 8.0f, ctx: 6144);
+    }
+
+    // Narrowed-KV greedy self-decode stays coherent (no #188-style collapse) on a template-correct
+    // prompt — both the headline Coder-30B and OLMoE (its raw-prompt collapse was the chat-template
+    // trap, fixed by ApplyChatTemplate above).
+    private const string CoherenceMessage = "Write a short sentence about the ocean.";
+    [Fact] public void Coder30B_Q8Kv_GreedyCoherent() => AssertGreedyCoherence(CoderPath(), "q8_0", CoherenceMessage);
+    [Fact] public void OLMoE_Q8Kv_GreedyCoherent()    => AssertGreedyCoherence(OlmoePath(), "q8_0", CoherenceMessage);
 }


### PR DESCRIPTION
## Summary

Fixes #230. `--kv-type bf16|q8_0` (`SHARPI_KV_DTYPE`, #179) was **silently ignored** by the layer-split pure-attention MoE hybrid (`CudaHybridForwardPass` — Qwen3-Coder-30B, OLMoE): its GPU KV was allocated fp32 with no dtype arg, so the flag was a no-op. Worse, **TierPlanner already prices the KV budget at the requested dtype** (RunCommand passes `ResolveConfiguredKvDType` to `Plan`), so the runtime allocated a 4× larger fp32 cache than the planner reserved — a plan/runtime mismatch that can over-commit near the SLRU threshold.

## Fix

Wire the dtype through: resolve `CudaForwardPass.ResolveConfiguredKvDType()` into `_kvDType`, allocate the GPU-trunk `_gpuKCache`/`_gpuVCache` at it, and route **every** GPU KV append/attention through `*Kv` dispatch helpers that pick the narrowed kernels (#179):
- per-token decode — `KvAppend`/`Attention` (+ gemma4 `AttentionSwa`),
- batched prefill — `KvAppendBatched`, `AttentionBatched`, `AttentionBatchedWave`,

each dispatching bf16 / q8_0 / fp32. **Narrowing is scoped to the GPU-resident layers**; CPU-offloaded layers keep their fp32 `SimdKernels` KV. Mirrors the dense path's guards — rejects **narrowed + TurboQuant** (TQ owns its ring) and **q8_0 with a non-%32 kvDim** geometry, both with clear errors instead of the silent fp32 no-op. The banner shows the KV tag. **fp32 default is byte-identical** (dispatch routes to the same kernels).

## Result (4070 Ti 12 GB, `Qwen3-Coder-30B-A3B -g -1 --kv-type q8_0`)

| | fp32 | q8_0 |
|---|---|---|
| GPU KV | 6144 MB | **1632 MB** |
| free after weights | 3652 MiB | **6724 MiB (+3 GiB)** |
| expert-cache budget | 3957 MB | **8469 MB** |
| decode | 24.3 t/s | 24.4 t/s |
| >4096 wave-q8 prefill (6169 tok) | — | 26.3 t/s, no OOM |

The freed VRAM more than doubles the SLRU expert-cache budget (and the runtime now matches what the planner reserved).

## Tests

New `CudaHybridKvDtypeTests` — bf16 **and** q8_0 teacher-forced **argmax-stable** vs fp32 (fp32 top-1 ∈ narrowed top-5 + bounded logit max-abs) on **Coder-30B and OLMoE**, 4/4 green. Existing fp32 `CudaHybridBatchedPrefillTests` unchanged (9/9). Release build clean under TreatWarningsAsErrors + AOT.

## Out of scope (noted in #230)

Vulkan (`GpuForwardPass`) and CPU (`ForwardPass`) still lack `--kv-type` (CPU's compression is `--tq`); they should warn rather than silently ignore — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)