### PR TITLE
perf(cuda): block-wise q8_0 scale cache in decode attention (#213)

### DIFF
--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -128,7 +128,7 @@ __device__ __forceinline__ float sharpi_kvload(const block_q8_0* __restrict__ p,
     return sharpi_fp16_to_fp32((unsigned int)p[b].d) * (float)p[b].qs[j];
 }
 
-// Issue #213: dot of a query vector q[0..n) with a CONTIGUOUS cache row at byte/element
+// Issue #213: dot of a query vector q[0..n) with a CONTIGUOUS cache row at element
 // offset `off`, specialized per cache dtype. fp32/bf16 are the same trivial per-element loop
 // the inlined sharpi_kvload produced (no change for those dtypes). The q8_0 overload caches the
 // per-32-block fp16 scale — loading + cvt'ing it once per block instead of 32× per element —
@@ -151,14 +151,15 @@ __device__ __forceinline__ float sharpi_kv_dot(const float* __restrict__ q, cons
 __device__ __forceinline__ float sharpi_kv_dot(const float* __restrict__ q, const block_q8_0* __restrict__ k, long off, int n)
 {
     float dot = 0.f;
-    long curB = -1;
-    float s = 0.f;
-    for (int d = 0; d < n; d++)
+    long b = off >> 5;              // block holding element `off`
+    int lane = (int)(off & 31);     // starting lane within that block (0 when off is 32-aligned)
+    for (int d = 0; d < n; )
     {
-        long i = off + d;
-        long b = i >> 5;
-        if (b != curB) { curB = b; s = sharpi_fp16_to_fp32((unsigned int)k[b].d); }
-        dot += q[d] * (s * (float)k[b].qs[i & 31]);
+        float s = sharpi_fp16_to_fp32((unsigned int)k[b].d);   // convert the fp16 scale ONCE per block
+        for (; lane < 32 && d < n; lane++, d++)
+            dot += q[d] * (s * (float)k[b].qs[lane]);
+        lane = 0;
+        b++;
     }
     return dot;
 }

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -128,6 +128,41 @@ __device__ __forceinline__ float sharpi_kvload(const block_q8_0* __restrict__ p,
     return sharpi_fp16_to_fp32((unsigned int)p[b].d) * (float)p[b].qs[j];
 }
 
+// Issue #213: dot of a query vector q[0..n) with a CONTIGUOUS cache row at byte/element
+// offset `off`, specialized per cache dtype. fp32/bf16 are the same trivial per-element loop
+// the inlined sharpi_kvload produced (no change for those dtypes). The q8_0 overload caches the
+// per-32-block fp16 scale — loading + cvt'ing it once per block instead of 32× per element —
+// while keeping the SAME per-element accumulation order and the SAME scale value, so it is
+// BIT-IDENTICAL to the per-element path. This removes the redundant scale work on the dominant
+// contiguous K-row read of decode attention (#213: q8 attention is compute-bound on the dequant,
+// not KV bandwidth — it reads ~4× fewer bytes than fp32 yet is ~50% slower).
+__device__ __forceinline__ float sharpi_kv_dot(const float* __restrict__ q, const float* __restrict__ k, long off, int n)
+{
+    float dot = 0.f;
+    for (int d = 0; d < n; d++) dot += q[d] * k[off + d];
+    return dot;
+}
+__device__ __forceinline__ float sharpi_kv_dot(const float* __restrict__ q, const unsigned short* __restrict__ k, long off, int n)
+{
+    float dot = 0.f;
+    for (int d = 0; d < n; d++) dot += q[d] * sharpi_bf16_to_fp32((unsigned int)k[off + d]);
+    return dot;
+}
+__device__ __forceinline__ float sharpi_kv_dot(const float* __restrict__ q, const block_q8_0* __restrict__ k, long off, int n)
+{
+    float dot = 0.f;
+    long curB = -1;
+    float s = 0.f;
+    for (int d = 0; d < n; d++)
+    {
+        long i = off + d;
+        long b = i >> 5;
+        if (b != curB) { curB = b; s = sharpi_fp16_to_fp32((unsigned int)k[b].d); }
+        dot += q[d] * (s * (float)k[b].qs[i & 31]);
+    }
+    return dot;
+}
+
 // Read one byte from a uint32-stride buffer at absolute byte offset B.
 __device__ __forceinline__ unsigned int sharpi_byte_at(const unsigned int* __restrict__ buf, long B)
 {
@@ -6536,10 +6571,8 @@ __device__ void llm_attention_swa_kv_impl(
 
     for (int t = (int)tid; t < eff_seq; t += 256) {
         int abs_t = t + window_start;
-        float dot = 0.f;
         long k_off = (long)(abs_t % max_seq_len) * (long)kv_dim + (long)kv_head * (long)head_dim;
-        for (int d = 0; d < head_dim; d++)
-            dot += q[q_off + d] * sharpi_kvload(k_cache, k_off + d);
+        float dot = sharpi_kv_dot(q + q_off, k_cache, k_off, head_dim);
         float score = dot * scale;
         if (use_shared) shared_scores[t] = score;
         else            head_scratch[t]  = score;
@@ -6775,10 +6808,8 @@ __device__ void llm_attention_kv_impl(
     float* head_scratch = scores_scratch + (long)h * (long)max_seq_len;
 
     for (int t = (int)tid; t < seq_len; t += 256) {
-        float dot = 0.f;
         long k_off = (long)t * (long)kv_dim + (long)kv_head * (long)head_dim;
-        for (int d = 0; d < head_dim; d++)
-            dot += q[q_off + d] * sharpi_kvload(k_cache, k_off + d);
+        float dot = sharpi_kv_dot(q + q_off, k_cache, k_off, head_dim);
         float score = dot * scale;
         if (use_shared) shared_scores[t] = score;
         else            head_scratch[t]  = score;


### PR DESCRIPTION
## What

#213 Phase 2. Caches the per-32-block fp16 scale **once per block** in the q8_0 decode-attention K-scores dot, instead of re-converting it on every element.

## Why

Phase-1 profiling (posted on #213) established the headline long-ctx decode collapse (~65→12 t/s) is **inherent per-token KV-read bandwidth** — attention is O(ctx)/token and fp32 degrades the same ~3.9×, so it is *not* fixable by a q8 kernel tweak. But the profile also isolated one q8-specific, bounded lever: the **q8_0 attention phase is ~50% slower than fp32** despite reading ~4× fewer bytes → it is **compute-bound on the per-element dequant**, not bandwidth.

The hot K-scores loop in `llm_attention_kv_impl` / `llm_attention_swa_kv_impl` called `sharpi_kvload(block_q8_0*, i)` per element, which re-locates the 32-element block **and** re-runs the `half→float` scale conversion for every element — 31/32 of that scale work is redundant on a contiguous head-dim row.

## How

New `sharpi_kv_dot(q, k_cache, off, n)` helper walks the contiguous row once and caches the scale per 32-block. The q8_0 overload is **bit-identical** to the per-element path:
- same scale value (same `sharpi_fp16_to_fp32`),
- same per-element accumulation order,
- only the redundant per-element scale re-convert is removed.

fp32/bf16 overloads are the same trivial loop the inlined `sharpi_kvload` already produced → no behavior change for those dtypes.

## Result — decode A/B (Gemma 4 E4B Q8_0, RTX 4070 Ti, 32 timed steps after a long prefill)

| ctx | fp32 | q8 (before) | q8 (after) |
|---|---|---|---|
| 2048 | 49.3 | 43.8 | 48.3 |
| 8192 | 31.5 | 24.5 | 29.3 |
| 16384 | 21.2 | 15.4 | 19.2 |
| 32768 | 12.8 | 8.6 | **11.2** |

~**75% of the q8-vs-fp32 decode gap recovered**; q8 @32K **+30%**. The inherent bandwidth curve is unchanged (documented on #213) — this closes the q8-specific overhead on top of it.

## Scope

Decode only — the measured bottleneck. q8 prefill >4096 runs the **TC2 flash** kernel (scattered shared-mem staging, no contiguous dequant loop) and the scalar `full_seq`/`swa_batched` q8 kernels are head-dim fallbacks. `sharpi_kvload` itself is **unmodified**, so all prefill paths are byte-unchanged → no prefill regression by construction.

## Validation

- `CudaForwardPassKvDtypeTests` + `CudaHybridKvDtypeTests` — **55 passed** (q8/bf16/fp32 decode argmax-stable vs fp32, batched + chunked prefill, greedy coherence incl. SWA ring-wrap, planner unit tests).
- `CudaAttnKernelsTests` + `CudaFlashAttnTests` — **8 passed** (fp32 attention kernels directly).
- Release build clean (`TreatWarningsAsErrors`, AOT analyzers).

No fp32/bf16 change, no short-ctx/prefill regression.

Closes #213.