### PR TITLE
fix(planner): price expert-cache budget for the pinned -g N split (#224)

### DIFF
--- a/samples/SharpInference.Sample.ToolCall/Program.cs
+++ b/samples/SharpInference.Sample.ToolCall/Program.cs
@@ -143,8 +143,9 @@ if (backendStr == "cuda")
         {
             var cpuBack   = new CpuBackend();
             var hw        = HardwareProfile.Detect(cuda);
-            var placement = TierPlanner.Plan(model, hp, hw);
-            placement     = placement with { GpuLayers = gpuLayers, CpuLayers = hp.NumLayers - gpuLayers };
+            // pinGpuLayers (not a `with { GpuLayers = }` override) so the MoE expert-cache budget
+            // is priced for this split, not the greedy auto one (#224).
+            var placement = TierPlanner.Plan(model, hp, hw, pinGpuLayers: gpuLayers);
             var chfwd     = new CudaHybridForwardPass(model, cuda, hp, placement);
             backend       = cpuBack;
             forward       = chfwd;

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -596,10 +596,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 if (wantHybrid)
                 {
                     var hwProfile = HardwareProfile.Detect(cuda);
+                    // pinGpuLayers prices the expert-cache budget (read by the MoE CPU-vs-SLRU
+                    // auto-decision) for this exact split. cudaGpuLayers equals the auto value on
+                    // the -g -1 path, so pinning is a no-op there and only matters on explicit -g N
+                    // (#224). A `with { GpuLayers = }` override would leave the budget stale.
                     var placement = TierPlanner.Plan(model, hp, hwProfile, settings.TurboQuant,
-                        requestedCtxSize: ctxSize, kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
-                    if (nGpuLayers != -1)
-                        placement = placement with { GpuLayers = cudaGpuLayers, CpuLayers = hp.NumLayers - cudaGpuLayers };
+                        requestedCtxSize: ctxSize, kvDtype: CudaForwardPass.ResolveConfiguredKvDType(),
+                        pinGpuLayers: cudaGpuLayers);
 
                     var chfwd = new CudaHybridForwardPass(model, cuda, hp, placement, settings.TurboQuant);
                     gpuFwd = chfwd;
@@ -703,12 +706,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 }
                 else
                 {
-                    // Hybrid: N layers GPU, rest CPU
+                    // Hybrid: N layers GPU, rest CPU. nGpuLayers is the auto value on -g -1 and the
+                    // explicit count otherwise; pinGpuLayers prices weights/KV/budget for it (#224).
                     var placement = TierPlanner.Plan(model, hp, hwProfile, settings.TurboQuant,
-                        requestedCtxSize: ctxSize);
-                    // Override with explicit -g/--ngl N if user specified it
-                    if (effNGpuLayers > 0)
-                        placement = placement with { GpuLayers = nGpuLayers, CpuLayers = hp.NumLayers - nGpuLayers };
+                        requestedCtxSize: ctxSize, pinGpuLayers: nGpuLayers);
 
                     var hfwd = new HybridForwardPass(model, gpu, hp, placement, settings.TurboQuant);
                     gpuFwd = hfwd;

--- a/src/SharpInference.Engine/TierPlanner.cs
+++ b/src/SharpInference.Engine/TierPlanner.cs
@@ -12,9 +12,18 @@ public static class TierPlanner
     /// <summary>
     /// Compute optimal layer placement for a given model and hardware profile.
     /// </summary>
+    /// <param name="pinGpuLayers">
+    /// When non-null, pins the GPU trunk-layer count (e.g. the user's explicit <c>-g N</c>) instead
+    /// of greedily auto-packing, and prices the trunk weights, KV, and <see cref="LayerPlacement.
+    /// ExpertCacheBudgetBytes"/> for THAT split. Callers must use this rather than a
+    /// <c>placement with { GpuLayers = N }</c> override, which would leave the expert-cache budget
+    /// (and KV/weight bytes) computed for the auto split — a stale value the MoE CPU-vs-SLRU
+    /// auto-decision then reads (issue #224). Clamped to <c>[0, NumLayers]</c>.
+    /// </param>
     public static LayerPlacement Plan(GgufModel model, ModelHyperparams hp,
         HardwareProfile hardware, bool turboQuant = false, int tqBits = 3,
-        int requestedCtxSize = 0, int tqFp32Window = 256, DType kvDtype = DType.Float32)
+        int requestedCtxSize = 0, int tqFp32Window = 256, DType kvDtype = DType.Float32,
+        int? pinGpuLayers = null)
     {
         if (hardware.VramBytes <= 0)
             return new LayerPlacement(0, hp.NumLayers, 0, 0, requestedCtxSize > 0 ? requestedCtxSize : hp.ContextLength);
@@ -65,21 +74,35 @@ public static class TierPlanner
         // Measure per-layer weight bytes
         long perLayerBytes = MeasureLayerBytes(model, hp, 0);
 
-        // Priority 2: Assign layers to GPU, greedily
+        // Priority 2: Assign layers to GPU.
         int gpuLayers = 0;
         long gpuWeightBytes = fixedGpuBytes;
-        for (int i = 0; i < hp.NumLayers; i++)
+        if (pinGpuLayers is int pin)
         {
-            long layerBytes = MeasureLayerBytes(model, hp, i);
-            if (vramBudget >= layerBytes)
+            // Caller pinned an explicit GPU trunk count (e.g. -g N). Honor it exactly and price the
+            // trunk weights / KV / expert-cache budget for THIS split rather than the greedy auto
+            // split. A pin that exceeds VRAM is the user's explicit choice (the forward pass
+            // enforces real fit), so we only clamp the leftover budget to >= 0 here.
+            gpuLayers = Math.Clamp(pin, 0, hp.NumLayers);
+            for (int i = 0; i < gpuLayers; i++)
+                gpuWeightBytes += MeasureLayerBytes(model, hp, i);
+            vramBudget = Math.Max(0, vramBudget - (gpuWeightBytes - fixedGpuBytes));
+        }
+        else
+        {
+            for (int i = 0; i < hp.NumLayers; i++)
             {
-                vramBudget -= layerBytes;
-                gpuWeightBytes += layerBytes;
-                gpuLayers++;
-            }
-            else
-            {
-                break; // layers are contiguous from 0
+                long layerBytes = MeasureLayerBytes(model, hp, i);
+                if (vramBudget >= layerBytes)
+                {
+                    vramBudget -= layerBytes;
+                    gpuWeightBytes += layerBytes;
+                    gpuLayers++;
+                }
+                else
+                {
+                    break; // layers are contiguous from 0
+                }
             }
         }
 

--- a/src/SharpInference.Engine/TierPlanner.cs
+++ b/src/SharpInference.Engine/TierPlanner.cs
@@ -71,9 +71,6 @@ public static class TierPlanner
         vramBudget -= fixedGpuBytes;
         if (vramBudget < 0) vramBudget = 0;
 
-        // Measure per-layer weight bytes
-        long perLayerBytes = MeasureLayerBytes(model, hp, 0);
-
         // Priority 2: Assign layers to GPU.
         int gpuLayers = 0;
         long gpuWeightBytes = fixedGpuBytes;

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -276,9 +276,10 @@ public static class InferenceEngineLoader
                 return (cfwd, cfwd.SupportsContinuousBatching);
             }
 
+            // pinGpuLayers (not a `with { GpuLayers = }` override) so the expert-cache budget the
+            // MoE CPU-vs-SLRU auto-decision reads is priced for THIS split, not the auto one (#224).
             var planForHybrid = TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize,
-                    kvDtype: CudaForwardPass.ResolveConfiguredKvDType())
-                with { GpuLayers = gpuLayers, CpuLayers = hp.NumLayers - gpuLayers };
+                kvDtype: CudaForwardPass.ResolveConfiguredKvDType(), pinGpuLayers: gpuLayers);
             var chfwd = new CudaHybridForwardPass(model, cuda, hp, planForHybrid, turboQuant);
             owned.Add(chfwd);
             return (chfwd, BatchingSupported: false);
@@ -312,8 +313,8 @@ public static class InferenceEngineLoader
                 return (gfwd, BatchingSupported: false);
             }
 
-            var planForHybrid = TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize)
-                with { GpuLayers = gpuLayers, CpuLayers = hp.NumLayers - gpuLayers };
+            var planForHybrid = TierPlanner.Plan(model, hp, hwProfile, turboQuant, requestedCtxSize: ctxSize,
+                pinGpuLayers: gpuLayers);
             var hfwd = new HybridForwardPass(model, vulkan, hp, planForHybrid, turboQuant);
             owned.Add(hfwd);
             return (hfwd, BatchingSupported: false);

--- a/tests/SharpInference.Tests.ForwardPass/TierPlannerPinTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/TierPlannerPinTests.cs
@@ -1,0 +1,86 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using Xunit;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #224: <see cref="TierPlanner.Plan"/> with <c>pinGpuLayers: N</c> must price the routed-
+/// expert cache budget (and KV / trunk-weight bytes) for the pinned split, not the greedy auto
+/// split. The CLI and server previously pinned an explicit <c>-g N</c> via
+/// <c>Plan(...) with { GpuLayers = N }</c>, which kept the auto-split
+/// <see cref="LayerPlacement.ExpertCacheBudgetBytes"/> — a stale value the MoE CPU-vs-SLRU
+/// auto-decision in <see cref="CudaHybridForwardPass"/> then read.
+///
+/// Loads OLMoE (a small MoE) and reads only GGUF metadata — no GPU, no inference — with a fixed
+/// <see cref="HardwareProfile"/> so the budget math is deterministic. Skipped when the model is
+/// not on disk (the planner needs real tensor sizes).
+/// </summary>
+public sealed class TierPlannerPinTests
+{
+    private static string? OlmoePath() => FirstExisting(
+        @"C:\p\sharpi\models\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf",
+        @"E:\models\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf");
+
+    private static string? FirstExisting(params string[] paths)
+    {
+        foreach (var p in paths)
+            if (File.Exists(p)) return p;
+        return null;
+    }
+
+    // 16 GB VRAM, fixed so the result does not depend on the test host's GPU.
+    private static HardwareProfile FixedHw() =>
+        new(VramBytes: 16L * 1024 * 1024 * 1024, RamBytes: 64L * 1024 * 1024 * 1024,
+            CpuCores: 8, EstPcieBandwidthGBps: 16.0, HasAvx512: true);
+
+    [Fact]
+    public void Plan_PinGpuLayers_RepricesExpertBudgetForThatSplit()
+    {
+        string? path = OlmoePath();
+        if (path is null) return; // model not on disk — skip
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.True(hp.IsMoE, "OLMoE must be detected as MoE");
+        Assert.True(hp.NumLayers >= 4, "need enough layers for a meaningful split");
+
+        var hw = FixedHw();
+        int few = Math.Max(1, hp.NumLayers / 4);
+        int many = Math.Max(few + 1, hp.NumLayers * 3 / 4);
+
+        // Fixed context so KV (and therefore the leftover expert budget) is deterministic and the
+        // auto-context solver does not absorb all free VRAM into KV.
+        var pFew = TierPlanner.Plan(model, hp, hw, requestedCtxSize: 4096, pinGpuLayers: few);
+        var pMany = TierPlanner.Plan(model, hp, hw, requestedCtxSize: 4096, pinGpuLayers: many);
+
+        // The pin is honored exactly.
+        Assert.Equal(few, pFew.GpuLayers);
+        Assert.Equal(many, pMany.GpuLayers);
+        Assert.Equal(hp.NumLayers - few, pFew.CpuLayers);
+
+        // More GPU trunk layers => more trunk weights + more KV => LESS room for the routed-expert
+        // cache. The old `with { GpuLayers = }` override would have given both the SAME (auto)
+        // budget; this asserts the budget now tracks the pinned split (the #224 fix).
+        Assert.True(pMany.GpuKvBytes > pFew.GpuKvBytes,
+            $"more layers must cost more KV: few={pFew.GpuKvBytes} many={pMany.GpuKvBytes}");
+        Assert.True(pMany.ExpertCacheBudgetBytes < pFew.ExpertCacheBudgetBytes,
+            $"few-layer budget ({pFew.ExpertCacheBudgetBytes}) must exceed many-layer budget ({pMany.ExpertCacheBudgetBytes})");
+        Assert.True(pFew.ExpertCacheBudgetBytes > 0, "few-layer split should leave a positive expert budget");
+        Assert.True(pMany.MoeRoutedExpertBytes > 0, "MoE must report a non-zero routed-expert cost");
+    }
+
+    [Fact]
+    public void Plan_PinGpuLayers_ClampsToValidRange()
+    {
+        string? path = OlmoePath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var hw = FixedHw();
+
+        Assert.Equal(hp.NumLayers, TierPlanner.Plan(model, hp, hw, pinGpuLayers: hp.NumLayers + 100).GpuLayers);
+        Assert.Equal(0, TierPlanner.Plan(model, hp, hw, pinGpuLayers: -5).GpuLayers);
+    }
+}


### PR DESCRIPTION
Closes #224.

## Problem
`TierPlanner.Plan` computes `ExpertCacheBudgetBytes` (and KV / trunk-weight bytes) for its own
greedy auto-placement. The CLI and server then overrode `GpuLayers` via
`placement with { GpuLayers = N }` on an explicit `-g N`, keeping the budget priced for the
**auto** split. `CudaHybridForwardPass` reads that now-stale `ExpertCacheBudgetBytes` for its
CPU-MoE-vs-GPU-SLRU auto-decision (`predictedSlots / totalExperts < 0.5`), so an explicit `-g N`
far from the auto split could select the wrong mode. Low severity — perf-selection only (both
modes are correct), self-correcting via `SHARPI_CPU_MOE=0|1`; the common `-g -1` path was unaffected.

## Fix
Add a `pinGpuLayers` parameter to `Plan`. When set it honors the pinned trunk count **and reprices**
trunk weights, KV, and the expert-cache budget for that split. All four override sites (CLI + server,
CUDA + Vulkan hybrid) now pass `pinGpuLayers` instead of the `with { GpuLayers = }` override, so no
consumer is ever fed a budget computed for a different layer count.

## Safety
- The `-g -1` auto path is **byte-identical**: pinning to the auto value reproduces the greedy
  result exactly (each greedy subtraction keeps `vramBudget >= 0`, so `max(0, initial - sumTrunk)`
  equals the greedy remainder). Only explicit `-g N` on a MoE hybrid changes — the bug being fixed.
- The Vulkan `HybridForwardPass` never read the budget (only `GpuLayers`/`CpuLayers`/ctx), so it was
  never miscued; the pin also makes its `Summary()` logging accurate.

## Tests
`TierPlannerPinTests` (GPU-free, GGUF-metadata-only, gated on OLMoE on disk): pinning fewer layers
yields a strictly larger expert-cache budget than pinning more, and the pin clamps to `[0, NumLayers]`.
Full Release build clean (`TreatWarningsAsErrors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)