### PR TITLE
perf(gemma4): GPU-side PLE pre-pass dequant for batched prefill (#247 item 1)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -841,6 +841,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             throw new InvalidOperationException($"UploadRawInto: handle {dst.Handle} not registered.");
         if ((nuint)src.Length > entry.byteSize)
             throw new ArgumentException($"UploadRawInto: source ({src.Length} bytes) exceeds destination capacity ({entry.byteSize} bytes).");
+        if (src.IsEmpty) return;   // nothing to copy; avoids fixed → null-ptr on an empty span
         fixed (byte* s = src)
             UploadViaStaging(entry.devPtr, s, (nuint)src.Length);
     }

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -129,6 +129,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _embedLookupQ6KKernel;   // #124: Q6_K tied embedding (Gemma 4 12B)
     private nint   _embedLookupQ80Kernel;
     private nint   _embedLookupQ80BatchedKernel;
+    private nint   _dequantRowsQ80Kernel;   // #247: GPU-side PLE pre-pass (Q8_0 rows → f32)
+    private nint   _dequantRowsQ6KKernel;   // #247: GPU-side PLE pre-pass (Q6_K rows → f32)
     private nint   _matvecF32Kernel;
     private nint   _matvecQ4KKernel;
     private nint   _matvecQ4KSoaKernel;     // #156: scale-pre-unpacked SoA decode matvec
@@ -823,6 +825,24 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         nuint byteSize = (nuint)(src.Length * sizeof(float));
         fixed (float* s = src)
             UploadViaStaging(dstPtr, s, byteSize);
+    }
+
+    /// <summary>
+    /// Copy <paramref name="src"/> raw bytes into an existing device buffer (no allocation).
+    /// Byte-typed sibling of <see cref="UploadInto"/>: the destination is sized for a max
+    /// capacity but a given call may push fewer bytes (e.g. a short final prefill chunk), so
+    /// the only requirement is that <paramref name="src"/> fits within <paramref name="dst"/>'s
+    /// allocation. Used by the GPU-side PLE pre-pass (issue #247) to stage gathered packed
+    /// quant rows before the on-device dequant.
+    /// </summary>
+    public void UploadRawInto(Tensor dst, ReadOnlySpan<byte> src)
+    {
+        if (!_devPtrs.TryGetValue(dst.Handle, out var entry))
+            throw new InvalidOperationException($"UploadRawInto: handle {dst.Handle} not registered.");
+        if ((nuint)src.Length > entry.byteSize)
+            throw new ArgumentException($"UploadRawInto: source ({src.Length} bytes) exceeds destination capacity ({entry.byteSize} bytes).");
+        fixed (byte* s = src)
+            UploadViaStaging(entry.devPtr, s, (nuint)src.Length);
     }
 
     // ── Direct-pinned Download/Upload overloads (issues #48/#49) ──────────
@@ -5301,6 +5321,55 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(embed_lookup_q8_0_batched) failed: {r}");
     }
 
+    /// <summary>
+    /// Dequantize <paramref name="nRows"/> CONTIGUOUS Q8_0-packed rows in
+    /// <paramref name="src"/> into the f32 buffer <paramref name="dst"/> ([nRows × rowDim]):
+    /// row i → row i. Issue #247: moves the Gemma-4 PLE pre-pass dequant off the CPU
+    /// <c>Parallel.For</c> (and shrinks the host→device upload 4× — packed quant bytes
+    /// instead of f32). Bit-identical to <c>Dequantize.ToFloat32(..., Q8_0)</c>.
+    /// <paramref name="rowDim"/> must be a multiple of 256.
+    /// </summary>
+    public void DequantRowsQ8_0(Tensor src, Tensor dst, int nRows, int rowDim)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if ((rowDim & 0xff) != 0)
+            throw new ArgumentException($"DequantRowsQ8_0 requires rowDim to be a multiple of 256 (got {rowDim}).");
+        if (nRows <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nRows), nRows, "nRows must be > 0.");
+
+        nint sP = GetDevPtr(src);
+        nint dP = GetDevPtr(dst);
+        int pN = nRows, pE = rowDim;
+        nint* args = stackalloc nint[4] { (nint)(&sP), (nint)(&dP), (nint)(&pN), (nint)(&pE) };
+        int r = NvrtcInterop.LaunchKernel(_dequantRowsQ80Kernel, (uint)nRows, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(dequant_rows_q8_0) failed: {r}");
+    }
+
+    /// <summary>
+    /// Q6_K analogue of <see cref="DequantRowsQ8_0"/> (issue #247). Bit-identical to
+    /// <c>Dequantize.ToFloat32(..., Q6_K)</c>. <paramref name="rowDim"/> must be a
+    /// multiple of 256.
+    /// </summary>
+    public void DequantRowsQ6K(Tensor src, Tensor dst, int nRows, int rowDim)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if ((rowDim & 0xff) != 0)
+            throw new ArgumentException($"DequantRowsQ6K requires rowDim to be a multiple of 256 (got {rowDim}).");
+        if (nRows <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nRows), nRows, "nRows must be > 0.");
+
+        nint sP = GetDevPtr(src);
+        nint dP = GetDevPtr(dst);
+        int pN = nRows, pE = rowDim;
+        nint* args = stackalloc nint[4] { (nint)(&sP), (nint)(&dP), (nint)(&pN), (nint)(&pE) };
+        int r = NvrtcInterop.LaunchKernel(_dequantRowsQ6KKernel, (uint)nRows, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(dequant_rows_q6k) failed: {r}");
+    }
+
     /// <summary>Set every element of <paramref name="dst"/> to zero.</summary>
     /// <remarks>
     /// The kernel writes fp32-sized lanes; for sub-fp32 dtypes (e.g. BFloat16)
@@ -5968,6 +6037,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _embedLookupF32Kernel, _embedLookupQ4KKernel, _embedLookupQ5KKernel,
             _embedLookupQ6KKernel,
             _embedLookupQ80Kernel, _embedLookupQ80BatchedKernel,
+            _dequantRowsQ80Kernel, _dequantRowsQ6KKernel,
             _matvecF32Kernel, _matvecQ40Kernel, _matvecQ4KKernel, _matvecQ5KKernel, _matvecQ6KKernel,
             _matvecQ80Kernel,
             _matvecF32N2Kernel, _matvecQ4KN2Kernel, _matvecQ5KN2Kernel, _matvecQ6KN2Kernel,
@@ -6073,6 +6143,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _embedLookupQ6KKernel  = GetKernelFunc("llm_embed_lookup_q6k");
         _embedLookupQ80Kernel  = GetKernelFunc("llm_embed_lookup_q8_0");
         _embedLookupQ80BatchedKernel = GetKernelFunc("llm_embed_lookup_q8_0_batched");
+        _dequantRowsQ80Kernel  = GetKernelFunc("llm_dequant_rows_q8_0");
+        _dequantRowsQ6KKernel  = GetKernelFunc("llm_dequant_rows_q6k");
         _matvecF32Kernel       = GetKernelFunc("llm_matvec_f32");
         _matvecQ4KKernel       = GetKernelFunc("llm_matvec_q4k");
         _matvecQ4KSoaKernel    = GetKernelFunc("llm_matvec_q4k_soa");

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -1033,6 +1033,94 @@ extern ""C"" __global__ void llm_embed_lookup_q8_0_batched(
     }
 }
 
+// ── Contiguous-row dequant (issue #247: GPU-side Gemma-4 PLE pre-pass) ───────
+// Dequantize n_rows CONTIGUOUS packed rows into an f32 [n_rows × row_dim] buffer:
+// row i of src → row i of dst (no token-id indirection — the caller has already
+// gathered the PLE rows for the prompt's tokens into a packed quant buffer, so the
+// expensive per-element dequant runs on the GPU instead of a CPU Parallel.For + a
+// 4×-larger float upload). The per-row decode is byte-for-byte identical to
+// llm_embed_lookup_q8_0 (same cvt.f32.f16 scale × int8), so the batched PLE row is
+// bit-identical to the CPU Dequantize.ToFloat32 the per-token oracle uses. row_dim
+// must be a multiple of 256 (8 Q8_0 blocks per outer iteration).
+extern ""C"" __global__ void llm_dequant_rows_q8_0(
+    const unsigned char* __restrict__ src,    // [n_rows * row_dim] Q8_0 packed
+    float* __restrict__ dst,                  // [n_rows * row_dim] f32
+    int n_rows, int row_dim)
+{
+    __shared__ unsigned char blk[272];
+    unsigned int tid = threadIdx.x;
+    int i = (int)blockIdx.x;
+    if (i >= n_rows) return;
+
+    int num_blocks = row_dim >> 5;
+    long bytes_per_row = (long)num_blocks * 34L;
+    long row_byte_base = (long)i * bytes_per_row;
+    float* out_row = dst + (long)i * row_dim;
+
+    int outer_iters = row_dim >> 8;
+    for (int outer = 0; outer < outer_iters; outer++) {
+        long base_byte = row_byte_base + (long)(outer * 8) * 34L;
+        if (tid < 272) blk[tid] = src[base_byte + tid];
+        if (tid < 16)  blk[256 + tid] = src[base_byte + 256 + tid];
+        __syncthreads();
+
+        unsigned int block_in_outer = tid >> 5;
+        unsigned int lane           = tid & 31u;
+        unsigned int block_off = block_in_outer * 34u;
+        unsigned int d_bits = (unsigned int)blk[block_off]
+                            | ((unsigned int)blk[block_off + 1u] << 8);
+        float d = sharpi_fp16_to_fp32(d_bits);
+        int q = (int)(signed char)blk[block_off + 2u + lane];
+        out_row[outer * 256 + (int)tid] = d * (float)q;
+        __syncthreads();
+    }
+}
+
+// Q6_K variant of llm_dequant_rows_q8_0. Per-element decode mirrors
+// llm_embed_lookup_q6k / llm_matvec_q6k exactly ((d·scale)·q, same order as the
+// CPU DequantQ6K), so the batched PLE row is bit-identical to the per-token CPU
+// dequant. row_dim must be a multiple of 256.
+extern ""C"" __global__ void llm_dequant_rows_q6k(
+    const unsigned char* __restrict__ src,    // [n_rows * row_dim] Q6_K packed
+    float* __restrict__ dst,                  // [n_rows * row_dim] f32
+    int n_rows, int row_dim)
+{
+    __shared__ unsigned char blk[210];
+    unsigned int tid = threadIdx.x;
+    int i = (int)blockIdx.x;
+    if (i >= n_rows) return;
+
+    int num_blocks = row_dim >> 8;            // row_dim / 256
+    long bytes_per_row = (long)num_blocks * 210L;
+    long row_byte_base = (long)i * bytes_per_row;
+    float* out_row = dst + (long)i * row_dim;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long base = row_byte_base + (long)block * 210L;
+        if (tid < 210) blk[tid] = src[base + tid];
+        __syncthreads();
+
+        unsigned int lane = tid & 31u;          // 0..31
+        unsigned int g    = tid >> 5;           // group 0..7
+        unsigned int isc  = lane >> 4;          // 0 or 1 (scale half)
+
+        float d = sharpi_fp16_to_fp32((unsigned int)blk[208] | ((unsigned int)blk[209] << 8));
+        float scale = d * (float)((signed char)blk[192 + 2u * g + isc]);
+
+        unsigned int ql_index = (g < 4u) ? (g & 1u) : (2u + (g & 1u));
+        unsigned int ql_byte  = blk[ql_index * 32u + lane];
+        unsigned int high     = (g >> 1) & 1u;
+        unsigned int nib      = high ? (ql_byte >> 4) : (ql_byte & 0xFu);
+
+        unsigned int qh_byte = (g < 4u) ? blk[128 + lane] : blk[160 + lane];
+        unsigned int shift   = 2u * (g & 3u);
+        int q = (int)(nib | (((qh_byte >> shift) & 3u) << 4)) - 32;
+
+        out_row[block * 256 + (int)tid] = scale * (float)q;
+        __syncthreads();
+    }
+}
+
 // ── MatVec F32 ─────────────────────────────────────────────────────────────
 // 256 threads/block, 8 rows/block, 32 threads/row → warp reduce.
 // One grid dim x covers ceil(rows/8) blocks.

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -2778,6 +2778,8 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             // memcpy per row (no FP work), reading the same table bytes the CPU dequant
             // touched but skipping the dequant math and shrinking the upload 4× (packed
             // quant bytes vs f32). The dequant itself then runs on the GPU.
+            // N ≤ PrefillBatchChunk (4096) and bpr ≤ ~11 KB, so N*bpr (~47 MB) stays well
+            // within int — the int offsets below don't overflow at the chunk cap.
             int bpr = _pleBytesPerRow;
             var qhost = _bpPleQuantHost!;
             System.Threading.Tasks.Parallel.For(0, N, i =>

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -159,6 +159,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     // Managed buffer for dequanting the active token's PLE row before upload.
     private readonly float[]? _pleRowHost;
     private readonly int _pleWidth;
+    // Issue #247: PLE table stays CPU-resident, but the batched pre-pass dequant can run
+    // on the GPU when the table is Q8_0/Q6_K (the only quants Gemma 4 E2B/E4B ship) and a
+    // PLE row (L*pleWidth) is a multiple of 256 (the dequant-rows kernel's block stride).
+    private readonly bool _pleGpuDequant;
+    private readonly DType _pleDType;
+    private readonly int _pleBytesPerRow;   // packed bytes per token's PLE row
 
     // Per-layer post-attention / post-FFN RmsNorm weights (Gemma 4). Each is a
     // [embDim] f32 vector. Uploaded with Gemma (w-1)→(w+1) offset baked in.
@@ -388,7 +394,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     private Tensor? _bpProjAll, _bpPleRowAll;             // [N × L*pleWidth]
     private Tensor? _bpPleGate;                            // [N × pleWidth]
     private Tensor? _bpPleY;                               // [N × embDim]
-    private float[]? _bpPleRowHostAll;                     // managed [N × L*pleWidth]
+    private float[]? _bpPleRowHostAll;                     // managed [N × L*pleWidth] (CPU-dequant fallback)
+    // Issue #247: GPU-side PLE pre-pass. When the table is Q8_0/Q6_K we gather the raw
+    // packed rows for the chunk's tokens (a cheap memcpy, no FP math) into a host byte
+    // buffer, upload it (4× smaller than the f32 rows), then dequant on the GPU into
+    // _bpPleRowAll — removing the CPU Parallel.For dequant that profiling pinned at ~30%
+    // of batched prefill. Quant buffers replace _bpPleRowHostAll on the GPU-dequant path.
+    private Tensor? _bpPleQuantDev;                        // [N × _pleBytesPerRow] packed (device)
+    private byte[]? _bpPleQuantHost;                       // managed [N × _pleBytesPerRow] gather buffer
     /// <summary>True if the most recent <see cref="Prefill"/> used the batched trunk.</summary>
     public bool LastPrefillWasBatched { get; private set; }
 
@@ -1124,10 +1137,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         }
 
         // ── Gemma 4 PLE plumbing ───────────────────────────────────────────────
-        // Per-layer-embedding table (~4.2 GB at Q8_0) MUST stay CPU-resident; the
-        // matching TierPlanner branch excludes it from the GPU weight budget.
-        // Forward gathers + dequants one row per token, pipes it through pinned
-        // host memory, then runs the projection on-GPU.
+        // The per-layer-embedding table (~2.3–3 GB; E2B/E4B only — the 12B has no PLE)
+        // MUST stay CPU-resident; the matching TierPlanner branch excludes it from the GPU
+        // weight budget. Per-token decode gathers + dequants one row on the CPU and pipes
+        // it through pinned host memory. The BATCHED prefill pre-pass instead gathers the
+        // chunk's raw packed rows (a memcpy, no FP) and dequants them on the GPU (issue
+        // #247) — the CPU Parallel.For dequant of N×stackedDim elements was ~30% of batched
+        // prefill (#141 profiling), and the packed upload is 4× smaller than the f32 rows.
         // The small per-layer F32 weights (inp_gate / proj / post_norm /
         // per_layer_model_proj / per_layer_proj_norm) all upload at construction —
         // ~215 MB total, trivially absorbed in VRAM and keeps the per-token hot
@@ -1145,6 +1161,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             }
 
             _cpuPleTokenEmbed = ResolveCpuTensor("per_layer_token_embd.weight");
+
+            // Decide whether the batched pre-pass dequants on the GPU (issue #247). The
+            // dequant-rows kernels cover Q8_0/Q6_K (Gemma 4 E2B/E4B ship one of these) and
+            // require a PLE row (L*pleWidth) to be a multiple of 256. Anything else (F32 /
+            // an exotic quant) keeps the CPU dequant fallback in BuildPerLayerProjectionsBatched.
+            _pleDType = _cpuPleTokenEmbed.Value.DType;
+            int pleStackedDim = L * _pleWidth;
+            _pleGpuDequant = (_pleDType == DType.Q8_0 || _pleDType == DType.Q6_K)
+                          && (pleStackedDim & 0xff) == 0
+                          && Environment.GetEnvironmentVariable("SHARPI_PLE_GPU_DEQUANT") != "0";
+            _pleBytesPerRow = (pleStackedDim / DTypeInfo.BlockSize(_pleDType))
+                            * DTypeInfo.BytesPerBlock(_pleDType);
 
             var projInfo = model.FindTensor("per_layer_model_proj.weight")!.Value;
             var projData = model.GetTensorData(projInfo);
@@ -2602,7 +2630,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             _bpPleRowAll  = _gpu.Allocate(TensorShape.D1(stacked));
             _bpPleGate    = _gpu.Allocate(TensorShape.D1((long)n * _pleWidth));
             _bpPleY       = _gpu.Allocate(TensorShape.D1(emb));
-            _bpPleRowHostAll = new float[stacked];
+            if (_pleGpuDequant)
+            {
+                // Packed quant rows: gather buffer (host) + staging buffer (device). The
+                // GPU dequant writes _bpPleRowAll, so the f32 host row buffer isn't needed.
+                long quantBytes = (long)n * _pleBytesPerRow;
+                _bpPleQuantDev  = _gpu.AllocateRawBytes(quantBytes, _pleDType, exact: true);
+                _bpPleQuantHost = new byte[quantBytes];
+            }
+            else
+                _bpPleRowHostAll = new float[stacked];
         }
         _bpCapacity = n;
     }
@@ -2611,11 +2648,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     {
         foreach (var t in new[] { _bpHidden, _bpResidual, _bpNorm, _bpQ, _bpAttnOut,
                                   _bpK, _bpV, _bpFfnGate, _bpFfnUp,
-                                  _bpProjAll, _bpPleRowAll, _bpPleGate, _bpPleY })
+                                  _bpProjAll, _bpPleRowAll, _bpPleGate, _bpPleY, _bpPleQuantDev })
             if (t is { } v) _gpu.Free(v);
         _bpHidden = _bpResidual = _bpNorm = _bpQ = _bpAttnOut = _bpK = _bpV =
-            _bpFfnGate = _bpFfnUp = _bpProjAll = _bpPleRowAll = _bpPleGate = _bpPleY = null;
+            _bpFfnGate = _bpFfnUp = _bpProjAll = _bpPleRowAll = _bpPleGate = _bpPleY =
+            _bpPleQuantDev = null;
         _bpPleRowHostAll = null;
+        _bpPleQuantHost = null;
         _bpCapacity = 0;
     }
 
@@ -2722,32 +2761,55 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// Batched PLE pre-pass: build <c>_bpProjAll</c> ([N × L*pleWidth]) for all N
     /// tokens. Mirrors <see cref="BuildPerLayerProjectionsGpu"/> kernel-for-kernel,
     /// batched: one proj GEMM-N, per-(token,layer) RmsNormBatched, full-buffer add/scale.
+    /// The PLE row dequant runs on the GPU when the table is Q8_0/Q6_K (issue #247) —
+    /// the CPU <see cref="System.Threading.Tasks.Parallel"/> dequant of N×stackedDim
+    /// elements + a 4×-larger f32 upload was ~30% of batched prefill (#141 profiling).
     /// </summary>
     private void BuildPerLayerProjectionsBatched(IReadOnlyList<int> tokens)
     {
         int N = tokens.Count, L = _hp.NumLayers;
         int stackedDim = L * _pleWidth;
         var pleRef = _cpuPleTokenEmbed!.Value;
-        int bytesPerRow = (stackedDim / DTypeInfo.BlockSize(pleRef.DType))
-                        * DTypeInfo.BytesPerBlock(pleRef.DType);
-
-        // CPU dequant of each token's PLE row into the [N × stackedDim] host buffer.
-        // Parallelized across tokens (each row is independent): for a long prompt
-        // this serial gather+dequant of N×stackedDim Q8_0 elements was ~30% of the
-        // whole batched prefill (issue #141 profiling).
-        var host = _bpPleRowHostAll!;
         byte* basePtr = pleRef.DataPtr;
-        var dtype = pleRef.DType;
-        System.Threading.Tasks.Parallel.For(0, N, i =>
+
+        if (_pleGpuDequant)
         {
-            byte* rowPtr = basePtr + (long)tokens[i] * bytesPerRow;
-            var dst = new Span<float>(host).Slice(i * stackedDim, stackedDim);
-            if (dtype == DType.Float32)
-                new ReadOnlySpan<float>((float*)rowPtr, stackedDim).CopyTo(dst);
+            // Gather the chunk's raw packed PLE rows into the host staging buffer — one
+            // memcpy per row (no FP work), reading the same table bytes the CPU dequant
+            // touched but skipping the dequant math and shrinking the upload 4× (packed
+            // quant bytes vs f32). The dequant itself then runs on the GPU.
+            int bpr = _pleBytesPerRow;
+            var qhost = _bpPleQuantHost!;
+            System.Threading.Tasks.Parallel.For(0, N, i =>
+            {
+                byte* rowPtr = basePtr + (long)tokens[i] * bpr;
+                new ReadOnlySpan<byte>(rowPtr, bpr)
+                    .CopyTo(new Span<byte>(qhost).Slice(i * bpr, bpr));
+            });
+            _gpu.UploadRawInto(_bpPleQuantDev!, new ReadOnlySpan<byte>(qhost, 0, N * bpr));
+            if (_pleDType == DType.Q8_0)
+                _gpu.DequantRowsQ8_0(_bpPleQuantDev!, _bpPleRowAll!, N, stackedDim);
             else
-                Dequantize.ToFloat32(new ReadOnlySpan<byte>(rowPtr, bytesPerRow), dst, dtype, stackedDim);
-        });
-        _gpu.UploadInto(_bpPleRowAll!, host);
+                _gpu.DequantRowsQ6K(_bpPleQuantDev!, _bpPleRowAll!, N, stackedDim);
+        }
+        else
+        {
+            // CPU dequant fallback (F32 table or a quant without a dequant-rows kernel).
+            // Parallelized across tokens (each row is independent).
+            int bytesPerRow = _pleBytesPerRow;
+            var host = _bpPleRowHostAll!;
+            var dtype = _pleDType;
+            System.Threading.Tasks.Parallel.For(0, N, i =>
+            {
+                byte* rowPtr = basePtr + (long)tokens[i] * bytesPerRow;
+                var dst = new Span<float>(host).Slice(i * stackedDim, stackedDim);
+                if (dtype == DType.Float32)
+                    new ReadOnlySpan<float>((float*)rowPtr, stackedDim).CopyTo(dst);
+                else
+                    Dequantize.ToFloat32(new ReadOnlySpan<byte>(rowPtr, bytesPerRow), dst, dtype, stackedDim);
+            });
+            _gpu.UploadInto(_bpPleRowAll!, host);
+        }
         _gpu.ScaleInPlace(_bpPleRowAll!, MathF.Sqrt(_pleWidth));
 
         // proj_per_layer = per_layer_model_proj @ hidden, for all N tokens.

--- a/tests/SharpInference.Tests.ForwardPass/CudaDequantRowsTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDequantRowsTests.cs
@@ -27,8 +27,7 @@ public sealed unsafe class CudaDequantRowsTests
         catch { return null; }
     }
 
-    private static ushort HalfToUshort(Half h) =>
-        BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+    private static ushort HalfToUshort(Half h) => BitConverter.HalfToUInt16Bits(h);
 
     /// <summary>
     /// Build <paramref name="rows"/> contiguous Q8_0 rows of <paramref name="rowDim"/>

--- a/tests/SharpInference.Tests.ForwardPass/CudaDequantRowsTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDequantRowsTests.cs
@@ -48,7 +48,7 @@ public sealed unsafe class CudaDequantRowsTests
                 bytes[off + 0] = (byte)(dHalf & 0xFF);
                 bytes[off + 1] = (byte)(dHalf >> 8);
                 for (int i = 0; i < 32; i++)
-                    bytes[off + 2 + i] = (byte)(sbyte)(rng.Next(255) - 127);
+                    bytes[off + 2 + i] = (byte)(sbyte)(rng.Next(256) - 128);   // full int8 range incl. -128
             }
         return bytes;
     }

--- a/tests/SharpInference.Tests.ForwardPass/CudaDequantRowsTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDequantRowsTests.cs
@@ -1,0 +1,138 @@
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #247: the Gemma-4 PLE batched pre-pass dequants the chunk's gathered packed
+/// rows on the GPU (<see cref="CudaBackend.DequantRowsQ8_0"/> /
+/// <see cref="CudaBackend.DequantRowsQ6K"/>) instead of a CPU <c>Parallel.For</c> + a
+/// 4×-larger f32 upload. The batched-prefill bit-exact oracle
+/// (<c>Gemma4_E4B_BatchedPrefill_GemmOff_MatchesSequentialBitExact</c>) only holds if the
+/// GPU dequant is byte-for-byte identical to the CPU <see cref="Dequantize.ToFloat32"/>
+/// that the per-token reference uses. These tests prove that directly on synthetic rows —
+/// model-free and fast, so no large GGUF or heavy inference is needed.
+///
+/// Both kernels compute <c>(d·scale)·q</c> with an exact <c>cvt.f32.f16</c> scale, the
+/// same arithmetic and order as the CPU dequant, so the result must be bit-identical (not
+/// merely close). Silently no-ops on hosts without CUDA, like the rest of the Cuda* tests.
+/// </summary>
+public sealed unsafe class CudaDequantRowsTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static ushort HalfToUshort(Half h) =>
+        BitConverter.ToUInt16(BitConverter.GetBytes(h), 0);
+
+    /// <summary>
+    /// Build <paramref name="rows"/> contiguous Q8_0 rows of <paramref name="rowDim"/>
+    /// elements. Layout per 32-element block (34 bytes): [d:fp16][qs:32 × int8]. d is a
+    /// finite plausible scale; qs is signed 8-bit. Mirrors the Q8_0 PLE-table layout.
+    /// </summary>
+    private static byte[] BuildQ8_0Rows(int rows, int rowDim, Random rng)
+    {
+        int blocksPerRow = rowDim / 32;
+        int bytesPerRow = blocksPerRow * 34;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 34;
+                ushort dHalf = HalfToUshort((Half)(rng.NextDouble() * 0.18 - 0.09));
+                bytes[off + 0] = (byte)(dHalf & 0xFF);
+                bytes[off + 1] = (byte)(dHalf >> 8);
+                for (int i = 0; i < 32; i++)
+                    bytes[off + 2 + i] = (byte)(sbyte)(rng.Next(255) - 127);
+            }
+        return bytes;
+    }
+
+    /// <summary>
+    /// Build <paramref name="rows"/> contiguous Q6_K rows of <paramref name="rowDim"/>
+    /// elements. Block layout (210 bytes / 256 elems): [ql:128][qh:64][scales:16 int8][d:fp16].
+    /// All bytes are valid Q6_K data (random ql/qh/int8-scales), with a finite fp16 block
+    /// scale so neither path produces a NaN that a bit comparison would treat specially.
+    /// </summary>
+    private static byte[] BuildQ6KRows(int rows, int rowDim, Random rng)
+    {
+        int blocksPerRow = rowDim / 256;
+        int bytesPerRow = blocksPerRow * 210;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 210;
+                for (int i = 0; i < 208; i++)            // ql + qh + int8 scales
+                    bytes[off + i] = (byte)rng.Next(256);
+                ushort dHalf = HalfToUshort((Half)(rng.NextDouble() * 0.02 + 0.001));
+                bytes[off + 208] = (byte)(dHalf & 0xFF);
+                bytes[off + 209] = (byte)(dHalf >> 8);
+            }
+        return bytes;
+    }
+
+    private static void AssertBitIdentical(CudaBackend gpu, byte[] packed, DType dtype,
+        int rows, int rowDim, bool q8)
+    {
+        long count = (long)rows * rowDim;
+        var cpu = new float[count];
+        Dequantize.ToFloat32(packed, cpu, dtype, count);
+
+        var src = gpu.UploadRaw(packed, TensorShape.D1(packed.Length), dtype);
+        var dst = gpu.Allocate(TensorShape.D1(count));
+        if (q8) gpu.DequantRowsQ8_0(src, dst, rows, rowDim);
+        else    gpu.DequantRowsQ6K(src, dst, rows, rowDim);
+        gpu.Synchronize();
+
+        var got = new float[count];
+        gpu.Download(dst, got);
+        gpu.Free(src);
+        gpu.Free(dst);
+
+        int mismatches = 0;
+        float maxAbs = 0;
+        for (long i = 0; i < count; i++)
+        {
+            if (BitConverter.SingleToInt32Bits(cpu[i]) != BitConverter.SingleToInt32Bits(got[i]))
+            {
+                if (mismatches < 3)
+                    Console.WriteLine($"  {dtype} rows={rows} dim={rowDim} [{i}]: gpu={got[i]:G9} cpu={cpu[i]:G9}");
+                mismatches++;
+            }
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(cpu[i] - got[i]));
+        }
+        Assert.True(mismatches == 0,
+            $"{dtype} dequant-rows not bit-identical to CPU: {mismatches}/{count} differ " +
+            $"(rows={rows}, dim={rowDim}, maxAbs={maxAbs:E3}).");
+    }
+
+    [Theory]
+    [InlineData(1, 256)]
+    [InlineData(3, 512)]
+    [InlineData(13, 10752)]   // the real Gemma-4 E4B PLE row (L=42 × pleWidth=256)
+    public void DequantRowsQ8_0_BitIdenticalToCpu(int rows, int rowDim)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var rng = new Random(20260615 + rows * 131 + rowDim);
+        AssertBitIdentical(gpu, BuildQ8_0Rows(rows, rowDim, rng), DType.Q8_0, rows, rowDim, q8: true);
+    }
+
+    [Theory]
+    [InlineData(1, 256)]
+    [InlineData(3, 512)]
+    [InlineData(13, 10752)]   // the real Gemma-4 E4B (q4_0) PLE row
+    public void DequantRowsQ6K_BitIdenticalToCpu(int rows, int rowDim)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var rng = new Random(20260615 + rows * 137 + rowDim);
+        AssertBitIdentical(gpu, BuildQ6KRows(rows, rowDim, rng), DType.Q6_K, rows, rowDim, q8: false);
+    }
+}


### PR DESCRIPTION
Implements **item #1** of the #247 Gemma 4 prefill attack plan — the PLE pre-pass dequant — and reports findings on the rest.

## What changed
The Gemma 4 batched-prefill PLE pre-pass (`BuildPerLayerProjectionsBatched`) dequanted each token's `per_layer_token_embd` row on the **CPU** (`Parallel.For` over N×10752 elements) and uploaded the full f32 rows. This moves the dequant to the **GPU**:

- Gather the chunk's **raw packed** rows on the CPU (a memcpy, no FP math).
- Upload the **4×-smaller** quant bytes (vs f32 rows).
- Dequant on-device into `_bpPleRowAll` via new contiguous-row kernels.

The PLE table stays **CPU-resident** (TierPlanner budget + auto-context untouched, no extra VRAM), so this is a **no-regression** change on the 12 GB card. New kernels `llm_dequant_rows_q8_0` / `llm_dequant_rows_q6k`; backend `DequantRowsQ8_0/Q6K` + `UploadRawInto`. Kill-switch `SHARPI_PLE_GPU_DEQUANT=0` (also the F32-table fallback).

## Correctness
- GPU dequant is **bit-identical** to CPU `Dequantize.ToFloat32` (both `(d·scale)·q`, exact `cvt.f32.f16`), so the strict `Gemma4_E4B_BatchedPrefill_GemmOff_MatchesSequentialBitExact` oracle still holds.
- New `CudaDequantRowsTests` proves bit-identity directly for Q8_0 + Q6_K incl. the real 10752-wide row (**6/6 pass**).
- Full `Gemma4CudaBatchedPrefillTests` suite passes **8/8** (incl. the bit-exact oracle, flash/GEMM/MMQ argmax oracles, past-window, chunked >4096).
- Solution builds clean (0 warnings under `TreatWarningsAsErrors`).

## Measured (E4B-Q8_0, `-g -1`, warm)
PLE phase **80 → 63 ms @ N=4096 (~21%)**, **8 → 4 ms @ N=972** — at zero VRAM cost, plus reduced host RAM and PCIe traffic. The `ple` phase is dominated by the unavoidable per-layer-proj GEMM, so the dequant was the removable slice; the original "~30% of batched prefill" (#141) doesn't reproduce on the current warm, layer-optimized path.

## Notes on the rest of #247
Investigated and reported in the issue:
- **#2 (windowed SWA flash) is already done** — both SWA and global layers route to `FlashAttentionPrefillTc2`.
- **#6 (VRAM weight cache) is a no-op on the local models** — they all use the MMQ path (cached SoA repack, no per-call weight work); it only helps Q6_K/Q5_K `_M`-quant trunks on multi-chunk/repeated prefills, none available to measure.
- **#5 (prefill CUDA graphs) buys <1.5% at N≥512** — prefill is compute-bound (matmul 567 ms + attn 310 ms of ~1063 ms @N=4096); graphs cut launch overhead (~4–12 ms), large + risky to implement (instrument all batched kernels).

A 12B note for the issue: the **12B has no PLE table** (`embedding_length_per_layer_input=0`) — PLE is E2B/E4B only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)