### PR TITLE
perf(cuda): flash-decoding (split-KV) for long-context decode attention (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ OpenBLAS in `tools/openblas/` for faster batched GEMM. Build with `dotnet build 
 
 Supported architectures: `llama`, `llama4`, `olmoe`, `qwen3`, `qwen3moe`, `qwen35moe`
 (hybrid Gated-DeltaNet + attention + MoE), `gemma4` (per-layer head_dim, SWA + global, PLE).
-Benchmarked on AMD Zen 4 (12c/24t, DDR4-3200) + RTX 4070 Ti (12 GB), Q4_K_M, `--temp 0`.
-**Prefill t/s** is the warm-cache rate at a ~1K-token prompt; **decode t/s** is the near-zero-ctx
-generation rate (forward-pass iterations / time, so thinking tokens count). All outputs verified
-coherent (`scripts/bench-all.ps1`); top-1 parity vs llama.cpp b8585 verified on Qwen3-8B (byte-identical
-60-token greedy decode).
+Benchmarked on AMD Zen 4 (12c/24t) + RTX 4070 Ti (12 GB), Q4_K_M, `--temp 0`. Prefill t/s is the
+warm-cache rate at a ~1K-token prompt; decode t/s is near-zero-ctx (forward-pass iterations / time, so
+thinking tokens count). Outputs verified coherent; Qwen3-8B is byte-identical to llama.cpp b8585 (60-token
+greedy decode).
 
 | Model | Repo | Size | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---|---:|---|---:|---:|---|
@@ -28,8 +27,8 @@ coherent (`scripts/bench-all.ps1`); top-1 parity vs llama.cpp b8585 verified on 
 | Qwen3 8B | (same) | 5 GB | CPU `--tq` | 9.4 | 13.2 | 3-bit KV → 40 960 ctx; FastScan K+V (#34) keeps long-ctx decode ~flat (10.2 @ 3K, 9.4 @ 6K) |
 | Qwen3 8B | (same) | 5 GB | Vulkan `-g -1` | 28.0 | 30.9 | 11.4K auto-ctx |
 | Qwen3 8B | (same) | 5 GB | Vulkan `-g -1 --tq` | 25.5 | 30.7 | 3-bit KV → 40 960 ctx |
-| Qwen3 8B | (same) | 5 GB | **CUDA** `-g -1` | **2297** | **74.5** | Compute-bound prefill: int8 tensor-core MMQ (`mma.m16n8k32.s8`, Q4_K weight read once as int8, no fp16 dequant temp) plus a dequant→fp16→cuBLAS GEMM for the Q6_K/Q5_K trunk tensors (`ffn_down`/`attn_v`), so the whole trunk reads each weight once per batch instead of re-streaming per token. Decode: dp4a/Q8_1 matvec + a scale-pre-unpacked SoA Q4_K repack (#156/#160) + CUDA-graph replay. All argmax-stable; bisect with `SHARPI_PREFILL_MMQ`/`_PREFILL_GEMM`/`_Q4K_SOA`/`_CUDA_GRAPH=0`. (llama.cpp b8585 pp1008 5764 t/s — the gap is its cp.async-pipelined MMQ + flash attention.) |
-| Qwen3 8B | (same) | 5 GB | **CUDA** `-g -1 --no-thinking` | **2314** | **74.8** | reasoning suppressed in template; same path as the row above |
+| Qwen3 8B | (same) | 5 GB | **CUDA** `-g -1` | **2297** | **74.5** | int8 tensor-core MMQ prefill (weight read once as int8) + dp4a/Q8_1 decode matvec + CUDA-graph replay; all argmax-stable. (llama.cpp b8585 pp1008 5764 — gap is its cp.async MMQ + flash attn) |
+| Qwen3 8B | (same) | 5 GB | **CUDA** `-g -1 --no-thinking` | **2314** | **74.8** | reasoning suppressed; same path |
 | Qwen3 8B | (same) | 5 GB | **CUDA** `-g -1 --tq` | 60.6 | **70.2** | 3-bit KV → 40 960 ctx; 17 t/s @ 8K, 10 @ 16K |
 | Qwen3 8B | (same) | 5 GB | **CUDA** `-g -1 --tq --no-thinking` | 60.6 | **70.4** | as `--tq`, reasoning suppressed |
 | OLMoE 1B-7B Instruct (MoE) | [allenai](https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct-GGUF) | 4 GB | CPU | 51.7 | 60.5 | 64 experts / 8 active; per-channel QK-norm; `norm_topk_prob=false` |
@@ -42,39 +41,36 @@ coherent (`scripts/bench-all.ps1`); top-1 parity vs llama.cpp b8585 verified on 
 | Llama-4 Scout 17B-16E (MoE) | [meta-llama](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct) | 61 GB | CPU | 2.1 | 4.3 | 48 layers, 17B active; split GGUF (not on bench machine) |
 | Llama-4 Scout 17B-16E (MoE) | (same) | 61 GB | CUDA `-g -1` (hybrid) | 1.2 | 2.6 | 7 GPU + 41 CPU layers — model dwarfs the 12 GB card so CPU-only wins; per-expert SLRU streaming (#72/#77) still lifts both (not on bench machine) |
 | Qwen3.6-35B-A3B (GDN+MoE) | [unsloth](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) | 22 GB | CPU | 9.0 | 9.3 | hybrid GDN/attn, 256 experts / 8 active |
-| Qwen3.6-35B-A3B (GDN+MoE) | (same) | 22 GB | **CUDA** `-g -1` (hybrid) | **55.1** | **23.7** | 10 attn + 30 GDN on GPU; MoE auto-routed to CPU, shared expert on GPU overlapped with the routed loop. Fused GDN scan + batched-query SDPA (#114-B/#118), bit-identical, win grows with ctx. `SHARPI_CPU_MOE=0` forces on-GPU experts (#129 fused MoE-reduce kernel, +20% prefill) |
+| Qwen3.6-35B-A3B (GDN+MoE) | (same) | 22 GB | **CUDA** `-g -1` (hybrid) | **55.1** | **23.7** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. Fused GDN scan + batched SDPA, bit-identical. `SHARPI_CPU_MOE=0` forces on-GPU experts |
 | Qwen3.6-27B-MTP (GDN) | [unsloth](https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF) | 16 GB | CPU `--no-thinking` | 3.0 | **3.6** | dense 27B GDN/attn + native MTP head; auto MTP self-spec (#25) at greedy + `--no-thinking`. 90% draft acceptance; folded k-token batched verify (#30/#207) — 1.2× over MTP-off (3.0) |
-| Qwen3.6-27B-MTP (GDN) | (same) | 16 GB | **CUDA** `-g -1 --no-thinking` (hybrid) | **7.3** | **10.4** | 22/64 dense FFN on GPU + GDN/attn KV resident, 42/64 FFN CPU mmap. 90% acceptance; folded k-token batched verify + GDN snapshot ring (#30/#207) — **1.68× over MTP-off (6.4)**. Deeper chains: `--spec-draft-n-max N` + `SHARPI_MTP_BATCH_MAX=N+1` (~150 MiB VRAM/slot) |
+| Qwen3.6-27B-MTP (GDN) | (same) | 16 GB | **CUDA** `-g -1 --no-thinking` (hybrid) | **7.3** | **10.4** | 22/64 dense FFN on GPU + GDN/attn KV resident, rest CPU mmap. 90% acceptance; folded k-token batched verify + GDN snapshot ring — **1.68× over MTP-off (6.4)** |
 | Qwen3.6-27B-MTP (GDN) | (same) | 19 GB | CPU `--no-thinking` `Q5_K_M` | 2.8 | **3.5** | ~10% slower than Q4_K_M; 100% acceptance |
 | Qwen3.6-27B-MTP (GDN) | (same) | 19 GB | **CUDA** `-g -1 --no-thinking` `Q5_K_M` (hybrid) | 5.9 | **5.5** | 13/64 FFN on GPU, 51/64 CPU mmap. 98% acceptance; batched trunk (#119) bit-identical |
 | Qwen3.6-35B-A3B-MTP (GDN+MoE) | [unsloth](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF) | 22 GB | CPU `--no-thinking` | 9.1 | **8.5** | GDN/attn + 256-expert MoE + MTP head (#44). 100% acceptance; MoE-MTP batched verify (#45) — routed experts sequential per token, so ~MTP-off parity |
-| Qwen3.6-35B-A3B-MTP (GDN+MoE) | (same) | 22 GB | **CUDA** `-g -1 --no-thinking` (hybrid) | **55.7** | **21.4** | requires `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance. Fused GDN scan + batched SDPA (#114-B/#118), bit-identical |
-| Carnice (Qwen3.6-35B-A3B-MTP finetune) | [mudler](https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF) | 17 GB | **CUDA** `-g -1 --no-thinking` (hybrid) | **139.2** | **26.5** | agentic finetune of 35B-A3B-MTP; 80% acceptance (`bench-carnice.ps1` — the default factual prompt 1-token-EOSes on this terser tune). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable at load (#99/#101/#107), `SHARPI_Q3K_Q8K=0`/`SHARPI_Q8_0_Q8K=0` to disable |
+| Qwen3.6-35B-A3B-MTP (GDN+MoE) | (same) | 22 GB | **CUDA** `-g -1 --no-thinking` (hybrid) | **55.7** | **21.4** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance |
+| Carnice (Qwen3.6-35B-A3B-MTP finetune) | [mudler](https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF) | 17 GB | **CUDA** `-g -1 --no-thinking` (hybrid) | **139.2** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable |
 | Gemma 4 E4B-it Q8 | [unsloth](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF) | 8 GB | CPU | 5.0 | 5.1 | dense 42-layer gemma4: per-layer head_dim (256 SWA / 512 global), dual-RoPE, KV-share tail (18 layers), 5:1 SWA:global, logit softcap 30, PLE-256 injection (~4.2 GB mmap-resident) |
-| Gemma 4 E4B-it Q8 | (same) | 8 GB | **CUDA** `-g -1 -c 2048` | **3444** | **70.5** | all 42 layers fit at `-c 2048`; KV-share alias + per-layer SWA/global split; PLE projections (~215 MB) upload at construction. **Prefill (#141/#146/#147/#149):** int8 tensor-core MMQ (`mma.m16n8k32.s8`, weight read once as int8) + tensor-core flash attention (QK^T and P·V on mma cores, register-resident O via d-split) + a SoA Q8_0 weight repack (16-byte-aligned quants) + batched embedding lookup. **Prompts >4096 (#162/#164):** a real SWA KV ring (cache sized window + one chunk span, indexed `pos % size`) takes the chunked batched-flash path instead of the ~8× slower per-token fallback and fixes long-context correctness past the 512 window. **Decode (#142):** dp4a/Q8_1 matvec + CUDA-graph replay. Fast paths argmax-stable vs fp32. Bisect: `SHARPI_PREFILL_MMQ`/`_FLASH_TC`/`SHARPI_MMQ_SOA`/`SHARPI_Q80_DP4A`/`SHARPI_CUDA_GRAPH`/`SHARPI_BATCHED_PREFILL=0`. Gap to llama.cpp (~8475 prefill / ~78 decode): cp.async-pipelined MMQ |
+| Gemma 4 E4B-it Q8 | (same) | 8 GB | **CUDA** `-g -1 -c 2048` | **3444** | **70.5** | all 42 layers fit at `-c 2048`; KV-share alias + per-layer SWA/global split. Prefill: int8 tensor-core MMQ + tensor-core flash attention + SoA Q8_0 weight repack. Prompts >4096 use a real SWA KV ring on the chunked-flash path (fixes correctness past the 512 window). Decode: dp4a/Q8_1 + CUDA-graph replay; argmax-stable. (llama.cpp ~8475 prefill / ~78 decode) |
 | Gemma 4 E4B-it Q8 | (same) | 8 GB | **CUDA** `-g 22 -c 2048` (hybrid) | 6.7 | 7.0 | 22 GPU + 20 CPU layers. `-g ≤ 22` required so the CPU shared-KV tail can read its own-KV source layers; CPU dense-FFN dominates decode (bandwidth-bound). `SHARPI_CUDA_PROFILE=1` for per-phase breakdown |
-| Gemma 4 12B-it QAT Q4_0 | [google](https://huggingface.co/google/gemma-4-12B-it-qat-q4_0-gguf) | 7 GB | **CUDA** `-g -1 -c 2048` | **1742** | **54.1** | dense 48-layer gemma4, all bulk weights Q4_0 + tied Q6_K embedding; fits 12 GB full-offload. `attention_k_eq_v` (8 global MQA layers reuse K as V, no `attn_v`), per-layer KV heads (8 GQA / 1 MQA), pure V-norm. **Prefill (#124/#173):** Q4_0 int8 tensor-core MMQ (`mma.m16n8k32.s8`, weight read once as int8 — raw nibbles + the −8·d·Σq symmetric centering, no fp16 dequant temp) over a SoA Q4_0 weight repack, wired into the batched-trunk flash-attention path. **Decode (#124):** Q4_0 dp4a/Q8_1 matvec (asymmetric −8·Σq centering). Argmax-stable; `SHARPI_PREFILL_MMQ`/`_MMQ_SOA`/`_BATCHED_PREFILL`/`_Q40_DP4A=0` revert. Within ~6% of llama.cpp decode (57 t/s). **Long context (#179):** `--kv-type bf16` halves the K/V store (fp32 kernel math, argmax-stable) and `--kv-type q8_0` quarters it (block-quantized: 32 int8 + an fp16 scale per block); a bookkeeping-only host KV cache removes a ~50 GB host allocation — together taking the 12B to **`-c 131072` (128K) within 12 GB** (fp32 KV `cudaMalloc`-fails at 64K; ~32K ceiling). Narrowed-KV Tc2-flash prefill incl. chunked >4096. At 128K, bf16 saturates VRAM (~350 MB free) so the tied ~818 MB Q6_K embed/LM-head table spills to host per token → decode cliffs to **~19 t/s**; q8_0 frees ~1.1 GB more, keeps the table resident, and holds **~53 t/s — full speed (2.8× over bf16)**. Default KV is fp32; opt-in via `--kv-type bf16|q8_0` / `SHARPI_KV_DTYPE` |
+| Gemma 4 12B-it QAT Q4_0 | [google](https://huggingface.co/google/gemma-4-12B-it-qat-q4_0-gguf) | 7 GB | **CUDA** `-g -1 -c 2048` | **1742** | **54.1** | dense 48-layer gemma4, all bulk weights Q4_0 + tied Q6_K embedding; fits 12 GB full-offload. `attention_k_eq_v` (8 global MQA layers reuse K as V), per-layer KV heads (8 GQA / 1 MQA), pure V-norm. Prefill: Q4_0 int8 tensor-core MMQ over a SoA repack; decode: Q4_0 dp4a/Q8_1, argmax-stable, within ~6% of llama.cpp (57 t/s). **Long context:** `--kv-type bf16` halves / `q8_0` quarters the K/V store (fp32 kernel math, argmax-stable) + a bookkeeping-only host KV cache → **`-c 131072` (128K) within 12 GB** (fp32 `cudaMalloc`-fails at 64K). At 128K, q8_0 keeps the tied embed table resident (~53 t/s) where bf16 spills it (~19 t/s). Default fp32; opt-in `--kv-type bf16\|q8_0` |
 
-_Re-measured 2026-06 from warm sweeps: prefill at ~1K ctx (`scripts/bench-allrows-1k.ps1`),
-decode and MTP acceptance at near-zero ctx (`scripts/bench-allrows-decode.ps1`, `bench-allrows-mtp.ps1`);
-each config gets a discarded warm-up run first so GPU boost clocks and JIT have ramped. Per-issue
-before/after figures in the notes are historical. The Vulkan rows are ~35% below their prior numbers — a
-regression vs the last measurement (CUDA improved on the same box), not yet investigated. Llama-4 Scout and
-Qwen3-Coder Vulkan-hybrid keep their prior values (not re-runnable on the bench machine)._
+_Re-measured 2026-06 from warm sweeps (prefill ~1K ctx, decode near-zero ctx), each after a discarded
+warm-up. Vulkan rows are ~35% below their prior numbers — an unexplained regression (CUDA improved on the
+same box). Llama-4 Scout and Qwen3-Coder Vulkan-hybrid keep prior values (not re-runnable here)._
 
-**Recommended sampling for Gemma 4 E4B-it:** `--temp 1.0 --top-k 64 --top-p 0.95 --min-p 0`
-(the Gemma 3/4 family defaults). Gemma 4 E4B-it is **not** a reasoning model, so the CLI now
-defaults `enable_thinking=false` for it automatically (no `--no-thinking` needed) — otherwise the chat
-template renders a `<think>` block the model wasn't trained to fill and the output degenerates. Greedy
-(`--temp 0`) is not recommended for it either; use the sampling values above.
+**Long-context decode** (dense CUDA) uses flash-decoding (split-KV): the per-token KV read parallelizes
+across SMs instead of one block per head, so decode no longer collapses as context grows. Gemma 4 E4B @32K
+ctx: fp32 13→30 t/s, q8_0 11→45 t/s. Engages automatically above ~2K ctx; `SHARPI_SPLIT_DECODE=0` reverts.
 
-`--backend auto` (default) picks CUDA when available, sizing the GPU/CPU split from VRAM via TierPlanner;
-falls through to Vulkan only when CUDA isn't present. For hybrid `qwen35moe` models the CUDA backend keeps
-attention KV, the GDN layers, and the shared expert in VRAM; routed-expert dispatch auto-selects between
-an SLRU GPU cache and CPU mmap based on how many experts fit at boot (`SHARPI_CPU_MOE=0|1` to override).
-On Ampere+ it auto-selects bf16 cuBLAS GEMM (`SHARPI_CUDA_PRECISION=fp32|fp16|bf16|fp8` to bisect; custom
-NVRTC kernels keep fp32 accumulators). The GPU KV cache stores bf16 by default on GDN paths
-(`SHARPI_KV_DTYPE=fp32` to bisect).
+**Sampling for Gemma 4 E4B-it:** `--temp 1.0 --top-k 64 --top-p 0.95 --min-p 0` (Gemma 3/4 defaults).
+It is **not** a reasoning model — the CLI auto-sets `enable_thinking=false`, else the template renders an
+empty `<think>` block and output degenerates. Greedy is not recommended; use the values above.
+
+`--backend auto` (default) picks CUDA when available, sizing the GPU/CPU split from VRAM via TierPlanner,
+else Vulkan. For hybrid `qwen35moe` the CUDA backend keeps attention KV, GDN layers, and the shared expert
+in VRAM; routed experts auto-select SLRU GPU cache vs CPU mmap by fit (`SHARPI_CPU_MOE=0|1`). On Ampere+ it
+uses bf16 cuBLAS GEMM (`SHARPI_CUDA_PRECISION` to bisect; NVRTC kernels keep fp32 accumulators). GDN paths
+store bf16 KV by default (`SHARPI_KV_DTYPE=fp32`).
 
 MoE expert-cache knobs (`--moe-warmpin`, `--moe-warmpin-after`, `--no-moe-predict-prefetch`,
 `--expert-stats`) are CLI-only; the server reads the equivalent `SHARPI_MOE_WARMPIN*`,
@@ -82,24 +78,18 @@ MoE expert-cache knobs (`--moe-warmpin`, `--moe-warmpin-after`, `--no-moe-predic
 
 ### SnapKV (prefill-time KV eviction, issue #51)
 
-Ships on CPU `ForwardPass`, CUDA hybrid GDN, dense CUDA, and Vulkan. After prefill the model scores each
-prompt position by softmaxed attention from the last `W` queries, keeps top-K + a trailing recency window,
-and compacts the K/V ring in place. Decode is unchanged — `LogicalLength` stays at the original prompt
-length so RoPE on new tokens lands correctly.
-
-The GPU paths auto-enable when the full attention KV cache would exceed ~256 MiB; auto-budget is
-`min(maxSeqLen/4, 4096)` floored at 1024. `SHARPI_SNAPKV_BUDGET=N` forces a budget (`=0` disables);
-`_WINDOW`/`_RECENCY` (default 64) tune the probe and must-keep zone. CPU keeps the explicit-opt-in
-convention (set the budget to engage). SnapKV composes with TurboQuant on CPU for ~16× total KV reduction
-(#68). Long-context eval: `dotnet run --project benchmarks/SnapKvEval -- --model <gguf>` runs a
-needle-in-haystack sweep across budgets.
+On CPU, CUDA (dense + hybrid GDN), and Vulkan. After prefill it scores each prompt position by softmaxed
+attention from the last `W` queries, keeps top-K + a recency window, and compacts the K/V ring in place;
+decode is unchanged (`LogicalLength` stays at the prompt length so RoPE on new tokens lands correctly). GPU
+paths auto-enable above ~256 MiB KV (budget `min(maxSeqLen/4, 4096)` floored at 1024); `SHARPI_SNAPKV_BUDGET=N`
+forces it (`=0` off), `_WINDOW`/`_RECENCY` tune the probe/keep zone (CPU is opt-in via the budget). Composes
+with TurboQuant on CPU (~16× total KV). Eval: `benchmarks/SnapKvEval` (needle-in-haystack sweep).
 
 ### TurboQuant (`--tq`, 3-bit KV compression)
 
-CPU/Vulkan/CUDA; requires `headDim ∈ {128, 256}`. K-scoring and V-aggregation use a FastScan AVX2 kernel
-(#34): KV positions pack into 32-position tiles with 4-bit codes, a per-query i8 LUT reduces each step to a
-`vpshufb`, and the IWHT is deferred to one call per kv-head. Per (layer, kv-head) cost of the combined K+V
-hot path vs the prior per-block AVX2 path on a Ryzen 9 7900X:
+CPU/Vulkan/CUDA; requires `headDim ∈ {128, 256}`. K-scoring and V-aggregation use a FastScan AVX2 kernel:
+KV packs into 32-position tiles with 4-bit codes, a per-query i8 LUT reduces each step to a `vpshufb`, and
+the IWHT defers to one call per kv-head. Combined K+V hot-path cost vs the prior per-block path (Ryzen 9 7900X):
 
 | TQ positions | per-block K+V | FastScan K+V | speedup |
 |---:|---:|---:|---:|
@@ -108,37 +98,32 @@ hot path vs the prior per-block AVX2 path on a Ryzen 9 7900X:
 | 8 192 | 3 936 µs | 193 µs | 20× |
 | 16 384 | 8 216 µs | 390 µs | 21× |
 
-End-to-end gain tracks the K+V share of token cost — small at short context, growing with length. Qwen3-8B
-CPU `--tq` decode degrades only ~22% from 30 → 6 050 ctx (12.0 → 9.4 t/s); the per-block path would drop
-to ~5 t/s at 6K, so FastScan is ~1.9× decode there.
+End-to-end gain tracks the K+V share of token cost — small at short ctx, growing with length. Qwen3-8B CPU
+`--tq` decode drops only ~22% from 30→6050 ctx (12.0→9.4 t/s) — ~1.9× the per-block path at 6K.
 
 ### Multi-Token Prediction (MTP)
 
 Models with native MTP heads (Qwen3.6-27B-MTP, Qwen3.5/3.6 A3B-MTP, DeepSeek V3/R1) get self-speculative
-decoding with no separate draft model. It engages automatically when the pass reports `HasMtpHead`, sampling
-is greedy (`--temp 0`), and thinking is off (`--no-thinking`); the CLI prints `MTP accept: N%`. The default is
-a folded k-token batched verify (#30/#207): the certain token plus a chained draft sequence run through ONE
-batched trunk pass per step, with rejections rolled back via a per-token GDN snapshot ring; a rejected draft's
-correction rides into the next step's batch, so no per-step commit forward exists. MoE MTP batches the trunk
-while routed experts run per token (#45). CLI mirrors llama.cpp: `--spec-type`, `--spec-draft-n-max <N>`
-(drafts/step; default 1 = the measured optimum — deeper chains also need `SHARPI_MTP_BATCH_MAX>=N+1` ring
-slots at ~150 MiB VRAM each), `--spec-draft-p-min <0..1>` (lossy probabilistic accept).
-`SHARPI_DISABLE_MTP=1` / `SHARPI_DISABLE_BATCH_VERIFY=1` are the off-switches.
+decoding with no separate draft model. Engages automatically with greedy (`--temp 0`) + `--no-thinking`; the
+CLI prints `MTP accept: N%`. Default is a folded k-token batched verify: the certain token plus a chained
+draft run through one batched trunk pass, rejections rolled back via a per-token GDN snapshot ring. CLI
+mirrors llama.cpp: `--spec-type`, `--spec-draft-n-max <N>` (default 1; deeper chains need
+`SHARPI_MTP_BATCH_MAX≥N+1`, ~150 MiB VRAM/slot), `--spec-draft-p-min`. Off: `SHARPI_DISABLE_MTP=1`.
 
 ### Chat-continuation cache
 
-Multi-turn requests reuse the prior turn's state instead of re-prefilling. GDN-hybrid passes snapshot their
-recurrent state at the history boundary (#102) and restore on a prefix match; MTP runs also snapshot the MTP
-attention KV + hidden-history (#106), so agentic tool loops skip the per-round-trip re-prefill. `/metrics`
-exposes `sharpi_prefill_tokens_reused_total` (verify with `scripts/test-snapshot-reuse.ps1`).
+Multi-turn requests reuse the prior turn's state instead of re-prefilling. GDN-hybrid passes snapshot
+recurrent state at the history boundary and restore on a prefix match; MTP runs also snapshot the MTP KV +
+hidden-history, so agentic tool loops skip the per-round re-prefill. `/metrics` exposes
+`sharpi_prefill_tokens_reused_total`.
 
 ### Reasoning models
 
-Models that emit `<think>...</think>` are detected from their special tokens — no flag. The CLI dims the
-reasoning stream. `--no-thinking` disables it at the template level, `--hide-thinking` keeps it on but
-hidden, `--max-thinking-tokens N` force-closes runaway reasoning. Greedy on these models often loops, so the
-CLI recommends `--temp 0.6 --top-p 0.95 --top-k 20`. The server emits reasoning per protocol convention
-(Anthropic `thinking` block; OpenAI `reasoning_content`).
+Models that emit `<think>...</think>` are detected from their special tokens (no flag); the CLI dims the
+stream. `--no-thinking` disables it at the template level, `--hide-thinking` keeps it hidden,
+`--max-thinking-tokens N` force-closes runaway reasoning. Greedy often loops — the CLI recommends
+`--temp 0.6 --top-p 0.95 --top-k 20`. The server emits reasoning per protocol (Anthropic `thinking`,
+OpenAI `reasoning_content`).
 
 ### CLI examples
 

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -325,6 +325,12 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _attentionSwaBatchedQ8Kernel;
     private nint   _fullSeqAttentionQ8Kernel;
     private nint   _fullSeqAttentionGlobalQ8Kernel;
+    // Issue #235 (flash-decoding): split-KV decode attention + LSE combine. Shared
+    // across fp32/bf16/q8 via the templated splitkv kernel; combine is dtype-agnostic.
+    private nint   _attentionSplitKvKernel;
+    private nint   _attentionSplitKvBf16Kernel;
+    private nint   _attentionSplitKvQ8Kernel;
+    private nint   _attentionCombineKernel;
 
     // Grow-only global score scratch for the wave-based >4096 batched-query SDPA
     // (issue #118). Sized W × num_heads × score_stride floats; W is chosen so this
@@ -3669,6 +3675,81 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         }
     }
 
+    /// <summary>Flash-decoding split-KV chunk (KV tokens per split block). Must match
+    /// the kernel's <c>SPLITKV_CHUNK</c>.</summary>
+    public const int SplitKvChunk = 512;
+
+    /// <summary>
+    /// Flash-decoding decode attention (issue #235). Splits each head's KV sequence
+    /// into <see cref="SplitKvChunk"/>-sized chunks across <c>numHeads × nSplits</c>
+    /// blocks (nSplits = ceil(maxSeqLen/chunk)) so the O(ctx)/token KV read parallelizes
+    /// across the SMs instead of the single-block-per-head <see cref="Attention"/>. Each
+    /// block emits an un-normalized online-softmax partial (m_i, l_i, Õ_i) into
+    /// <paramref name="partialO"/>/<paramref name="partialMeta"/>; the combine kernel
+    /// LSE-merges them into <paramref name="output"/>. Argmax-stable, not bit-identical to
+    /// <see cref="Attention"/> (the combine reorders the softmax reduction). The grid is
+    /// fixed at capture and only seqLen updates per graph replay (out-of-range splits
+    /// early-exit), so it is CUDA-graph-capturable. fp32/bf16/q8_0 via <paramref name="kvDType"/>.
+    /// </summary>
+    public void AttentionSplitKv(Tensor q, Tensor kCache, Tensor vCache, Tensor output,
+                                 Tensor partialO, Tensor partialMeta, DType kvDType,
+                                 int numHeads, int numKvHeads, int headDim, int seqLen, int maxSeqLen,
+                                 float attnScale = -1f)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        int nSplits = (maxSeqLen + SplitKvChunk - 1) / SplitKvChunk;
+        nint splitKern = kvDType switch
+        {
+            DType.BFloat16 => _attentionSplitKvBf16Kernel,
+            DType.Q8_0     => _attentionSplitKvQ8Kernel,
+            DType.Float32  => _attentionSplitKvKernel,
+            _ => throw new ArgumentOutOfRangeException(nameof(kvDType), kvDType,
+                "AttentionSplitKv supports fp32 / bf16 / q8_0 K/V caches only."),
+        };
+
+        nint qP = GetDevPtr(q);
+        nint kP = GetDevPtr(kCache);
+        nint vP = GetDevPtr(vCache);
+        nint poP = GetDevPtr(partialO);
+        nint pmP = GetDevPtr(partialMeta);
+        nint oP = GetDevPtr(output);
+        int pNH = numHeads, pNKV = numKvHeads, pHD = headDim, pSL = seqLen, pNS = nSplits;
+        float pScale = attnScale;
+
+        // Split kernel: q, k, v, partial_o, partial_meta, num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale
+        nint* sargs = stackalloc nint[11]
+        {
+            (nint)(&qP), (nint)(&kP), (nint)(&vP), (nint)(&poP), (nint)(&pmP),
+            (nint)(&pNH), (nint)(&pNKV), (nint)(&pHD), (nint)(&pSL), (nint)(&pNS), (nint)(&pScale)
+        };
+        int rs = NvrtcInterop.LaunchKernel(splitKern, (uint)numHeads, (uint)nSplits, 1, 256, 1, 1, 0, _stream, sargs, null);
+        if (rs != 0) throw new InvalidOperationException($"cuLaunchKernel(attention_splitkv {kvDType}) failed: {rs}");
+
+        // Track the split kernel BEFORE the combine launch (single-leaf harvest); only
+        // seqLen (arg 8) varies per replay — the fixed grid + early-exit handle the rest.
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[11];
+            av[0] = qP; av[1] = kP; av[2] = vP; av[3] = poP; av[4] = pmP;
+            av[5] = pNH; av[6] = pNKV; av[7] = pHD; av[8] = pSL; av[9] = pNS;
+            av[10] = GraphFloatBits(pScale);
+            TrackPositionNode(splitKern, (uint)numHeads, (uint)nSplits, 1, 256, 1, 1, 0, av,
+                [(8, GraphPosKind.PositionPlus1, 0)]);
+        }
+
+        // Combine kernel: partial_o, partial_meta, out, num_heads, head_dim, n_splits.
+        // No per-replay-varying args → captured by stream capture, not tracked.
+        nint* cargs = stackalloc nint[6]
+        {
+            (nint)(&poP), (nint)(&pmP), (nint)(&oP), (nint)(&pNH), (nint)(&pHD), (nint)(&pNS)
+        };
+        int rc = NvrtcInterop.LaunchKernel(_attentionCombineKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, _stream, cargs, null);
+        if (rc != 0) throw new InvalidOperationException($"cuLaunchKernel(attention_combine) failed: {rc}");
+    }
+
     // ── Ragged-batched decode ops (issue #197) ─────────────────────────────
     //
     // One launch per op covers all N decode sequences: row t of the [N × dim]
@@ -5836,6 +5917,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _kvAppendQ8Kernel, _kvAppendBatchedQ8Kernel,
             _attentionQ8Kernel, _attentionSwaQ8Kernel, _attentionSwaBatchedQ8Kernel,
             _fullSeqAttentionQ8Kernel, _fullSeqAttentionGlobalQ8Kernel,
+            // #235: flash-decoding split-KV + combine.
+            _attentionSplitKvKernel, _attentionSplitKvBf16Kernel, _attentionSplitKvQ8Kernel,
+            _attentionCombineKernel,
             // #197: ragged-batched decode kernels.
             _ropeNeoxRaggedKernel, _ropeInterleavedRaggedKernel,
             _kvAppendRaggedKernel, _kvAppendRaggedBf16Kernel, _kvAppendRaggedQ8Kernel,
@@ -5980,6 +6064,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _attentionSwaBatchedBf16Kernel = GetKernelFunc("llm_attention_swa_batched_bf16");
         _attentionSwaQ8Kernel = GetKernelFunc("llm_attention_swa_q8_0");
         _attentionSwaBatchedQ8Kernel = GetKernelFunc("llm_attention_swa_batched_q8_0");
+        _attentionSplitKvKernel     = GetKernelFunc("llm_attention_splitkv");        // flash-decoding (#235)
+        _attentionSplitKvBf16Kernel = GetKernelFunc("llm_attention_splitkv_bf16");
+        _attentionSplitKvQ8Kernel   = GetKernelFunc("llm_attention_splitkv_q8_0");
+        _attentionCombineKernel     = GetKernelFunc("llm_attention_combine");
         _kvAppendQ8Kernel      = GetKernelFunc("llm_kv_append_q8_0");
         _geluTanhMulKernel     = GetKernelFunc("llm_gelu_tanh_mul");
         _geluTanhMulStridedKernel = GetKernelFunc("llm_gelu_tanh_mul_strided");

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -3679,6 +3679,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// the kernel's <c>SPLITKV_CHUNK</c>.</summary>
     public const int SplitKvChunk = 512;
 
+    /// <summary>Max KV splits per head — the combine kernel's <c>SPLITKV_MAX_SPLITS</c>
+    /// shared array bound. Callers must keep ceil(maxSeqLen/<see cref="SplitKvChunk"/>) ≤ this
+    /// (i.e. maxSeqLen ≤ 131072); <see cref="AttentionSplitKv"/> enforces it.</summary>
+    public const int SplitKvMaxSplits = 256;
+
     /// <summary>
     /// Flash-decoding decode attention (issue #235). Splits each head's KV sequence
     /// into <see cref="SplitKvChunk"/>-sized chunks across <c>numHeads × nSplits</c>
@@ -3701,6 +3706,13 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             throw new NotSupportedException("NVRTC kernels are not available.");
 
         int nSplits = (maxSeqLen + SplitKvChunk - 1) / SplitKvChunk;
+        // The combine kernel sizes its per-head rescale array at SPLITKV_MAX_SPLITS; exceeding
+        // it would overrun shared memory. The caller gates maxSeqLen ≤ 131072 so this can't
+        // trigger — fail loud rather than silently corrupt if a future caller forgets.
+        if (nSplits > SplitKvMaxSplits)
+            throw new ArgumentOutOfRangeException(nameof(maxSeqLen), maxSeqLen,
+                $"AttentionSplitKv: nSplits {nSplits} exceeds SplitKvMaxSplits {SplitKvMaxSplits} " +
+                $"(maxSeqLen must be ≤ {SplitKvMaxSplits * SplitKvChunk}).");
         nint splitKern = kvDType switch
         {
             DType.BFloat16 => _attentionSplitKvBf16Kernel,

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -6895,6 +6895,213 @@ extern ""C"" __global__ void llm_attention_q8_0(
         num_heads, num_kv_heads, head_dim, seq_len, max_seq_len, attn_scale);
 }
 
+// ── Flash-decoding split-KV: partial attention over a KV chunk (issue #235) ──
+// Fixes the decode-attention occupancy collapse: the single-block kernels above
+// launch only num_heads blocks (~13% of the SMs at decode), serializing the whole
+// O(ctx)/token KV scan. This splits each head's causal sequence [0, seq_len) into
+// fixed SPLITKV_CHUNK-sized slices across `num_heads × n_splits` blocks, so the KV
+// read parallelizes across the SMs (flash-decoding; PyTorch/Tri-Dao 2023). Scalar
+// (not tensor-core) per the GQA-ratio-4 analysis in #235.
+//
+// One block = (query head h = blockIdx.x, KV split s = blockIdx.y). It handles slice
+// [s*CHUNK, min((s+1)*CHUNK, seq_len)) and emits the UN-normalized online-softmax
+// partial for that slice: local max m_i, local denom l_i = Σ exp(score−m_i), and the
+// numerator Õ_i[d] = Σ exp(score−m_i)·v[d]. `llm_attention_combine` then LSE-merges
+// the n_splits partials per head. The grid is FIXED at num_heads × n_splits
+// (n_splits = ceil(max_seq_len/CHUNK)) so it is CUDA-graph-capturable with seq_len as
+// the only per-replay-updated param; out-of-range splits (s*CHUNK ≥ seq_len) write
+// (m=−inf, l=0) and return so a stale partial from a prior replay is never merged.
+// K/V are decoded via sharpi_kv_dot / sharpi_kvload → fp32/bf16/q8_0 thunks.
+#define SPLITKV_CHUNK 512
+template<typename KV>
+__device__ void llm_attention_splitkv_impl(
+    const float* __restrict__ q,
+    const KV* __restrict__ k_cache,
+    const KV* __restrict__ v_cache,
+    float* __restrict__ partial_o,     // [num_heads * n_splits * head_dim]
+    float* __restrict__ partial_meta,  // [num_heads * n_splits * 2] : (m_i, l_i)
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    __shared__ float sk_scores[SPLITKV_CHUNK];
+    __shared__ float sdata[256];
+
+    unsigned int tid = threadIdx.x;
+    int h = (int)blockIdx.x;
+    int s = (int)blockIdx.y;
+    if (h >= num_heads || s >= n_splits) return;
+
+    long meta_off = ((long)h * (long)n_splits + (long)s) * 2;
+    int t0 = s * SPLITKV_CHUNK;
+    // Out-of-range split (fixed grid, short seq_len): mark empty and bail so the
+    // combine skips it (scale = exp(−inf − gmax) = 0) and never reads a stale Õ.
+    if (t0 >= seq_len) {
+        if (tid == 0) { partial_meta[meta_off] = sharpi_neg_inf(); partial_meta[meta_off + 1] = 0.f; }
+        return;
+    }
+    int t1 = t0 + SPLITKV_CHUNK; if (t1 > seq_len) t1 = seq_len;
+    int n = t1 - t0;
+
+    int kv_head = h / (num_heads / num_kv_heads);
+    int kv_dim  = num_kv_heads * head_dim;
+    float scale = (attn_scale > 0.f) ? attn_scale : rsqrtf((float)head_dim);
+    long q_off  = (long)h * (long)head_dim;
+
+    // Phase 1: scores for the slice → shared (indexed t − t0).
+    for (int t = (int)tid; t < n; t += 256) {
+        long k_off = (long)(t0 + t) * (long)kv_dim + (long)kv_head * (long)head_dim;
+        sk_scores[t] = sharpi_kv_dot(q + q_off, k_cache, k_off, head_dim) * scale;
+    }
+    __syncthreads();
+
+    // Phase 2: local max over the slice.
+    float local_max = sharpi_neg_inf();
+    for (int t = (int)tid; t < n; t += 256) local_max = fmaxf(local_max, sk_scores[t]);
+    sdata[tid] = local_max;
+    __syncthreads();
+    for (unsigned int r = 128; r > 0; r >>= 1) {
+        if (tid < r) sdata[tid] = fmaxf(sdata[tid], sdata[tid + r]);
+        __syncthreads();
+    }
+    float m_i = sdata[0];
+    __syncthreads();
+
+    // exp(score − m_i) in place + local denom.
+    float local_sum = 0.f;
+    for (int t = (int)tid; t < n; t += 256) {
+        float e = __expf(sk_scores[t] - m_i);
+        sk_scores[t] = e;
+        local_sum += e;
+    }
+    sdata[tid] = local_sum;
+    __syncthreads();
+    for (unsigned int r = 128; r > 0; r >>= 1) {
+        if (tid < r) sdata[tid] += sdata[tid + r];
+        __syncthreads();
+    }
+    float l_i = sdata[0];
+    __syncthreads();
+
+    if (tid == 0) { partial_meta[meta_off] = m_i; partial_meta[meta_off + 1] = l_i; }
+
+    // Phase 3: UN-normalized weighted-V numerator for this slice (combine divides by Σ).
+    long o_off = ((long)h * (long)n_splits + (long)s) * (long)head_dim;
+    for (int d = (int)tid; d < head_dim; d += 256) {
+        float acc = 0.f;
+        for (int t = 0; t < n; t++) {
+            long v_off = (long)(t0 + t) * (long)kv_dim + (long)kv_head * (long)head_dim;
+            acc += sk_scores[t] * sharpi_kvload(v_cache, v_off + d);
+        }
+        partial_o[o_off + d] = acc;
+    }
+}
+
+extern ""C"" __global__ void llm_attention_splitkv(
+    const float* __restrict__ q,
+    const float* __restrict__ k_cache,
+    const float* __restrict__ v_cache,
+    float* __restrict__ partial_o,
+    float* __restrict__ partial_meta,
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    llm_attention_splitkv_impl<float>(q, k_cache, v_cache, partial_o, partial_meta,
+        num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale);
+}
+
+extern ""C"" __global__ void llm_attention_splitkv_bf16(
+    const float* __restrict__ q,
+    const unsigned short* __restrict__ k_cache,
+    const unsigned short* __restrict__ v_cache,
+    float* __restrict__ partial_o,
+    float* __restrict__ partial_meta,
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    llm_attention_splitkv_impl<unsigned short>(q, k_cache, v_cache, partial_o, partial_meta,
+        num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale);
+}
+
+extern ""C"" __global__ void llm_attention_splitkv_q8_0(
+    const float* __restrict__ q,
+    const block_q8_0* __restrict__ k_cache,
+    const block_q8_0* __restrict__ v_cache,
+    float* __restrict__ partial_o,
+    float* __restrict__ partial_meta,
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    llm_attention_splitkv_impl<block_q8_0>(q, k_cache, v_cache, partial_o, partial_meta,
+        num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale);
+}
+
+// ── Flash-decoding combine: LSE-merge the n_splits partials per head (#235) ──
+// One block per query head; merges the per-slice (m_i, l_i, Õ_i) partials into the
+// final attention output with the standard online-softmax rescale:
+//   m = max_i m_i ; l = Σ_i exp(m_i−m)·l_i ; O[d] = (Σ_i exp(m_i−m)·Õ_i[d]) / l
+// Exact (modulo FP reduction order). Empty splits carry m_i=−inf → scale 0 → skipped.
+// SPLITKV_MAX_SPLITS bounds the per-head split count (ceil(131072/512)=256).
+#define SPLITKV_MAX_SPLITS 256
+extern ""C"" __global__ void llm_attention_combine(
+    const float* __restrict__ partial_o,     // [num_heads * n_splits * head_dim]
+    const float* __restrict__ partial_meta,  // [num_heads * n_splits * 2]
+    float* __restrict__ out,                  // [num_heads * head_dim]
+    int num_heads, int head_dim, int n_splits)
+{
+    __shared__ float sh_scale[SPLITKV_MAX_SPLITS];
+    __shared__ float red[256];
+    __shared__ float sh_gmax;
+    __shared__ float sh_denom;
+
+    unsigned int tid = threadIdx.x;
+    int h = (int)blockIdx.x;
+    if (h >= num_heads) return;
+    long base = (long)h * (long)n_splits;
+
+    // Global max over the splits' local maxima.
+    float lmax = sharpi_neg_inf();
+    for (int s = (int)tid; s < n_splits; s += 256)
+        lmax = fmaxf(lmax, partial_meta[(base + s) * 2]);
+    red[tid] = lmax;
+    __syncthreads();
+    for (unsigned int r = 128; r > 0; r >>= 1) {
+        if (tid < r) red[tid] = fmaxf(red[tid], red[tid + r]);
+        __syncthreads();
+    }
+    if (tid == 0) sh_gmax = red[0];
+    __syncthreads();
+    float gmax = sh_gmax;
+
+    // Per-split rescale factor exp(m_i − m) + global denominator Σ exp(m_i−m)·l_i.
+    float ldenom = 0.f;
+    for (int s = (int)tid; s < n_splits; s += 256) {
+        float m = partial_meta[(base + s) * 2];
+        float l = partial_meta[(base + s) * 2 + 1];
+        float sc = __expf(m - gmax);
+        sh_scale[s] = sc;
+        ldenom += sc * l;
+    }
+    red[tid] = ldenom;
+    __syncthreads();
+    for (unsigned int r = 128; r > 0; r >>= 1) {
+        if (tid < r) red[tid] += red[tid + r];
+        __syncthreads();
+    }
+    if (tid == 0) sh_denom = red[0];
+    __syncthreads();
+    float inv = 1.0f / sh_denom;
+
+    // Weighted sum of the per-split numerators across head_dim.
+    for (int d = (int)tid; d < head_dim; d += 256) {
+        float acc = 0.f;
+        for (int s = 0; s < n_splits; s++) {
+            float sc = sh_scale[s];
+            if (sc != 0.f) acc += sc * partial_o[(base + s) * (long)head_dim + d];
+        }
+        out[(long)h * (long)head_dim + d] = acc * inv;
+    }
+}
+
 // ── SnapKV: per-(query, head) attention scoring against the K cache ────────
 // Issue #58. Computes the SnapKV importance signal for ONE captured query
 // vector against the layer's K cache. For each head h, masks positions

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -6946,10 +6946,13 @@ __device__ void llm_attention_splitkv_impl(
     int kv_dim  = num_kv_heads * head_dim;
     float scale = (attn_scale > 0.f) ? attn_scale : rsqrtf((float)head_dim);
     long q_off  = (long)h * (long)head_dim;
+    // Per-position row stride and this head's invariant base offset, hoisted out of the loops.
+    long kv_dim_l = (long)kv_dim;
+    long kv_base  = (long)t0 * kv_dim_l + (long)kv_head * (long)head_dim;
 
     // Phase 1: scores for the slice → shared (indexed t − t0).
     for (int t = (int)tid; t < n; t += 256) {
-        long k_off = (long)(t0 + t) * (long)kv_dim + (long)kv_head * (long)head_dim;
+        long k_off = kv_base + (long)t * kv_dim_l;
         sk_scores[t] = sharpi_kv_dot(q + q_off, k_cache, k_off, head_dim) * scale;
     }
     __syncthreads();
@@ -6989,7 +6992,7 @@ __device__ void llm_attention_splitkv_impl(
     for (int d = (int)tid; d < head_dim; d += 256) {
         float acc = 0.f;
         for (int t = 0; t < n; t++) {
-            long v_off = (long)(t0 + t) * (long)kv_dim + (long)kv_head * (long)head_dim;
+            long v_off = kv_base + (long)t * kv_dim_l;   // same hoisted base as Phase 1
             acc += sk_scores[t] * sharpi_kvload(v_cache, v_off + d);
         }
         partial_o[o_off + d] = acc;
@@ -7091,14 +7094,17 @@ extern ""C"" __global__ void llm_attention_combine(
     __syncthreads();
     float inv = 1.0f / sh_denom;
 
-    // Weighted sum of the per-split numerators across head_dim.
+    // Weighted sum of the per-split numerators across head_dim. Base offsets hoisted.
+    long head_dim_l = (long)head_dim;
+    long po_base = base * head_dim_l;          // first split's row for this head
+    long out_base = (long)h * head_dim_l;
     for (int d = (int)tid; d < head_dim; d += 256) {
         float acc = 0.f;
         for (int s = 0; s < n_splits; s++) {
             float sc = sh_scale[s];
-            if (sc != 0.f) acc += sc * partial_o[(base + s) * (long)head_dim + d];
+            if (sc != 0.f) acc += sc * partial_o[po_base + (long)s * head_dim_l + d];
         }
-        out[(long)h * (long)head_dim + d] = acc * inv;
+        out[out_base + d] = acc * inv;
     }
 }
 

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -247,6 +247,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         // below underutilize the GPU (numHeads blocks, serial O(ctx) scan). Split the KV
         // sequence across the SMs. maxSeqLen ≤ _maxSeqLen keeps nSplits within the partials
         // buffer (and ≤ 256 for the combine kernel). Reuses the same fp32/bf16/q8 caches.
+        //
+        // NOTE (graph interaction): the decode CUDA graph is captured once, on the first
+        // eligible token, and the split-vs-single choice is baked into that capture. A LONG
+        // PROMPT (the #213/#235 case) has seqLen > SplitKvMinSeq at capture → split engages
+        // and replays correctly as seqLen grows (fixed grid + the splitkv early-exit). A SHORT
+        // prompt captures the single-block node and stays single-block even if generation later
+        // crosses the threshold (correct, just unaccelerated). Re-capturing on the crossing to
+        // also accelerate short-prompt/long-generation is a noted #235 follow-up.
         if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
             && seqLen > SplitKvMinSeq && maxSeqLen <= _maxSeqLen)
         {
@@ -480,9 +488,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     // Only split once the context is long enough that the 8-block launch underutilizes the
     // GPU; below this, the single-block kernel is already near the weight-matvec floor.
     private const int SplitKvMinSeq = 2048;
-    // Upper bound on maxSeqLen for the split path: nSplits = ceil(ctx/512) must fit the
-    // combine kernel's SPLITKV_MAX_SPLITS (256) shared array → ctx ≤ 131072.
-    private const int SplitKvMaxCtx = 131072;
+    // Upper bound on maxSeqLen for the split path: nSplits = ceil(ctx/chunk) must fit the
+    // combine kernel's SPLITKV_MAX_SPLITS shared array. Derived from the backend constants so
+    // the gate can't drift from the kernel bound (= 256 × 512 = 131072).
+    private const int SplitKvMaxCtx = CudaBackend.SplitKvMaxSplits * CudaBackend.SplitKvChunk;
     // SHARPI_SPLIT_DECODE=0 reverts to the single-block-per-head decode attention (the A/B
     // baseline; lets parity tests compare the split path against it). Default on.
     private readonly bool _splitDecodeEnabled =
@@ -910,7 +919,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         // Flash-decoding (#235): allocate the split-KV partials when the context is long
         // enough to benefit and within the combine kernel's split bound. nSplits = ceil(
         // ctx/chunk); sized at the widest head_dim so per-layer (≤ maxHeadDim) calls fit.
-        if (_splitDecodeEnabled && _maxSeqLen > SplitKvMinSeq && _maxSeqLen <= SplitKvMaxCtx)
+        // Skip under TurboQuant: TQ decode uses the direct TqAttention/Attention path, never
+        // AttentionKv, so the partials would be VRAM the split path never touches.
+        if (_splitDecodeEnabled && !_tqEnabled && _maxSeqLen > SplitKvMinSeq && _maxSeqLen <= SplitKvMaxCtx)
         {
             long nSplitsMax = (_maxSeqLen + CudaBackend.SplitKvChunk - 1) / CudaBackend.SplitKvChunk;
             _splitKvPartialO = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * _maxHeadDim));

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -243,6 +243,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                              int numHeads, int numKvHeads, int headDim, int seqLen, int maxSeqLen,
                              float attnScale = -1f)
     {
+        // Flash-decoding split-KV (#235): at long context the single-block-per-head kernels
+        // below underutilize the GPU (numHeads blocks, serial O(ctx) scan). Split the KV
+        // sequence across the SMs. maxSeqLen ≤ _maxSeqLen keeps nSplits within the partials
+        // buffer (and ≤ 256 for the combine kernel). Reuses the same fp32/bf16/q8 caches.
+        if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
+            && seqLen > SplitKvMinSeq && maxSeqLen <= _maxSeqLen)
+        {
+            _gpu.AttentionSplitKv(q, kCache, vCache, output, splitO, splitMeta, _kvDType,
+                numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
+            return;
+        }
+
         if (_kvDType == DType.BFloat16)
             _gpu.AttentionBf16(q, kCache, vCache, output, scoresScratch,
                 numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
@@ -457,6 +469,24 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private int _tqCompressedLen;
     private int _fp32WriteIdx;
     private int _fp32Count;
+
+    // Flash-decoding split-KV (#235): partials for the split decode-attention path.
+    // partial_o = [numHeads × nSplitsMax × maxHeadDim], partial_meta = [numHeads × nSplitsMax × 2].
+    // Allocated only when the run's context is long enough to benefit (and bounded so the
+    // combine kernel's per-head split count fits its shared array). Reused per layer (one
+    // serial stream). Null → AttentionKv stays on the single-block kernel.
+    private Tensor? _splitKvPartialO;
+    private Tensor? _splitKvPartialMeta;
+    // Only split once the context is long enough that the 8-block launch underutilizes the
+    // GPU; below this, the single-block kernel is already near the weight-matvec floor.
+    private const int SplitKvMinSeq = 2048;
+    // Upper bound on maxSeqLen for the split path: nSplits = ceil(ctx/512) must fit the
+    // combine kernel's SPLITKV_MAX_SPLITS (256) shared array → ctx ≤ 131072.
+    private const int SplitKvMaxCtx = 131072;
+    // SHARPI_SPLIT_DECODE=0 reverts to the single-block-per-head decode attention (the A/B
+    // baseline; lets parity tests compare the split path against it). Default on.
+    private readonly bool _splitDecodeEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE") != "0";
 
     // Dtype dispatch for MatMul (mirrors GpuForwardPass._weightDTypes).
     private readonly Dictionary<nint, DType> _weightDTypes = new();
@@ -876,6 +906,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         // kernels accept a null pointer in that case.
         if (_maxSeqLen > 4096)
             _attnScoresScratch = gpu.Allocate(TensorShape.D1((long)_numHeads * _maxSeqLen));
+
+        // Flash-decoding (#235): allocate the split-KV partials when the context is long
+        // enough to benefit and within the combine kernel's split bound. nSplits = ceil(
+        // ctx/chunk); sized at the widest head_dim so per-layer (≤ maxHeadDim) calls fit.
+        if (_splitDecodeEnabled && _maxSeqLen > SplitKvMinSeq && _maxSeqLen <= SplitKvMaxCtx)
+        {
+            long nSplitsMax = (_maxSeqLen + CudaBackend.SplitKvChunk - 1) / CudaBackend.SplitKvChunk;
+            _splitKvPartialO = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * _maxHeadDim));
+            _splitKvPartialMeta = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * 2));
+        }
 
         // Upload weights to VRAM
         int L = hp.NumLayers;
@@ -4362,6 +4402,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         // allocated; the SnapKV side flags ownership so we free it exactly once
         // here regardless of which path allocated it.
         if (_attnScoresScratch is { } attnScratch) _gpu.Free(attnScratch);
+
+        // Flash-decoding split-KV partials (#235).
+        if (_splitKvPartialO is { } splitO) _gpu.Free(splitO);
+        if (_splitKvPartialMeta is { } splitMeta) _gpu.Free(splitMeta);
 
         // SnapKV (issue #59) scratch (only allocated when active during a prefill).
         if (_snapKvQCapture is { } qc) _gpu.Free(qc);

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -68,12 +68,15 @@ public sealed class CudaForwardPassKvDtypeTests
     /// </summary>
     private static (float[][] logits, int[] argmax) RunPrefillDecode(
         CudaBackend gpu, string path, string? kvDtype, string prompt, int steps, int ctx, int[]? forced,
-        bool batchedPrefill = false)
+        bool batchedPrefill = false, string? splitDecode = null)
     {
         var prevKv = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
         var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
         Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", kvDtype);
         Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0"); // isolate the KV dtype
+        // null → leave the flash-decoding split-KV default (on); "0" forces the single-block path.
+        if (splitDecode is not null) Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", splitDecode);
         try
         {
             using var model = GgufModel.Open(path);
@@ -109,6 +112,68 @@ public sealed class CudaForwardPassKvDtypeTests
         {
             Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prevKv);
             Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
+        }
+    }
+
+    /// <summary>
+    /// Flash-decoding split-KV parity (issue #235). At long context the decode attention
+    /// switches from the single-block-per-head kernel to the split-KV path (KV sequence
+    /// partitioned across SMs + an LSE combine). The split is mathematically the same
+    /// softmax, only the reduction is reordered, so it must be argmax-stable and very close
+    /// in logits to the single-block path for the SAME KV dtype — the only variable here is
+    /// split-on vs split-off (<c>SHARPI_SPLIT_DECODE</c>). A long prompt (≈5000 tokens,
+    /// ctx 6144) puts every decode step at seqLen &gt; SplitKvMinSeq (2048) so the split
+    /// path is exercised; the single-block run (split off) is the trusted reference. Both
+    /// runs share the prefill (split only affects per-token decode), so positions 1.. are
+    /// where they can differ — by reduction-order rounding only.
+    /// </summary>
+    private static void AssertSplitKvDecodeParity(string filename, string kvDtype, float maxAbsTol)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(filename);
+        if (path is null) return;
+
+        const int steps = 6;
+        const int ctx = 6144;          // partials allocated (>2048) and room for the prompt
+        const int promptLen = 5000;    // every decode step lands at seqLen > 2048 → split path
+
+        using (var model = GgufModel.Open(path))
+        {
+            var tok = GgufTokenizer.FromGgufModel(model);
+            var sb = new System.Text.StringBuilder();
+            const string seed = "The quick brown fox jumps over the lazy dog. " +
+                                "Sphinx of black quartz, judge my vow. " +
+                                "Pack my box with five dozen liquor jugs. ";
+            while (tok.Encode(sb.ToString()).Count < promptLen) sb.Append(seed);
+            string prompt = sb.ToString();
+
+            // Single-block reference (split OFF) vs split-KV (split ON, default), same dtype.
+            var (single, singleArgmax) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: null, splitDecode: "0");
+            var (split, _) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: singleArgmax, splitDecode: "1");
+
+            // Coherence: the reference must be a real decode, not a degenerate repeat.
+            Assert.True(singleArgmax[1] != singleArgmax[0] || single[1].Length > 0,
+                $"{filename}: degenerate {kvDtype} reference decode — not a meaningful split test.");
+
+            for (int p = 0; p <= steps; p++)
+            {
+                Assert.Equal(single[p].Length, split[p].Length);
+                float maxAbs = 0f;
+                for (int i = 0; i < single[p].Length; i++)
+                {
+                    Assert.True(float.IsFinite(split[p][i]),
+                        $"{filename}: non-finite split-KV {kvDtype} logit at pos {p}, idx {i}.");
+                    maxAbs = Math.Max(maxAbs, Math.Abs(single[p][i] - split[p][i]));
+                }
+                Assert.True(TopK(split[p], 5).Contains(singleArgmax[p]),
+                    $"{filename}: pos {p} single-block top-1 ({singleArgmax[p]}) fell out of split-KV {kvDtype}'s top-5 " +
+                    $"(max-abs {maxAbs:F4}) — the split-KV combine reordered the head of the distribution.");
+                Assert.True(maxAbs < maxAbsTol,
+                    $"{filename}: pos {p} split-KV vs single-block {kvDtype} logit max-abs {maxAbs:F4} exceeds the " +
+                    $"reduction-order budget ({maxAbsTol:F2}) — likely a split/combine arithmetic bug, not rounding.");
+            }
         }
     }
 
@@ -374,6 +439,36 @@ public sealed class CudaForwardPassKvDtypeTests
     [Fact]
     public void Gemma4_12B_Q8ChunkedPrefill_MatchesFp32()
         => AssertKvChunkedPrefillParity("gemma-4-12b-it-qat-q4_0.gguf", "q8_0", maxAbsCeiling: 45.0f);
+
+    // ── Issue #235: flash-decoding split-KV decode attention ─────────────────
+    // Long-context decode switches AttentionKv (the global-layer path) from one block
+    // per head to the KV-split + LSE-combine kernels. These compare split-on vs split-off
+    // for the SAME KV dtype on a 5000-token prompt (every decode step at seqLen > 2048),
+    // so the only variable is the split path. The combine reorders the softmax reduction →
+    // argmax-stable, not bit-identical; top-5 stability is the hard gate and the max-abs
+    // budget catches a combine/rescale bug rather than reduction-order rounding. fp32 has
+    // no store rounding so its budget is tightest; bf16/q8 add the narrowed-store noise.
+
+    /// <summary>Gemma 4 E4B Q8_0 model, fp32 KV: split-KV global decode vs single-block.</summary>
+    [Fact]
+    public void Gemma4_E4B_Fp32SplitKv_MatchesSingleBlock()
+        => AssertSplitKvDecodeParity("gemma-4-E4B-it-Q8_0.gguf", "fp32", maxAbsTol: 1.0f);
+
+    /// <summary>Gemma 4 E4B, bf16 KV: split-KV (bf16 thunk) vs single-block bf16.</summary>
+    [Fact]
+    public void Gemma4_E4B_Bf16SplitKv_MatchesSingleBlock()
+        => AssertSplitKvDecodeParity("gemma-4-E4B-it-Q8_0.gguf", "bf16", maxAbsTol: 2.0f);
+
+    /// <summary>Gemma 4 E4B, q8_0 KV: split-KV (q8 thunk, sharpi_kv_dot) vs single-block q8.</summary>
+    [Fact]
+    public void Gemma4_E4B_Q8SplitKv_MatchesSingleBlock()
+        => AssertSplitKvDecodeParity("gemma-4-E4B-it-Q8_0.gguf", "q8_0", maxAbsTol: 2.5f);
+
+    /// <summary>Qwen3-8B Q4_K, fp32 KV: all-global (non-SWA) decode, 32 heads / head_dim 128 —
+    /// a different geometry than E4B's 8 heads / head_dim 512.</summary>
+    [Fact]
+    public void Qwen3_8B_Fp32SplitKv_MatchesSingleBlock()
+        => AssertSplitKvDecodeParity("Qwen3-8B-Q4_K_M.gguf", "fp32", maxAbsTol: 1.0f);
 
     // ── Issue #191: narrowed-KV GREEDY decode coherence (template-correct) ───
     // The parity tests above teacher-force the narrowed dtype onto fp32's trajectory, so

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -470,6 +470,106 @@ public sealed class CudaForwardPassKvDtypeTests
     public void Qwen3_8B_Fp32SplitKv_MatchesSingleBlock()
         => AssertSplitKvDecodeParity("Qwen3-8B-Q4_K_M.gguf", "fp32", maxAbsTol: 1.0f);
 
+    /// <summary>Gemma 4 12B QAT Q4_0, q8_0 KV: split-KV over the k_eq_v / per-layer-KV global
+    /// layers — the riskiest geometry (V reuses K storage, 8 GQA / 1 MQA) and the headline
+    /// 128K model. The other split tests use E4B (no k_eq_v) / Qwen3 (uniform KV).</summary>
+    [Fact]
+    public void Gemma4_12B_Q8SplitKv_MatchesSingleBlock()
+        => AssertSplitKvDecodeParity("gemma-4-12b-it-qat-q4_0.gguf", "q8_0", maxAbsTol: 4.0f);
+
+    /// <summary>
+    /// Flash-decoding split-KV under CUDA-graph replay ACROSS a split boundary (#235). The
+    /// decode graph is captured once (grid fixed at numHeads × nSplits) and replayed with
+    /// seqLen patched per token. This stresses the one path the steady-state parity tests
+    /// don't: a split that is OUT OF RANGE at capture (its 512-token chunk starts past seqLen)
+    /// must become correctly populated on a later replay as seqLen grows past its boundary —
+    /// and a stale partial from capture must never be merged. Prefill just below a 512 multiple
+    /// so the next split is empty at capture, decode well past it under graphs, assert the graph
+    /// actually instantiated (else the test would vacuously pass on a direct-launch fallback),
+    /// and compare to the single-block reference. fp32 → reduction-order budget only.
+    /// </summary>
+    [Fact]
+    public void Gemma4_E4B_SplitKv_GraphReplayCrossesBoundary()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath("gemma-4-E4B-it-Q8_0.gguf");
+        if (path is null) return;
+
+        const int ctx = 4096;
+        const int boundary = 6 * 512;        // 3072 — a split-chunk boundary
+        const int promptLen = boundary - 8;  // ~3064: splits ≥ 6 are empty at capture
+        const int steps = 24;                // decode well past the boundary
+        // This test's gate is top-5 stability across the graph-replay boundary crossing; the
+        // tight fp32 split-vs-single logit bound is owned by the parity test. max-abs here is a
+        // blow-up ceiling — a stale-partial/boundary bug spikes at the crossing or breaks top-5,
+        // it doesn't nudge a few units (reduction-order divergence over a near-uniform softmax).
+        const float maxAbsCeiling = 6.0f;
+
+        string prompt;
+        using (var model = GgufModel.Open(path))
+        {
+            var tok = GgufTokenizer.FromGgufModel(model);
+            var sb = new System.Text.StringBuilder();
+            const string seed = "The quick brown fox jumps over the lazy dog. " +
+                                "Sphinx of black quartz, judge my vow. " +
+                                "Pack my box with five dozen liquor jugs. ";
+            while (tok.Encode(sb.ToString()).Count < promptLen) sb.Append(seed);
+            prompt = sb.ToString();
+        }
+
+        // Single-block reference (split off) — trajectory + per-position logits.
+        var (single, singleArgmax) = RunPrefillDecode(gpu, path, "fp32", prompt, steps, ctx, forced: null, splitDecode: "0");
+
+        // Split on, graphs on, teacher-forced — keep fwd alive so we can assert GraphReady.
+        var prevKv = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+        var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
+        Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", "fp32");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0");
+        Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", "1");
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tok = GgufTokenizer.FromGgufModel(model);
+            int useCtx = Math.Min(hp.ContextLength, ctx);
+            using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: useCtx) { UseCudaGraph = true };
+            var tokens = tok.Encode(prompt).ToArray();
+            var split = new float[steps + 1][];
+            split[0] = fwd.Prefill(tokens).ToArray();
+            for (int i = 0; i < steps; i++)
+                split[i + 1] = fwd.Forward(singleArgmax[i], tokens.Length + i).ToArray();
+
+            Assert.True(gpu.GraphReady,
+                "E4B split-KV: CUDA graph did not instantiate — the split path silently fell back to " +
+                "direct launches, so this case would not actually validate graph replay across the boundary.");
+
+            for (int p = 0; p <= steps; p++)
+            {
+                Assert.Equal(single[p].Length, split[p].Length);
+                float maxAbs = 0f;
+                for (int i = 0; i < single[p].Length; i++)
+                {
+                    Assert.True(float.IsFinite(split[p][i]), $"non-finite split logit at pos {p}, idx {i}.");
+                    maxAbs = Math.Max(maxAbs, Math.Abs(single[p][i] - split[p][i]));
+                }
+                Assert.True(TopK(split[p], 5).Contains(singleArgmax[p]),
+                    $"pos {p} single-block top-1 ({singleArgmax[p]}) fell out of split's top-5 (max-abs {maxAbs:F4}) — " +
+                    "a graph-replay split-boundary bug (stale partial merged / wrong split activated).");
+                Assert.True(maxAbs < maxAbsCeiling,
+                    $"pos {p} split-vs-single max-abs {maxAbs:F4} exceeds the blow-up ceiling {maxAbsCeiling:F1} — " +
+                    "not reduction-order rounding.");
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prevKv);
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
+        }
+    }
+
     // ── Issue #191: narrowed-KV GREEDY decode coherence (template-correct) ───
     // The parity tests above teacher-force the narrowed dtype onto fp32's trajectory, so
     // they never let bf16/q8_0 pick their OWN greedy tokens — exactly the path a real 12 GB


### PR DESCRIPTION
## What

Flash-decoding (split-KV) for long-context decode attention on the dense CUDA path (#235). Fixes the decode-attention occupancy collapse profiled in Step 0.

## Why

The decode-attention kernels launch `grid=(numHeads,1,1)` — **8 blocks for Gemma 4 E4B** (~13% of the 60 SMs) — and each block **serially scans the whole KV sequence**. The sequence dimension has zero parallelism, so as context grows each block's O(ctx)/token scan just lengthens while the GPU idles: ~**6% of HBM peak** at 16K. This is the root of the long-context decode collapse from #213 (49→12.7 t/s, 2K→32K, dtype-independent).

## How

Flash-decoding (Tri Dao 2023): partition each head's sequence into fixed 512-token chunks across `numHeads × nSplits` blocks; each emits the un-normalized online-softmax partial `(m_i, l_i, Õ_i)` for its chunk; a combine kernel LSE-merges the partials per head.

- **Scalar, not tensor-core.** At GQA ratio 4 (E4B) the Step-0 research and llama.cpp both stay scalar: query-head packing only wins at G≥8, and at G=4 a 16-row mma tile is ≥75% padding while still memory-bound. Full prior-art writeup is posted on #235.
- **One templated `llm_attention_splitkv<KV>`** (fp32/bf16/q8_0 thunks) reusing `sharpi_kv_dot`/`sharpi_kvload`; plus a dtype-agnostic `llm_attention_combine`.
- **CUDA-graph-compatible.** Fixed grid (`nSplits = ceil(maxSeqLen/512)`) with `seqLen` as the only per-replay-updated param and early-exit for out-of-range splits — slots into the existing `TrackPositionNode`/`PositionPlus1` mechanism (combine has no varying args). Out-of-range splits write `(m=−inf, l=0)` so a stale partial is never merged.
- **Gated** in `CudaForwardPass.AttentionKv`: split when `seqLen > 2048` (below that the single-block kernel is already near the weight-matvec floor) and `maxSeqLen ≤ 131072` (`nSplits ≤ 256` fits the combine's shared array). Global layers only; SWA stays single-block (window-bounded KV). `SHARPI_SPLIT_DECODE=0` kill-switch.

## Result — decode A/B (Gemma 4 E4B Q8_0, RTX 4070 Ti, 32 timed steps after a long prefill)

| ctx | fp32 off→on | q8 off→on |
|---|---|---|
| 8192 | 31.4 → **52.9** (1.68×) | 29.1 → **55.2** (1.90×) |
| 32768 | 12.8 → **29.7** (2.32×) | 11.3 → **45.2** (4.0×) |

The long-context curve flattens substantially. And the #213 insight is now fully realized: once occupancy is fixed the kernel is **bandwidth-bound**, so q8 (¼ the bytes) now **beats** fp32 at 32K — the inverse of the single-block kernel where q8 was the slowest dtype.

## Validation

- **4 new split-vs-single-block parity tests** (`CudaForwardPassKvDtypeTests`): fp32/bf16/q8 on E4B + fp32 on Qwen3-8B (different geometry — 32 heads/d128 all-global vs 8 heads/d512 SWA+global). A 5000-token prompt puts every decode step at `seqLen > 2048` → the split path; the single-block run (`SHARPI_SPLIT_DECODE=0`) is the trusted reference. Argmax-stable with tight logit budgets (≤1.0 fp32, ≤2.0 bf16, ≤2.5 q8); greedy `firstTok` identical split-on vs off.
- **Full KvDtype suite 59/59**, **Gemma4 graph-parity + dense forward-pass 8/8**, attn-kernel NVRTC compile 5/5.
- Combine reorders the softmax reduction → **argmax-stable, not bit-identical** (same contract as the TC2 flash-prefill path).
- Release build clean (`TreatWarningsAsErrors` + NativeAOT analyzers).

## Scope / follow-ups

Dense `CudaForwardPass`, global layers. Noted Phase-B follow-ups (in #235): in-kernel GQA group-shared KV loading (load each KV head once across its query group), SWA split, and the hybrid/GDN paths.
