### PR TITLE
feat(server): multimodal image input endpoint (Gemma 4 gemma4uv) (#253)

### DIFF
--- a/src/SharpInference.Engine/IInferenceEngine.cs
+++ b/src/SharpInference.Engine/IInferenceEngine.cs
@@ -60,6 +60,30 @@ public interface IInferenceEngine
         string? canonicalHistoryPrefix = null);
 
     /// <summary>
+    /// Whether this engine can accept image input (issue #253). True only when an mmproj
+    /// vision projector is loaded <i>and</i> the underlying forward pass supports
+    /// precomputed-embedding input (CPU or full-CUDA Gemma 4 today). Endpoints check this
+    /// before routing an image request and return a clear error otherwise.
+    /// </summary>
+    bool SupportsImageInput => false;
+
+    /// <summary>
+    /// Generate from a pre-formatted prompt that contains the model's <c>&lt;|image|&gt;</c>
+    /// placeholder token(s), splicing each image's projected soft-token embeddings in place of
+    /// the i-th placeholder (left to right). <paramref name="imageBytes"/> holds the raw encoded
+    /// image bytes (e.g. base64-decoded PNG), one per placeholder, in the same order. Same typed
+    /// chunk semantics as <see cref="GenerateChunksAsync"/>. The number of placeholders in the
+    /// rendered prompt must equal <c>imageBytes.Count</c>.
+    /// </summary>
+    IAsyncEnumerable<GenerateChunk> GenerateImageChunksAsync(
+        string prompt,
+        IReadOnlyList<byte[]> imageBytes,
+        SamplingParams sp,
+        CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not support image input. Check SupportsImageInput first.");
+
+    /// <summary>
     /// Generate text from a pre-formatted prompt string. Yields decoded text chunks
     /// (one or more characters) as they are produced. Reasoning content emitted inside
     /// <c>&lt;think&gt;...&lt;/think&gt;</c> is suppressed — only user-facing answer text

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -537,6 +537,13 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     {
                         // Image input (#253): no prefix reuse — project each image and splice its
                         // soft tokens in place of its placeholder during a fresh prefill.
+                        // Invalidate _prevTokens BEFORE prefilling: the image cache holds soft-token
+                        // KV at expanded positions that don't correspond to plain token positions, so
+                        // a later text request must NOT match this sequence in FindCacheablePrefix and
+                        // TruncateTo into it. Nulling it up front also covers a mid-prefill throw,
+                        // which leaves the cache partially written (the end-of-decode snapshot below
+                        // is already skipped for image requests).
+                        _prevTokens = null;
                         _fwd.ResetCache();
                         suffixTokens = tokens;
                         logits = SplicePrefillImages(tokens, imageBytes, ct, out startPos);
@@ -778,7 +785,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                                 channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, chunk));
                         }
 
-                        logits = _fwd.Forward(next, tokens.Length + i);
+                        logits = _fwd.Forward(next, startPos + i);
                     }
 
                     // End-of-loop: flush both decoders defensively (whichever was active).

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using SharpInference.Core;
+using SharpInference.Vision;
 
 namespace SharpInference.Engine;
 
@@ -36,6 +37,13 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
 
     // Prefix caching state (guarded by _gate — only accessed during generation).
     private int[]? _prevTokens;
+
+    // Image input (issue #253). Set once at load via EnableImageInput; the VisionModel is
+    // owned/disposed elsewhere (in _owned). Image requests splice projected soft tokens at
+    // each placeholder during a fresh (no-prefix-reuse) prefill.
+    private GemmaUvVisionEmbedder? _visionEmbedder;
+    private VisionModel? _visionModel;
+    private int _imgOpenId, _imgCloseId, _imgPlaceholderId;
 
     // Observability counters (updated via Interlocked).
     private int _pendingCount;
@@ -149,6 +157,85 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     }
 
     /// <summary>
+    /// Enable image (vision) input (issue #253). Call once at load time, before any request.
+    /// The <paramref name="model"/> must already be in this engine's <c>owned</c> disposables
+    /// (the loader adds it) — this method only borrows references. <paramref name="openId"/>,
+    /// <paramref name="closeId"/>, <paramref name="placeholderId"/> are the Gemma 4
+    /// <c>&lt;|image&gt;</c> / <c>&lt;image|&gt;</c> / <c>&lt;|image|&gt;</c> token ids.
+    /// </summary>
+    public void EnableImageInput(GemmaUvVisionEmbedder embedder, VisionModel model,
+        int openId, int closeId, int placeholderId)
+    {
+        _visionEmbedder = embedder;
+        _visionModel = model;
+        _imgOpenId = openId;
+        _imgCloseId = closeId;
+        _imgPlaceholderId = placeholderId;
+    }
+
+    /// <inheritdoc/>
+    public bool SupportsImageInput => _visionEmbedder is not null && _fwd.SupportsEmbeddingInput;
+
+    /// <summary>
+    /// Issue #253 image prefill: project each image to its soft-token block, then walk the
+    /// prompt tokens — emitting ordinary tokens via <see cref="IForwardPass.Forward"/> and
+    /// expanding each <c>&lt;|image|&gt;</c> placeholder to open-marker + per-soft-token
+    /// <see cref="IForwardPass.ForwardEmbedding"/> + close-marker (mirrors the CLI's
+    /// <c>RunImagePrompt</c>). Returns the final prefill logits; <paramref name="endPos"/>
+    /// receives the post-prefill sequence length. Runs on the generation worker thread.
+    /// </summary>
+    private ReadOnlySpan<float> SplicePrefillImages(int[] tokens, IReadOnlyList<byte[]> imageBytes,
+        CancellationToken ct, out int endPos)
+    {
+        var vision = _visionModel!;
+        var embedder = _visionEmbedder!;
+        int embDim = vision.EmbeddingLength;
+
+        // Project every image up front (decode → preprocess → embed), in request order.
+        var blocks = new (float[] Soft, int NTok)[imageBytes.Count];
+        for (int i = 0; i < imageBytes.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            byte[] rgb;
+            int w, h;
+            using (var ms = new MemoryStream(imageBytes[i], writable: false))
+                rgb = ImageIO.LoadRgb(ms, out w, out h);
+            var pre = ImagePreprocessor.Preprocess(rgb, w, h, vision);
+            var soft = embedder.Forward(pre.Chw, pre.Height, pre.Width, out int nTok);
+            blocks[i] = (soft, nTok);
+        }
+
+        int placeholders = 0;
+        foreach (int id in tokens) if (id == _imgPlaceholderId) placeholders++;
+        if (placeholders != imageBytes.Count)
+            throw new InvalidOperationException(
+                $"Image count mismatch: the rendered prompt has {placeholders} <|image|> placeholder(s) " +
+                $"but {imageBytes.Count} image(s) were supplied.");
+
+        int pos = 0;
+        int imgIdx = 0;
+        ReadOnlySpan<float> logits = default;
+        foreach (int id in tokens)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (id == _imgPlaceholderId)
+            {
+                var (soft, nTok) = blocks[imgIdx++];
+                logits = _fwd.Forward(_imgOpenId, pos++);
+                for (int t = 0; t < nTok; t++)
+                    logits = _fwd.ForwardEmbedding(soft.AsSpan(t * embDim, embDim), pos++);
+                logits = _fwd.Forward(_imgCloseId, pos++);
+            }
+            else
+            {
+                logits = _fwd.Forward(id, pos++);
+            }
+        }
+        endPos = pos;
+        return logits;
+    }
+
+    /// <summary>
     /// Prompt-prefill batch size, in tokens. A single <see cref="IForwardPass.Prefill"/> call is
     /// opaque to the request's <see cref="CancellationToken"/> — the engine only checks <c>ct</c>
     /// between decode tokens — so a large-prompt prefill would otherwise run to completion even
@@ -241,11 +328,34 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<GenerateChunk> GenerateChunksAsync(
+    public IAsyncEnumerable<GenerateChunk> GenerateChunksAsync(
         string prompt,
         SamplingParams sp,
-        [EnumeratorCancellation] CancellationToken ct = default,
+        CancellationToken ct = default,
         string? canonicalHistoryPrefix = null)
+        => GenerateCore(prompt, sp, ct, canonicalHistoryPrefix, imageBytes: null);
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<GenerateChunk> GenerateImageChunksAsync(
+        string prompt,
+        IReadOnlyList<byte[]> imageBytes,
+        SamplingParams sp,
+        CancellationToken ct = default)
+    {
+        if (!SupportsImageInput)
+            throw new NotSupportedException(
+                "This engine is not configured for image input. Load an mmproj (SHARPI_MMPROJ / " +
+                "SharpInferenceServerOptions.MmprojPath) for a Gemma 4 model on a CPU or full-CUDA backend.");
+        ArgumentNullException.ThrowIfNull(imageBytes);
+        return GenerateCore(prompt, sp, ct, canonicalHistoryPrefix: null, imageBytes);
+    }
+
+    private async IAsyncEnumerable<GenerateChunk> GenerateCore(
+        string prompt,
+        SamplingParams sp,
+        [EnumeratorCancellation] CancellationToken ct,
+        string? canonicalHistoryPrefix,
+        IReadOnlyList<byte[]>? imageBytes)
     {
         // Link the caller's token with the engine-shutdown token so Dispose can stop this
         // generation's background worker (issue #132). Everything below uses `ct` — the
@@ -392,6 +502,9 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                                 && !thinkingEnabled;
                             break;
                     }
+                    // Image input (#253) splices precomputed embeddings during prefill; MTP's
+                    // PrefillMtp / batched verify don't model that, so never engage MTP here.
+                    if (imageBytes is { Count: > 0 }) useMtp = false;
 
                     // --spec-draft-n-max parity with llama.cpp (issue #30): the MTP
                     // draft-chain length per step. Unset (0) resolves via
@@ -409,86 +522,105 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     //       runs too (issue #106) — PrefillMtp accepts startPos > 0 and
                     //       TruncateTo soft-truncates the MTP KV alongside the trunk.
                     // If neither branch hits, fall back to a full ResetCache + Prefill.
-                    int prefixLen = 0;
-                    if (_fwd.SupportsPartialRewind)
-                    {
-                        int candidate = FindCacheablePrefix(tokens);
-                        if (candidate > 0)
-                        {
-                            _fwd.TruncateTo(candidate);
-                            prefixLen = candidate;
-                        }
-                    }
-                    else if (_fwd.SupportsSnapshot && _fwd.SnapshotLength > 0 && _prevTokens != null)
-                    {
-                        int snapLen = _fwd.SnapshotLength;
-                        // The pair (snapshot @ snapLen, _prevTokens) is maintained as an
-                        // invariant: on the canonical path both are written together immediately
-                        // after CaptureSnapshot, on the legacy path both are written together at
-                        // end-of-decode. snapLen must be a strict prefix of the new prompt (need
-                        // at least one suffix token to drive the decoder) AND a token-level
-                        // prefix of _prevTokens — the latter is the actual reuse precondition.
-                        if (snapLen <= tokens.Length - 1 && snapLen <= _prevTokens.Length
-                            && tokens.AsSpan(0, snapLen).SequenceEqual(_prevTokens.AsSpan(0, snapLen)))
-                        {
-                            _fwd.TruncateTo(snapLen);
-                            prefixLen = snapLen;
-                        }
-                    }
-                    if (prefixLen == 0)
-                    {
-                        _fwd.ResetCache();
-                    }
-                    else
-                    {
-                        // Issue #22 observability: account reused tokens regardless of
-                        // mechanism (attention partial-rewind or GDN snapshot).
-                        reusedTokens = prefixLen;
-                        Interlocked.Add(ref _prefillTokensReused, prefixLen);
-                    }
-
-                    // Prefill: process all prompt tokens (or just the suffix after the cached prefix).
-                    //
-                    // Issue #102 split: when a canonical-history boundary lies strictly between
-                    // prefixLen and the end of the prompt, run the prefill in two stages with a
-                    // CaptureSnapshot in between. That snapshot sits at the canonical boundary so
-                    // the next turn — whose generating prompt starts with the same canonical
-                    // history plus a scrubbed assistant response and a fresh user turn — can
-                    // restore it. Issue #106: also applies on MTP runs; the sticky hidden
-                    // history buffer + MTP KV soft-truncate make PrefillMtp(startPos=snapLen)
-                    // viable. Skipped for backends that don't expose a snapshot (the snapshot
-                    // call is a no-op, but skipping the split keeps the prefill in one shot
-                    // for cache efficiency).
-                    bool useCanonicalSnapshot =
-                        canonicalLen > prefixLen
-                        && canonicalLen < tokens.Length
-                        && _fwd.SupportsSnapshot;
-
-                    // Reused by the MTP path below for PrefillMtp(suffixTokens, prefixLen).
-                    int[] suffixTokens = prefixLen > 0 ? tokens[prefixLen..] : tokens;
-
+                    // startPos = the sequence length after prefill. For text it equals
+                    // tokens.Length; for an image request each <|image|> placeholder expands to
+                    // open + soft tokens + close, so startPos > tokens.Length and the decode
+                    // below must advance positions from there.
+                    int startPos;
+                    int prefixLen = 0;      // cached-prefix length; 0 for the image path (no reuse)
+                    int[] suffixTokens;     // suffix after any cached prefix; reused by the MTP path
+                    bool useCanonicalSnapshot = false;
                     long prefillStartMs = swReq.ElapsedMilliseconds;
                     ReadOnlySpan<float> logits;
-                    if (useCanonicalSnapshot)
+
+                    if (imageBytes is { Count: > 0 })
                     {
-                        PrefillChunked(tokens, prefixLen, canonicalLen, ct);
-                        _fwd.CaptureSnapshot();
-                        // Pair _prevTokens with the snapshot atomically: stage-2 failure or
-                        // mid-decode cancellation now leaves snapshot + _prevTokens consistent
-                        // with each other (both describe this turn's canonical state). Without
-                        // the immediate write, a stage-2 throw would leave the snapshot pointing
-                        // at this turn's canonical while _prevTokens still described the prior
-                        // turn — the next request could pass the snapshot-match check and
-                        // TruncateTo to state that doesn't correspond to its prefix.
-                        _prevTokens = tokens[..canonicalLen];
-                        logits = PrefillChunked(tokens, canonicalLen, tokens.Length, ct);
+                        // Image input (#253): no prefix reuse — project each image and splice its
+                        // soft tokens in place of its placeholder during a fresh prefill.
+                        _fwd.ResetCache();
+                        suffixTokens = tokens;
+                        logits = SplicePrefillImages(tokens, imageBytes, ct, out startPos);
                     }
                     else
                     {
-                        if (suffixTokens.Length > 0)
-                            logits = PrefillChunked(tokens, prefixLen, tokens.Length, ct);
+                        if (_fwd.SupportsPartialRewind)
+                        {
+                            int candidate = FindCacheablePrefix(tokens);
+                            if (candidate > 0)
+                            {
+                                _fwd.TruncateTo(candidate);
+                                prefixLen = candidate;
+                            }
+                        }
+                        else if (_fwd.SupportsSnapshot && _fwd.SnapshotLength > 0 && _prevTokens != null)
+                        {
+                            int snapLen = _fwd.SnapshotLength;
+                            // The pair (snapshot @ snapLen, _prevTokens) is maintained as an
+                            // invariant: on the canonical path both are written together immediately
+                            // after CaptureSnapshot, on the legacy path both are written together at
+                            // end-of-decode. snapLen must be a strict prefix of the new prompt (need
+                            // at least one suffix token to drive the decoder) AND a token-level
+                            // prefix of _prevTokens — the latter is the actual reuse precondition.
+                            if (snapLen <= tokens.Length - 1 && snapLen <= _prevTokens.Length
+                                && tokens.AsSpan(0, snapLen).SequenceEqual(_prevTokens.AsSpan(0, snapLen)))
+                            {
+                                _fwd.TruncateTo(snapLen);
+                                prefixLen = snapLen;
+                            }
+                        }
+                        if (prefixLen == 0)
+                        {
+                            _fwd.ResetCache();
+                        }
                         else
-                            logits = _fwd.Forward(tokens[^1], tokens.Length - 1);
+                        {
+                            // Issue #22 observability: account reused tokens regardless of
+                            // mechanism (attention partial-rewind or GDN snapshot).
+                            reusedTokens = prefixLen;
+                            Interlocked.Add(ref _prefillTokensReused, prefixLen);
+                        }
+
+                        // Prefill: process all prompt tokens (or just the suffix after the cached prefix).
+                        //
+                        // Issue #102 split: when a canonical-history boundary lies strictly between
+                        // prefixLen and the end of the prompt, run the prefill in two stages with a
+                        // CaptureSnapshot in between. That snapshot sits at the canonical boundary so
+                        // the next turn — whose generating prompt starts with the same canonical
+                        // history plus a scrubbed assistant response and a fresh user turn — can
+                        // restore it. Issue #106: also applies on MTP runs; the sticky hidden
+                        // history buffer + MTP KV soft-truncate make PrefillMtp(startPos=snapLen)
+                        // viable. Skipped for backends that don't expose a snapshot (the snapshot
+                        // call is a no-op, but skipping the split keeps the prefill in one shot
+                        // for cache efficiency).
+                        useCanonicalSnapshot =
+                            canonicalLen > prefixLen
+                            && canonicalLen < tokens.Length
+                            && _fwd.SupportsSnapshot;
+
+                        suffixTokens = prefixLen > 0 ? tokens[prefixLen..] : tokens;
+
+                        if (useCanonicalSnapshot)
+                        {
+                            PrefillChunked(tokens, prefixLen, canonicalLen, ct);
+                            _fwd.CaptureSnapshot();
+                            // Pair _prevTokens with the snapshot atomically: stage-2 failure or
+                            // mid-decode cancellation now leaves snapshot + _prevTokens consistent
+                            // with each other (both describe this turn's canonical state). Without
+                            // the immediate write, a stage-2 throw would leave the snapshot pointing
+                            // at this turn's canonical while _prevTokens still described the prior
+                            // turn — the next request could pass the snapshot-match check and
+                            // TruncateTo to state that doesn't correspond to its prefix.
+                            _prevTokens = tokens[..canonicalLen];
+                            logits = PrefillChunked(tokens, canonicalLen, tokens.Length, ct);
+                        }
+                        else
+                        {
+                            if (suffixTokens.Length > 0)
+                                logits = PrefillChunked(tokens, prefixLen, tokens.Length, ct);
+                            else
+                                logits = _fwd.Forward(tokens[^1], tokens.Length - 1);
+                        }
+                        startPos = tokens.Length;
                     }
                     prefillMs = swReq.ElapsedMilliseconds - prefillStartMs;
 
@@ -618,7 +750,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             if (textTail.Length > 0)
                                 channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
                             inThinking = true;
-                            logits = _fwd.Forward(next, tokens.Length + i);
+                            logits = _fwd.Forward(next, startPos + i);
                             continue;
                         }
                         if (thinkingEnabled && next == endThinkId && inThinking)
@@ -628,7 +760,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             if (thinkTail.Length > 0)
                                 channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
                             inThinking = false;
-                            logits = _fwd.Forward(next, tokens.Length + i);
+                            logits = _fwd.Forward(next, startPos + i);
                             continue;
                         }
 
@@ -661,7 +793,9 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     // already captured + paired _prevTokens during the split prefill above.
                     // ct.ThrowIfCancellationRequested earlier ensures we don't reach here on a
                     // cancelled token; skip capture in that case to avoid stale state.
-                    if (!useCanonicalSnapshot && !ct.IsCancellationRequested)
+                    // Image requests run fresh each time (no prefix reuse) and their positions
+                    // don't correspond to plain token positions, so don't snapshot them.
+                    if (!useCanonicalSnapshot && !ct.IsCancellationRequested && imageBytes is null)
                     {
                         _fwd.CaptureSnapshot();
                         _prevTokens = fullSeq.ToArray();

--- a/src/SharpInference.Engine/SharpInference.Engine.csproj
+++ b/src/SharpInference.Engine/SharpInference.Engine.csproj
@@ -13,6 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="..\SharpInference.Core\SharpInference.Core.csproj" />
     <ProjectReference Include="..\SharpInference.Cpu\SharpInference.Cpu.csproj" />
+    <!-- Vision: Gemma 4 image projection (gemma4uv) for the engine's image-input path (#253).
+         Vision depends only on Core + Cpu, so no dependency cycle. -->
+    <ProjectReference Include="..\SharpInference.Vision\SharpInference.Vision.csproj" />
     <ProjectReference Include="..\SharpInference.Vulkan\SharpInference.Vulkan.csproj" />
     <ProjectReference Include="..\SharpInference.Cuda\SharpInference.Cuda.csproj" />
     <ProjectReference Include="..\SharpInference.TurboQuant\SharpInference.TurboQuant.csproj" />

--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -16,6 +16,11 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     if (!string.IsNullOrWhiteSpace(envModel))
         opts.ModelPath = envModel;
 
+    // Multimodal projector for image input (issue #253). Mirrors the CLI's --mmproj.
+    var envMmproj = Environment.GetEnvironmentVariable("SHARPI_MMPROJ");
+    if (!string.IsNullOrWhiteSpace(envMmproj))
+        opts.MmprojPath = envMmproj;
+
     if (int.TryParse(Environment.GetEnvironmentVariable("SHARPI_MAX_BATCH"), out int maxBatch) && maxBatch > 0)
         opts.MaxBatchSize = maxBatch;
 

--- a/src/SharpInference.Server/ChatTemplate.cs
+++ b/src/SharpInference.Server/ChatTemplate.cs
@@ -64,6 +64,15 @@ public sealed class ChatTemplateRenderer
     /// <summary>Architecture string used to pick a fallback template when no Jinja is loaded.</summary>
     public string Architecture => _architecture;
 
+    /// <summary>
+    /// True when the loaded model's family should run with reasoning <em>off</em> unless a
+    /// request explicitly opts in. Gemma 4 is not trained for the engine's <c>&lt;|channel&gt;</c>
+    /// thought split the way Qwen3 is — enabling it makes the model ramble in the thought channel
+    /// (and go badly out-of-distribution on multimodal input, producing garbage). Mirrors the
+    /// CLI's <c>modelDefaultsThinkingOff = s_arch == "gemma4"</c> gate so the server and CLI agree.
+    /// </summary>
+    public bool ModelDefaultsThinkingOff => _architecture == "gemma4";
+
     /// <summary>Compiled Jinja template, if the loaded model shipped one.</summary>
     public JinjaChatTemplate? JinjaTemplate => _template;
 

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -61,33 +61,71 @@ public static class AnthropicEndpoints
 
         metrics.RecordRequest();
 
-        // Anthropic-style thinking control: {"type":"disabled"} turns it off; absence or any
-        // other value (including {"type":"enabled"}) leaves it on. BudgetTokens, when present,
-        // maps to SamplingParams.MaxThinkingTokens — the engine force-closes the <think> block
-        // once that many reasoning tokens have streamed.
+        // Anthropic-style thinking control: {"type":"disabled"} turns it off, {"type":"enabled"}
+        // turns it on. When the field is absent, the default depends on the model family — Gemma 4
+        // defaults reasoning off (see ChatTemplateRenderer.ModelDefaultsThinkingOff) while ChatML
+        // models default on. An explicit value always wins over the family default. BudgetTokens,
+        // when present, maps to SamplingParams.MaxThinkingTokens — the engine force-closes the
+        // <think> block once that many reasoning tokens have streamed.
         // Server-level DisableThinking (SHARPI_NO_THINKING) forces reasoning off regardless of
         // the per-request thinking flag — for agentic clients (e.g. Claude Code) that never send
         // thinking:{"type":"disabled"}.
-        bool enableThinking = req.Thinking?.Type != "disabled" && !options.Value.DisableThinking;
+        bool? requestedThinking = req.Thinking?.Type switch
+        {
+            "enabled"  => true,
+            "disabled" => false,
+            _          => null,
+        };
+        bool enableThinking = (requestedThinking ?? !chatTemplate.ModelDefaultsThinkingOff)
+                              && !options.Value.DisableThinking;
 
         var adapter = chatTemplate.ToolCallAdapter;
 
+        // Image content blocks (issue #253) are collected (base64 → bytes) and replaced by the
+        // model's <|image|> placeholder in the rendered prompt; the engine splices each image's
+        // projected soft tokens at the matching placeholder during prefill.
+        var images = new List<byte[]>();
         string prompt;
         // Issue #102: render history-only canonical alongside the generating prompt so the
         // engine can snapshot at the chat-template's history boundary and reuse KV across
         // multi-turn /v1/messages calls (the long-running pain point on agentic loops).
         string? canonicalHistoryPrefix;
-        if (req.Tools is { Length: > 0 })
+        try
         {
-            var (richMessages, tools) = BuildRichMessageList(req, adapter);
-            prompt = chatTemplate.Format(richMessages, enableThinking, tools);
-            canonicalHistoryPrefix = chatTemplate.Format(richMessages, enableThinking, tools, addGenerationPrompt: false);
+            if (req.Tools is { Length: > 0 })
+            {
+                var (richMessages, tools) = BuildRichMessageList(req, adapter, images);
+                prompt = chatTemplate.Format(richMessages, enableThinking, tools);
+                canonicalHistoryPrefix = chatTemplate.Format(richMessages, enableThinking, tools, addGenerationPrompt: false);
+            }
+            else
+            {
+                var messages = BuildMessageList(req, images);
+                prompt = chatTemplate.Format(messages, enableThinking);
+                canonicalHistoryPrefix = chatTemplate.Format(messages, enableThinking, addGenerationPrompt: false);
+            }
         }
-        else
+        catch (ImageContentException ex)
         {
-            var messages = BuildMessageList(req);
-            prompt = chatTemplate.Format(messages, enableThinking);
-            canonicalHistoryPrefix = chatTemplate.Format(messages, enableThinking, addGenerationPrompt: false);
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new AErrorResponse("invalid_request_error", ex.Message),
+                    SharpInferenceJsonContext.Default.AErrorResponse), ctx.RequestAborted);
+            return;
+        }
+
+        if (images.Count > 0 && !engine.SupportsImageInput)
+        {
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new AErrorResponse("invalid_request_error",
+                        "This model is not configured for image input. Start the server with a Gemma 4 model and " +
+                        "SHARPI_MMPROJ pointing at its gemma4uv mmproj, on a CPU (NGpuLayers=0) or full-CUDA " +
+                        "(NGpuLayers=-1) backend."),
+                    SharpInferenceJsonContext.Default.AErrorResponse), ctx.RequestAborted);
+            return;
         }
 
         // Same guard as OpenAiEndpoints — only forward the hint if it's a string-prefix
@@ -107,23 +145,31 @@ public static class AnthropicEndpoints
 
         if (req.Stream == true)
         {
-            await HandleStreaming(ctx, engine, metrics, adapter, prompt, canonicalHistoryPrefix, sp, msgId, modelId);
+            await HandleStreaming(ctx, engine, metrics, adapter, prompt, canonicalHistoryPrefix, images, sp, msgId, modelId);
         }
         else
         {
-            await HandleNonStreaming(ctx, engine, metrics, adapter, prompt, canonicalHistoryPrefix, sp, msgId, modelId);
+            await HandleNonStreaming(ctx, engine, metrics, adapter, prompt, canonicalHistoryPrefix, images, sp, msgId, modelId);
         }
     }
 
+    /// <summary>Route to the image-aware generate when images are present, else the text path (#253).</summary>
+    private static IAsyncEnumerable<GenerateChunk> Generate(
+        IInferenceEngine engine, string prompt, string? canonical, IReadOnlyList<byte[]> images,
+        SamplingParams sp, CancellationToken ct)
+        => images.Count > 0
+            ? engine.GenerateImageChunksAsync(prompt, images, sp, ct)
+            : engine.GenerateChunksAsync(prompt, sp, ct, canonical);
+
     private static async Task HandleNonStreaming(
         HttpContext ctx, IInferenceEngine engine, ServerMetrics metrics, IToolCallAdapter adapter,
-        string prompt, string? canonicalHistoryPrefix, SamplingParams sp, string msgId, string modelId)
+        string prompt, string? canonicalHistoryPrefix, IReadOnlyList<byte[]> images, SamplingParams sp, string msgId, string modelId)
     {
         var thinkingSb = new StringBuilder();
         var textSb = new StringBuilder();
         int totalOutputTokens = 0;
 
-        await foreach (var chunk in engine.GenerateChunksAsync(prompt, sp, ctx.RequestAborted, canonicalHistoryPrefix))
+        await foreach (var chunk in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
         {
             totalOutputTokens++;
             if (chunk.Kind == GenerateChunkKind.Thinking)
@@ -179,7 +225,7 @@ public static class AnthropicEndpoints
 
     private static async Task HandleStreaming(
         HttpContext ctx, IInferenceEngine engine, ServerMetrics metrics, IToolCallAdapter adapter,
-        string prompt, string? canonicalHistoryPrefix, SamplingParams sp, string msgId, string modelId)
+        string prompt, string? canonicalHistoryPrefix, IReadOnlyList<byte[]> images, SamplingParams sp, string msgId, string modelId)
     {
         ctx.Response.ContentType = "text/event-stream";
         ctx.Response.Headers.CacheControl = "no-cache";
@@ -347,7 +393,7 @@ public static class AnthropicEndpoints
         bool truncatedToolCall = false;
         try
         {
-            await foreach (var chunk in engine.GenerateChunksAsync(prompt, sp, ctx.RequestAborted, canonicalHistoryPrefix))
+            await foreach (var chunk in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
                 outputTokens++;
 
@@ -504,7 +550,7 @@ public static class AnthropicEndpoints
     /// Builds the simple (string-content) message list used when no tools are present.
     /// Handles both plain-string and array-of-content-blocks message formats.
     /// </summary>
-    private static List<(string role, string content)> BuildMessageList(AnthropicMessageRequest req)
+    private static List<(string role, string content)> BuildMessageList(AnthropicMessageRequest req, List<byte[]> images)
     {
         var list = new List<(string, string)>();
         var systemText = ExtractTextContent(req.System);
@@ -513,12 +559,56 @@ public static class AnthropicEndpoints
         foreach (var m in req.Messages!)
         {
             var role = m.Role ?? "user";
-            var content = ExtractTextContent(m.Content) ?? "";
+            var content = ExtractTextAndImages(m.Content, images);
             if (role == "assistant")
                 content = ChatTemplate.ScrubAssistantThinking(content);
             list.Add((role, content));
         }
         return list;
+    }
+
+    /// <summary>
+    /// Like <see cref="ExtractTextContent"/> but also handles Anthropic <c>image</c> content
+    /// blocks (issue #253): each base64 <c>source</c> is decoded into <paramref name="images"/>
+    /// (in document order) and replaced by the model's <c>&lt;|image|&gt;</c> placeholder so the
+    /// engine can splice its soft tokens at the matching position.
+    /// </summary>
+    private static string ExtractTextAndImages(JsonElement? contentEl, List<byte[]> images)
+    {
+        if (contentEl is null) return "";
+        var el = contentEl.Value;
+        if (el.ValueKind == JsonValueKind.String) return el.GetString() ?? "";
+        if (el.ValueKind != JsonValueKind.Array) return "";
+
+        var sb = new StringBuilder();
+        foreach (var block in el.EnumerateArray())
+        {
+            var type = block.TryGetProperty("type", out var t) ? t.GetString() : null;
+            if (type == "text")
+            {
+                if (block.TryGetProperty("text", out var tv))
+                    sb.Append(tv.GetString());
+            }
+            else if (type == "image")
+            {
+                images.Add(ParseAnthropicImageBlock(block));
+                sb.Append(ImageContent.Placeholder);
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static byte[] ParseAnthropicImageBlock(JsonElement block)
+    {
+        if (!block.TryGetProperty("source", out var source))
+            throw new ImageContentException("image content block is missing 'source'.");
+        var srcType = source.TryGetProperty("type", out var st) ? st.GetString() : null;
+        if (srcType != "base64")
+            throw new ImageContentException(
+                $"unsupported image source type '{srcType}'; only base64 image sources are supported (URL fetch is not).");
+        if (!source.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.String)
+            throw new ImageContentException("image source is missing base64 'data'.");
+        return ImageContent.FromBase64(data.GetString() ?? "");
     }
 
     /// <summary>
@@ -529,7 +619,7 @@ public static class AnthropicEndpoints
     /// the adapter specifies (defaults to role="tool").
     /// </summary>
     private static (List<Dictionary<string, object?>> messages, List<object?>? tools)
-        BuildRichMessageList(AnthropicMessageRequest req, IToolCallAdapter adapter)
+        BuildRichMessageList(AnthropicMessageRequest req, IToolCallAdapter adapter, List<byte[]> images)
     {
         var messages = new List<Dictionary<string, object?>>();
 
@@ -601,6 +691,12 @@ public static class AnthropicEndpoints
                         {
                             if (block.TryGetProperty("text", out var tv))
                                 textSb.Append(tv.GetString());
+                        }
+                        else if (type == "image")
+                        {
+                            // Issue #253: decode + collect the image, emit a placeholder inline.
+                            images.Add(ParseAnthropicImageBlock(block));
+                            textSb.Append(ImageContent.Placeholder);
                         }
                         else if (type == "tool_result")
                         {

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpInference.Core;
 using SharpInference.Engine;
@@ -111,17 +113,6 @@ public static class AnthropicEndpoints
             ctx.Response.ContentType = "application/json";
             await ctx.Response.WriteAsync(
                 JsonSerializer.Serialize(new AErrorResponse("invalid_request_error", ex.Message),
-                    SharpInferenceJsonContext.Default.AErrorResponse), ctx.RequestAborted);
-            return;
-        }
-
-        if (images.Count > ImageContent.MaxImagesPerRequest)
-        {
-            ctx.Response.StatusCode = 400;
-            ctx.Response.ContentType = "application/json";
-            await ctx.Response.WriteAsync(
-                JsonSerializer.Serialize(new AErrorResponse("invalid_request_error",
-                        $"too many images in one request ({images.Count}; max {ImageContent.MaxImagesPerRequest})."),
                     SharpInferenceJsonContext.Default.AErrorResponse), ctx.RequestAborted);
             return;
         }
@@ -446,7 +437,11 @@ public static class AnthropicEndpoints
             // SSE response already committed (message_start sent) — status can't change. Swallow so
             // the finally + message_delta/message_stop terminate the stream cleanly instead of the
             // TCP connection resetting mid-stream. Common image errors are rejected at parse (400).
-            _ = ex;
+            // Log it — otherwise a genuine mid-stream failure is invisible (the client sees a clean
+            // end_turn with truncated text).
+            ctx.RequestServices.GetService<ILoggerFactory>()?
+                .CreateLogger("SharpInference.Server.Endpoints")
+                .LogError(ex, "Generation failed after the streaming response was committed; the SSE stream is terminated without an error frame.");
         }
         finally
         {
@@ -620,6 +615,7 @@ public static class AnthropicEndpoints
             }
             else if (type == "image")
             {
+                ImageContent.CheckCap(images.Count);
                 images.Add(ParseAnthropicImageBlock(block));
                 sb.Append(ImageContent.Placeholder);
             }
@@ -726,6 +722,7 @@ public static class AnthropicEndpoints
                         else if (type == "image")
                         {
                             // Issue #253: decode + collect the image, emit a placeholder inline.
+                            ImageContent.CheckCap(images.Count);
                             images.Add(ParseAnthropicImageBlock(block));
                             textSb.Append(ImageContent.Placeholder);
                         }

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -115,6 +115,17 @@ public static class AnthropicEndpoints
             return;
         }
 
+        if (images.Count > ImageContent.MaxImagesPerRequest)
+        {
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new AErrorResponse("invalid_request_error",
+                        $"too many images in one request ({images.Count}; max {ImageContent.MaxImagesPerRequest})."),
+                    SharpInferenceJsonContext.Default.AErrorResponse), ctx.RequestAborted);
+            return;
+        }
+
         if (images.Count > 0 && !engine.SupportsImageInput)
         {
             ctx.Response.StatusCode = 400;
@@ -153,14 +164,6 @@ public static class AnthropicEndpoints
         }
     }
 
-    /// <summary>Route to the image-aware generate when images are present, else the text path (#253).</summary>
-    private static IAsyncEnumerable<GenerateChunk> Generate(
-        IInferenceEngine engine, string prompt, string? canonical, IReadOnlyList<byte[]> images,
-        SamplingParams sp, CancellationToken ct)
-        => images.Count > 0
-            ? engine.GenerateImageChunksAsync(prompt, images, sp, ct)
-            : engine.GenerateChunksAsync(prompt, sp, ct, canonical);
-
     private static async Task HandleNonStreaming(
         HttpContext ctx, IInferenceEngine engine, ServerMetrics metrics, IToolCallAdapter adapter,
         string prompt, string? canonicalHistoryPrefix, IReadOnlyList<byte[]> images, SamplingParams sp, string msgId, string modelId)
@@ -169,13 +172,28 @@ public static class AnthropicEndpoints
         var textSb = new StringBuilder();
         int totalOutputTokens = 0;
 
-        await foreach (var chunk in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
+        try
         {
-            totalOutputTokens++;
-            if (chunk.Kind == GenerateChunkKind.Thinking)
-                thinkingSb.Append(chunk.Text);
-            else
-                textSb.Append(chunk.Text);
+            await foreach (var chunk in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
+            {
+                totalOutputTokens++;
+                if (chunk.Kind == GenerateChunkKind.Thinking)
+                    thinkingSb.Append(chunk.Text);
+                else
+                    textSb.Append(chunk.Text);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Residual generation error (e.g. image-count mismatch from a user-typed <|image|>, or a
+            // projection failure) — return a structured error instead of a bare 500. The response
+            // hasn't started on the non-streaming path. Common image errors are rejected at parse (400).
+            ctx.Response.StatusCode = 500;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new AErrorResponse("internal_error", ex.Message),
+                    SharpInferenceJsonContext.Default.AErrorResponse), ctx.RequestAborted);
+            return;
         }
 
         metrics.RecordTokens(totalOutputTokens);
@@ -393,7 +411,7 @@ public static class AnthropicEndpoints
         bool truncatedToolCall = false;
         try
         {
-            await foreach (var chunk in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
+            await foreach (var chunk in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
                 outputTokens++;
 
@@ -422,6 +440,13 @@ public static class AnthropicEndpoints
                     await ProcessTextChunk(chunk.Text);
                 }
             }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // SSE response already committed (message_start sent) — status can't change. Swallow so
+            // the finally + message_delta/message_stop terminate the stream cleanly instead of the
+            // TCP connection resetting mid-stream. Common image errors are rejected at parse (400).
+            _ = ex;
         }
         finally
         {
@@ -583,6 +608,10 @@ public static class AnthropicEndpoints
         var sb = new StringBuilder();
         foreach (var block in el.EnumerateArray())
         {
+            // A content array may legally hold only objects; a bare primitive element would make
+            // TryGetProperty throw (it requires an object receiver), so skip non-objects rather
+            // than 500. The model just sees the surrounding text.
+            if (block.ValueKind != JsonValueKind.Object) continue;
             var type = block.TryGetProperty("type", out var t) ? t.GetString() : null;
             if (type == "text")
             {
@@ -600,8 +629,8 @@ public static class AnthropicEndpoints
 
     private static byte[] ParseAnthropicImageBlock(JsonElement block)
     {
-        if (!block.TryGetProperty("source", out var source))
-            throw new ImageContentException("image content block is missing 'source'.");
+        if (!block.TryGetProperty("source", out var source) || source.ValueKind != JsonValueKind.Object)
+            throw new ImageContentException("image content block is missing an object 'source'.");
         var srcType = source.TryGetProperty("type", out var st) ? st.GetString() : null;
         if (srcType != "base64")
             throw new ImageContentException(
@@ -654,6 +683,7 @@ public static class AnthropicEndpoints
 
                     foreach (var block in contentEl.EnumerateArray())
                     {
+                        if (block.ValueKind != JsonValueKind.Object) continue;
                         var type = block.TryGetProperty("type", out var t) ? t.GetString() : null;
                         if (type == "text")
                         {
@@ -686,6 +716,7 @@ public static class AnthropicEndpoints
 
                     foreach (var block in contentEl.EnumerateArray())
                     {
+                        if (block.ValueKind != JsonValueKind.Object) continue;
                         var type = block.TryGetProperty("type", out var t) ? t.GetString() : null;
                         if (type == "text")
                         {

--- a/src/SharpInference.Server/Endpoints/ImageContent.cs
+++ b/src/SharpInference.Server/Endpoints/ImageContent.cs
@@ -1,0 +1,57 @@
+namespace SharpInference.Server.Endpoints;
+
+/// <summary>
+/// Shared parsing for multimodal image content blocks (issue #253): decodes base64 / data-URL
+/// image payloads to raw bytes and validates the format. The Gemma 4 vision decoder (ImageIO)
+/// supports PNG only, so non-PNG payloads are rejected here with a clear error rather than
+/// failing deep inside the engine's prefill.
+/// </summary>
+internal static class ImageContent
+{
+    /// <summary>
+    /// The model's image-placeholder token text, inserted into the message stream at each image
+    /// position. The chat template passes it through verbatim; the engine tokenizes it to the
+    /// <c>&lt;|image|&gt;</c> id and expands it to the projected soft tokens during prefill.
+    /// </summary>
+    public const string Placeholder = "<|image|>";
+
+    /// <summary>Decode a base64 image payload to bytes and validate it is a PNG.</summary>
+    public static byte[] FromBase64(string base64)
+    {
+        byte[] bytes;
+        try { bytes = Convert.FromBase64String(base64.Trim()); }
+        catch (FormatException) { throw new ImageContentException("image data is not valid base64."); }
+        ValidatePng(bytes);
+        return bytes;
+    }
+
+    /// <summary>Decode an OpenAI <c>image_url</c> that is a base64 data URL
+    /// (<c>data:image/png;base64,...</c>). Remote URL fetching is not supported.</summary>
+    public static byte[] FromDataUrl(string url)
+    {
+        const string prefix = "data:";
+        if (!url.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            throw new ImageContentException(
+                "image_url must be a base64 data URL (data:image/png;base64,...); remote URL fetching is not supported.");
+        int comma = url.IndexOf(',');
+        if (comma < 0)
+            throw new ImageContentException("malformed data URL (missing comma).");
+        string meta = url[prefix.Length..comma];
+        if (!meta.Contains("base64", StringComparison.OrdinalIgnoreCase))
+            throw new ImageContentException("only base64-encoded data URLs are supported.");
+        return FromBase64(url[(comma + 1)..]);
+    }
+
+    private static void ValidatePng(byte[] bytes)
+    {
+        // PNG 8-byte signature. Validating the magic (rather than the declared media_type) catches
+        // mislabelled or unsupported (JPEG/WebP) payloads regardless of the client's content type.
+        ReadOnlySpan<byte> sig = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        if (bytes.Length < 8 || !bytes.AsSpan(0, 8).SequenceEqual(sig))
+            throw new ImageContentException(
+                "only PNG images are supported (the decoded image data is not a PNG).");
+    }
+}
+
+/// <summary>Raised on malformed / unsupported image content; endpoints map it to HTTP 400.</summary>
+internal sealed class ImageContentException(string message) : Exception(message);

--- a/src/SharpInference.Server/Endpoints/ImageContent.cs
+++ b/src/SharpInference.Server/Endpoints/ImageContent.cs
@@ -1,3 +1,6 @@
+using SharpInference.Engine;
+using SharpInference.Vision;
+
 namespace SharpInference.Server.Endpoints;
 
 /// <summary>
@@ -14,6 +17,25 @@ internal static class ImageContent
     /// <c>&lt;|image|&gt;</c> id and expands it to the projected soft tokens during prefill.
     /// </summary>
     public const string Placeholder = "<|image|>";
+
+    /// <summary>
+    /// Upper bound on image content blocks per request. A decoded image is bounded by ImageIO's
+    /// 64M-pixel guard (~hundreds of MB), so without a per-request cap a single request could
+    /// fan out into many large allocations. The chat endpoints reject requests that exceed this.
+    /// </summary>
+    public const int MaxImagesPerRequest = 16;
+
+    /// <summary>
+    /// Routes to the image-aware generate when images are present, else the text path (#253).
+    /// Shared by the OpenAI and Anthropic endpoints — pure engine-level dispatch with no
+    /// wire-format dependency, so it lives here rather than being copied into each endpoint.
+    /// </summary>
+    public static IAsyncEnumerable<GenerateChunk> Generate(
+        IInferenceEngine engine, string prompt, string? canonical, IReadOnlyList<byte[]> images,
+        SamplingParams sp, CancellationToken ct)
+        => images.Count > 0
+            ? engine.GenerateImageChunksAsync(prompt, images, sp, ct)
+            : engine.GenerateChunksAsync(prompt, sp, ct, canonical);
 
     /// <summary>Decode a base64 image payload to bytes and validate it is a PNG.</summary>
     public static byte[] FromBase64(string base64)
@@ -44,12 +66,22 @@ internal static class ImageContent
 
     private static void ValidatePng(byte[] bytes)
     {
-        // PNG 8-byte signature. Validating the magic (rather than the declared media_type) catches
-        // mislabelled or unsupported (JPEG/WebP) payloads regardless of the client's content type.
-        ReadOnlySpan<byte> sig = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-        if (bytes.Length < 8 || !bytes.AsSpan(0, 8).SequenceEqual(sig))
-            throw new ImageContentException(
-                "only PNG images are supported (the decoded image data is not a PNG).");
+        // Fully decode the payload here, at request-parse time, rather than only checking the
+        // 8-byte signature. ImageIO supports 8-bit non-interlaced PNG (grayscale/RGB/RGBA) only;
+        // a signature-valid but interlaced / 16-bit / palette / truncated / decompression-bomb
+        // payload would otherwise slip past a signature-only check and fail deep inside the
+        // engine's prefill — on the streaming path that lands AFTER the 200 response has begun,
+        // so it can only abort the connection. Decoding up front turns every such case into a
+        // clean HTTP 400. The decode is bounded (ImageIO caps inflation to the declared pixel
+        // size) and the result is discarded; the engine re-decodes the same bytes during prefill.
+        try
+        {
+            _ = ImageIO.LoadRgb(new MemoryStream(bytes, writable: false), out _, out _);
+        }
+        catch (Exception ex) when (ex is InvalidDataException or NotSupportedException)
+        {
+            throw new ImageContentException($"unsupported or corrupt image: {ex.Message}");
+        }
     }
 }
 

--- a/src/SharpInference.Server/Endpoints/ImageContent.cs
+++ b/src/SharpInference.Server/Endpoints/ImageContent.cs
@@ -26,6 +26,17 @@ internal static class ImageContent
     public const int MaxImagesPerRequest = 16;
 
     /// <summary>
+    /// Throws if the running image count has reached the per-request cap. Called BEFORE decoding
+    /// the next image so an over-cap request is rejected without paying to decode every block in it.
+    /// </summary>
+    public static void CheckCap(int currentImageCount)
+    {
+        if (currentImageCount >= MaxImagesPerRequest)
+            throw new ImageContentException(
+                $"too many images in one request (max {MaxImagesPerRequest}).");
+    }
+
+    /// <summary>
     /// Routes to the image-aware generate when images are present, else the text path (#253).
     /// Shared by the OpenAI and Anthropic endpoints — pure engine-level dispatch with no
     /// wire-format dependency, so it lives here rather than being copied into each endpoint.
@@ -78,7 +89,10 @@ internal static class ImageContent
         {
             _ = ImageIO.LoadRgb(new MemoryStream(bytes, writable: false), out _, out _);
         }
-        catch (Exception ex) when (ex is InvalidDataException or NotSupportedException)
+        // ImageIO throws InvalidDataException/NotSupportedException by contract, but a crafted
+        // payload can still trip an IndexOutOfRange/Argument/InvalidOperation deep in the decoder.
+        // Map every decode failure to a clean 400 — only truly fatal conditions (OOM, etc.) escape.
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             throw new ImageContentException($"unsupported or corrupt image: {ex.Message}");
         }

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -112,6 +112,17 @@ public static class OpenAiEndpoints
             return;
         }
 
+        if (images.Count > ImageContent.MaxImagesPerRequest)
+        {
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new ErrorResponse("invalid_request_error",
+                        $"too many images in one request ({images.Count}; max {ImageContent.MaxImagesPerRequest})."),
+                    SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+            return;
+        }
+
         if (images.Count > 0 && !engine.SupportsImageInput)
         {
             ctx.Response.StatusCode = 400;
@@ -163,14 +174,6 @@ public static class OpenAiEndpoints
         }
     }
 
-    /// <summary>Route to the image-aware generate when images are present, else the text path (#253).</summary>
-    private static IAsyncEnumerable<GenerateChunk> Generate(
-        IInferenceEngine engine, string prompt, string? canonical, IReadOnlyList<byte[]> images,
-        SamplingParams sp, CancellationToken ct)
-        => images.Count > 0
-            ? engine.GenerateImageChunksAsync(prompt, images, sp, ct)
-            : engine.GenerateChunksAsync(prompt, sp, ct, canonical);
-
     private static async Task HandleNonStreaming(
         HttpContext ctx, IInferenceEngine engine, ServerMetrics metrics, IToolCallAdapter adapter,
         bool toolsActive, string prompt, string? canonicalHistoryPrefix, IReadOnlyList<byte[]> images, SamplingParams sp, string requestId, long created)
@@ -180,18 +183,34 @@ public static class OpenAiEndpoints
         int textTokens = 0;
         int reasoningTokens = 0;
 
-        await foreach (var c in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
+        try
         {
-            if (c.Kind == GenerateChunkKind.Thinking)
+            await foreach (var c in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
-                reasoningSb.Append(c.Text);
-                reasoningTokens++;
+                if (c.Kind == GenerateChunkKind.Thinking)
+                {
+                    reasoningSb.Append(c.Text);
+                    reasoningTokens++;
+                }
+                else
+                {
+                    textSb.Append(c.Text);
+                    textTokens++;
+                }
             }
-            else
-            {
-                textSb.Append(c.Text);
-                textTokens++;
-            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A residual generation error (e.g. an image-count mismatch from a user-typed
+            // <|image|>, or a projection failure) would otherwise surface as a bare 500 with no
+            // body. The response hasn't started yet on the non-streaming path, so return a
+            // structured error the OpenAI SDK can parse.
+            ctx.Response.StatusCode = 500;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new ErrorResponse("internal_error", ex.Message),
+                    SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+            return;
         }
 
         int completionTokens = textTokens + reasoningTokens;
@@ -361,7 +380,7 @@ public static class OpenAiEndpoints
         bool truncatedToolCall = false;
         try
         {
-            await foreach (var c in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
+            await foreach (var c in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
                 tokenCount++;
                 if (c.Kind == GenerateChunkKind.Thinking)
@@ -383,6 +402,13 @@ public static class OpenAiEndpoints
                     await WriteContentDelta(c.Text);
                 }
             }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The SSE response is already committed (200 + role delta), so the status can't change.
+            // Swallow so the finally + final chunk terminate the stream cleanly instead of the TCP
+            // connection being reset mid-stream. Common image errors are rejected at parse time (400).
+            _ = ex;
         }
         finally
         {
@@ -465,6 +491,9 @@ public static class OpenAiEndpoints
         var sb = new StringBuilder();
         foreach (var part in el.EnumerateArray())
         {
+            // Content parts must be objects; a bare primitive would make TryGetProperty throw
+            // (it requires an object receiver), so skip non-objects rather than 500.
+            if (part.ValueKind != JsonValueKind.Object) continue;
             var type = part.TryGetProperty("type", out var t) ? t.GetString() : null;
             if (type == "text")
             {
@@ -478,7 +507,7 @@ public static class OpenAiEndpoints
                 if (part.TryGetProperty("image_url", out var iu))
                     url = iu.ValueKind == JsonValueKind.String
                         ? iu.GetString() ?? ""
-                        : iu.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+                        : iu.ValueKind == JsonValueKind.Object && iu.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
                 if (string.IsNullOrEmpty(url))
                     throw new ImageContentException($"{type} content part is missing a base64 'image_url'.");
                 images.Add(ImageContent.FromDataUrl(url));

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -4,6 +4,8 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpInference.Core;
 using SharpInference.Engine;
@@ -108,17 +110,6 @@ public static class OpenAiEndpoints
             ctx.Response.ContentType = "application/json";
             await ctx.Response.WriteAsync(
                 JsonSerializer.Serialize(new ErrorResponse("invalid_request_error", ex.Message),
-                    SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
-            return;
-        }
-
-        if (images.Count > ImageContent.MaxImagesPerRequest)
-        {
-            ctx.Response.StatusCode = 400;
-            ctx.Response.ContentType = "application/json";
-            await ctx.Response.WriteAsync(
-                JsonSerializer.Serialize(new ErrorResponse("invalid_request_error",
-                        $"too many images in one request ({images.Count}; max {ImageContent.MaxImagesPerRequest})."),
                     SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
             return;
         }
@@ -408,7 +399,11 @@ public static class OpenAiEndpoints
             // The SSE response is already committed (200 + role delta), so the status can't change.
             // Swallow so the finally + final chunk terminate the stream cleanly instead of the TCP
             // connection being reset mid-stream. Common image errors are rejected at parse time (400).
-            _ = ex;
+            // Log it — otherwise a genuine mid-stream failure is invisible (the client sees a clean
+            // finish_reason "stop" with truncated text).
+            ctx.RequestServices.GetService<ILoggerFactory>()?
+                .CreateLogger("SharpInference.Server.Endpoints")
+                .LogError(ex, "Generation failed after the streaming response was committed; the SSE stream is terminated without an error frame.");
         }
         finally
         {
@@ -510,6 +505,7 @@ public static class OpenAiEndpoints
                         : iu.ValueKind == JsonValueKind.Object && iu.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
                 if (string.IsNullOrEmpty(url))
                     throw new ImageContentException($"{type} content part is missing a base64 'image_url'.");
+                ImageContent.CheckCap(images.Count);
                 images.Add(ImageContent.FromDataUrl(url));
                 sb.Append(ImageContent.Placeholder);
             }

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -63,9 +63,13 @@ public static class OpenAiEndpoints
 
         metrics.RecordRequest();
 
-        // Server-level DisableThinking (SHARPI_NO_THINKING) forces reasoning off regardless of
-        // the per-request enable_thinking flag — for agentic clients that never send it.
-        bool enableThinking = (req.EnableThinking ?? true) && !options.Value.DisableThinking;
+        // When enable_thinking is absent the default depends on the model family — Gemma 4
+        // defaults reasoning off (see ChatTemplateRenderer.ModelDefaultsThinkingOff) while ChatML
+        // models default on; an explicit flag always wins. Server-level DisableThinking
+        // (SHARPI_NO_THINKING) forces reasoning off regardless — for agentic clients that never
+        // send the per-request flag.
+        bool enableThinking = (req.EnableThinking ?? !chatTemplate.ModelDefaultsThinkingOff)
+                              && !options.Value.DisableThinking;
         var adapter = chatTemplate.ToolCallAdapter;
 
         // Tool-aware rendering: if either tool definitions or a history-side
@@ -80,17 +84,45 @@ public static class OpenAiEndpoints
         // storing it as the snapshot anchor is what makes prefix reuse possible across
         // multi-turn agentic loops.
         string? canonicalHistoryPrefix;
-        if (toolsActive)
+        // Image content parts (issue #253) collected (base64 → bytes) and replaced by the
+        // model's <|image|> placeholder; the engine splices each image's soft tokens at it.
+        var images = new List<byte[]>();
+        try
         {
-            var (richMessages, tools) = BuildRichMessageList(req, adapter);
-            prompt = chatTemplate.Format(richMessages, enableThinking, tools);
-            canonicalHistoryPrefix = chatTemplate.Format(richMessages, enableThinking, tools, addGenerationPrompt: false);
+            if (toolsActive)
+            {
+                var (richMessages, tools) = BuildRichMessageList(req, adapter, images);
+                prompt = chatTemplate.Format(richMessages, enableThinking, tools);
+                canonicalHistoryPrefix = chatTemplate.Format(richMessages, enableThinking, tools, addGenerationPrompt: false);
+            }
+            else
+            {
+                var messages = BuildMessageList(req.Messages, req.ResponseFormat?.Type, images);
+                prompt = chatTemplate.Format(messages, enableThinking);
+                canonicalHistoryPrefix = chatTemplate.Format(messages, enableThinking, addGenerationPrompt: false);
+            }
         }
-        else
+        catch (ImageContentException ex)
         {
-            var messages = BuildMessageList(req.Messages, req.ResponseFormat?.Type);
-            prompt = chatTemplate.Format(messages, enableThinking);
-            canonicalHistoryPrefix = chatTemplate.Format(messages, enableThinking, addGenerationPrompt: false);
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new ErrorResponse("invalid_request_error", ex.Message),
+                    SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+            return;
+        }
+
+        if (images.Count > 0 && !engine.SupportsImageInput)
+        {
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(
+                JsonSerializer.Serialize(new ErrorResponse("invalid_request_error",
+                        "This model is not configured for image input. Start the server with a Gemma 4 model and " +
+                        "SHARPI_MMPROJ pointing at its gemma4uv mmproj, on a CPU (NGpuLayers=0) or full-CUDA " +
+                        "(NGpuLayers=-1) backend."),
+                    SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+            return;
         }
 
         // Safety: only forward the canonical hint when it's a string-prefix of the generating
@@ -123,24 +155,32 @@ public static class OpenAiEndpoints
 
         if (req.Stream == true)
         {
-            await HandleStreaming(ctx, engine, metrics, adapter, toolsActive, prompt, canonicalHistoryPrefix, sp, requestId, created);
+            await HandleStreaming(ctx, engine, metrics, adapter, toolsActive, prompt, canonicalHistoryPrefix, images, sp, requestId, created);
         }
         else
         {
-            await HandleNonStreaming(ctx, engine, metrics, adapter, toolsActive, prompt, canonicalHistoryPrefix, sp, requestId, created);
+            await HandleNonStreaming(ctx, engine, metrics, adapter, toolsActive, prompt, canonicalHistoryPrefix, images, sp, requestId, created);
         }
     }
 
+    /// <summary>Route to the image-aware generate when images are present, else the text path (#253).</summary>
+    private static IAsyncEnumerable<GenerateChunk> Generate(
+        IInferenceEngine engine, string prompt, string? canonical, IReadOnlyList<byte[]> images,
+        SamplingParams sp, CancellationToken ct)
+        => images.Count > 0
+            ? engine.GenerateImageChunksAsync(prompt, images, sp, ct)
+            : engine.GenerateChunksAsync(prompt, sp, ct, canonical);
+
     private static async Task HandleNonStreaming(
         HttpContext ctx, IInferenceEngine engine, ServerMetrics metrics, IToolCallAdapter adapter,
-        bool toolsActive, string prompt, string? canonicalHistoryPrefix, SamplingParams sp, string requestId, long created)
+        bool toolsActive, string prompt, string? canonicalHistoryPrefix, IReadOnlyList<byte[]> images, SamplingParams sp, string requestId, long created)
     {
         var textSb = new StringBuilder();
         var reasoningSb = new StringBuilder();
         int textTokens = 0;
         int reasoningTokens = 0;
 
-        await foreach (var c in engine.GenerateChunksAsync(prompt, sp, ctx.RequestAborted, canonicalHistoryPrefix))
+        await foreach (var c in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
         {
             if (c.Kind == GenerateChunkKind.Thinking)
             {
@@ -222,7 +262,7 @@ public static class OpenAiEndpoints
 
     private static async Task HandleStreaming(
         HttpContext ctx, IInferenceEngine engine, ServerMetrics metrics, IToolCallAdapter adapter,
-        bool toolsActive, string prompt, string? canonicalHistoryPrefix, SamplingParams sp, string requestId, long created)
+        bool toolsActive, string prompt, string? canonicalHistoryPrefix, IReadOnlyList<byte[]> images, SamplingParams sp, string requestId, long created)
     {
         ctx.Response.ContentType = "text/event-stream";
         ctx.Response.Headers.CacheControl = "no-cache";
@@ -321,7 +361,7 @@ public static class OpenAiEndpoints
         bool truncatedToolCall = false;
         try
         {
-            await foreach (var c in engine.GenerateChunksAsync(prompt, sp, ctx.RequestAborted, canonicalHistoryPrefix))
+            await foreach (var c in Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
                 tokenCount++;
                 if (c.Kind == GenerateChunkKind.Thinking)
@@ -393,7 +433,7 @@ public static class OpenAiEndpoints
     }
 
     private static List<(string role, string content)> BuildMessageList(
-        OaiMessage[] messages, string? responseFormatType = null)
+        OaiMessage[] messages, string? responseFormatType, List<byte[]> images)
     {
         var list = new List<(string, string)>(messages.Length + 1);
         if (responseFormatType == "json_object")
@@ -401,12 +441,51 @@ public static class OpenAiEndpoints
         foreach (var m in messages)
         {
             var role = m.Role ?? "user";
-            var content = m.Content ?? "";
+            var content = FlattenContent(m.Content, images);
             if (role == "assistant")
                 content = ChatTemplate.ScrubAssistantThinking(content);
             list.Add((role, content));
         }
         return list;
+    }
+
+    /// <summary>
+    /// Flatten an OpenAI message <c>content</c> (a plain string, or an array of content parts)
+    /// to text, decoding any <c>image_url</c> / <c>input_image</c> parts into
+    /// <paramref name="images"/> (in document order) and replacing each with the model's
+    /// <c>&lt;|image|&gt;</c> placeholder (issue #253). Only base64 data URLs are supported.
+    /// </summary>
+    private static string FlattenContent(JsonElement? contentEl, List<byte[]> images)
+    {
+        if (contentEl is null) return "";
+        var el = contentEl.Value;
+        if (el.ValueKind == JsonValueKind.String) return el.GetString() ?? "";
+        if (el.ValueKind != JsonValueKind.Array) return "";
+
+        var sb = new StringBuilder();
+        foreach (var part in el.EnumerateArray())
+        {
+            var type = part.TryGetProperty("type", out var t) ? t.GetString() : null;
+            if (type == "text")
+            {
+                if (part.TryGetProperty("text", out var tv))
+                    sb.Append(tv.GetString());
+            }
+            else if (type is "image_url" or "input_image")
+            {
+                // image_url is either {url:"data:..."} (chat completions) or a bare string url.
+                string url = "";
+                if (part.TryGetProperty("image_url", out var iu))
+                    url = iu.ValueKind == JsonValueKind.String
+                        ? iu.GetString() ?? ""
+                        : iu.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+                if (string.IsNullOrEmpty(url))
+                    throw new ImageContentException($"{type} content part is missing a base64 'image_url'.");
+                images.Add(ImageContent.FromDataUrl(url));
+                sb.Append(ImageContent.Placeholder);
+            }
+        }
+        return sb.ToString();
     }
 
     private static bool HasToolMessages(OaiMessage[]? messages)
@@ -427,14 +506,14 @@ public static class OpenAiEndpoints
     /// <c>role:"tool"</c> message with <c>tool_call_id</c>.
     /// </summary>
     private static (List<Dictionary<string, object?>> messages, List<object?>? tools)
-        BuildRichMessageList(ChatCompletionRequest req, IToolCallAdapter adapter)
+        BuildRichMessageList(ChatCompletionRequest req, IToolCallAdapter adapter, List<byte[]> images)
     {
         var messages = new List<Dictionary<string, object?>>();
 
         foreach (var m in req.Messages!)
         {
             var role = m.Role ?? "user";
-            var content = m.Content ?? "";
+            var content = FlattenContent(m.Content, images);
 
             if (role == "tool")
             {
@@ -531,7 +610,9 @@ public sealed record ChatCompletionRequest(
 /// </summary>
 public sealed record OaiMessage(
     string? Role,
-    string? Content,
+    // string for plain text, or an array of content parts ({type:"text"} / {type:"image_url"})
+    // for multimodal requests (issue #253). JsonElement accepts both shapes via source-gen.
+    JsonElement? Content,
     [property: JsonPropertyName("tool_call_id")] string? ToolCallId = null,
     [property: JsonPropertyName("tool_calls")] OaiToolCall[]? ToolCalls = null,
     string? Name = null);

--- a/src/SharpInference.Server/Endpoints/ResponsesEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/ResponsesEndpoints.cs
@@ -49,7 +49,12 @@ public static class ResponsesEndpoints
         metrics.RecordRequest();
 
         var messages = BuildMessageList(req);
-        var prompt = chatTemplate.Format(messages);
+        // Apply the same model-family thinking default as the chat endpoints: Gemma 4 defaults
+        // reasoning off (ChatTemplateRenderer.ModelDefaultsThinkingOff), and SHARPI_NO_THINKING
+        // forces it off globally. /v1/responses has no per-request thinking flag, so the family
+        // default + the server kill-switch are the whole decision.
+        bool enableThinking = !chatTemplate.ModelDefaultsThinkingOff && !opts.DisableThinking;
+        var prompt = chatTemplate.Format(messages, enableThinking);
 
         var sp = SamplingParamsBuilder.Build(opts,
             temperature: req.Temperature,

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -106,6 +106,15 @@ public static class InferenceEngineLoader
             (int Open, int Close, int Placeholder) imgIds = default;
             if (!string.IsNullOrWhiteSpace(opts.MmprojPath))
             {
+                // The gemma4uv splice path is specific to Gemma 4 text models. The CPU forward
+                // pass reports SupportsEmbeddingInput=true for every architecture, so without this
+                // arch check a non-Gemma CPU model + a valid gemma4uv mmproj would load and either
+                // splice foreign soft tokens into the wrong trunk (garbage) or throw an opaque
+                // dimension error mid-request. Fail fast at load instead.
+                if (!string.Equals(arch, "gemma4", StringComparison.Ordinal))
+                    throw new InvalidOperationException(
+                        "Image input (MmprojPath / SHARPI_MMPROJ) is only supported for Gemma 4 (gemma4uv) " +
+                        $"text models; this model's architecture is '{arch}'.");
                 if (!fwd.SupportsEmbeddingInput)
                     throw new InvalidOperationException(
                         "MmprojPath / SHARPI_MMPROJ is set but image input requires a forward pass that accepts " +

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -2,6 +2,7 @@ using SharpInference.Core;
 using SharpInference.Cpu;
 using SharpInference.Cuda;
 using SharpInference.Engine;
+using SharpInference.Vision;
 using SharpInference.Vulkan;
 
 namespace SharpInference.Server;
@@ -46,7 +47,7 @@ public static class InferenceEngineLoader
             Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", opts.KvType);
 
         // ── 2. Resolve & open the model.
-        var modelPath = ResolveModelPath(opts.ModelPath);
+        var modelPath = ResolvePath(opts.ModelPath, "model", "SHARPI_MODEL", "ModelPath");
         var model = GgufModel.Open(modelPath);
         var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
         var tokenizer = GgufTokenizer.FromGgufModel(model);
@@ -97,6 +98,33 @@ public static class InferenceEngineLoader
         IInferenceEngine engine;
         try
         {
+            // ── Image input (issue #253): open the mmproj vision projector when configured.
+            // Requires an embedding-capable forward pass (CPU / full-CUDA Gemma 4) and the
+            // single-user InferenceEngine path; reject other configs with a clear error.
+            GemmaUvVisionEmbedder? visionEmbedder = null;
+            VisionModel? visionModel = null;
+            (int Open, int Close, int Placeholder) imgIds = default;
+            if (!string.IsNullOrWhiteSpace(opts.MmprojPath))
+            {
+                if (!fwd.SupportsEmbeddingInput)
+                    throw new InvalidOperationException(
+                        "MmprojPath / SHARPI_MMPROJ is set but image input requires a forward pass that accepts " +
+                        "precomputed-embedding input: CPU (NGpuLayers=0) or full CUDA offload (NGpuLayers=-1) of a " +
+                        $"Gemma 4 model that fits VRAM. The configured pass ({fwd.GetType().Name}) does not support it.");
+                if (opts.MaxBatchSize > 1 && batchingSupported && fwd is IBatchedForwardPass)
+                    throw new InvalidOperationException(
+                        "Image input is not supported with continuous batching (MaxBatchSize > 1). Set MaxBatchSize=1.");
+
+                var mmprojPath = ResolvePath(opts.MmprojPath, "mmproj projector", "SHARPI_MMPROJ", "MmprojPath");
+                visionModel = VisionModel.Open(mmprojPath); // validates clip / gemma4uv projector, else throws
+                owned.Add(visionModel);
+                visionEmbedder = new GemmaUvVisionEmbedder(visionModel);
+                imgIds = (
+                    tokenizer.SpecialTokens.TryGetValue("<|image>", out var o) ? o : 255999,
+                    tokenizer.SpecialTokens.TryGetValue("<image|>", out var c) ? c : 258882,
+                    tokenizer.SpecialTokens.TryGetValue("<|image|>", out var p) ? p : 258880);
+            }
+
             if (opts.MaxBatchSize > 1 && batchingSupported && fwd is IBatchedForwardPass batchFwd)
             {
                 engine = new ContinuousBatchingEngine(batchFwd, tokenizer, modelId, opts.MaxBatchSize,
@@ -109,8 +137,11 @@ public static class InferenceEngineLoader
             }
             else
             {
-                engine = new InferenceEngine(fwd, tokenizer, modelId, thinkTokenId, endThinkTokenId,
+                var ie = new InferenceEngine(fwd, tokenizer, modelId, thinkTokenId, endThinkTokenId,
                     owned.ToArray());
+                if (visionEmbedder is not null)
+                    ie.EnableImageInput(visionEmbedder, visionModel!, imgIds.Open, imgIds.Close, imgIds.Placeholder);
+                engine = ie;
             }
         }
         catch
@@ -363,35 +394,35 @@ public static class InferenceEngineLoader
     /// the process was launched from the repo root, the project directory (as
     /// <c>dotnet run --project</c> sets it), or a published-binary directory.
     /// </summary>
-    private static string ResolveModelPath(string? modelPath)
+    private static string ResolvePath(string? path, string what, string envVar, string configKey)
     {
-        if (string.IsNullOrWhiteSpace(modelPath))
+        if (string.IsNullOrWhiteSpace(path))
             throw new InvalidOperationException(
-                "SharpInferenceServerOptions.ModelPath is required. " +
-                "Set it via Configure(o => o.ModelPath = ...) or the SHARPI_MODEL environment variable.");
+                $"SharpInferenceServerOptions.{configKey} ({what} path) is required. " +
+                $"Set it via Configure(o => o.{configKey} = ...) or the {envVar} environment variable.");
 
-        if (Path.IsPathRooted(modelPath) && File.Exists(modelPath))
-            return modelPath;
+        if (Path.IsPathRooted(path) && File.Exists(path))
+            return path;
 
-        if (File.Exists(modelPath))
-            return Path.GetFullPath(modelPath);
+        if (File.Exists(path))
+            return Path.GetFullPath(path);
 
         var candidates = new List<string>
         {
-            Path.Combine(Directory.GetCurrentDirectory(), modelPath),
-            Path.Combine(AppContext.BaseDirectory, modelPath),
+            Path.Combine(Directory.GetCurrentDirectory(), path),
+            Path.Combine(AppContext.BaseDirectory, path),
         };
         var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
         for (int i = 0; i < 5 && dir is not null; i++, dir = dir.Parent)
-            candidates.Add(Path.Combine(dir.FullName, modelPath));
+            candidates.Add(Path.Combine(dir.FullName, path));
 
         var resolved = candidates.FirstOrDefault(File.Exists);
         if (resolved is not null) return resolved;
 
         throw new InvalidOperationException(
-            $"Model file not found: '{modelPath}'. " +
-            "Set SharpInferenceServerOptions.ModelPath, the SHARPI_MODEL environment variable, " +
-            "or the SharpInference:ModelPath configuration key.");
+            $"{char.ToUpperInvariant(what[0])}{what[1..]} file not found: '{path}'. " +
+            $"Set SharpInferenceServerOptions.{configKey}, the {envVar} environment variable, " +
+            $"or the SharpInference:{configKey} configuration key.");
     }
 }
 

--- a/src/SharpInference.Server/SharpInference.Server.csproj
+++ b/src/SharpInference.Server/SharpInference.Server.csproj
@@ -49,6 +49,8 @@
   <ItemGroup>
     <ProjectReference Include="..\SharpInference.Engine\SharpInference.Engine.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference.Cpu\SharpInference.Cpu.csproj" PrivateAssets="all" />
+    <!-- Vision: image-input loader path (#253). Bundled inside the SharpInference meta-package. -->
+    <ProjectReference Include="..\SharpInference.Vision\SharpInference.Vision.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference\SharpInference.csproj" />
   </ItemGroup>
 

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -36,6 +36,17 @@ public sealed class SharpInferenceServerOptions
     public string? ModelPath { get; set; }
 
     /// <summary>
+    /// Optional path to a multimodal projector GGUF (mmproj-*.gguf) enabling image input
+    /// (issue #253). Only Gemma 4 <c>gemma4uv</c> projectors are supported today, and only on a
+    /// backend whose forward pass accepts precomputed-embedding input (CPU, i.e.
+    /// <see cref="NGpuLayers"/>=0, or full CUDA offload, <see cref="NGpuLayers"/>=-1, of a model
+    /// that fits VRAM). Set via this property, the <c>SHARPI_MMPROJ</c> environment variable, or
+    /// the <c>SharpInference:MmprojPath</c> configuration key. When unset, image content blocks
+    /// are rejected with a clear error.
+    /// </summary>
+    public string? MmprojPath { get; set; }
+
+    /// <summary>
     /// Architecture hint used by <see cref="ChatTemplateRenderer"/> as a fallback when the
     /// model's GGUF metadata is missing <c>general.architecture</c> and no Jinja template
     /// is bundled. Defaults to <c>"qwen2"</c> (ChatML).

--- a/src/SharpInference.Vision/ImageIO.cs
+++ b/src/SharpInference.Vision/ImageIO.cs
@@ -84,20 +84,22 @@ public static class ImageIO
             _ => throw new NotSupportedException($"PNG color type {colorType} not supported (use grayscale/RGB/RGBA).")
         };
 
-        // Inflate the zlib stream (handles header + adler).
-        idat.Position = 0;
-        byte[] raw;
-        using (var zlib = new ZLibStream(idat, CompressionMode.Decompress))
-        using (var outMs = new MemoryStream(h * (1 + w * channels)))
-        {
-            zlib.CopyTo(outMs);
-            raw = outMs.ToArray();
-        }
-
         int stride = w * channels;
         int expected = h * (1 + stride);
-        if (raw.Length < expected)
-            throw new InvalidDataException($"PNG data too short: {raw.Length} < {expected}.");
+
+        // Inflate the zlib stream (handles header + adler), bounded to the exact size a
+        // non-interlaced 8-bit PNG must produce (one filter byte + one stride per scanline).
+        // Reading only `expected` bytes — and never draining the remainder of the stream —
+        // both bounds the allocation (already capped by the 64M-pixel dimension guard above)
+        // and defeats decompression bombs: a tiny IDAT that would inflate to gigabytes of
+        // zeros can no longer exhaust memory, since we stop after the bytes we actually unfilter.
+        idat.Position = 0;
+        var raw = new byte[expected];
+        int filled;
+        using (var zlib = new ZLibStream(idat, CompressionMode.Decompress))
+            filled = zlib.ReadAtLeast(raw, expected, throwOnEndOfStream: false);
+        if (filled < expected)
+            throw new InvalidDataException($"PNG data too short: {filled} < {expected}.");
 
         // Unfilter scanlines in place into a contiguous pixel buffer.
         var pixels = new byte[h * stride];

--- a/src/SharpInference.Vision/ImageIO.cs
+++ b/src/SharpInference.Vision/ImageIO.cs
@@ -51,6 +51,11 @@ public static class ImageIO
             switch (type)
             {
                 case "IHDR":
+                    // IHDR is always exactly 13 bytes; the fields below read png[dataOff+8..12].
+                    // A shorter declared length (clen < 13) would read past this chunk — when the
+                    // chunk is the last bytes in the buffer that is an out-of-bounds read. Reject it.
+                    if (clen < 13)
+                        throw new InvalidDataException($"PNG IHDR chunk too short: {clen} bytes (need 13).");
                     w = ReadUInt32BE(png, dataOff);
                     h = ReadUInt32BE(png, dataOff + 4);
                     bitDepth = png[dataOff + 8];

--- a/src/SharpInference/SharpInference.csproj
+++ b/src/SharpInference/SharpInference.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\SharpInference.Vulkan\SharpInference.Vulkan.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference.Cuda\SharpInference.Cuda.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference.Engine\SharpInference.Engine.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\SharpInference.Vision\SharpInference.Vision.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference.Pipeline\SharpInference.Pipeline.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference.TurboQuant\SharpInference.TurboQuant.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\SharpInference.Diffusion\SharpInference.Diffusion.csproj" PrivateAssets="all" />

--- a/tests/SharpInference.Tests.Server/ImageEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/ImageEndpointTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SharpInference.Engine;
+using SharpInference.Server;
+
+namespace SharpInference.Tests.Server;
+
+/// <summary>
+/// Wire-format tests for multimodal image input (issue #253). They exercise the Anthropic
+/// <c>image</c> content-block and OpenAI <c>image_url</c> part parsing, the dispatch to the
+/// engine's image path, and the rejection cases — all against a <see cref="FakeInferenceEngine"/>
+/// so no model or mmproj is required. (The fake never decodes the bytes; the endpoint's
+/// PNG-signature validation is what the bad-format test exercises.)
+/// </summary>
+public sealed class ImageEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ImageEndpointTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    // Bytes that pass the endpoint's PNG-signature check (the fake engine never decodes them).
+    private static string FakePngBase64()
+        => Convert.ToBase64String([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3, 4]);
+
+    private HttpClient ClientWith(FakeInferenceEngine engine)
+        => _factory.WithWebHostBuilder(b => b.ConfigureServices(s =>
+            s.AddSingleton<IInferenceEngine>(engine))).CreateClient();
+
+    [Fact]
+    public async Task Anthropic_ImageBlock_RoutesToImagePathWithPlaceholder()
+    {
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "text", text = "What is in this image?" },
+                    new { type = "image", source = new { type = "base64", media_type = "image/png", data = FakePngBase64() } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(1, fake.LastImageCount);
+        Assert.Contains("<|image|>", fake.LastPrompt!);
+        Assert.Contains("What is in this image?", fake.LastPrompt!);
+    }
+
+    [Fact]
+    public async Task OpenAi_ImageUrlDataUrl_RoutesToImagePathWithPlaceholder()
+    {
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var dataUrl = "data:image/png;base64," + FakePngBase64();
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "text", text = "Describe:" },
+                    new { type = "image_url", image_url = new { url = dataUrl } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(1, fake.LastImageCount);
+        Assert.Contains("<|image|>", fake.LastPrompt!);
+    }
+
+    [Fact]
+    public async Task OpenAi_MultipleImages_AllCounted()
+    {
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var dataUrl = "data:image/png;base64," + FakePngBase64();
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "text", text = "Compare" },
+                    new { type = "image_url", image_url = new { url = dataUrl } },
+                    new { type = "text", text = "and" },
+                    new { type = "image_url", image_url = new { url = dataUrl } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(2, fake.LastImageCount);
+    }
+
+    [Fact]
+    public async Task OpenAi_PlainStringContent_StillWorks()
+    {
+        // The OaiMessage.Content type changed from string? to JsonElement?; a plain-string
+        // content must still deserialize and route to the text path (back-compat).
+        var fake = new FakeInferenceEngine("m");
+        var client = ClientWith(fake);
+        var req = new { model = "m", max_tokens = 8, messages = new object[] { new { role = "user", content = "hello" } } };
+
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(0, fake.LastImageCount);
+        Assert.Contains("hello", fake.LastPrompt!);
+    }
+
+    [Fact]
+    public async Task Anthropic_ImageOnNonImageModel_Returns400()
+    {
+        var fake = new FakeInferenceEngine("text-only"); // SupportsImages = false
+        var client = ClientWith(fake);
+        var req = new
+        {
+            model = "text-only",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "image", source = new { type = "base64", media_type = "image/png", data = FakePngBase64() } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("image input", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Anthropic_NonPngImage_Returns400()
+    {
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var jpegBase64 = Convert.ToBase64String([0xFF, 0xD8, 0xFF, 0xE0, 1, 2, 3, 4]); // JPEG magic, not PNG
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "image", source = new { type = "base64", media_type = "image/jpeg", data = jpegBase64 } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("PNG", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task OpenAi_RemoteImageUrl_Returns400()
+    {
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "image_url", image_url = new { url = "https://example.com/cat.png" } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("data URL", await resp.Content.ReadAsStringAsync());
+    }
+}

--- a/tests/SharpInference.Tests.Server/ImageEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/ImageEndpointTests.cs
@@ -20,8 +20,16 @@ public sealed class ImageEndpointTests : IClassFixture<WebApplicationFactory<Pro
 
     public ImageEndpointTests(WebApplicationFactory<Program> factory) => _factory = factory;
 
-    // Bytes that pass the endpoint's PNG-signature check (the fake engine never decodes them).
-    private static string FakePngBase64()
+    // A real, fully decodable 2x2 RGB PNG. The endpoint now decode-validates images at parse
+    // time (so format errors become a clean 400 before generation), so the routing tests need a
+    // genuinely decodable payload rather than a bare signature.
+    private const string RealPng2x2Base64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR42mM4IScHRAwQCgAfJgQRSo6NIAAAAABJRU5ErkJggg==";
+
+    private static string FakePngBase64() => RealPng2x2Base64;
+
+    // Valid 8-byte PNG signature but no IHDR — passes a signature-only check, fails a real decode.
+    private static string SignatureOnlyPngBase64()
         => Convert.ToBase64String([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3, 4]);
 
     private HttpClient ClientWith(FakeInferenceEngine engine)
@@ -197,5 +205,55 @@ public sealed class ImageEndpointTests : IClassFixture<WebApplicationFactory<Pro
 
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         Assert.Contains("data URL", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Anthropic_SignatureValidButUndecodablePng_Returns400()
+    {
+        // A payload with a valid 8-byte PNG signature but no decodable body must be rejected with
+        // a clean 400 at parse time, not surface as a 500 deep in the engine's prefill (#259 review).
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[]
+            {
+                new { role = "user", content = new object[]
+                {
+                    new { type = "image", source = new { type = "base64", media_type = "image/png", data = SignatureOnlyPngBase64() } },
+                } },
+            },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Equal(0, fake.LastImageCount); // never reached the engine
+    }
+
+    [Fact]
+    public async Task OpenAi_TooManyImages_Returns400()
+    {
+        var fake = new FakeInferenceEngine("gemma-4-12b") { SupportsImages = true };
+        var client = ClientWith(fake);
+        var dataUrl = "data:image/png;base64," + RealPng2x2Base64;
+        // 17 images (one over the cap of 16).
+        var parts = new List<object> { new { type = "text", text = "Compare" } };
+        for (int i = 0; i < 17; i++)
+            parts.Add(new { type = "image_url", image_url = new { url = dataUrl } });
+        var req = new
+        {
+            model = "gemma-4-12b",
+            max_tokens = 8,
+            messages = new object[] { new { role = "user", content = parts.ToArray() } },
+        };
+
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("too many images", await resp.Content.ReadAsStringAsync());
+        Assert.Equal(0, fake.LastImageCount);
     }
 }

--- a/tests/SharpInference.Tests.Server/ServerLibraryTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerLibraryTests.cs
@@ -654,6 +654,33 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddSharpInference_MmprojPath_ConfigurableViaConfigKeyAndConfigure()
+    {
+        // Issue #253: the vision projector must be settable through SharpInferenceServerOptions
+        // — both the SharpInference:MmprojPath config key and the inline Configure callback —
+        // not only the SHARPI_MMPROJ environment variable.
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SharpInference:ModelPath"]  = "/tmp/model.gguf",
+                ["SharpInference:MmprojPath"] = "/tmp/mmproj.gguf",
+            })
+            .Build();
+
+        var fromConfig = new ServiceCollection();
+        fromConfig.AddSharpInference(cfg);
+        using var spConfig = fromConfig.BuildServiceProvider();
+        Assert.Equal("/tmp/mmproj.gguf",
+            spConfig.GetRequiredService<IOptions<SharpInferenceServerOptions>>().Value.MmprojPath);
+
+        var fromConfigure = new ServiceCollection();
+        fromConfigure.AddSharpInference(opts => opts.MmprojPath = "/code/mmproj.gguf");
+        using var spConfigure = fromConfigure.BuildServiceProvider();
+        Assert.Equal("/code/mmproj.gguf",
+            spConfigure.GetRequiredService<IOptions<SharpInferenceServerOptions>>().Value.MmprojPath);
+    }
+
+    [Fact]
     public void AddSharpInference_InlineConfigure_OverridesConfigurationValues()
     {
         // The Action<Options> callback runs AFTER the IConfiguration bind, so inline

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -842,19 +842,31 @@ public sealed class ServerTests : IClassFixture<WebApplicationFactory<Program>>
 
     // ── Tool calling ─────────────────────────────────────────────────────────
 
+    // Builds a test host with the qwen <tool_call> tool-call adapter pinned. Without this the
+    // default ChatTemplateRenderer is constructed from the bound Architecture option, which a
+    // developer's (gitignored) appsettings.Local.json can set to a non-qwen value — that file is
+    // loaded by WebApplicationFactory<Program>, so the tool-call tests would otherwise pass in CI
+    // but fail locally with whatever adapter the local config selects.
+    private static WebApplicationFactory<Program> ToolHostFactory(FakeInferenceEngine engine) =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s =>
+            {
+                s.AddSingleton(new ChatTemplateRenderer("qwen2"));
+                s.AddSingleton<IInferenceEngine>(engine);
+            }));
+
     [Fact]
     public async Task AnthropicMessages_WithTools_NonStreaming_ReturnsToolUseBlock()
     {
         // Model output contains a <tool_call> block — endpoint must parse it and return
         // a tool_use content block with stop_reason = "tool_use".
-        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
-            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
-                "test-model",
-                [
-                    (GenerateChunkKind.Text, "<tool_call>\n"),
-                    (GenerateChunkKind.Text, "{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}"),
-                    (GenerateChunkKind.Text, "\n</tool_call>"),
-                ]))));
+        var factory = ToolHostFactory(new FakeInferenceEngine(
+            "test-model",
+            [
+                (GenerateChunkKind.Text, "<tool_call>\n"),
+                (GenerateChunkKind.Text, "{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}"),
+                (GenerateChunkKind.Text, "\n</tool_call>"),
+            ]));
         var client = factory.CreateClient();
 
         var req = new
@@ -893,13 +905,12 @@ public sealed class ServerTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact]
     public async Task AnthropicMessages_WithTools_NonStreaming_TextBeforeToolCall_ReturnsBothBlocks()
     {
-        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
-            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
-                "test-model",
-                [
-                    (GenerateChunkKind.Text, "Let me check that for you."),
-                    (GenerateChunkKind.Text, "<tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"/foo\"}}\n</tool_call>"),
-                ]))));
+        var factory = ToolHostFactory(new FakeInferenceEngine(
+            "test-model",
+            [
+                (GenerateChunkKind.Text, "Let me check that for you."),
+                (GenerateChunkKind.Text, "<tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"/foo\"}}\n</tool_call>"),
+            ]));
         var client = factory.CreateClient();
 
         var req = new
@@ -926,14 +937,13 @@ public sealed class ServerTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact]
     public async Task AnthropicMessages_WithTools_Streaming_EmitsToolUseEvents()
     {
-        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
-            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
-                "test-model",
-                [
-                    (GenerateChunkKind.Text, "<tool_call>\n"),
-                    (GenerateChunkKind.Text, "{\"name\": \"bash\", \"arguments\": {\"command\": \"ls\"}}"),
-                    (GenerateChunkKind.Text, "\n</tool_call>"),
-                ]))));
+        var factory = ToolHostFactory(new FakeInferenceEngine(
+            "test-model",
+            [
+                (GenerateChunkKind.Text, "<tool_call>\n"),
+                (GenerateChunkKind.Text, "{\"name\": \"bash\", \"arguments\": {\"command\": \"ls\"}}"),
+                (GenerateChunkKind.Text, "\n</tool_call>"),
+            ]));
         var client = factory.CreateClient();
 
         var req = new

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -1160,6 +1160,12 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
     /// <summary>The rendered prompt handed to the most recent generation call.</summary>
     public string? LastPrompt { get; private set; }
 
+    /// <summary>Image-input support flag (issue #253) and capture of the most recent image
+    /// dispatch, so wire-level tests can confirm image content reached the engine.</summary>
+    public bool SupportsImages { get; init; }
+    public bool SupportsImageInput => SupportsImages;
+    public int LastImageCount { get; private set; }
+
     public async IAsyncEnumerable<GenerateChunk> GenerateChunksAsync(
         string prompt,
         SamplingParams sp,
@@ -1169,6 +1175,24 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
         LastSamplingParams = sp;
         LastCanonicalHistoryPrefix = canonicalHistoryPrefix;
         LastPrompt = prompt;
+        foreach (var (kind, text) in _script)
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return new GenerateChunk(kind, text);
+        }
+    }
+
+    public async IAsyncEnumerable<GenerateChunk> GenerateImageChunksAsync(
+        string prompt,
+        IReadOnlyList<byte[]> imageBytes,
+        SamplingParams sp,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        LastSamplingParams = sp;
+        LastCanonicalHistoryPrefix = null;
+        LastPrompt = prompt;
+        LastImageCount = imageBytes.Count;
         foreach (var (kind, text) in _script)
         {
             ct.ThrowIfCancellationRequested();

--- a/tests/SharpInference.Tests.Vision/ImagePipelineTests.cs
+++ b/tests/SharpInference.Tests.Vision/ImagePipelineTests.cs
@@ -142,4 +142,65 @@ public class ImagePipelineTests
             s.WriteByte((byte)(v >> 8)); s.WriteByte((byte)v);
         }
     }
+
+    [Fact]
+    public void LoadRgb_HugeInflatingIdat_DecodesToDeclaredSizeOnly()
+    {
+        // Decompression-bomb guard (#259 review): a 1x1 PNG whose IDAT inflates to ~64 MB of
+        // zeros must decode to exactly the declared 1x1 pixel, reading only the `expected` bytes
+        // (4 = one filter byte + one RGB triple). Without the bound the decoder would materialize
+        // the full 64 MB. The decode must succeed (not throw) and return the declared size.
+        byte[] idat = ZlibCompress(new byte[64 * 1024 * 1024]); // 64 MB of zeros -> tiny compressed
+        Assert.True(idat.Length < 100_000, "zlib bomb payload should be small");
+        using var ms = new MemoryStream(BuildPng(1, 1, colorType: 2, idat));
+
+        byte[] rgb = ImageIO.LoadRgb(ms, out int w, out int h);
+
+        Assert.Equal(1, w);
+        Assert.Equal(1, h);
+        Assert.Equal(3, rgb.Length);            // 1x1 RGB
+        Assert.Equal(new byte[] { 0, 0, 0 }, rgb);
+    }
+
+    [Fact]
+    public void LoadRgb_IdatShorterThanDeclared_Throws()
+    {
+        // IHDR declares 4x4 RGB (expected raw = 4*(1+4*3) = 52 bytes) but the IDAT only inflates
+        // to 10 bytes — the bounded read returns fewer than `expected`, which must surface as the
+        // "too short" InvalidDataException rather than reading past the buffer.
+        byte[] idat = ZlibCompress(new byte[10]);
+        using var ms = new MemoryStream(BuildPng(4, 4, colorType: 2, idat));
+
+        Assert.Throws<InvalidDataException>(() => ImageIO.LoadRgb(ms, out _, out _));
+    }
+
+    private static byte[] ZlibCompress(byte[] data)
+    {
+        using var outMs = new MemoryStream();
+        using (var z = new System.IO.Compression.ZLibStream(outMs, System.IO.Compression.CompressionLevel.SmallestSize, leaveOpen: true))
+            z.Write(data, 0, data.Length);
+        return outMs.ToArray();
+    }
+
+    // Builds a minimal PNG (signature + IHDR + IDAT + IEND); CRCs are zero since the decoder
+    // does not verify them. `idat` is the already-zlib-compressed image data.
+    private static byte[] BuildPng(int w, int h, int colorType, byte[] idat)
+    {
+        using var ms = new MemoryStream();
+        ms.Write([137, 80, 78, 71, 13, 10, 26, 10]);
+        WriteBE(ms, 13); ms.Write("IHDR"u8.ToArray());
+        WriteBE(ms, w); WriteBE(ms, h);
+        ms.WriteByte(8); ms.WriteByte((byte)colorType);
+        ms.WriteByte(0); ms.WriteByte(0); ms.WriteByte(0);
+        WriteBE(ms, 0); // IHDR CRC (unchecked)
+        WriteBE(ms, idat.Length); ms.Write("IDAT"u8.ToArray()); ms.Write(idat); WriteBE(ms, 0);
+        WriteBE(ms, 0); ms.Write("IEND"u8.ToArray()); WriteBE(ms, 0);
+        return ms.ToArray();
+
+        static void WriteBE(Stream s, int v)
+        {
+            s.WriteByte((byte)(v >> 24)); s.WriteByte((byte)(v >> 16));
+            s.WriteByte((byte)(v >> 8)); s.WriteByte((byte)v);
+        }
+    }
 }


### PR DESCRIPTION
Closes #253.

Wires encoder-free Gemma 4 vision (the CLI's `--image` from #250) through the API
server's Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/completions`) endpoints.

## Design — engine owns vision, server passes bytes
- `InferenceEngine.EnableImageInput(...)`, `SupportsImageInput`, and
  `GenerateImageChunksAsync(...)`. `SplicePrefillImages` projects each image
  (decode → preprocess → embed) and splices `open + soft tokens + close` at every
  `<|image|>` placeholder during a fresh prefill (mirrors the CLI's `RunImagePrompt`).
- `IInferenceEngine` gains default interface members so existing implementers inherit
  a "no image support" stub.
- `InferenceEngineLoader` opens the mmproj `VisionModel` when configured and rejects
  unsupported configs (non-embedding pass, batched, or a non-Gemma text model) with a clear error.

## Server surface
- New `ImageContent` helper: base64 / data-URL decode + **full PNG decode-validation at parse
  time** (unsupported / corrupt / decompression-bomb payloads → HTTP 400 before any response).
- Anthropic `image` content blocks (`source.type=base64`) and OpenAI `image_url` /
  `input_image` parts (data URL). Each image is collected and replaced inline by the
  model's `<|image|>` placeholder, multi-image per message in document order (capped at 16/request).
- `MmprojPath` option settable via `SHARPI_MMPROJ` env, the `SharpInference:MmprojPath`
  config key, **or** `Configure(o => o.MmprojPath = ...)`.

## Gemma 4 thinking default
Gemma 4 is not a reasoning model. The server defaults thinking **off** for it
(`ChatTemplateRenderer.ModelDefaultsThinkingOff`), matching the CLI and applied uniformly
across `/v1/messages`, `/v1/chat/completions`, and `/v1/responses`. An explicit request
flag still wins; `SHARPI_NO_THINKING` still forces off.

## Review cycle
A multi-agent adversarial review of the initial diff found — and this PR fixes — two real
bugs that single-image smoke tests masked:
- **Decode position:** content tokens were forwarded at `tokens.Length + i` instead of
  `startPos + i`, so multi-token image responses decoded over the spliced soft-token KV with
  wrong RoPE positions (the repetition/garbling). Fixed → output is now clean and coherent.
- **Cross-request KV reuse:** the image path didn't invalidate `_prevTokens`, letting a later
  text request reuse image-soft-token KV. Fixed.
- **Decompression-bomb DoS:** `ImageIO` inflated the PNG IDAT unbounded; now bounded to the
  exact decoded size.
- Robustness: bad images / malformed JSON → clean 400 (not 500 / aborted stream); engine
  errors during generation are surfaced gracefully.

## Tests / verification
- 9 wire-format image tests + `MmprojPath` configurability + `ImageIO` bomb-cap tests.
- Full solution builds clean in Release (`TreatWarningsAsErrors`); Tests.Server green
  (the 3 `WithTools` failures are a local-`appsettings` artifact, unrelated — they fail on
  master too).
- **End-to-end on a 4070 Ti** with the 12B `gemma4uv` model + its mmproj: both endpoints
  return clean, coherent descriptions of a real image (e.g. *"A serene, misty landscape
  features a calm lake reflecting a mountain range under a clear blue sky."*).

## Deferred (noted, out of scope)
- `/v1/responses` does not yet accept image content (text-only; pre-existing).
- The Gemma 4 image token-id fallbacks are duplicated with the CLI (intentional, by the
  byte-identical-copy design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)