### PR TITLE
feat(cli): -f/--file prompt-file support (llama.cpp-compatible)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -198,10 +198,21 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         {
             if (!File.Exists(promptFile))
             {
-                AnsiConsole.MarkupLine($"[red]Prompt file not found:[/] {promptFile}");
+                AnsiConsole.MarkupLine($"[red]Prompt file not found:[/] {Markup.Escape(promptFile)}");
                 return 1;
             }
-            settings.Prompt = File.ReadAllText(promptFile);
+            // Read failures (locked file, permissions, bad path) should fail loud + clean, not
+            // throw a stack trace; Escape the message since paths can carry Spectre markup chars.
+            try
+            {
+                settings.Prompt = File.ReadAllText(promptFile);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                          or System.Security.SecurityException or NotSupportedException)
+            {
+                AnsiConsole.MarkupLine($"[red]Error reading prompt file:[/] {Markup.Escape(ex.Message)}");
+                return 1;
+            }
         }
 
         if (settings.MinBatchBlas > 0)

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -24,7 +24,11 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
         [CommandOption("-p|--prompt")]
         [Description("Input prompt (default: interactive chat)")]
-        public string? Prompt { get; init; }
+        public string? Prompt { get; set; }
+
+        [CommandOption("-f|--file")]
+        [Description("Read the prompt from a file (llama.cpp -f/--file). Overrides -p when both are given; useful for prompts longer than the shell's command-line limit.")]
+        public string? PromptFile { get; init; }
 
         [CommandOption("-n|--n-predict")]
         [Description("Number of tokens to predict (default: 512)")]
@@ -188,6 +192,18 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
     protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
     {
+        // --file/-f (llama.cpp): load the prompt from a file. Overrides -p; lets prompts exceed
+        // the shell command-line length limit. Read as-is (no trailing-newline stripping).
+        if (settings.PromptFile is { Length: > 0 } promptFile)
+        {
+            if (!File.Exists(promptFile))
+            {
+                AnsiConsole.MarkupLine($"[red]Prompt file not found:[/] {promptFile}");
+                return 1;
+            }
+            settings.Prompt = File.ReadAllText(promptFile);
+        }
+
         if (settings.MinBatchBlas > 0)
             SimdKernels.MinBatchForBlas = settings.MinBatchBlas;
 


### PR DESCRIPTION
## Summary

Adds `-f`/`--file <path>` to the `run` CLI (llama.cpp's arg name) to read the prompt from a file. Resolved once at the top of `Execute` into `settings.Prompt`, so every downstream prompt path (single-turn, chat, format/template) works unchanged. Overrides `-p` when both are given; reads the file as-is (no trailing-newline stripping); a missing file errors loudly (exit 1).

## Motivation

A prompt longer than the OS command-line length limit (~32K chars on Windows) can't be passed via `-p` — it fails with *"The filename or extension is too long."* This surfaced while profiling long-context decode (#213): a ~16K-token prompt couldn't be fed via `-p`.

## Verified (CLI)
- short file → prefilled (30 tok);
- ~16K-token file → **prefilled 10460 tok, no arg-length error**;
- missing file → `Prompt file not found: …` (exit 1).

Build clean under TreatWarningsAsErrors + AOT. ~15 lines; self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)