### PR TITLE
perf(cuda): split-KV for the layer-split MoE hybrid pass (#238)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -508,11 +508,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private Tensor? _splitKvPartialMeta;
     // Only split once the context is long enough that the 8-block launch underutilizes the
     // GPU; below this, the single-block kernel is already near the weight-matvec floor.
-    // Internal so CudaHybridForwardPass reuses the same gate (#238).
-    internal const int SplitKvMinSeq = 2048;
+    // (CudaHybridForwardPass uses its own higher HybridSplitMinSeq — #238.)
+    private const int SplitKvMinSeq = 2048;
     // Upper bound on maxSeqLen for the split path: nSplits = ceil(ctx/chunk) must fit the
     // combine kernel's SPLITKV_MAX_SPLITS shared array. Derived from the backend constants so
-    // the gate can't drift from the kernel bound (= 256 × 512 = 131072).
+    // the gate can't drift from the kernel bound (= 256 × 512 = 131072). Internal so the hybrid
+    // pass reuses the same bound (#238).
     internal const int SplitKvMaxCtx = CudaBackend.SplitKvMaxSplits * CudaBackend.SplitKvChunk;
     // SHARPI_SPLIT_DECODE=0 reverts to the single-block-per-head decode attention (the A/B
     // baseline; lets parity tests compare the split path against it). Default on.

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -508,11 +508,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private Tensor? _splitKvPartialMeta;
     // Only split once the context is long enough that the 8-block launch underutilizes the
     // GPU; below this, the single-block kernel is already near the weight-matvec floor.
-    private const int SplitKvMinSeq = 2048;
+    // Internal so CudaHybridForwardPass reuses the same gate (#238).
+    internal const int SplitKvMinSeq = 2048;
     // Upper bound on maxSeqLen for the split path: nSplits = ceil(ctx/chunk) must fit the
     // combine kernel's SPLITKV_MAX_SPLITS shared array. Derived from the backend constants so
     // the gate can't drift from the kernel bound (= 256 × 512 = 131072).
-    private const int SplitKvMaxCtx = CudaBackend.SplitKvMaxSplits * CudaBackend.SplitKvChunk;
+    internal const int SplitKvMaxCtx = CudaBackend.SplitKvMaxSplits * CudaBackend.SplitKvChunk;
     // SHARPI_SPLIT_DECODE=0 reverts to the single-block-per-head decode attention (the A/B
     // baseline; lets parity tests compare the split path against it). Default on.
     private readonly bool _splitDecodeEnabled =

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -47,6 +47,20 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // (or a 1-float placeholder when _maxSeqLen ≤ 4096). Shared by both the TQ and
     // FP32 attention shaders when seq_len exceeds the shared-memory fast-path cap.
     private readonly Tensor _gpuAttnScoresScratch;
+    // Flash-decoding split-KV (#235/#237/#238): partials for the split decode-attention path on
+    // the GPU-resident attention layers. Same layout/gate as CudaForwardPass; null → per-head.
+    private Tensor? _splitKvPartialO;
+    private Tensor? _splitKvPartialMeta;
+    private readonly bool _splitDecodeEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE") != "0";
+    private readonly string? _splitGroupedMode =
+        Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE_GROUPED");
+    // Hybrid split threshold (#238) — HIGHER than the dense 2048. Decode A/B (Coder-30B q8, 4070
+    // Ti): split wins 1.49× @6K, 1.63× @8K, 2.08× @16K, but is only break-even at 4096 (1.03×) and
+    // a small fast all-GPU MoE (OLMoE, 16 heads, ctx-capped at 4096) REGRESSES 2× there — attention
+    // is a tiny share of its fast decode, so the split's fixed overhead dominates. seqLen > 4096
+    // excludes OLMoE's whole range while keeping every confirmed Coder win.
+    private const int HybridSplitMinSeq = 4096;
     private readonly Dictionary<nint, DType> _gpuWeightDTypes = new();
 
     // ── CPU resources (layers nGpuLayers..numLayers-1) ──
@@ -477,6 +491,17 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         {
             long scratchElems = _maxSeqLen > 4096 ? (long)_numHeads * _maxSeqLen : 1L;
             _gpuAttnScoresScratch = gpu.Allocate(TensorShape.D1(scratchElems));
+        }
+
+        // Flash-decoding split-KV partials (#238) — allocate when the context is long enough to
+        // benefit and within the combine kernel's split bound. Mirrors CudaForwardPass; skipped
+        // under TurboQuant (TQ decode uses its own TqAttention path, never the split kernels).
+        if (_splitDecodeEnabled && !_tqEnabled
+            && _maxSeqLen > HybridSplitMinSeq && _maxSeqLen <= CudaForwardPass.SplitKvMaxCtx)
+        {
+            long nSplitsMax = (_maxSeqLen + CudaBackend.SplitKvChunk - 1) / CudaBackend.SplitKvChunk;
+            _splitKvPartialO = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * _maxHeadDim));
+            _splitKvPartialMeta = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * 2));
         }
 
         TraceVram("before per-layer weight upload");
@@ -1514,6 +1539,17 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     private void AttentionKv(Tensor q, Tensor kCache, Tensor vCache, Tensor output, Tensor? scoresScratch,
                              int numHeads, int numKvHeads, int headDim, int seqLen, int maxSeqLen, float attnScale = -1f)
     {
+        // Flash-decoding split-KV (#238): at long ctx the single-block-per-head kernels below
+        // underutilize the GPU. Mirrors the dense CudaForwardPass gate (incl. #237 grouped).
+        if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
+            && seqLen > HybridSplitMinSeq && maxSeqLen <= _maxSeqLen)
+        {
+            bool grouped = CudaForwardPass.ShouldUseGroupedSplit(_splitGroupedMode, _kvDType, numHeads, numKvHeads, seqLen);
+            _gpu.AttentionSplitKv(q, kCache, vCache, output, splitO, splitMeta, _kvDType,
+                numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale, grouped: grouped);
+            return;
+        }
+
         if (_kvDType == DType.BFloat16)
             _gpu.AttentionBf16(q, kCache, vCache, output, scoresScratch, numHeads, numKvHeads, headDim, seqLen, maxSeqLen, attnScale);
         else if (_kvDType == DType.Q8_0)
@@ -3172,6 +3208,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         _gpu.Free(_gpuHidden); _gpu.Free(_gpuResidual); _gpu.Free(_gpuNormBuf);
         _gpu.Free(_gpuQ); _gpu.Free(_gpuK); _gpu.Free(_gpuV); _gpu.Free(_gpuAttnOut);
         _gpu.Free(_gpuFfnGate); _gpu.Free(_gpuFfnUp); _gpu.Free(_gpuLogits);
+        if (_splitKvPartialO is { } spo) _gpu.Free(spo);
+        if (_splitKvPartialMeta is { } spm) _gpu.Free(spm);
         if (_gpuRouterLogits is not null) _gpu.Free(_gpuRouterLogits);
         if (_gpuMoeSharedOut is not null) _gpu.Free(_gpuMoeSharedOut);
         if (_gpuMoeExpertOut is not null) _gpu.Free(_gpuMoeExpertOut);

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
@@ -100,9 +100,13 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
     /// Flash-decoding split-KV parity on the hybrid pass (#238). At long ctx the hybrid decode
     /// attention switches from the single-block kernel to the split-KV + combine path (the same
     /// kernels the dense #235/#237 tests validate bit-faithfully). This confirms the hybrid WIRING
-    /// (dispatch gate, partials buffer, graph interaction) is correct: a &gt;4096-token prompt puts
-    /// every decode step past the hybrid split threshold, and the single-block run (split off) is the
-    /// trusted reference. Argmax-stable, not bit-identical (the combine reorders the reduction).
+    /// (dispatch gate, partials buffer alloc/free, dtype dispatch) is correct: a &gt;4096-token prompt
+    /// puts every decode step past the hybrid split threshold, and the single-block run (split off) is
+    /// the trusted reference. Argmax-stable, not bit-identical (the combine reorders the reduction).
+    /// NOTE: the MoE hybrid runs decode EAGER (no CUDA-graph capture), so this covers the eager path;
+    /// the split-under-graph-replay interaction is validated on the dense path
+    /// (Gemma4_E4B_SplitKv_GraphReplayCrossesBoundary). A partial-offload Gemma4 hybrid (which DOES
+    /// graph-capture the split branch) is a noted follow-up.
     /// </summary>
     private void AssertHybridSplitKvParity(string? path, string kvDtype, float maxAbsTol)
     {
@@ -285,8 +289,10 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
     /// <summary>Hybrid split-KV decode (#238) vs single-block on Coder-30B q8 at &gt;4096 ctx —
     /// the layer-split MoE hybrid is the model that reaches the hybrid split threshold (OLMoE caps
     /// at 4096 and never splits). Decode A/B confirmed the win (1.49× @6K → 2.08× @16K); this fences
-    /// correctness of the wiring.</summary>
-    [Fact] public void Coder30B_Q8SplitKv_MatchesSingleBlock() => AssertHybridSplitKvParity(CoderPath(), "q8_0", maxAbsTol: 6.0f);
+    /// correctness of the wiring. Same-dtype (q8-vs-q8) so the only divergence is the combine's
+    /// reduction reorder → a tighter budget than the cross-dtype Coder q8-vs-fp32 test (6.0); top-5
+    /// stability is the hard gate.</summary>
+    [Fact] public void Coder30B_Q8SplitKv_MatchesSingleBlock() => AssertHybridSplitKvParity(CoderPath(), "q8_0", maxAbsTol: 4.0f);
 
     /// <summary>
     /// >4096 wave path (AttentionBatchedWaveQ8_0): a single Prefill of &gt;4096 tokens makes

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridKvDtypeTests.cs
@@ -46,10 +46,14 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
     }
 
     private static (float[][] logits, int[] argmax) RunPrefillDecode(
-        CudaBackend gpu, string path, string? kvDtype, string prompt, int steps, int ctx, int[]? forced)
+        CudaBackend gpu, string path, string? kvDtype, string prompt, int steps, int ctx, int[]? forced,
+        string? splitDecode = null)
     {
         var prev = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+        var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
         Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", kvDtype);
+        // null → flash-decoding split default (on, #238); "0" forces the single-block path.
+        if (splitDecode is not null) Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", splitDecode);
         try
         {
             using var model = GgufModel.Open(path);
@@ -85,7 +89,65 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
             }
             return (perPos, argmax);
         }
-        finally { Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prev); }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prev);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
+        }
+    }
+
+    /// <summary>
+    /// Flash-decoding split-KV parity on the hybrid pass (#238). At long ctx the hybrid decode
+    /// attention switches from the single-block kernel to the split-KV + combine path (the same
+    /// kernels the dense #235/#237 tests validate bit-faithfully). This confirms the hybrid WIRING
+    /// (dispatch gate, partials buffer, graph interaction) is correct: a &gt;4096-token prompt puts
+    /// every decode step past the hybrid split threshold, and the single-block run (split off) is the
+    /// trusted reference. Argmax-stable, not bit-identical (the combine reorders the reduction).
+    /// </summary>
+    private void AssertHybridSplitKvParity(string? path, string kvDtype, float maxAbsTol)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) { _out.WriteLine("SKIP: no CUDA"); return; }
+        if (path is null) { _out.WriteLine("SKIP: model not on disk"); return; }
+
+        const int steps = 5;
+        const int ctx = 5120;          // > the 4096 hybrid split threshold
+        const int promptLen = 4200;    // every decode step lands at seqLen > 4096 → split path
+
+        string prompt;
+        using (var model = GgufModel.Open(path))
+        {
+            var tok = GgufTokenizer.FromGgufModel(model);
+            var sb = new System.Text.StringBuilder();
+            const string seed = "The quick brown fox jumps over the lazy dog. " +
+                                "Sphinx of black quartz, judge my vow. Pack my box with five dozen liquor jugs. ";
+            while (tok.Encode(sb.ToString()).Count < promptLen) sb.Append(seed);
+            prompt = sb.ToString();
+        }
+
+        float[][] single, split; int[] singleArgmax;
+        try
+        {
+            (single, singleArgmax) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: null, splitDecode: "0");
+            (split, _) = RunPrefillDecode(gpu, path, kvDtype, prompt, steps, ctx, forced: singleArgmax, splitDecode: "1");
+        }
+        catch (InvalidOperationException) { _out.WriteLine("SKIP: construction OOM'd"); return; }
+
+        for (int p = 0; p <= steps; p++)
+        {
+            Assert.Equal(single[p].Length, split[p].Length);
+            float maxAbs = 0f;
+            for (int i = 0; i < single[p].Length; i++)
+            {
+                Assert.True(float.IsFinite(split[p][i]), $"{kvDtype}: non-finite split logit at pos {p}, idx {i}.");
+                maxAbs = Math.Max(maxAbs, Math.Abs(single[p][i] - split[p][i]));
+            }
+            Assert.True(TopK(split[p], 5).Contains(singleArgmax[p]),
+                $"{kvDtype}: pos {p} single-block top-1 ({singleArgmax[p]}) fell out of the hybrid split top-5 " +
+                $"(maxAbs {maxAbs:F4}) — the hybrid split-KV wiring reordered the head of the distribution.");
+            Assert.True(maxAbs < maxAbsTol,
+                $"{kvDtype}: pos {p} hybrid split-vs-single logit max-abs {maxAbs:F4} exceeds {maxAbsTol:F2} — a wiring bug.");
+        }
     }
 
     private static HashSet<int> TopK(float[] v, int k)
@@ -219,6 +281,12 @@ public sealed class CudaHybridKvDtypeTests : IDisposable
     [Fact] public void OLMoE_Q8Kv_ArgmaxStable()  => AssertKvParity(OlmoePath(), "q8_0", Prompt, maxAbsTol: 3.5f);
     [Fact] public void Coder30B_Bf16Kv_ArgmaxStable() => AssertKvParity(CoderPath(), "bf16", Prompt, maxAbsTol: 5.0f);
     [Fact] public void Coder30B_Q8Kv_ArgmaxStable()  => AssertKvParity(CoderPath(), "q8_0", Prompt, maxAbsTol: 6.0f);
+
+    /// <summary>Hybrid split-KV decode (#238) vs single-block on Coder-30B q8 at &gt;4096 ctx —
+    /// the layer-split MoE hybrid is the model that reaches the hybrid split threshold (OLMoE caps
+    /// at 4096 and never splits). Decode A/B confirmed the win (1.49× @6K → 2.08× @16K); this fences
+    /// correctness of the wiring.</summary>
+    [Fact] public void Coder30B_Q8SplitKv_MatchesSingleBlock() => AssertHybridSplitKvParity(CoderPath(), "q8_0", maxAbsTol: 6.0f);
 
     /// <summary>
     /// >4096 wave path (AttentionBatchedWaveQ8_0): a single Prefill of &gt;4096 tokens makes


### PR DESCRIPTION
## What

Extend flash-decoding split-KV (#235/#237) to the layer-split MoE hybrid pass (`CudaHybridForwardPass`: Qwen3-Coder-30B, Llama-4 Scout, …). It was dense-only; the hybrid's GPU-resident attention layers still hit the long-ctx occupancy collapse #235 fixed.

## How

Wire the existing `CudaBackend.AttentionSplitKv` (+ partials buffer, dtype dispatch, the #237 grouped auto-select) into `CudaHybridForwardPass.AttentionKv`, mirroring the dense gate. **Reuses the validated #235/#237 kernels unchanged** — only the dispatch/buffer wiring is new.

## Measurement (the gate) — Qwen3-Coder-30B-A3B Q4_K_M, q8 KV, 4070 Ti, split on/off

| ctx | off | on | on/off |
|---|---|---|---|
| 4096 | 16.5 | 17.1 | 1.03 (break-even) |
| 6144 | 13.9 | **20.7** | **1.49** |
| 8192 | 12.0 | **19.5** | **1.63** |
| 16384 | 7.7 | **16.1** | **2.08** |

Attention **is** a meaningful share of the (CPU-MoE-bound) long-ctx hybrid decode — a clear win for the big layer-split model.

## The threshold: seqLen > 4096 (not the dense 2048)

A small fast all-GPU MoE — **OLMoE** (16 heads, context-capped at 4096) — **regresses 2×** (59→32 t/s) when split at 4096: attention is a tiny fraction of its fast decode, so the split's fixed overhead dominates. Raising the hybrid threshold to `seqLen > 4096` (`HybridSplitMinSeq`) excludes OLMoE's entire operating range (no regression) while keeping every confirmed Coder win (break-even at 4096, growing to 2.08× at 16K). `SHARPI_SPLIT_DECODE=0` kill-switch; skipped under TurboQuant.

## Validation

- **`Coder30B_Q8SplitKv_MatchesSingleBlock`**: split-vs-single-block at >4096 ctx, argmax-stable + tight logit budget (the hybrid wiring is correct). The A/B also confirmed q8 first-token matched single-block at all 4 ctx points.
- **OLMoE short-ctx** hybrid tests unaffected (ctx 2048 < gate → split off).
- Kernel correctness carries from the dense #235/#237 bit-faithful parity tests (same `AttentionSplitKv`).
- Release build clean (`TreatWarningsAsErrors`, NativeAOT).

## Scope / follow-up

`CudaHybridForwardPass` (layer-split MoE). The **GDN hybrid pass** (`CudaHybridGdnForwardPass`, Qwen3.6) has a different attention dispatch and GDN-dominated decode — deferred to its own measurement-gated follow-up (it has only ~10 attention layers, so the payoff is uncertain).
