### PR TITLE
perf(cuda): GQA head-sharing for split-KV decode (auto fp32 long-ctx) (#237)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -331,6 +331,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _attentionSplitKvBf16Kernel;
     private nint   _attentionSplitKvQ8Kernel;
     private nint   _attentionCombineKernel;
+    // Issue #237 (GQA head-sharing): split-KV variant that processes a KV head's whole
+    // query group per block (grid num_kv_heads × n_splits), loading each K/V slice once.
+    private nint   _attentionSplitKvGroupedKernel;
+    private nint   _attentionSplitKvGroupedBf16Kernel;
+    private nint   _attentionSplitKvGroupedQ8Kernel;
 
     // Grow-only global score scratch for the wave-based >4096 batched-query SDPA
     // (issue #118). Sized W × num_heads × score_stride floats; W is chosen so this
@@ -3695,11 +3700,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// <see cref="Attention"/> (the combine reorders the softmax reduction). The grid is
     /// fixed at capture and only seqLen updates per graph replay (out-of-range splits
     /// early-exit), so it is CUDA-graph-capturable. fp32/bf16/q8_0 via <paramref name="kvDType"/>.
+    ///
+    /// <paramref name="grouped"/> (issue #237): one block handles a KV head's whole query
+    /// group (grid <c>numKvHeads × nSplits</c>), loading each K/V slice once and reusing it
+    /// across the <c>G = numHeads/numKvHeads</c> query heads — ~G× less KV HBM read on the
+    /// bandwidth-bound long-ctx decode, at the cost of G× fewer blocks. Emits the SAME
+    /// per-query-head partials (combine + layout unchanged). Requires <c>numHeads % numKvHeads
+    /// == 0</c> and <c>G ≤ 8</c>.
     /// </summary>
     public void AttentionSplitKv(Tensor q, Tensor kCache, Tensor vCache, Tensor output,
                                  Tensor partialO, Tensor partialMeta, DType kvDType,
                                  int numHeads, int numKvHeads, int headDim, int seqLen, int maxSeqLen,
-                                 float attnScale = -1f)
+                                 float attnScale = -1f, bool grouped = false)
     {
         EnsureImageKernels();
         if (!_imageKernelsAvailable)
@@ -3713,11 +3725,23 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             throw new ArgumentOutOfRangeException(nameof(maxSeqLen), maxSeqLen,
                 $"AttentionSplitKv: nSplits {nSplits} exceeds SplitKvMaxSplits {SplitKvMaxSplits} " +
                 $"(maxSeqLen must be ≤ {SplitKvMaxSplits * SplitKvChunk}).");
-        nint splitKern = kvDType switch
+
+        // GQA head-sharing (#237): G query heads per block; grid X = numKvHeads, one extern
+        // shared float per (group head × chunk slot). G ≤ 8 (kernel's dots/acc/po_base arrays).
+        int group = grouped ? numHeads / numKvHeads : 1;
+        if (grouped && (numHeads % numKvHeads != 0 || group > 8))
+            throw new ArgumentOutOfRangeException(nameof(numKvHeads), numKvHeads,
+                $"Grouped split-KV requires numHeads % numKvHeads == 0 and G ≤ 8 (got numHeads={numHeads}, numKvHeads={numKvHeads}).");
+        uint gridX = grouped ? (uint)numKvHeads : (uint)numHeads;
+        uint sharedBytes = grouped ? (uint)(group * SplitKvChunk * sizeof(float)) : 0u;
+        nint splitKern = (grouped, kvDType) switch
         {
-            DType.BFloat16 => _attentionSplitKvBf16Kernel,
-            DType.Q8_0     => _attentionSplitKvQ8Kernel,
-            DType.Float32  => _attentionSplitKvKernel,
+            (false, DType.BFloat16) => _attentionSplitKvBf16Kernel,
+            (false, DType.Q8_0)     => _attentionSplitKvQ8Kernel,
+            (false, DType.Float32)  => _attentionSplitKvKernel,
+            (true,  DType.BFloat16) => _attentionSplitKvGroupedBf16Kernel,
+            (true,  DType.Q8_0)     => _attentionSplitKvGroupedQ8Kernel,
+            (true,  DType.Float32)  => _attentionSplitKvGroupedKernel,
             _ => throw new ArgumentOutOfRangeException(nameof(kvDType), kvDType,
                 "AttentionSplitKv supports fp32 / bf16 / q8_0 K/V caches only."),
         };
@@ -3737,8 +3761,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             (nint)(&qP), (nint)(&kP), (nint)(&vP), (nint)(&poP), (nint)(&pmP),
             (nint)(&pNH), (nint)(&pNKV), (nint)(&pHD), (nint)(&pSL), (nint)(&pNS), (nint)(&pScale)
         };
-        int rs = NvrtcInterop.LaunchKernel(splitKern, (uint)numHeads, (uint)nSplits, 1, 256, 1, 1, 0, _stream, sargs, null);
-        if (rs != 0) throw new InvalidOperationException($"cuLaunchKernel(attention_splitkv {kvDType}) failed: {rs}");
+        int rs = NvrtcInterop.LaunchKernel(splitKern, gridX, (uint)nSplits, 1, 256, 1, 1, sharedBytes, _stream, sargs, null);
+        if (rs != 0) throw new InvalidOperationException($"cuLaunchKernel(attention_splitkv {kvDType} grouped={grouped}) failed: {rs}");
 
         // Track the split kernel BEFORE the combine launch (single-leaf harvest); only
         // seqLen (arg 8) varies per replay — the fixed grid + early-exit handle the rest.
@@ -3748,7 +3772,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             av[0] = qP; av[1] = kP; av[2] = vP; av[3] = poP; av[4] = pmP;
             av[5] = pNH; av[6] = pNKV; av[7] = pHD; av[8] = pSL; av[9] = pNS;
             av[10] = GraphFloatBits(pScale);
-            TrackPositionNode(splitKern, (uint)numHeads, (uint)nSplits, 1, 256, 1, 1, 0, av,
+            TrackPositionNode(splitKern, gridX, (uint)nSplits, 1, 256, 1, 1, sharedBytes, av,
                 [(8, GraphPosKind.PositionPlus1, 0)]);
         }
 
@@ -5932,6 +5956,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             // #235: flash-decoding split-KV + combine.
             _attentionSplitKvKernel, _attentionSplitKvBf16Kernel, _attentionSplitKvQ8Kernel,
             _attentionCombineKernel,
+            _attentionSplitKvGroupedKernel, _attentionSplitKvGroupedBf16Kernel, _attentionSplitKvGroupedQ8Kernel,
             // #197: ragged-batched decode kernels.
             _ropeNeoxRaggedKernel, _ropeInterleavedRaggedKernel,
             _kvAppendRaggedKernel, _kvAppendRaggedBf16Kernel, _kvAppendRaggedQ8Kernel,
@@ -6079,6 +6104,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _attentionSplitKvKernel     = GetKernelFunc("llm_attention_splitkv");        // flash-decoding (#235)
         _attentionSplitKvBf16Kernel = GetKernelFunc("llm_attention_splitkv_bf16");
         _attentionSplitKvQ8Kernel   = GetKernelFunc("llm_attention_splitkv_q8_0");
+        _attentionSplitKvGroupedKernel     = GetKernelFunc("llm_attention_splitkv_grouped");      // GQA head-sharing (#237)
+        _attentionSplitKvGroupedBf16Kernel = GetKernelFunc("llm_attention_splitkv_grouped_bf16");
+        _attentionSplitKvGroupedQ8Kernel   = GetKernelFunc("llm_attention_splitkv_grouped_q8_0");
         _attentionCombineKernel     = GetKernelFunc("llm_attention_combine");
         _kvAppendQ8Kernel      = GetKernelFunc("llm_kv_append_q8_0");
         _geluTanhMulKernel     = GetKernelFunc("llm_gelu_tanh_mul");

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -3729,9 +3729,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         // GQA head-sharing (#237): G query heads per block; grid X = numKvHeads, one extern
         // shared float per (group head × chunk slot). G ≤ 8 (kernel's dots/acc/po_base arrays).
         int group = grouped ? numHeads / numKvHeads : 1;
-        if (grouped && (numHeads % numKvHeads != 0 || group > 8))
+        if (grouped && (numKvHeads < 2 || numHeads % numKvHeads != 0 || group < 2 || group > 8))
             throw new ArgumentOutOfRangeException(nameof(numKvHeads), numKvHeads,
-                $"Grouped split-KV requires numHeads % numKvHeads == 0 and G ≤ 8 (got numHeads={numHeads}, numKvHeads={numKvHeads}).");
+                $"Grouped split-KV requires numKvHeads ≥ 2, numHeads % numKvHeads == 0, and G ∈ [2,8] " +
+                $"(got numHeads={numHeads}, numKvHeads={numKvHeads}).");
         uint gridX = grouped ? (uint)numKvHeads : (uint)numHeads;
         uint sharedBytes = grouped ? (uint)(group * SplitKvChunk * sizeof(float)) : 0u;
         nint splitKern = (grouped, kvDType) switch

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -3728,7 +3728,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
 
         // GQA head-sharing (#237): G query heads per block; grid X = numKvHeads, one extern
         // shared float per (group head × chunk slot). G ≤ 8 (kernel's dots/acc/po_base arrays).
-        int group = grouped ? numHeads / numKvHeads : 1;
+        // numKvHeads ≥ 2 guards the division below (a caller passing grouped with numKvHeads ≤ 0
+        // would otherwise DivideByZero before the guard); the guard's `< 2` short-circuits the `%`.
+        int group = (grouped && numKvHeads >= 2) ? numHeads / numKvHeads : 1;
         if (grouped && (numKvHeads < 2 || numHeads % numKvHeads != 0 || group < 2 || group > 8))
             throw new ArgumentOutOfRangeException(nameof(numKvHeads), numKvHeads,
                 $"Grouped split-KV requires numKvHeads ≥ 2, numHeads % numKvHeads == 0, and G ∈ [2,8] " +

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -7108,6 +7108,179 @@ extern ""C"" __global__ void llm_attention_combine(
     }
 }
 
+// ── Multi-query dot for GQA head-sharing (#237): one K read, GF FMAs ─────────
+// GF dots of GF query rows (q_base[g*head_dim + .], g=0..GF-1) against one contiguous
+// K row at element offset `off`. Each K element is read ONCE and fused into all GF
+// accumulators, so the K HBM read is amortized across the query group (vs GF separate
+// sharpi_kv_dot calls each re-reading the row). q8_0 keeps the per-32-block scale cache
+// (block-walk identical to sharpi_kv_dot). dots[] must hold ≥ GF (GF ≤ 8, host-enforced).
+__device__ __forceinline__ void sharpi_kv_dot_multi(const float* __restrict__ q_base, int head_dim, int gf,
+                                                     const float* __restrict__ k, long off, float* dots)
+{
+    for (int g = 0; g < gf; g++) dots[g] = 0.f;
+    for (int d = 0; d < head_dim; d++) {
+        float kd = k[off + d];
+        for (int g = 0; g < gf; g++) dots[g] += q_base[(long)g * (long)head_dim + d] * kd;
+    }
+}
+__device__ __forceinline__ void sharpi_kv_dot_multi(const float* __restrict__ q_base, int head_dim, int gf,
+                                                     const unsigned short* __restrict__ k, long off, float* dots)
+{
+    for (int g = 0; g < gf; g++) dots[g] = 0.f;
+    for (int d = 0; d < head_dim; d++) {
+        float kd = sharpi_bf16_to_fp32((unsigned int)k[off + d]);
+        for (int g = 0; g < gf; g++) dots[g] += q_base[(long)g * (long)head_dim + d] * kd;
+    }
+}
+__device__ __forceinline__ void sharpi_kv_dot_multi(const float* __restrict__ q_base, int head_dim, int gf,
+                                                     const block_q8_0* __restrict__ k, long off, float* dots)
+{
+    for (int g = 0; g < gf; g++) dots[g] = 0.f;
+    long b = off >> 5;
+    int lane = (int)(off & 31);
+    for (int d = 0; d < head_dim; ) {
+        float s = sharpi_fp16_to_fp32((unsigned int)k[b].d);
+        for (; lane < 32 && d < head_dim; lane++, d++) {
+            float kd = s * (float)k[b].qs[lane];
+            for (int g = 0; g < gf; g++) dots[g] += q_base[(long)g * (long)head_dim + d] * kd;
+        }
+        lane = 0; b++;
+    }
+}
+
+// ── GQA head-sharing split-KV (#237): one block per (KV head, KV split) ──────
+// Variant of llm_attention_splitkv that loads each K/V slice element ONCE and reuses it
+// across the G = num_heads/num_kv_heads query heads sharing that KV head, instead of G
+// separate blocks each re-reading the slice (the per-head split's G× redundant HBM read,
+// which dominates the now-bandwidth-bound long-ctx decode — #235/#237). grid =
+// (num_kv_heads, n_splits); each block emits the SAME per-query-head partials the per-head
+// kernel does, so llm_attention_combine + the partials layout are unchanged. Dynamic shared
+// = G*SPLITKV_CHUNK floats (per-head exp-weights). G ≤ 8 (dots/acc/po_base arrays).
+template<typename KV>
+__device__ void llm_attention_splitkv_grouped_impl(
+    const float* __restrict__ q,
+    const KV* __restrict__ k_cache,
+    const KV* __restrict__ v_cache,
+    float* __restrict__ partial_o,     // [num_heads * n_splits * head_dim]
+    float* __restrict__ partial_meta,  // [num_heads * n_splits * 2] : (m_i, l_i)
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    extern __shared__ float g_scores[];   // [G * SPLITKV_CHUNK]
+    __shared__ float sdata[256];
+
+    unsigned int tid = threadIdx.x;
+    int kv = (int)blockIdx.x;
+    int s  = (int)blockIdx.y;
+    if (kv >= num_kv_heads || s >= n_splits) return;
+
+    int G  = num_heads / num_kv_heads;    // query heads per KV head (group size)
+    int h0 = kv * G;                       // first query head of this group
+    int t0 = s * SPLITKV_CHUNK;
+    // Out-of-range split (fixed grid, short seq_len): mark all G heads' partials empty so
+    // the combine skips them (scale = exp(−inf − gmax) = 0) and never reads a stale Õ.
+    if (t0 >= seq_len) {
+        if ((int)tid < G) {
+            long mo = ((long)(h0 + (int)tid) * (long)n_splits + (long)s) * 2;
+            partial_meta[mo] = sharpi_neg_inf(); partial_meta[mo + 1] = 0.f;
+        }
+        return;
+    }
+    int t1 = t0 + SPLITKV_CHUNK; if (t1 > seq_len) t1 = seq_len;
+    int n = t1 - t0;
+
+    int kv_dim = num_kv_heads * head_dim;
+    float scale = (attn_scale > 0.f) ? attn_scale : rsqrtf((float)head_dim);
+    long kv_dim_l = (long)kv_dim;
+    long kv_base  = (long)t0 * kv_dim_l + (long)kv * (long)head_dim;
+    const float* q_base = q + (long)h0 * (long)head_dim;
+    // Per-head partial-O row base, hoisted out of the Phase-3 loops.
+    long po_base[8];
+    for (int g = 0; g < G; g++)
+        po_base[g] = ((long)(h0 + g) * (long)n_splits + (long)s) * (long)head_dim;
+
+    // Phase 1: G dots per slice position — K row read once, GF FMAs.
+    for (int t = (int)tid; t < n; t += 256) {
+        float dots[8];
+        sharpi_kv_dot_multi(q_base, head_dim, G, k_cache, kv_base + (long)t * kv_dim_l, dots);
+        for (int g = 0; g < G; g++) g_scores[g * SPLITKV_CHUNK + t] = dots[g] * scale;
+    }
+    __syncthreads();
+
+    // Phase 2: per query head — max, exp in place, sum → (m_i, l_i). sdata reused per g.
+    for (int g = 0; g < G; g++) {
+        float* sc = g_scores + g * SPLITKV_CHUNK;
+        float lmax = sharpi_neg_inf();
+        for (int t = (int)tid; t < n; t += 256) lmax = fmaxf(lmax, sc[t]);
+        sdata[tid] = lmax;
+        __syncthreads();
+        for (unsigned int r = 128; r > 0; r >>= 1) { if (tid < r) sdata[tid] = fmaxf(sdata[tid], sdata[tid + r]); __syncthreads(); }
+        float m_i = sdata[0];
+        __syncthreads();
+        float lsum = 0.f;
+        for (int t = (int)tid; t < n; t += 256) { float e = __expf(sc[t] - m_i); sc[t] = e; lsum += e; }
+        sdata[tid] = lsum;
+        __syncthreads();
+        for (unsigned int r = 128; r > 0; r >>= 1) { if (tid < r) sdata[tid] += sdata[tid + r]; __syncthreads(); }
+        float l_i = sdata[0];
+        if (tid == 0) {
+            long mo = ((long)(h0 + g) * (long)n_splits + (long)s) * 2;
+            partial_meta[mo] = m_i; partial_meta[mo + 1] = l_i;
+        }
+        __syncthreads();
+    }
+
+    // Phase 3: UN-normalized weighted-V numerator — V row read once, GF FMAs.
+    for (int d = (int)tid; d < head_dim; d += 256) {
+        float acc[8];
+        for (int g = 0; g < G; g++) acc[g] = 0.f;
+        for (int t = 0; t < n; t++) {
+            float vd = sharpi_kvload(v_cache, kv_base + (long)t * kv_dim_l + d);
+            for (int g = 0; g < G; g++) acc[g] += g_scores[g * SPLITKV_CHUNK + t] * vd;
+        }
+        for (int g = 0; g < G; g++) partial_o[po_base[g] + d] = acc[g];
+    }
+}
+
+extern ""C"" __global__ void llm_attention_splitkv_grouped(
+    const float* __restrict__ q,
+    const float* __restrict__ k_cache,
+    const float* __restrict__ v_cache,
+    float* __restrict__ partial_o,
+    float* __restrict__ partial_meta,
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    llm_attention_splitkv_grouped_impl<float>(q, k_cache, v_cache, partial_o, partial_meta,
+        num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale);
+}
+
+extern ""C"" __global__ void llm_attention_splitkv_grouped_bf16(
+    const float* __restrict__ q,
+    const unsigned short* __restrict__ k_cache,
+    const unsigned short* __restrict__ v_cache,
+    float* __restrict__ partial_o,
+    float* __restrict__ partial_meta,
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    llm_attention_splitkv_grouped_impl<unsigned short>(q, k_cache, v_cache, partial_o, partial_meta,
+        num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale);
+}
+
+extern ""C"" __global__ void llm_attention_splitkv_grouped_q8_0(
+    const float* __restrict__ q,
+    const block_q8_0* __restrict__ k_cache,
+    const block_q8_0* __restrict__ v_cache,
+    float* __restrict__ partial_o,
+    float* __restrict__ partial_meta,
+    int num_heads, int num_kv_heads, int head_dim,
+    int seq_len, int n_splits, float attn_scale)
+{
+    llm_attention_splitkv_grouped_impl<block_q8_0>(q, k_cache, v_cache, partial_o, partial_meta,
+        num_heads, num_kv_heads, head_dim, seq_len, n_splits, attn_scale);
+}
+
 // ── SnapKV: per-(query, head) attention scoring against the K cache ────────
 // Issue #58. Computes the SnapKV importance signal for ONE captured query
 // vector against the layer's K cache. For each head h, masks positions

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -258,19 +258,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
             && seqLen > SplitKvMinSeq && maxSeqLen <= _maxSeqLen)
         {
-            // GQA head-sharing (#237). Eligible only when a KV head's query group (G) fits the
-            // grouped kernel's arrays (2..8), divides evenly, and there are ≥2 KV heads (else the
-            // grid X = numKvHeads is too small to fill the SMs). Within that: "0" forces per-head,
-            // "1" forces grouped, unset auto-selects grouped only for fp32 at long ctx (where the
-            // bandwidth-bound read makes the G× traffic saving beat the G× block-count loss).
-            int g = numKvHeads >= 2 ? numHeads / numKvHeads : 0;
-            bool eligible = numKvHeads >= 2 && numHeads % numKvHeads == 0 && g >= 2 && g <= 8;
-            bool grouped = eligible && _splitGroupedMode switch
-            {
-                "0" => false,
-                "1" => true,
-                _   => _kvDType == DType.Float32 && seqLen >= GroupedMinSeqFp32,
-            };
+            bool grouped = ShouldUseGroupedSplit(_splitGroupedMode, _kvDType, numHeads, numKvHeads, seqLen);
             _gpu.AttentionSplitKv(q, kCache, vCache, output, splitO, splitMeta, _kvDType,
                 numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale, grouped: grouped);
             return;
@@ -285,6 +273,26 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         else
             _gpu.Attention(q, kCache, vCache, output, scoresScratch,
                 numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
+    }
+
+    /// <summary>
+    /// GQA head-sharing dispatch decision (#237) — the production default that routes
+    /// <see cref="AttentionKv"/> to the grouped split-KV kernel. Eligible only when a KV head's
+    /// query group <c>G = numHeads/numKvHeads</c> fits the grouped kernel's arrays (2..8), divides
+    /// evenly, and there are ≥2 KV heads (else grid X = numKvHeads is too small to fill the SMs).
+    /// Within that: <paramref name="mode"/> "0" forces per-head, "1" forces grouped, unset
+    /// auto-selects grouped only for fp32 at long ctx (where the bandwidth-bound read makes the
+    /// G× traffic saving beat the G× block-count loss — see #237 A/B). Pure function so the
+    /// shipping default is unit-tested without a GPU.
+    /// </summary>
+    internal static bool ShouldUseGroupedSplit(string? mode, DType kvDType, int numHeads, int numKvHeads, int seqLen)
+    {
+        if (mode == "0") return false;
+        int g = numKvHeads >= 2 ? numHeads / numKvHeads : 0;
+        bool eligible = numKvHeads >= 2 && numHeads % numKvHeads == 0 && g >= 2 && g <= 8;
+        if (!eligible) return false;                 // can't launch grouped (host would throw)
+        if (mode == "1") return true;                // forced on, eligible
+        return kvDType == DType.Float32 && seqLen >= GroupedMinSeqFp32;   // auto
     }
 
     private void AttentionSwaKv(Tensor q, Tensor kCache, Tensor vCache, Tensor output,

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -258,8 +258,21 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
             && seqLen > SplitKvMinSeq && maxSeqLen <= _maxSeqLen)
         {
+            // GQA head-sharing (#237). Eligible only when a KV head's query group (G) fits the
+            // grouped kernel's arrays (2..8), divides evenly, and there are ≥2 KV heads (else the
+            // grid X = numKvHeads is too small to fill the SMs). Within that: "0" forces per-head,
+            // "1" forces grouped, unset auto-selects grouped only for fp32 at long ctx (where the
+            // bandwidth-bound read makes the G× traffic saving beat the G× block-count loss).
+            int g = numKvHeads >= 2 ? numHeads / numKvHeads : 0;
+            bool eligible = numKvHeads >= 2 && numHeads % numKvHeads == 0 && g >= 2 && g <= 8;
+            bool grouped = eligible && _splitGroupedMode switch
+            {
+                "0" => false,
+                "1" => true,
+                _   => _kvDType == DType.Float32 && seqLen >= GroupedMinSeqFp32,
+            };
             _gpu.AttentionSplitKv(q, kCache, vCache, output, splitO, splitMeta, _kvDType,
-                numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
+                numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale, grouped: grouped);
             return;
         }
 
@@ -496,6 +509,19 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     // baseline; lets parity tests compare the split path against it). Default on.
     private readonly bool _splitDecodeEnabled =
         Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE") != "0";
+    // GQA head-sharing (#237): one block per KV head's query group, loading each KV slice once
+    // (G× less KV HBM read at the cost of G× fewer blocks). The decode A/B (E4B, head_dim 512,
+    // 2 KV heads, 4070 Ti) showed it only beats the per-head split when the read is genuinely
+    // bandwidth-bound: fp32 (4 B/elem) at ctx ≥ ~24K (+11% @24K, +23% @32K). q8/bf16 read too few
+    // bytes to be bandwidth-bound, so the G× fewer blocks lose; below ~24K fp32 loses to occupancy.
+    // → AUTO-select only for fp32 at long ctx (GroupedMinSeqFp32) with an eligible head config.
+    // SHARPI_SPLIT_DECODE_GROUPED: "0" forces per-head, "1" forces grouped whenever eligible
+    // (for bisecting); unset = auto. Heuristic tuned to E4B-class shapes — other head_dims shift
+    // the crossover, so the override exists.
+    private readonly string? _splitGroupedMode =
+        Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE_GROUPED");
+    // fp32-only long-ctx threshold where grouped's traffic saving beats its occupancy loss (E4B).
+    private const int GroupedMinSeqFp32 = 24576;
 
     // Dtype dispatch for MatMul (mirrors GpuForwardPass._weightDTypes).
     private readonly Dictionary<nint, DType> _weightDTypes = new();

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -68,15 +68,18 @@ public sealed class CudaForwardPassKvDtypeTests
     /// </summary>
     private static (float[][] logits, int[] argmax) RunPrefillDecode(
         CudaBackend gpu, string path, string? kvDtype, string prompt, int steps, int ctx, int[]? forced,
-        bool batchedPrefill = false, string? splitDecode = null)
+        bool batchedPrefill = false, string? splitDecode = null, string? groupedDecode = null)
     {
         var prevKv = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
         var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
         var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
+        var prevGrouped = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE_GROUPED");
         Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", kvDtype);
         Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0"); // isolate the KV dtype
         // null → leave the flash-decoding split-KV default (on); "0" forces the single-block path.
         if (splitDecode is not null) Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", splitDecode);
+        // null → auto (grouped only for fp32 ≥24K); "1" forces grouped, "0" forces per-head (#237).
+        if (groupedDecode is not null) Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE_GROUPED", groupedDecode);
         try
         {
             using var model = GgufModel.Open(path);
@@ -113,6 +116,7 @@ public sealed class CudaForwardPassKvDtypeTests
             Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prevKv);
             Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap);
             Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE_GROUPED", prevGrouped);
         }
     }
 
@@ -569,6 +573,77 @@ public sealed class CudaForwardPassKvDtypeTests
             Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
         }
     }
+
+    // ── Issue #237: GQA head-sharing (grouped split-KV) ──────────────────────
+    // The grouped kernel processes a KV head's whole query group per block, loading each
+    // K/V slice once. It re-derives the same softmax with a one-KV-read schedule → must be
+    // argmax-stable vs the single-block reference for every dtype (correctness is dtype-
+    // independent; the AUTO gate only enables it for fp32 ≥ 24K, but the kernel must be right
+    // for all three thunks). We FORCE grouped (SHARPI_SPLIT_DECODE_GROUPED=1) so a feasible
+    // 5000-token prompt exercises it, and compare to the single-block run.
+
+    private static void AssertGroupedSplitKvParity(string filename, string kvDtype, float maxAbsTol)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(filename);
+        if (path is null) return;
+
+        const int steps = 6;
+        const int ctx = 6144;
+        const int promptLen = 5000;
+        using (var model = GgufModel.Open(path))
+        {
+            var tok = GgufTokenizer.FromGgufModel(model);
+            var sb = new System.Text.StringBuilder();
+            const string seed = "The quick brown fox jumps over the lazy dog. " +
+                                "Sphinx of black quartz, judge my vow. " +
+                                "Pack my box with five dozen liquor jugs. ";
+            while (tok.Encode(sb.ToString()).Count < promptLen) sb.Append(seed);
+            string prompt = sb.ToString();
+
+            var (single, singleArgmax) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: null, splitDecode: "0");
+            var (grouped, _) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: singleArgmax, splitDecode: "1", groupedDecode: "1");
+
+            for (int p = 0; p <= steps; p++)
+            {
+                Assert.Equal(single[p].Length, grouped[p].Length);
+                float maxAbs = 0f;
+                for (int i = 0; i < single[p].Length; i++)
+                {
+                    Assert.True(float.IsFinite(grouped[p][i]),
+                        $"{filename}: non-finite grouped {kvDtype} logit at pos {p}, idx {i}.");
+                    maxAbs = Math.Max(maxAbs, Math.Abs(single[p][i] - grouped[p][i]));
+                }
+                Assert.True(TopK(grouped[p], 5).Contains(singleArgmax[p]),
+                    $"{filename}: pos {p} single-block top-1 ({singleArgmax[p]}) fell out of grouped {kvDtype}'s top-5 " +
+                    $"(max-abs {maxAbs:F4}) — a GQA head-sharing bug.");
+                Assert.True(maxAbs < maxAbsTol,
+                    $"{filename}: pos {p} grouped vs single-block {kvDtype} logit max-abs {maxAbs:F4} exceeds " +
+                    $"{maxAbsTol:F2} — a head-sharing schedule bug, not reduction-order rounding.");
+            }
+        }
+    }
+
+    /// <summary>Gemma 4 E4B (2 KV heads, G=4): grouped fp32 vs single-block.</summary>
+    [Fact]
+    public void Gemma4_E4B_Fp32Grouped_MatchesSingleBlock()
+        => AssertGroupedSplitKvParity("gemma-4-E4B-it-Q8_0.gguf", "fp32", maxAbsTol: 1.0f);
+
+    /// <summary>Gemma 4 E4B, bf16 KV grouped thunk vs single-block (kernel correct for all dtypes).</summary>
+    [Fact]
+    public void Gemma4_E4B_Bf16Grouped_MatchesSingleBlock()
+        => AssertGroupedSplitKvParity("gemma-4-E4B-it-Q8_0.gguf", "bf16", maxAbsTol: 2.0f);
+
+    /// <summary>Gemma 4 E4B, q8_0 KV grouped thunk (sharpi_kv_dot_multi block-walk) vs single-block.</summary>
+    [Fact]
+    public void Gemma4_E4B_Q8Grouped_MatchesSingleBlock()
+        => AssertGroupedSplitKvParity("gemma-4-E4B-it-Q8_0.gguf", "q8_0", maxAbsTol: 2.5f);
+
+    /// <summary>Qwen3-8B (8 KV heads, G=4): a different group geometry than E4B's 2 KV heads.</summary>
+    [Fact]
+    public void Qwen3_8B_Fp32Grouped_MatchesSingleBlock()
+        => AssertGroupedSplitKvParity("Qwen3-8B-Q4_K_M.gguf", "fp32", maxAbsTol: 1.0f);
 
     // ── Issue #191: narrowed-KV GREEDY decode coherence (template-correct) ───
     // The parity tests above teacher-force the narrowed dtype onto fp32's trajectory, so

--- a/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaForwardPassKvDtypeTests.cs
@@ -645,6 +645,34 @@ public sealed class CudaForwardPassKvDtypeTests
     public void Qwen3_8B_Fp32Grouped_MatchesSingleBlock()
         => AssertGroupedSplitKvParity("Qwen3-8B-Q4_K_M.gguf", "fp32", maxAbsTol: 1.0f);
 
+    /// <summary>
+    /// The #237 grouped-split dispatch gate (the shipping default) — pure logic, no GPU. A mis-fire
+    /// (selecting grouped for an ineligible head config) would hit the host-side throw in
+    /// AttentionSplitKv, so the auto/eligibility/override boundaries are fenced here. Note: the
+    /// kernel's G=8 array bound (dots[8]/acc[8]) is not exercised end-to-end (no on-disk model has
+    /// G=8 with numKvHeads≥2); the eligibility boundary (G=8 ok, G=9 rejected) is checked below.
+    /// </summary>
+    [Fact]
+    public void ShouldUseGroupedSplit_GatesCorrectly()
+    {
+        // auto (mode null): grouped only for fp32 at long ctx (≥24576) with an eligible head config.
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.Q8_0,    8, 2, 32768)); // q8 never auto
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.BFloat16, 8, 2, 32768)); // bf16 never auto
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 8, 2, 16384)); // below threshold
+        Assert.True (CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 8, 2, 24576)); // fp32 long-ctx
+        Assert.True (CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 8, 2, 65536));
+        // ineligible head configs → never grouped (would otherwise hit the host throw / a 1-wide grid).
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 8, 1, 32768)); // MQA: numKvHeads<2
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 8, 8, 32768)); // MHA: G=1
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 8, 3, 32768)); // not divisible
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 18, 2, 32768)); // G=9 > 8
+        Assert.True (CudaForwardPass.ShouldUseGroupedSplit(null, DType.Float32, 16, 2, 32768)); // G=8 boundary ok
+        // overrides.
+        Assert.True (CudaForwardPass.ShouldUseGroupedSplit("1", DType.Q8_0,    8, 2, 100));   // forced on + eligible
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit("1", DType.Float32, 8, 1, 32768)); // forced but ineligible
+        Assert.False(CudaForwardPass.ShouldUseGroupedSplit("0", DType.Float32, 8, 2, 32768)); // forced off
+    }
+
     // ── Issue #191: narrowed-KV GREEDY decode coherence (template-correct) ───
     // The parity tests above teacher-force the narrowed dtype onto fp32's trajectory, so
     // they never let bf16/q8_0 pick their OWN greedy tokens — exactly the path a real 12 GB


### PR DESCRIPTION
## What

GQA head-sharing for the split-KV decode-attention path (#237, follow-up to #235). One block handles a KV head's whole query group, loading each K/V slice **once** instead of G separate blocks each re-reading it.

## Why

The per-head split kernel runs one block per `(query-head, KV-split)`. With GQA, the `G = numHeads/numKvHeads` query heads sharing a KV head are G separate blocks each re-reading the *same* KV slice → at long ctx (KV exceeds L2) that's **G× redundant HBM reads**, which inflate the now-bandwidth-bound long-ctx decode.

## How

- `llm_attention_splitkv_grouped<KV>` (fp32/bf16/q8 thunks) + `sharpi_kv_dot_multi`: grid `(num_kv_heads, n_splits)`; each block reads each K/V element **once** and fuses it into all G query rows' online-softmax states (dynamic shared `G × CHUNK`). Emits the **same per-query-head partials** → `llm_attention_combine` and the partials layout are unchanged.
- Argmax-stable, not bit-identical (re-derived reduction order; same contract as the per-head split).

## Measurement (E4B, head_dim 512, 2 KV heads, RTX 4070 Ti) — decode A/B vs the per-head split

| ctx | fp32 grouped/per-head | q8 grouped/per-head |
|---|---|---|
| 8192 | 49.2 / 53.2 (lose) | 51.0 / 55.5 (lose) |
| 24576 | 41.1 / 37.2 (**+11%**) | — |
| 32768 | 36.8 / 29.9 (**+23%**) | 40.8 / 45.2 (lose) |

The G× traffic cut only beats the G× fewer blocks when the read is **genuinely bandwidth-bound**. The 32K row is decisive: at identical 128 blocks, **fp32 wins but q8 loses** → it's bandwidth, not occupancy. q8/bf16 read too few bytes to be bandwidth-bound, and below ~24K fp32 loses to occupancy.

## Decision: auto-enable only where it wins

Grouped is **auto-selected only for fp32 at seqLen ≥ 24576** with an eligible head config (`numKvHeads ≥ 2`, `G ∈ [2,8]`, divides evenly). Everything else (q8/bf16, short ctx, MQA) keeps the per-head split. `SHARPI_SPLIT_DECODE_GROUPED`: `0` forces per-head, `1` forces grouped (bisect), unset = auto. The crossover is tuned to E4B-class shapes (head_dim 512); other head_dims shift it, hence the override.

## Validation

- **4 grouped-vs-single-block parity tests** (forced grouped): fp32/bf16/q8 on E4B + fp32 on Qwen3-8B's 8-KV-head geometry — argmax-stable, tight logit budgets (1.0/2.0/2.5). The kernel is correct for all dtypes even though auto only uses fp32.
- **6 per-head split + graph-boundary tests** stay green — the dispatch change is inert below the fp32/24K gate.
- Release build clean (`TreatWarningsAsErrors`, NativeAOT).

## Scope

Dense `CudaForwardPass` global layers, E4B-class GQA. Hybrid paths remain #238. The chunk stays 512 (no combine-cap change); a smaller chunk wouldn't rescue q8 (not bandwidth-bound), so it wasn't pursued.
