### PR TITLE
perf(cuda): split-KV for the GDN hybrid pass — completes #238

### DIFF
--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -3830,8 +3830,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             _gpu.KvAppend(_gpuK, _gpuV, _gpuKCache[layer]!, _gpuVCache[layer]!, kvDim, kvPosition, _maxSeqLen);
 
         int seqLen = kvPosition + 1;
-        // Flash-decoding split-KV (#238) at long ctx; else the single-block kernel. Mirrors the
-        // dense/MoE-hybrid gate (incl. the #237 grouped auto-select).
+        // Flash-decoding split-KV (#238) at long ctx; else the single-block kernel. Uses the
+        // #237 grouped auto-select like the dense/MoE-hybrid passes. (No `maxSeqLen <= _maxSeqLen`
+        // guard as on the dense path: this site always passes _maxSeqLen as the cache extent, so
+        // nSplits == the buffer's nSplitsMax exactly — there is no per-call maxSeqLen to bound.)
         if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
             && seqLen > GdnSplitMinSeq)
         {
@@ -4015,6 +4017,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // 3. Layer-0 invariant: reserve a block on the MTP KV bookkeeping cache
         //    before any append at a new page boundary.
         mtpCache.ReserveBlock();
+        // The MTP DRAFT head is a single attention layer, so split-KV (#238) is deliberately
+        // not wired here — the occupancy win is negligible for one layer (the main-model verify
+        // via GpuAttnBlockAt does get the split). Stays single-block.
         if (_kvDType == DType.BFloat16)
         {
             _gpu.KvAppendBf16(_gpuK, _gpuV, kCache, vCache, kvDim, position, _maxSeqLen);

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -97,6 +97,22 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private readonly Tensor _gpuV;           // [numKvHeads * headDim] = 512
     private readonly Tensor _gpuAttnOut;     // [numHeads * headDim] = 4096
     private readonly Tensor _gpuAttnScratch; // attention scores spill scratch
+    // Flash-decoding split-KV (#238) for the GPU attention layers' per-token decode. Same
+    // mechanism as the dense/MoE-hybrid passes; null → single-block. GDN decode is GDN-scan +
+    // MoE dominated with only the attention layers' KV growing, so this is measurement-gated.
+    private Tensor? _splitKvPartialO;
+    private Tensor? _splitKvPartialMeta;
+    private readonly bool _splitDecodeEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE") != "0";
+    private readonly string? _splitGroupedMode =
+        Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE_GROUPED");
+    // GDN attention is a smaller share than the MoE hybrid (only ~10 attention layers vs the GDN
+    // scan + MoE), so the split overhead amortizes only at genuinely long ctx. #238 GDN A/B
+    // (Qwen3.6-35B-A3B, bf16, 4070 Ti, CPU-page-cache-warm) showed a clean +19% at 16K; the 8K
+    // number was cold-cache-confounded (mmap'd CPU-MoE). Threshold conservatively at the
+    // clean-win region (8192) since with so few attention layers a moderate-ctx split risks the
+    // OLMoE-style overhead regression and 4096–8192 is unverified for this pass.
+    private const int GdnSplitMinSeq = 8192;
     private readonly Tensor _gpuRouterLogits;
     private readonly Tensor _gpuFfnGate;
     private readonly Tensor _gpuFfnUp;
@@ -772,6 +788,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // Attention scores scratch — only needed when ctx > 4096; otherwise placeholder.
         long scratchElems = _maxSeqLen > 4096 ? (long)_numHeads * _maxSeqLen : 1L;
         _gpuAttnScratch = gpu.Allocate(TensorShape.D1(scratchElems));
+        // Flash-decoding split-KV partials (#238) — allocate when ctx is long enough and within the
+        // combine kernel's split bound. Uniform head_dim (no per-layer), so size at _headDim.
+        if (_splitDecodeEnabled
+            && _maxSeqLen > GdnSplitMinSeq && _maxSeqLen <= CudaForwardPass.SplitKvMaxCtx)
+        {
+            long nSplitsMax = (_maxSeqLen + CudaBackend.SplitKvChunk - 1) / CudaBackend.SplitKvChunk;
+            _splitKvPartialO = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * _headDim));
+            _splitKvPartialMeta = gpu.Allocate(TensorShape.D1((long)_numHeads * nSplitsMax * 2));
+        }
         // MoE-only GPU scratch: router logits, expert intermediate buffers, shared
         // expert output. For dense FFN (qwen35 27B-MTP) these are unused and
         // _numExperts=_expertDim=0, so skip allocation entirely. Fields are
@@ -3800,22 +3825,29 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // logical prompt length — same +1 invariant. BatchForward2 passes
         // kvPosition = startPos[+1] for two sequential appends within one call.
         if (_kvDType == DType.BFloat16)
+            _gpu.KvAppendBf16(_gpuK, _gpuV, _gpuKCache[layer]!, _gpuVCache[layer]!, kvDim, kvPosition, _maxSeqLen);
+        else
+            _gpu.KvAppend(_gpuK, _gpuV, _gpuKCache[layer]!, _gpuVCache[layer]!, kvDim, kvPosition, _maxSeqLen);
+
+        int seqLen = kvPosition + 1;
+        // Flash-decoding split-KV (#238) at long ctx; else the single-block kernel. Mirrors the
+        // dense/MoE-hybrid gate (incl. the #237 grouped auto-select).
+        if (_splitKvPartialO is { } splitO && _splitKvPartialMeta is { } splitMeta
+            && seqLen > GdnSplitMinSeq)
         {
-            _gpu.KvAppendBf16(_gpuK, _gpuV, _gpuKCache[layer]!, _gpuVCache[layer]!,
-                kvDim, kvPosition, _maxSeqLen);
+            bool grouped = CudaForwardPass.ShouldUseGroupedSplit(_splitGroupedMode, _kvDType, _numHeads, _numKvHeads, seqLen);
+            _gpu.AttentionSplitKv(_gpuQ, _gpuKCache[layer]!, _gpuVCache[layer]!, _gpuAttnOut, splitO, splitMeta,
+                _kvDType, _numHeads, _numKvHeads, _headDim, seqLen, _maxSeqLen, attnScale: -1f, grouped: grouped);
+        }
+        else if (_kvDType == DType.BFloat16)
+        {
             _gpu.AttentionBf16(_gpuQ, _gpuKCache[layer]!, _gpuVCache[layer]!, _gpuAttnOut,
-                _gpuAttnScratch,
-                _numHeads, _numKvHeads, _headDim,
-                (kvPosition + 1), _maxSeqLen);
+                _gpuAttnScratch, _numHeads, _numKvHeads, _headDim, seqLen, _maxSeqLen);
         }
         else
         {
-            _gpu.KvAppend(_gpuK, _gpuV, _gpuKCache[layer]!, _gpuVCache[layer]!,
-                kvDim, kvPosition, _maxSeqLen);
             _gpu.Attention(_gpuQ, _gpuKCache[layer]!, _gpuVCache[layer]!, _gpuAttnOut,
-                _gpuAttnScratch,
-                _numHeads, _numKvHeads, _headDim,
-                (kvPosition + 1), _maxSeqLen);
+                _gpuAttnScratch, _numHeads, _numKvHeads, _headDim, seqLen, _maxSeqLen);
         }
 
         _gpu.SigmoidMulInPlace(_gpuAttnOut, _gpuGate);
@@ -5645,6 +5677,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         _gpu.Free(_gpuV);
         _gpu.Free(_gpuAttnOut);
         _gpu.Free(_gpuAttnScratch);
+        if (_splitKvPartialO is { } spo) _gpu.Free(spo);
+        if (_splitKvPartialMeta is { } spm) _gpu.Free(spm);
         if (_hp.IsMoE)
         {
             _gpu.Free(_gpuRouterLogits);

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnForwardPassTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnForwardPassTests.cs
@@ -432,4 +432,97 @@ public sealed class CudaHybridGdnForwardPassTests
         Array.Copy(sorted, topK, K);
         return (top1, topK);
     }
+
+    /// <summary>
+    /// Flash-decoding split-KV parity on the GDN hybrid pass (#238). The ~10 GPU attention
+    /// layers' per-token decode (GpuAttnBlockAt) switches to the split-KV + combine path above
+    /// the GDN threshold (8192). This confirms the GDN wiring is correct: a &gt;8192-token prompt
+    /// puts every decode step on the split path, and the single-block run (split off) is the
+    /// reference. Argmax-stable, not bit-identical (the combine reorders the reduction; the GDN
+    /// stack also carries its usual ~1e-3/layer Q8_1 noise over 40 layers, so the max-abs bound is
+    /// a blow-up ceiling and top-5 stability is the hard gate). Slow (22 GB model + &gt;8K GDN
+    /// prefill ×2); skips when the model isn't on disk.
+    /// </summary>
+    [Fact]
+    public void CudaHybridGdnForwardPass_SplitKv_MatchesSingleBlock()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindHybridModelPath();
+        if (path is null) return;
+
+        const int steps = 4;
+        const int ctx = 9216;          // > the 8192 GDN split threshold
+        const int promptLen = 8300;    // every decode step lands at seqLen > 8192 → split path
+        const float maxAbsCeiling = 10.0f;
+
+        (float[][] logits, int[] argmax) RunGdn(string split, int[]? forced)
+        {
+            var pKv = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+            var pMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+            var pSp = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
+            Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", "bf16");
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", split);
+            try
+            {
+                using var model = GgufModel.Open(path);
+                var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+                var tok = GgufTokenizer.FromGgufModel(model);
+                int useCtx = Math.Min(hp.ContextLength, ctx);
+                var placement = new LayerPlacement(GpuLayers: hp.NumLayers, CpuLayers: 0,
+                    GpuWeightBytes: 0, GpuKvBytes: 0, RecommendedCtxSize: useCtx);
+                using var fwd = new CudaHybridGdnForwardPass(model, gpu, hp, placement);
+                var sb = new System.Text.StringBuilder();
+                const string seed = "The quick brown fox jumps over the lazy dog. Sphinx of black quartz. ";
+                while (tok.Encode(sb.ToString()).Count < promptLen) sb.Append(seed);
+                var tokens = tok.Encode(sb.ToString()).ToArray();
+                var perPos = new float[steps + 1][];
+                var argmax = new int[steps + 1];
+                perPos[0] = fwd.Prefill(tokens).ToArray();
+                argmax[0] = Sampler.Greedy(perPos[0]);
+                for (int i = 0; i < steps; i++)
+                {
+                    int fed = forced is not null ? forced[i] : argmax[i];
+                    perPos[i + 1] = fwd.Forward(fed, tokens.Length + i).ToArray();
+                    argmax[i + 1] = Sampler.Greedy(perPos[i + 1]);
+                }
+                return (perPos, argmax);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", pKv);
+                Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", pMoe);
+                Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", pSp);
+            }
+        }
+
+        var (single, singleArgmax) = RunGdn("0", forced: null);
+        var (split, _) = RunGdn("1", forced: singleArgmax);
+
+        for (int p = 0; p <= steps; p++)
+        {
+            Assert.Equal(single[p].Length, split[p].Length);
+            float maxAbs = 0f;
+            for (int i = 0; i < single[p].Length; i++)
+            {
+                Assert.True(float.IsFinite(split[p][i]), $"non-finite split logit at pos {p}, idx {i}.");
+                maxAbs = Math.Max(maxAbs, Math.Abs(single[p][i] - split[p][i]));
+            }
+            Assert.True(TopK(split[p], 5).Contains(singleArgmax[p]),
+                $"pos {p} single-block top-1 ({singleArgmax[p]}) fell out of GDN split's top-5 (max-abs {maxAbs:F4}).");
+            Assert.True(maxAbs < maxAbsCeiling,
+                $"pos {p} GDN split-vs-single max-abs {maxAbs:F4} exceeds the blow-up ceiling {maxAbsCeiling:F1}.");
+        }
+    }
+
+    private static HashSet<int> TopK(float[] v, int k)
+    {
+        var idx = new int[v.Length];
+        for (int i = 0; i < v.Length; i++) idx[i] = i;
+        Array.Sort(idx, (a, b) => v[b].CompareTo(v[a]));
+        var set = new HashSet<int>(k);
+        for (int i = 0; i < k && i < idx.Length; i++) set.Add(idx[i]);
+        return set;
+    }
 }


### PR DESCRIPTION
## What

Completes #238 — extends flash-decoding split-KV to `CudaHybridGdnForwardPass` (Qwen3.6-35B/27B), the last forward pass that still ran single-block decode attention on its GPU attention layers. (The dense path was #235/#237; the layer-split MoE hybrid was #240.)

## How

Wire `CudaBackend.AttentionSplitKv` into `GpuAttnBlockAt` — the per-token attention site used by both `Forward` (single-user) and `BatchForward2` (MTP k-token verify) — mirroring the dense/MoE-hybrid gate (incl. the #237 grouped auto-select). Reuses the validated #235/#237 kernels; only the dispatch/partials-buffer/dispose wiring is new. GDN KV is fp32/bf16 (no q8).

## Measurement (Qwen3.6-35B-A3B, bf16 KV, 4070 Ti, split on/off)

| ctx | off | on | on/off |
|---|---|---|---|
| 8192 | 16.4 | 24.5 | 1.50 (cold-confounded) |
| 16384 | 20.6 | 24.6 | **1.20** |

Clean **+19% at 16K**. The 8K ratio is **cold-cache-confounded**: this is a CPU-MoE mmap model and the bench opens a fresh model per run, so the *first* run (8K-off) reads cold (`off@16K=20.6 > off@8K=16.4` — backwards for a real ctx effect — confirms it). By the 16K runs the OS page cache is warm for both off and on, so 1.20× is the clean number. Correctness: first-token matched single-block (561/561) at both ctx.

The win is smaller than the MoE hybrid's 2.08× — expected, since GDN decode has only ~10 attention layers vs the GDN scan + MoE.

## Threshold: seqLen > 8192 (conservative)

The attention share is small, so the split overhead amortizes only at genuinely long ctx; with so few attention layers a moderate-ctx split risks the OLMoE-style overhead regression. `GdnSplitMinSeq = 8192` targets the clean-win region (4096–8192 is unverified for this pass). `SHARPI_SPLIT_DECODE=0` kill-switch.

## Validation

- **`CudaHybridGdnForwardPass_SplitKv_MatchesSingleBlock`** — split-vs-single-block at >8192, argmax-stable + blow-up ceiling (top-5 is the hard gate; the GDN stack carries ~1e-3/layer Q8_1 noise over 40 layers, so a tight logit bound isn't meaningful here). The A/B also matched first-token 561/561 at 8192 and 16384.
- Existing GDN tests (ctx ≤ 4096 < gate → split off) unaffected.
- Release build clean (`TreatWarningsAsErrors`, NativeAOT).

With this, #238 is complete (both hybrid passes) and the flash-decoding arc spans dense (#235), GQA head-sharing (#237), MoE hybrid (#240), and GDN hybrid (this).
