### PR TITLE
docs: long-context decode flash-decoding spans dense + hybrid passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ same box). Llama-4 Scout and Qwen3-Coder Vulkan-hybrid keep prior values (not re
 
 **Long-context decode** uses flash-decoding (split-KV) on every CUDA path — dense, MoE-hybrid, and
 GDN-hybrid: the per-token KV read parallelizes across SMs instead of one block per head, so decode no longer
-collapses as context grows. At long ctx: Gemma 4 E4B (dense) fp32 13→30 / q8 11→45 t/s @32K; Qwen3-Coder-30B
+collapses as context grows. At long ctx: Gemma 4 E4B (dense) fp32 13→30 / q8 11→45 t/s @32K; Qwen3-Coder-30B-A3B
 (MoE hybrid) q8 7.7→16.1 t/s @16K; Qwen3.6-35B-A3B (GDN hybrid) bf16 +19% @16K. Engages automatically above
-~2K ctx (dense) / 4K (MoE hybrid) / 8K (GDN); `SHARPI_SPLIT_DECODE=0` reverts.
+~2K ctx (dense) / 4K (MoE-hybrid) / 8K (GDN-hybrid); `SHARPI_SPLIT_DECODE=0` reverts.
 
 **Sampling for Gemma 4 E4B-it:** `--temp 1.0 --top-k 64 --top-p 0.95 --min-p 0` (Gemma 3/4 defaults).
 It is **not** a reasoning model — the CLI auto-sets `enable_thinking=false`, else the template renders an

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ _Re-measured 2026-06 from warm sweeps (prefill ~1K ctx, decode near-zero ctx), e
 warm-up. Vulkan rows are ~35% below their prior numbers — an unexplained regression (CUDA improved on the
 same box). Llama-4 Scout and Qwen3-Coder Vulkan-hybrid keep prior values (not re-runnable here)._
 
-**Long-context decode** (dense CUDA) uses flash-decoding (split-KV): the per-token KV read parallelizes
-across SMs instead of one block per head, so decode no longer collapses as context grows. Gemma 4 E4B @32K
-ctx: fp32 13→30 t/s, q8_0 11→45 t/s. Engages automatically above ~2K ctx; `SHARPI_SPLIT_DECODE=0` reverts.
+**Long-context decode** uses flash-decoding (split-KV) on every CUDA path — dense, MoE-hybrid, and
+GDN-hybrid: the per-token KV read parallelizes across SMs instead of one block per head, so decode no longer
+collapses as context grows. At long ctx: Gemma 4 E4B (dense) fp32 13→30 / q8 11→45 t/s @32K; Qwen3-Coder-30B
+(MoE hybrid) q8 7.7→16.1 t/s @16K; Qwen3.6-35B-A3B (GDN hybrid) bf16 +19% @16K. Engages automatically above
+~2K ctx (dense) / 4K (MoE hybrid) / 8K (GDN); `SHARPI_SPLIT_DECODE=0` reverts.
 
 **Sampling for Gemma 4 E4B-it:** `--temp 1.0 --top-k 64 --top-p 0.95 --min-p 0` (Gemma 3/4 defaults).
 It is **not** a reasoning model — the CLI auto-sets `enable_thinking=false`, else the template renders an


### PR DESCRIPTION
## What

Update the README "Long-context decode" note: it said "(dense CUDA)" but flash-decoding (split-KV) now covers all three CUDA forward passes after #240 (MoE hybrid) and #241 (GDN hybrid).

## Changes

- Note now reads "on every CUDA path — dense, MoE-hybrid, and GDN-hybrid".
- Added the new long-ctx model numbers: Qwen3-Coder-30B (MoE hybrid) q8 7.7→16.1 t/s @16K (2.08×); Qwen3.6-35B-A3B (GDN hybrid) bf16 +19% @16K; kept the dense Gemma 4 E4B figures.
- Noted the per-path engage thresholds (dense ~2K / MoE-hybrid 4K / GDN 8K).

## No table changes

The headline perf table is near-zero-ctx decode / ~1K-ctx prefill. Split-KV only engages at long ctx (>2K–8K), so no table cell changes — same as the original #235 doc update.

Docs-only.