### PR TITLE
fix(cuda): async-upload staging ring + 201 dangling-event fix; MoE miss-stall timer (#217)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -47,17 +47,24 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // stream without flushing it. Lazily created on first background upload —
     // costs nothing for backends that never prefetch experts.
     private nint   _uploadStream;
-    // Per-upload pinned staging used by UploadBackground*. A second cudaMallocHost'd
-    // buffer that the upload stream reads from. The async-upload lock serializes
-    // concurrent calls so the staging contents stay valid until the in-flight DMA
-    // completes (we wait on the previous event before re-filling the buffer).
-    private nint   _asyncPinnedBuf;
-    private nuint  _asyncPinnedBufSize;
+    // Ring of pinned staging buffers for UploadBackground* (issue #217). Each async upload
+    // copies into the next slot's cudaMallocHost'd buffer, DMAs from it on the upload stream,
+    // and records a BACKEND-OWNED fence event. A slot is only drained (host wait) when it
+    // wraps around AsyncRingSlots uploads later — by which time its DMA has long completed —
+    // so the host can queue a whole layer's expert uploads without blocking, and they
+    // pipeline on the upload stream while the compute stream runs.
+    //
+    // The previous single-buffer design reused the CALLER's handle event as the staging-reuse
+    // fence, but the slot manager's ReleaseUploadHandle destroys that event; the backend then
+    // synchronized a freed event and got cudaErrorDeviceUninitialized (201) the moment the
+    // path was driven from the inference / prefetcher threads. A backend-owned per-slot fence
+    // is never freed by the caller, so it both fixes that and enables the ring.
+    private const int AsyncRingSlots = 32;
+    private readonly nint[]  _asyncRingBuf   = new nint[AsyncRingSlots];
+    private readonly nuint[] _asyncRingSize  = new nuint[AsyncRingSlots];
+    private readonly nint[]  _asyncRingFence = new nint[AsyncRingSlots];
+    private long _asyncRingIdx;
     private readonly object _asyncUploadLock = new();
-    // Event recorded at the end of the most recent UploadBackground; the next
-    // call waits on it before re-using _asyncPinnedBuf to avoid overwriting an
-    // in-flight DMA source. Created lazily, reused for the buffer's lifetime.
-    private nint   _asyncPinnedBufEvent;
 
     // Maximum im2col tile buffer size. All row-aligned tile sizes fit within this bound.
     private const long MaxTileBytes = 2560L * 1024 * 1024; // 2.5 GiB — fits all layers in a single tile
@@ -1485,32 +1492,43 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         nint ev;
         lock (_asyncUploadLock)
         {
-            EnsureAsyncPinnedBuf(byteSize);
+            int slot = (int)(_asyncRingIdx++ % AsyncRingSlots);
 
-            // Drain the previous async upload before overwriting the shared staging
-            // buffer — the in-flight DMA still reads from _asyncPinnedBuf and a
-            // host-side memcpy here would corrupt it. The wait is on the host because
-            // it gates a host memcpy, not another GPU launch.
-            if (_asyncPinnedBufEvent != nint.Zero)
+            // Drain THIS slot's previous DMA (AsyncRingSlots uploads ago) before reusing its
+            // staging buffer. The fence is backend-owned — never destroyed by the caller — so
+            // unlike the old caller-event reuse this can't synchronize a freed event. In steady
+            // state the DMA finished long ago, so this does not block the host.
+            if (_asyncRingFence[slot] != nint.Zero)
             {
-                int sr = CuBlasInterop.EventSynchronize(_asyncPinnedBufEvent);
-                if (sr != 0)
-                    throw new InvalidOperationException($"cudaEventSynchronize (drain prev async upload) failed: {sr}");
+                int dr = CuBlasInterop.EventSynchronize(_asyncRingFence[slot]);
+                if (dr != 0)
+                    throw new InvalidOperationException($"cudaEventSynchronize (drain async staging slot) failed: {dr}");
             }
 
-            Buffer.MemoryCopy(src, (void*)_asyncPinnedBuf, _asyncPinnedBufSize, byteSize);
+            // Grow this slot's staging buffer if the tensor doesn't fit.
+            if (_asyncRingBuf[slot] == nint.Zero || byteSize > _asyncRingSize[slot])
+            {
+                if (_asyncRingBuf[slot] != nint.Zero) CuBlasInterop.FreeHost(_asyncRingBuf[slot]);
+                nuint newSize = Math.Max(byteSize, _asyncRingSize[slot] * 2);
+                if (newSize < 1024 * 1024) newSize = 1024 * 1024;
+                int mr = CuBlasInterop.MallocHost(out _asyncRingBuf[slot], newSize);
+                if (mr != 0)
+                    throw new InvalidOperationException($"cudaMallocHost (async upload staging, {newSize} B) failed: {mr}");
+                _asyncRingSize[slot] = newSize;
+            }
 
-            int rc = CuBlasInterop.CudaMemcpyAsync(devPtr, _asyncPinnedBuf, byteSize,
+            Buffer.MemoryCopy(src, (void*)_asyncRingBuf[slot], _asyncRingSize[slot], byteSize);
+
+            int rc = CuBlasInterop.CudaMemcpyAsync(devPtr, _asyncRingBuf[slot], byteSize,
                 CuBlasInterop.HostToDevice, _uploadStream);
             if (rc != 0)
                 throw new InvalidOperationException($"cudaMemcpyAsync (UploadBackground) failed: {rc}");
 
-            // Per-call event: timing disabled (we never measure these — the readiness
-            // event is consumed by stream-wait or an EventQuery poll only).
+            // Caller's readiness event (consumed by WaitForUpload's cross-stream wait / an
+            // EventQuery poll, then destroyed by ReleaseUploadHandle). DisableTiming.
             int er = CuBlasInterop.EventCreateWithFlags(out ev, CuBlasInterop.EventDisableTiming);
             if (er != 0)
                 throw new InvalidOperationException($"cudaEventCreateWithFlags failed: {er}");
-
             int rr = CuBlasInterop.EventRecord(ev, _uploadStream);
             if (rr != 0)
             {
@@ -1518,10 +1536,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
                 throw new InvalidOperationException($"cudaEventRecord failed: {rr}");
             }
 
-            // Replace the buffer-reuse fence with the freshly recorded event. We
-            // never destroy this reference — ev is owned by the caller's handle;
-            // the *next* UploadBackgroundCore call only reads it via EventSynchronize.
-            _asyncPinnedBufEvent = ev;
+            // Backend-owned staging fence for this slot: signals when this slot's DMA (and
+            // thus the host's freedom to overwrite its buffer) completes. Created once per
+            // slot, re-recorded on each reuse.
+            if (_asyncRingFence[slot] == nint.Zero)
+            {
+                int fe = CuBlasInterop.EventCreateWithFlags(out _asyncRingFence[slot], CuBlasInterop.EventDisableTiming);
+                if (fe != 0)
+                    throw new InvalidOperationException($"cudaEventCreateWithFlags (staging fence) failed: {fe}");
+            }
+            int fr = CuBlasInterop.EventRecord(_asyncRingFence[slot], _uploadStream);
+            if (fr != 0)
+                throw new InvalidOperationException($"cudaEventRecord (staging fence) failed: {fr}");
         }
 
         var handleId = (nint)Interlocked.Increment(ref _nextHandle);
@@ -1543,23 +1569,6 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
                 throw new InvalidOperationException($"cudaStreamCreate (upload stream) failed: {r}");
             _uploadStream = s;
         }
-    }
-
-    private void EnsureAsyncPinnedBuf(nuint required)
-    {
-        if (_asyncPinnedBuf != nint.Zero && required <= _asyncPinnedBufSize) return;
-        // Drain any in-flight DMA reading the old buffer before freeing it.
-        if (_asyncPinnedBufEvent != nint.Zero && _asyncPinnedBuf != nint.Zero)
-            CuBlasInterop.EventSynchronize(_asyncPinnedBufEvent);
-        if (_asyncPinnedBuf != nint.Zero)
-            CuBlasInterop.FreeHost(_asyncPinnedBuf);
-
-        nuint newSize = Math.Max(required, _asyncPinnedBufSize * 2);
-        if (newSize < 1024 * 1024) newSize = 1024 * 1024;
-        int r = CuBlasInterop.MallocHost(out _asyncPinnedBuf, newSize);
-        if (r != 0)
-            throw new InvalidOperationException($"cudaMallocHost (async upload staging, {newSize} B) failed: {r}");
-        _asyncPinnedBufSize = newSize;
     }
 
     /// <summary>
@@ -6745,11 +6754,21 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _uploadStream = nint.Zero;
         }
 
-        if (_asyncPinnedBuf != nint.Zero)
+        // Free the async staging ring: each slot's pinned buffer + its backend-owned fence
+        // event (the upload stream was synchronized + destroyed above, so all DMAs are done).
+        for (int i = 0; i < AsyncRingSlots; i++)
         {
-            CuBlasInterop.FreeHost(_asyncPinnedBuf);
-            _asyncPinnedBuf = nint.Zero;
-            _asyncPinnedBufSize = 0;
+            if (_asyncRingFence[i] != nint.Zero)
+            {
+                CuBlasInterop.EventDestroy(_asyncRingFence[i]);
+                _asyncRingFence[i] = nint.Zero;
+            }
+            if (_asyncRingBuf[i] != nint.Zero)
+            {
+                CuBlasInterop.FreeHost(_asyncRingBuf[i]);
+                _asyncRingBuf[i] = nint.Zero;
+                _asyncRingSize[i] = 0;
+            }
         }
 
         if (_pinnedBuf != nint.Zero)

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -1388,9 +1388,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // it lives in the same _devPtrs table and is freed via Free() like any
     // other tensor.
     //
-    // Concurrent UploadBackground* calls are serialized by _asyncUploadLock
-    // because they share the _asyncPinnedBuf staging — the lock also ensures
-    // the previous transfer's DMA drains before we overwrite the staging bytes.
+    // Concurrent UploadBackground* calls are serialized by _asyncUploadLock while
+    // they pick a staging-ring slot and record events. They do NOT serialize on the
+    // prior DMA: each call uses its own ring slot and only drains (host wait) when a
+    // slot wraps around AsyncRingSlots uploads later, so up to AsyncRingSlots transfers
+    // can be in flight at once (see the _asyncRing* fields).
 
     /// <summary>
     /// Async H2D upload on the dedicated upload stream. The returned tensor's
@@ -1538,16 +1540,23 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
 
             // Backend-owned staging fence for this slot: signals when this slot's DMA (and
             // thus the host's freedom to overwrite its buffer) completes. Created once per
-            // slot, re-recorded on each reuse.
+            // slot, re-recorded on each reuse. On a failure here the caller never receives a
+            // handle, so destroy the just-created caller event ev ourselves to avoid leaking it.
             if (_asyncRingFence[slot] == nint.Zero)
             {
                 int fe = CuBlasInterop.EventCreateWithFlags(out _asyncRingFence[slot], CuBlasInterop.EventDisableTiming);
                 if (fe != 0)
+                {
+                    CuBlasInterop.EventDestroy(ev);
                     throw new InvalidOperationException($"cudaEventCreateWithFlags (staging fence) failed: {fe}");
+                }
             }
             int fr = CuBlasInterop.EventRecord(_asyncRingFence[slot], _uploadStream);
             if (fr != 0)
+            {
+                CuBlasInterop.EventDestroy(ev);
                 throw new InvalidOperationException($"cudaEventRecord (staging fence) failed: {fr}");
+            }
         }
 
         var handleId = (nint)Interlocked.Increment(ref _nextHandle);

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -1494,7 +1494,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         nint ev;
         lock (_asyncUploadLock)
         {
-            int slot = (int)(_asyncRingIdx++ % AsyncRingSlots);
+            // Bitwise-AND (AsyncRingSlots is a power of two) instead of % so the index stays
+            // in [0, AsyncRingSlots) even in the impossible event the long counter wraps past
+            // 2^63 — a negative `% 32` would yield a negative slot and an IndexOutOfRange.
+            int slot = (int)(_asyncRingIdx++ & (AsyncRingSlots - 1));
 
             // Drain THIS slot's previous DMA (AsyncRingSlots uploads ago) before reusing its
             // staging buffer. The fence is backend-owned — never destroyed by the caller — so
@@ -1507,15 +1510,26 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
                     throw new InvalidOperationException($"cudaEventSynchronize (drain async staging slot) failed: {dr}");
             }
 
-            // Grow this slot's staging buffer if the tensor doesn't fit.
+            // Grow this slot's staging buffer if the tensor doesn't fit. Free the old buffer and
+            // zero the slot FIRST, so if the MallocHost below fails the slot holds no stale or
+            // garbage pointer for Dispose to (double-)free.
             if (_asyncRingBuf[slot] == nint.Zero || byteSize > _asyncRingSize[slot])
             {
-                if (_asyncRingBuf[slot] != nint.Zero) CuBlasInterop.FreeHost(_asyncRingBuf[slot]);
-                nuint newSize = Math.Max(byteSize, _asyncRingSize[slot] * 2);
+                if (_asyncRingBuf[slot] != nint.Zero)
+                {
+                    CuBlasInterop.FreeHost(_asyncRingBuf[slot]);
+                    _asyncRingBuf[slot] = nint.Zero;
+                }
+                nuint oldSize = _asyncRingSize[slot];
+                _asyncRingSize[slot] = 0;
+                nuint newSize = Math.Max(byteSize, oldSize * 2);
                 if (newSize < 1024 * 1024) newSize = 1024 * 1024;
                 int mr = CuBlasInterop.MallocHost(out _asyncRingBuf[slot], newSize);
                 if (mr != 0)
+                {
+                    _asyncRingBuf[slot] = nint.Zero;
                     throw new InvalidOperationException($"cudaMallocHost (async upload staging, {newSize} B) failed: {mr}");
+                }
                 _asyncRingSize[slot] = newSize;
             }
 

--- a/src/SharpInference.Engine/CudaExpertSlotManager.cs
+++ b/src/SharpInference.Engine/CudaExpertSlotManager.cs
@@ -115,7 +115,9 @@ public sealed class CudaExpertSlotManager : IDisposable, IExpertPrefetchTarget
             }
 
             _profiler.RecordMiss(layer, expertId);
-            // Time only the blocking upload — the stall issue #217's overlap hides.
+            // Time the on-miss UploadExpert call — the synchronous expert-weight streaming
+            // (host stage + H2D, drained on this or the next call) that #217's overlap aimed
+            // to hide. Wraps only the upload, not the cache/lock bookkeeping.
             long t0 = Stopwatch.GetTimestamp();
             slot = UploadExpert(layer, expertId);
             _profiler.RecordMissStall(Stopwatch.GetTimestamp() - t0);

--- a/src/SharpInference.Engine/CudaExpertSlotManager.cs
+++ b/src/SharpInference.Engine/CudaExpertSlotManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using SharpInference.Core;
 using SharpInference.Cpu;
@@ -114,7 +115,10 @@ public sealed class CudaExpertSlotManager : IDisposable, IExpertPrefetchTarget
             }
 
             _profiler.RecordMiss(layer, expertId);
+            // Time only the blocking upload — the stall issue #217's overlap hides.
+            long t0 = Stopwatch.GetTimestamp();
             slot = UploadExpert(layer, expertId);
+            _profiler.RecordMissStall(Stopwatch.GetTimestamp() - t0);
             _cache.Put(layer, expertId, slot);
             MaybeWarmPin();
             return slot;

--- a/src/SharpInference.Engine/ExpertSlotManager.cs
+++ b/src/SharpInference.Engine/ExpertSlotManager.cs
@@ -93,7 +93,10 @@ public sealed class ExpertSlotManager : IDisposable, IExpertPrefetchTarget
             }
 
             _profiler.RecordMiss(layer, expertId);
-            // Time only the blocking upload — the stall issue #217's overlap hides.
+            // Time the on-miss UploadExpert call — the synchronous expert-weight streaming
+            // that #217's overlap aimed to hide. Wraps only the upload, not the bookkeeping.
+            // (On the Vulkan path the forward pass services misses via TryGetCached + a CPU
+            // fallback, not GetOrLoad, so this site rarely fires there.)
             long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
             slot = UploadExpert(layer, expertId);
             _profiler.RecordMissStall(System.Diagnostics.Stopwatch.GetTimestamp() - t0);

--- a/src/SharpInference.Engine/ExpertSlotManager.cs
+++ b/src/SharpInference.Engine/ExpertSlotManager.cs
@@ -93,7 +93,10 @@ public sealed class ExpertSlotManager : IDisposable, IExpertPrefetchTarget
             }
 
             _profiler.RecordMiss(layer, expertId);
+            // Time only the blocking upload — the stall issue #217's overlap hides.
+            long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
             slot = UploadExpert(layer, expertId);
+            _profiler.RecordMissStall(System.Diagnostics.Stopwatch.GetTimestamp() - t0);
             _cache.Put(layer, expertId, slot);
             MaybeWarmPin();
             return slot;

--- a/src/SharpInference.Pipeline/ExpertAccessProfiler.cs
+++ b/src/SharpInference.Pipeline/ExpertAccessProfiler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 namespace SharpInference.Pipeline;
@@ -15,6 +16,12 @@ public sealed class ExpertAccessProfiler
     private readonly long[] _misses; // same layout
     private long _totalHits;
     private long _totalMisses;
+
+    // Wall time (Stopwatch ticks) spent in the SYNCHRONOUS on-miss expert upload —
+    // the stall the issue #217 prefetch/overlap work hides. Driven caller-side so the
+    // timer wraps only the blocking upload, not the cache/lock bookkeeping. An A/B with
+    // prefetch on vs off should show this collapse even as the miss count holds.
+    private long _missStallTicks;
 
     // Warm-pin snapshot. Populated once when the slot manager pins the hot set;
     // PrintStats uses these to compute before/after-warm hit rates so callers can
@@ -47,6 +54,15 @@ public sealed class ExpertAccessProfiler
 
     public long TotalHits => Interlocked.Read(ref _totalHits);
     public long TotalMisses => Interlocked.Read(ref _totalMisses);
+
+    /// <summary>
+    /// Accumulate the wall time of one synchronous on-miss upload. <paramref name="stopwatchTicks"/>
+    /// is a <see cref="Stopwatch.GetTimestamp"/> delta (call site wraps only the blocking upload).
+    /// </summary>
+    public void RecordMissStall(long stopwatchTicks) => Interlocked.Add(ref _missStallTicks, stopwatchTicks);
+
+    /// <summary>Total wall time spent in synchronous on-miss expert uploads, in milliseconds.</summary>
+    public double MissStallMs => Interlocked.Read(ref _missStallTicks) * 1000.0 / Stopwatch.Frequency;
 
     public double OverallHitRate
     {
@@ -180,6 +196,8 @@ public sealed class ExpertAccessProfiler
         long th = TotalHits, tm = TotalMisses;
         double rate = (th + tm) == 0 ? 0.0 : (double)th / (th + tm);
         sb.AppendLine($"[ExpertAccessProfiler] overall hit rate: {rate:P1} ({th} hits / {th + tm} accesses)");
+        double stallMs = MissStallMs;
+        sb.AppendLine($"[ExpertAccessProfiler] sync miss-stall: {stallMs:F1} ms over {tm} misses ({(tm == 0 ? 0.0 : stallMs / tm):F3} ms/miss)");
 
         if (_warmPinned is not null)
         {

--- a/src/SharpInference.Pipeline/ExpertAccessProfiler.cs
+++ b/src/SharpInference.Pipeline/ExpertAccessProfiler.cs
@@ -17,11 +17,14 @@ public sealed class ExpertAccessProfiler
     private long _totalHits;
     private long _totalMisses;
 
-    // Wall time (Stopwatch ticks) spent in the SYNCHRONOUS on-miss expert upload —
-    // the stall the issue #217 prefetch/overlap work hides. Driven caller-side so the
-    // timer wraps only the blocking upload, not the cache/lock bookkeeping. An A/B with
-    // prefetch on vs off should show this collapse even as the miss count holds.
+    // Wall time (Stopwatch ticks) spent in the SYNCHRONOUS on-miss expert upload, plus the
+    // number of such uploads timed. Driven caller-side (around UploadExpert in GetOrLoad) so
+    // the timer wraps only the blocking upload, not the cache/lock bookkeeping. Reported per
+    // STALLED upload rather than per miss: a backend whose forward pass services misses via
+    // TryGetCached + a separate fallback (the Vulkan path) records the miss but no stall, so
+    // averaging over TotalMisses would understate ms/upload.
     private long _missStallTicks;
+    private long _missStallCount;
 
     // Warm-pin snapshot. Populated once when the slot manager pins the hot set;
     // PrintStats uses these to compute before/after-warm hit rates so callers can
@@ -59,10 +62,17 @@ public sealed class ExpertAccessProfiler
     /// Accumulate the wall time of one synchronous on-miss upload. <paramref name="stopwatchTicks"/>
     /// is a <see cref="Stopwatch.GetTimestamp"/> delta (call site wraps only the blocking upload).
     /// </summary>
-    public void RecordMissStall(long stopwatchTicks) => Interlocked.Add(ref _missStallTicks, stopwatchTicks);
+    public void RecordMissStall(long stopwatchTicks)
+    {
+        Interlocked.Add(ref _missStallTicks, stopwatchTicks);
+        Interlocked.Increment(ref _missStallCount);
+    }
 
     /// <summary>Total wall time spent in synchronous on-miss expert uploads, in milliseconds.</summary>
     public double MissStallMs => Interlocked.Read(ref _missStallTicks) * 1000.0 / Stopwatch.Frequency;
+
+    /// <summary>Number of synchronous on-miss uploads timed (the denominator for ms/upload).</summary>
+    public long MissStallCount => Interlocked.Read(ref _missStallCount);
 
     public double OverallHitRate
     {
@@ -197,7 +207,8 @@ public sealed class ExpertAccessProfiler
         double rate = (th + tm) == 0 ? 0.0 : (double)th / (th + tm);
         sb.AppendLine($"[ExpertAccessProfiler] overall hit rate: {rate:P1} ({th} hits / {th + tm} accesses)");
         double stallMs = MissStallMs;
-        sb.AppendLine($"[ExpertAccessProfiler] sync miss-stall: {stallMs:F1} ms over {tm} misses ({(tm == 0 ? 0.0 : stallMs / tm):F3} ms/miss)");
+        long stallN = MissStallCount;
+        sb.AppendLine($"[ExpertAccessProfiler] sync miss-stall: {stallMs:F1} ms over {stallN} synchronous upload(s) ({(stallN == 0 ? 0.0 : stallMs / stallN):F3} ms each)");
 
         if (_warmPinned is not null)
         {

--- a/tests/SharpInference.Tests.ForwardPass/CudaAsyncUploadTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaAsyncUploadTests.cs
@@ -174,6 +174,48 @@ public sealed class CudaAsyncUploadTests
     }
 
     /// <summary>
+    /// Issue #217 staging ring: issuing more uploads than the ring's slot count forces
+    /// slot reuse — the drain-then-re-record of a backend-owned fence + staging-buffer reuse
+    /// the ring exists to make safe. Every upload must still round-trip its own distinct
+    /// payload; a stale staging slot, a wrong-fence drain, or an off-by-one in the slot index
+    /// would corrupt the tensors uploaded after the first wrap. (The other tests issue ≤5
+    /// uploads and never wrap, so this is the only coverage of the reuse path.)
+    /// </summary>
+    [Fact]
+    public void UploadBackground_RingWrap_AllPayloadsRoundTrip()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int N = 64;    // > the 32-slot ring → at least one full wrap (each slot reused)
+        const int Len = 257; // distinct, multi-element payload per upload
+        var handles = new CudaUploadHandle[N];
+        var sources = new float[N][];
+        for (int u = 0; u < N; u++)
+        {
+            var s = new float[Len];
+            for (int i = 0; i < Len; i++) s[i] = u * 1000f + i; // unique per (upload, index)
+            sources[u] = s;
+            handles[u] = gpu.UploadBackground(s, TensorShape.D1(Len));
+        }
+
+        for (int u = 0; u < N; u++)
+        {
+            gpu.WaitForUpload(handles[u]);
+            var rt = new float[Len];
+            gpu.Download(handles[u].Tensor, rt);
+            for (int i = 0; i < Len; i++)
+                Assert.Equal(sources[u][i], rt[i]);
+        }
+
+        for (int u = 0; u < N; u++)
+        {
+            gpu.ReleaseUploadHandle(handles[u]);
+            gpu.Free(handles[u].Tensor);
+        }
+    }
+
+    /// <summary>
     /// Backend.UploadStream is nint.Zero until the first background upload, then
     /// becomes non-zero and is reused across subsequent calls. Validates the
     /// lazy-init contract documented on the property.

--- a/tests/SharpInference.Tests.Pipeline/PipelineTests.cs
+++ b/tests/SharpInference.Tests.Pipeline/PipelineTests.cs
@@ -31,6 +31,37 @@ public sealed class PipelineTests
         Assert.NotNull(evicted);
     }
 
+    // ── issue #217 miss-stall timer ─────────────────────────────────────────
+
+    [Fact]
+    public void Profiler_MissStall_StartsAtZero()
+    {
+        var p = new SharpInference.Pipeline.ExpertAccessProfiler(numLayers: 2, numExperts: 4);
+        Assert.Equal(0.0, p.MissStallMs);
+    }
+
+    [Fact]
+    public void Profiler_MissStall_AccumulatesTicks()
+    {
+        var p = new SharpInference.Pipeline.ExpertAccessProfiler(numLayers: 2, numExperts: 4);
+        // One second's worth of Stopwatch ticks, added twice → ~2000 ms.
+        long oneSecondTicks = System.Diagnostics.Stopwatch.Frequency;
+        p.RecordMissStall(oneSecondTicks);
+        p.RecordMissStall(oneSecondTicks);
+        Assert.Equal(2000.0, p.MissStallMs, precision: 0);
+    }
+
+    [Fact]
+    public void Profiler_MissStall_PrintedInStats()
+    {
+        var p = new SharpInference.Pipeline.ExpertAccessProfiler(numLayers: 1, numExperts: 2);
+        p.RecordMiss(0, 0);
+        p.RecordMissStall(System.Diagnostics.Stopwatch.Frequency / 10); // ~100 ms
+        var sw = new System.IO.StringWriter();
+        p.PrintStats(sw);
+        Assert.Contains("miss-stall", sw.ToString());
+    }
+
     [Fact]
     public void ExpertCache_DifferentLayersSameExpertId_TrackedSeparately()
     {


### PR DESCRIPTION
Two fixes surfaced while investigating #217. The overlap optimization itself **does not pay off** (decode on the GPU-SLRU path is PCIe-bandwidth-bound, not upload-latency-bound — see the [issue thread](https://github.com/pekkah/SharpInference/issues/217)), so the prefetch/overlap wiring was dropped. These two fixes are independent of the overlap and stand on their own.

## 1. Async-upload `cudaEventSynchronize` 201 + staging ring (`CudaBackend.cs`)
`UploadBackground*` reused the **caller's** handle event as the single staging buffer's reuse fence. But the slot manager's `ReleaseUploadHandle` **destroys** that event — so the backend then synchronized a *freed* event and threw `cudaErrorDeviceUninitialized` (201) the instant the async path was driven from a thread other than the backend-init thread.

The async path had **zero real callers** before this (only unit tests, which run on the init thread), so the latent bug was never hit. Replaced the single staging buffer with a **ring of 32 pinned buffers, each with a backend-owned fence event** (never freed by the caller): fixes the 201 and lets uploads pipeline. All 6 `CudaAsyncUploadTests` still pass.

## 2. MoE miss-stall timer (`ExpertAccessProfiler`)
`RecordMissStall` / `MissStallMs` + a `PrintStats` line, wired around the synchronous on-miss `UploadExpert` in both `CudaExpertSlotManager.GetOrLoad` and `ExpertSlotManager.GetOrLoad`. Quantifies the synchronous upload stall the issue targeted (~3168 ms on a Coder-30B GPU-SLRU decode); shown via `SHARPI_EXPERT_STATS=<path>`. 3 unit tests.

## Verification
- Full Release build clean (`TreatWarningsAsErrors` + AOT/trim analyzers).
- 6/6 `CudaAsyncUploadTests` (exercise the ring) + 3 profiler tests pass.
- Coder-30B GPU-SLRU decode unchanged at 17.9 t/s (the sync path is untouched; the ring only affects the async path).

## Why the overlap was dropped (recorded on #217)
A/B after a full backend redesign (the staging ring): baseline **17.9** → item 1 overlap **11.8** → item 1+2 **8.7** t/s. Overlap improves hit-rate (57.7→63.9%) and cuts miss-stall (3168→2465 ms) yet **regresses wall-time ~1.5–2×** — the async event/stream-wait overhead exceeds the small compute available to hide DMA behind, and speculative prefetch steals PCIe bandwidth the real uploads need. The decode is bandwidth-bound, so overlap can't win; only reducing *traffic* helps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)