### PR TITLE
perf(cuda): GPU-side greedy argmax for decode + MTP verify (#219)

### DIFF
--- a/src/SharpInference.Core/IForwardPass.cs
+++ b/src/SharpInference.Core/IForwardPass.cs
@@ -10,6 +10,31 @@ public interface IForwardPass : IDisposable
     ReadOnlySpan<float> Forward(int token, int position);
 
     /// <summary>
+    /// Whether <see cref="ForwardArgmax"/> computes the greedy argmax on-device, avoiding the
+    /// per-token full-vocab logits download (issue #219). Defaults to <c>false</c>; GPU passes that
+    /// implement an on-device argmax override this. The engine consults it only on the pure-greedy
+    /// decode path (temperature 0, no logit bias), where the full logits are never needed.
+    /// </summary>
+    bool SupportsGpuArgmax => false;
+
+    /// <summary>
+    /// Run one token and return only the greedy argmax — the highest-logit token id and its value —
+    /// without materializing the full-vocab logits on the host (issue #219). The default falls back
+    /// to <see cref="Forward"/> + a CPU argmax scan; backends reporting
+    /// <see cref="SupportsGpuArgmax"/> override it with a device-side reduction. The argmax MUST match
+    /// a left-to-right strict-<c>&gt;</c> host scan: highest value wins, lowest index on a tie.
+    /// </summary>
+    (int Token, float Logit) ForwardArgmax(int token, int position)
+    {
+        var logits = Forward(token, position);
+        int idx = 0;
+        float max = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > max) { max = logits[i]; idx = i; }
+        return (idx, max);
+    }
+
+    /// <summary>
     /// Batch-process prompt tokens and return logits for the last token.
     /// Faster than sequential Forward() calls for long prompts due to batched GEMM.
     /// </summary>
@@ -200,6 +225,40 @@ public interface IForwardPass : IDisposable
         throw new NotSupportedException(
             $"{GetType().Name} does not implement BatchVerify. " +
             "Check SupportsBatchVerify before calling.");
+
+    /// <summary>
+    /// Whether <see cref="BatchVerifyArgmax"/> computes the per-position verify argmax on-device,
+    /// so a greedy verify (pMin = 1.0) downloads k <c>(index, value)</c> pairs instead of k
+    /// full-vocab logits vectors (issue #219). Defaults to <c>false</c>; GPU verify passes override
+    /// it. Consulted only on the greedy verify path, where the full distributions are never needed.
+    /// </summary>
+    bool SupportsBatchVerifyArgmax => false;
+
+    /// <summary>
+    /// Greedy-verify counterpart of <see cref="BatchVerify"/>: processes the k tokens as one packed
+    /// pass with identical cache effects (the caller rolls back exactly as for BatchVerify), and
+    /// returns <c>result[i]</c> = the argmax (token id + logit value) of the logits after
+    /// <c>tokens[i]</c>, without materializing the full per-position distributions. Only sound when
+    /// the consumer needs the argmax alone (greedy accept / saved next-token). The default falls
+    /// back to <see cref="BatchVerify"/> + a host argmax per position (same lowest-index tie-break);
+    /// GPU passes reporting <see cref="SupportsBatchVerifyArgmax"/> override it with a device-side
+    /// row reduction that skips the k×vocab download.
+    /// </summary>
+    (int Index, float Value)[] BatchVerifyArgmax(int[] tokens, int startPos)
+    {
+        var batch = BatchVerify(tokens, startPos);
+        var result = new (int Index, float Value)[batch.Length];
+        for (int i = 0; i < batch.Length; i++)
+        {
+            var l = batch[i];
+            int idx = 0;
+            float max = l[0];
+            for (int j = 1; j < l.Length; j++)
+                if (l[j] > max) { max = l[j]; idx = j; }
+            result[i] = (idx, max);
+        }
+        return result;
+    }
 
     /// <summary>
     /// Maximum token count accepted by a single <see cref="BatchVerify"/> call.

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -3469,6 +3469,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
 
         if (_argmaxRowsOut is null || _argmaxRowsOut.ElementCount < rows * 2)
         {
+            if (_argmaxRowsOut is { } prev) Free(prev);   // return the smaller rental before growing
             _argmaxRowsOut = Allocate(TensorShape.D1(rows * 2));
             _argmaxRowsHost = new float[rows * 2];
         }

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -247,6 +247,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _geluTanhMulKernel;
     private nint   _geluTanhMulStridedKernel;
     private nint   _softcapKernel;
+    private nint   _argmaxPartialKernel;   // #219 greedy argmax — pass 1 (per-block reduction)
+    private nint   _argmaxFinalKernel;     // #219 greedy argmax — pass 2 (reduce partials)
+    private nint   _argmaxRowsKernel;      // #219 batched argmax — one block per row (MTP/spec verify)
     private nint   _clearF32Kernel;
     private nint   _quantizeQ81Kernel;
     // Track A (#124/#173): SoA Q8_1 activation producer + the SoA-weight+SoA-activation
@@ -399,6 +402,16 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// </summary>
     public bool Q80Dp4aEnabled { get; set; } =
         Environment.GetEnvironmentVariable("SHARPI_Q80_DP4A") != "0";
+
+    /// <summary>
+    /// Issue #219: compute the greedy argmax on-device (<see cref="Argmax"/>) so a decode token
+    /// downloads 8 bytes (index + value) instead of the full-vocab logits with a blocking stream
+    /// sync. Bit-exact with the host scan (<c>Sampler.Greedy</c>) for finite logits. Default on;
+    /// <c>SHARPI_GPU_ARGMAX=0</c> forces the legacy full-download path. Settable so parity oracles
+    /// can pin both sides.
+    /// </summary>
+    public bool GpuArgmaxEnabled { get; set; } =
+        Environment.GetEnvironmentVariable("SHARPI_GPU_ARGMAX") != "0";
 
     /// <summary>
     /// Issue #124: route Q4_0 decode matvecs through the dp4a/Q8_1 kernel
@@ -3384,6 +3397,97 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(softcap_inplace) failed: {r}");
     }
 
+    // #219 GPU greedy argmax scratch (lazily allocated on first Argmax call): the per-block
+    // (value, index) partials and the 8-byte (index-bits, value) output. The index buffer is a
+    // Float32 tensor used as raw int storage — the kernel writes/reads it as int*.
+    private const int ArgmaxBlocks = 256;
+    private const int ArgmaxThreads = 256;
+    private Tensor? _argmaxPartialVal;
+    private Tensor? _argmaxPartialIdx;
+    private Tensor? _argmaxOut;
+
+    /// <summary>
+    /// Issue #219: greedy argmax of <paramref name="logits"/> computed on-device, returning the
+    /// winning <c>(index, value)</c> after a single 8-byte download. Replaces a full-vocab D2H +
+    /// host scan on the greedy decode path. Bit-exact with <c>Sampler.Greedy</c> for finite logits,
+    /// including the lowest-index tie-break. Launched on the same stream as the producing forward
+    /// pass, so it sees the just-computed logits; the final download synchronizes the stream.
+    /// </summary>
+    public (int Index, float Value) Argmax(Tensor logits)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        int n = (int)logits.ElementCount;
+        if (n <= 0) throw new ArgumentException("Argmax requires a non-empty logits tensor.", nameof(logits));
+
+        _argmaxPartialVal ??= Allocate(TensorShape.D1(ArgmaxBlocks));
+        _argmaxPartialIdx ??= Allocate(TensorShape.D1(ArgmaxBlocks));
+        _argmaxOut        ??= Allocate(TensorShape.D1(2));
+
+        int blocks = Math.Min(ArgmaxBlocks, (n + ArgmaxThreads - 1) / ArgmaxThreads);
+
+        nint lPtr = GetDevPtr(logits);
+        nint pvPtr = GetDevPtr(_argmaxPartialVal);
+        nint piPtr = GetDevPtr(_argmaxPartialIdx);
+        int pN = n;
+        nint* a1 = stackalloc nint[4] { (nint)(&lPtr), (nint)(&pN), (nint)(&pvPtr), (nint)(&piPtr) };
+        int r1 = NvrtcInterop.LaunchKernel(_argmaxPartialKernel, (uint)blocks, 1, 1, ArgmaxThreads, 1, 1, 0, _stream, a1, null);
+        if (r1 != 0) throw new InvalidOperationException($"cuLaunchKernel(llm_argmax_partial) failed: {r1}");
+
+        nint outPtr = GetDevPtr(_argmaxOut);
+        int pNumParts = blocks;
+        nint* a2 = stackalloc nint[4] { (nint)(&pvPtr), (nint)(&piPtr), (nint)(&pNumParts), (nint)(&outPtr) };
+        int r2 = NvrtcInterop.LaunchKernel(_argmaxFinalKernel, 1, 1, 1, ArgmaxThreads, 1, 1, 0, _stream, a2, null);
+        if (r2 != 0) throw new InvalidOperationException($"cuLaunchKernel(llm_argmax_final) failed: {r2}");
+
+        // 8-byte D2H + StreamSynchronize (drains the two kernels above). out[0] = index (int bits),
+        // out[1] = value (float).
+        Span<float> result = stackalloc float[2];
+        Download(_argmaxOut, result);
+        return (BitConverter.SingleToInt32Bits(result[0]), result[1]);
+    }
+
+    // #219 batched-argmax scratch: a [maxRows*2] device output + matching host buffer, grown on demand.
+    private Tensor? _argmaxRowsOut;
+    private float[] _argmaxRowsHost = [];
+
+    /// <summary>
+    /// Issue #219: per-row greedy argmax over a packed <c>[rows × rowStride]</c> logits buffer
+    /// (the MTP / speculative verify positions), returning one <c>(index, value)</c> per row after
+    /// a single <c>rows*8</c>-byte download instead of the full <c>rows × vocab</c> D2H. Each row's
+    /// valid length is <paramref name="validLen"/> (<= <paramref name="rowStride"/>); the argmax is
+    /// over <c>[0, validLen)</c>. Same lowest-index tie-break and bit-exactness as <see cref="Argmax"/>.
+    /// </summary>
+    public (int Index, float Value)[] ArgmaxRows(Tensor logits, int rows, int validLen, int rowStride)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (rows <= 0) return [];
+
+        if (_argmaxRowsOut is null || _argmaxRowsOut.ElementCount < rows * 2)
+        {
+            _argmaxRowsOut = Allocate(TensorShape.D1(rows * 2));
+            _argmaxRowsHost = new float[rows * 2];
+        }
+
+        nint lPtr = GetDevPtr(logits);
+        nint outPtr = GetDevPtr(_argmaxRowsOut);
+        int pN = validLen;
+        int pStride = rowStride;
+        nint* args = stackalloc nint[4] { (nint)(&lPtr), (nint)(&pN), (nint)(&pStride), (nint)(&outPtr) };
+        int r = NvrtcInterop.LaunchKernel(_argmaxRowsKernel, (uint)rows, 1, 1, ArgmaxThreads, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(llm_argmax_rows) failed: {r}");
+
+        Download(_argmaxRowsOut, _argmaxRowsHost.AsSpan(0, rows * 2));   // rows*8 bytes + sync
+        var result = new (int, float)[rows];
+        for (int i = 0; i < rows; i++)
+            result[i] = (BitConverter.SingleToInt32Bits(_argmaxRowsHost[i * 2]), _argmaxRowsHost[i * 2 + 1]);
+        return result;
+    }
+
     public void SiLU(Tensor x) =>
         throw new NotSupportedException("Use SiLuMul(gate, up) for fused SwiGLU on CUDA.");
 
@@ -6091,6 +6195,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _attentionKernel, _attentionBf16Kernel, _attentionSwaKernel, _attentionSwaBatchedKernel,
             _attentionSwaBf16Kernel, _attentionSwaBatchedBf16Kernel,
             _geluTanhMulKernel, _geluTanhMulStridedKernel, _softcapKernel,
+            _argmaxPartialKernel, _argmaxFinalKernel, _argmaxRowsKernel,   // #219
             _clearF32Kernel, _quantizeQ81Kernel,
             _scaleRowsKernel, _moeWeightedReduceKernel,
             _tqRotateQueryKernel, _tqKvAppendKernel, _tqAttentionKernel,
@@ -6268,6 +6373,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _geluTanhMulKernel     = GetKernelFunc("llm_gelu_tanh_mul");
         _geluTanhMulStridedKernel = GetKernelFunc("llm_gelu_tanh_mul_strided");
         _softcapKernel         = GetKernelFunc("llm_softcap_inplace");
+        _argmaxPartialKernel   = GetKernelFunc("llm_argmax_partial");   // #219
+        _argmaxFinalKernel     = GetKernelFunc("llm_argmax_final");     // #219
+        _argmaxRowsKernel      = GetKernelFunc("llm_argmax_rows");      // #219
         _clearF32Kernel        = GetKernelFunc("llm_clear_f32");
         _quantizeQ81Kernel     = GetKernelFunc("llm_quantize_q8_1");
         _quantizeQ81SoaKernel  = GetKernelFunc("llm_quantize_q8_1_soa");      // Track A (#124/#173)

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -390,6 +390,107 @@ extern ""C"" __global__ void llm_sigmoid_inplace(float* __restrict__ x, int n)
     x[i] = 1.0f / (1.0f + __expf(-x[i]));
 }
 
+// ── Greedy argmax (#219): two-pass block reduction over the vocab logits ─────
+// Replaces the per-token full-vocab D2H + host scan when the sampler is greedy: the
+// (idx, value) pair is reduced on-device and only 8 bytes are downloaded.
+// Tie-break MUST match Sampler.Greedy (CPU): it scans left-to-right with a strict
+// `>`, so the FIRST (lowest-index) occurrence of the maximum survives. Every reduction
+// step here therefore keeps the LOWER index on an exact value tie. Threads init their
+// running value to -FLT_MAX with index 0; for finite logits (the decode contract, which
+// the coherence tests guard) every element beats the sentinel, so the result is bit-exact
+// with the host scan. (A NaN-at-index-0 buffer is the one degenerate case where the host's
+// `logits[0]` seed and this sentinel disagree — not reachable with finite decode logits.)
+#define SHARPI_ARGMAX_NEG_INF (-3.402823466e38f)
+
+extern ""C"" __global__ void llm_argmax_partial(
+    const float* __restrict__ logits, int n, float* __restrict__ partialVal, int* __restrict__ partialIdx)
+{
+    __shared__ float sVal[256];
+    __shared__ int   sIdx[256];
+    int tid = (int)threadIdx.x;
+    float best = SHARPI_ARGMAX_NEG_INF;
+    int bestIdx = 0;
+    for (int i = (int)(blockIdx.x * blockDim.x) + tid; i < n; i += (int)(gridDim.x * blockDim.x))
+    {
+        float v = logits[i];
+        if (v > best) { best = v; bestIdx = i; }
+    }
+    sVal[tid] = best; sIdx[tid] = bestIdx;
+    __syncthreads();
+    for (int s = (int)blockDim.x >> 1; s > 0; s >>= 1)
+    {
+        if (tid < s)
+        {
+            float ov = sVal[tid + s]; int oi = sIdx[tid + s];
+            if (ov > sVal[tid] || (ov == sVal[tid] && oi < sIdx[tid])) { sVal[tid] = ov; sIdx[tid] = oi; }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) { partialVal[blockIdx.x] = sVal[0]; partialIdx[blockIdx.x] = sIdx[0]; }
+}
+
+// Second pass: one block reduces the per-block partials. out[0] holds the winning index
+// (raw int bits), out[1] the winning value (float).
+extern ""C"" __global__ void llm_argmax_final(
+    const float* __restrict__ partialVal, const int* __restrict__ partialIdx, int numParts, void* out)
+{
+    __shared__ float sVal[256];
+    __shared__ int   sIdx[256];
+    int tid = (int)threadIdx.x;
+    float best = SHARPI_ARGMAX_NEG_INF;
+    int bestIdx = 0;
+    for (int i = tid; i < numParts; i += (int)blockDim.x)
+    {
+        float v = partialVal[i]; int idx = partialIdx[i];
+        if (v > best || (v == best && idx < bestIdx)) { best = v; bestIdx = idx; }
+    }
+    sVal[tid] = best; sIdx[tid] = bestIdx;
+    __syncthreads();
+    for (int s = (int)blockDim.x >> 1; s > 0; s >>= 1)
+    {
+        if (tid < s)
+        {
+            float ov = sVal[tid + s]; int oi = sIdx[tid + s];
+            if (ov > sVal[tid] || (ov == sVal[tid] && oi < sIdx[tid])) { sVal[tid] = ov; sIdx[tid] = oi; }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) { ((int*)out)[0] = sIdx[0]; ((float*)out)[1] = sVal[0]; }
+}
+
+// Batched argmax (#219, MTP/spec verify): one block per row reduces row `blockIdx.x` of a
+// [rows × rowStride] buffer (the packed per-position verify logits), writing (idx, value) pairs
+// to out[2*row], out[2*row+1]. Same lowest-index tie-break as the single-row kernels. Rows run on
+// separate SMs in parallel, so k argmaxes cost ~one row's reduction instead of k full-vocab D2H.
+extern ""C"" __global__ void llm_argmax_rows(
+    const float* __restrict__ logits, int n, int rowStride, void* out)
+{
+    __shared__ float sVal[256];
+    __shared__ int   sIdx[256];
+    int row = (int)blockIdx.x;
+    int tid = (int)threadIdx.x;
+    const float* r = logits + (long long)row * (long long)rowStride;
+    float best = SHARPI_ARGMAX_NEG_INF;
+    int bestIdx = 0;
+    for (int i = tid; i < n; i += (int)blockDim.x)
+    {
+        float v = r[i];
+        if (v > best) { best = v; bestIdx = i; }
+    }
+    sVal[tid] = best; sIdx[tid] = bestIdx;
+    __syncthreads();
+    for (int s = (int)blockDim.x >> 1; s > 0; s >>= 1)
+    {
+        if (tid < s)
+        {
+            float ov = sVal[tid + s]; int oi = sIdx[tid + s];
+            if (ov > sVal[tid] || (ov == sVal[tid] && oi < sIdx[tid])) { sVal[tid] = ov; sIdx[tid] = oi; }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) { ((int*)out)[row * 2] = sIdx[0]; ((float*)out)[row * 2 + 1] = sVal[0]; }
+}
+
 // ── Softmax in place ───────────────────────────────────────────────────────
 // 1 block of 256 threads. 3-pass: max, exp+sum, normalize.
 extern ""C"" __global__ void llm_softmax(float* __restrict__ x, int n)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -50,6 +50,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
 
     private readonly float[] _logitsBuf;
 
+    // #219 greedy argmax: when set by ForwardArgmax, the shared logits tail (FinishLogits) runs an
+    // on-device argmax + 8-byte download instead of the full-vocab D2H, and stashes the result here.
+    private bool _argmaxOnly;
+    private (int Token, float Logit) _lastArgmax;
+
     // Scratch buffers in VRAM
     private readonly Tensor _hidden;
     private readonly Tensor _residual;
@@ -1354,6 +1359,46 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// </summary>
     public bool UseCudaGraph { get => _useCudaGraph; set => _useCudaGraph = value; }
 
+    /// <summary>
+    /// #219 logits tail shared by <see cref="Forward"/> and <see cref="ForwardGemma4"/>: either the
+    /// full-vocab D2H + sync, or — when called from <see cref="ForwardArgmax"/> — an on-device argmax
+    /// and an 8-byte download. The argmax runs on the same stream after the device region produced
+    /// (and, for Gemma 4, softcapped) <c>_logits</c>, so it sees the final logits.
+    /// </summary>
+    private void FinishLogits()
+    {
+        if (_argmaxOnly)
+            _lastArgmax = _gpu.Argmax(_logits);
+        else
+        {
+            _gpu.Download(_logits, _logitsBuf);
+            _gpu.Synchronize();
+        }
+    }
+
+    /// <inheritdoc/>
+    // #219: only the non-profiled decode paths share FinishLogits; the SHARPI_CUDA_PROFILE /
+    // SHARPI_DECODE_REGIONS variants keep the full download so their phase timings stay meaningful.
+    public bool SupportsGpuArgmax => _gpu.GpuArgmaxEnabled && !s_profile && !s_regionProfile;
+
+    /// <inheritdoc/>
+    public (int Token, float Logit) ForwardArgmax(int token, int position)
+    {
+        if (!SupportsGpuArgmax)
+        {
+            // Kill-switch off or a profiling variant is active (which keeps the full download):
+            // fall back to a full forward + host scan, matching Sampler.Greedy's tie-break.
+            var l = Forward(token, position);
+            int j = 0; float m = l[0];
+            for (int i = 1; i < l.Length; i++) if (l[i] > m) { m = l[i]; j = i; }
+            return (j, m);
+        }
+        _argmaxOnly = true;
+        try { Forward(token, position); }   // dispatches to Forward/ForwardGemma4; tail does the argmax
+        finally { _argmaxOnly = false; }
+        return _lastArgmax;
+    }
+
     /// <inheritdoc/>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
@@ -1399,8 +1444,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                 _fp32Count++;
         }
 
-        _gpu.Download(_logits, _logitsBuf);
-        _gpu.Synchronize();
+        FinishLogits();
 
         _kvLength = Math.Max(_kvLength, position + 1);
         return _logitsBuf;
@@ -1720,8 +1764,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         if (!TryRunGemma4DeviceRegionViaGraph(position))
             RunGemma4DeviceRegion(position);
 
-        _gpu.Download(_logits, _logitsBuf);
-        _gpu.Synchronize();
+        FinishLogits();
 
         _kvLength = Math.Max(_kvLength, position + 1);
         return _logitsBuf;

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -407,6 +407,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private byte* _batchSnapshotBuf;
     private long _batchSnapshotCap;
     private bool _batchSnapshotValid;
+    private bool _bvArgmaxOnly;                                // #219 greedy-verify fast path
+    private (int Index, float Value)[] _bvArgmaxResult = [];   // #219 result stashed by the tail
     private int _batchStartPos;        // startPos of the most recent batched verify
     private int _batchK;               // token count of the most recent batched verify
 
@@ -3257,6 +3259,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         && !KvCacheCompacted
         && Environment.GetEnvironmentVariable("SHARPI_DISABLE_BATCH_VERIFY") != "1";
 
+    /// <inheritdoc/>
+    // #219: the verify lm_head logits are produced on-device anyway, so the greedy verify can
+    // reduce them to per-position argmaxes here instead of downloading k×vocab. Same kill switch.
+    public bool SupportsBatchVerifyArgmax => SupportsBatchVerify && _gpu.GpuArgmaxEnabled;
+
     /// <inheritdoc />
     /// On the GPU-GDN trunk the ceiling is the device snapshot ring's capacity
     /// (slots + 1, reserved at construction — SHARPI_MTP_BATCH_MAX). The
@@ -3745,6 +3752,32 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         //    weight dtype supports it, else a per-token MatMul loop.
         var normAll = _gpuBtNorm!;   // free to reuse after the last trunk layer
         _gpu.RmsNormBatched(normAll, stream, _gpuOutputNorm!, k, embDim, _hp.RmsNormEps);
+
+        // #219 greedy verify (pMin=1.0): reduce the lm_head output to one (idx, value) per position
+        // on-device — a k*8-byte download — instead of materializing and downloading k×vocab logits.
+        if (_bvArgmaxOnly)
+        {
+            if (BatchedMatMulSupported(_gpuOutputWeight!))
+            {
+                GpuMatMulBatched(_gpuBvLogitsAll!, _gpuOutputWeight!, normAll, k);
+                _bvArgmaxResult = _gpu.ArgmaxRows(_gpuBvLogitsAll!, k, _hp.VocabSize, _hp.VocabSize);
+            }
+            else
+            {
+                var outDtA = _gpuWeightDTypes.TryGetValue(_gpuOutputWeight!.Handle, out var dtA)
+                    ? dtA : DType.Float32;
+                _bvArgmaxResult = new (int, float)[k];
+                for (int i = 0; i < k; i++)
+                {
+                    _gpu.CopyDeviceRegion(_gpuHidden, 0, normAll, i * embBytes, embBytes);
+                    _gpu.MatMul(_gpuLogits, _gpuOutputWeight!, _gpuHidden, outDtA);
+                    _bvArgmaxResult[i] = _gpu.Argmax(_gpuLogits);
+                }
+            }
+            _batchSnapshotValid = true;
+            return [];
+        }
+
         var result = new float[k][];
         if (BatchedMatMulSupported(_gpuOutputWeight!))
         {
@@ -3771,6 +3804,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
         _batchSnapshotValid = true;
         return result;
+    }
+
+    /// <inheritdoc/>
+    public (int Index, float Value)[] BatchVerifyArgmax(int[] tokens, int startPos)
+    {
+        _bvArgmaxOnly = true;
+        try { BatchVerify(tokens, startPos); }   // identical trunk + cache effects; tail does the argmax
+        finally { _bvArgmaxOnly = false; }
+        return _bvArgmaxResult;
     }
 
     /// <summary>

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -708,6 +708,15 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     }
                     int thinkingCount = 0;
 
+                    // #219: on the pure-greedy path (temp 0, no logit bias) with a pass that can
+                    // argmax on-device, carry just the next token id instead of downloading the full
+                    // vocab logits every step. gpuNext holds the argmax of the most recent forward;
+                    // the first comes from the prefill logits already on the host.
+                    bool useGpuArgmax = sp.Temperature <= 0f
+                        && _fwd.SupportsGpuArgmax
+                        && sp.LogitBias is not { Count: > 0 };
+                    int gpuNext = useGpuArgmax ? Sampler.Greedy(logits) : 0;
+
                     for (int i = 0; i < sp.MaxNewTokens; i++)
                     {
                         ct.ThrowIfCancellationRequested();
@@ -721,6 +730,10 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             && thinkingEnabled && endThinkId > 0)
                         {
                             next = endThinkId;
+                        }
+                        else if (useGpuArgmax)
+                        {
+                            next = gpuNext;
                         }
                         else
                         {
@@ -757,7 +770,8 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             if (textTail.Length > 0)
                                 channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
                             inThinking = true;
-                            logits = _fwd.Forward(next, startPos + i);
+                            if (useGpuArgmax) gpuNext = _fwd.ForwardArgmax(next, startPos + i).Token;
+                            else logits = _fwd.Forward(next, startPos + i);
                             continue;
                         }
                         if (thinkingEnabled && next == endThinkId && inThinking)
@@ -767,7 +781,8 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             if (thinkTail.Length > 0)
                                 channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
                             inThinking = false;
-                            logits = _fwd.Forward(next, startPos + i);
+                            if (useGpuArgmax) gpuNext = _fwd.ForwardArgmax(next, startPos + i).Token;
+                            else logits = _fwd.Forward(next, startPos + i);
                             continue;
                         }
 
@@ -785,7 +800,8 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                                 channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, chunk));
                         }
 
-                        logits = _fwd.Forward(next, startPos + i);
+                        if (useGpuArgmax) gpuNext = _fwd.ForwardArgmax(next, startPos + i).Token;
+                        else logits = _fwd.Forward(next, startPos + i);
                     }
 
                     // End-of-loop: flush both decoders defensively (whichever was active).

--- a/src/SharpInference.Engine/MtpDecoder.cs
+++ b/src/SharpInference.Engine/MtpDecoder.cs
@@ -58,6 +58,11 @@ public sealed class MtpDecoder
     private int _nextPos;
     private readonly float[] _savedMainLogits;
     private float[] _savedHidden;
+    // #219: on the greedy verify fast path (pMin=1.0 + BatchVerifyArgmax) we carry only the saved
+    // next-token's argmax index, not its full logits. _hasSavedArgmax says which is current; every
+    // full-logits write to _savedMainLogits clears it, every argmax-path save sets it.
+    private int _savedMainArgmax;
+    private bool _hasSavedArgmax;
 
     // Acceptance statistics (per Decode call cumulative)
     private long _totalDraftsEmitted;
@@ -121,6 +126,7 @@ public sealed class MtpDecoder
 
         _nextPos = nextPosition;
         lastMainLogits.CopyTo(_savedMainLogits);
+        _hasSavedArgmax = false;
         // Snapshot the main pass's current LastHidden so the first draft can use it.
         var h = _fwd.LastHidden;
         if (h.IsEmpty)
@@ -220,7 +226,7 @@ public sealed class MtpDecoder
             // Each iter emits up to 2 tokens.
             int remaining = maxTokens - generated;
 
-            int t1 = ArgMax(_savedMainLogits);
+            int t1 = _hasSavedArgmax ? _savedMainArgmax : ArgMax(_savedMainLogits);
             if (IsStop(t1, stopTokenIds)) return;
             emitToken(t1); generated++;
             if (generated >= maxTokens) return;
@@ -257,6 +263,7 @@ public sealed class MtpDecoder
                 // logits so a follow-up call resumes from a consistent state.
                 _fwd.LastHidden.CopyTo(_savedHidden);
                 mainLogits.CopyTo(_savedMainLogits);
+                _hasSavedArgmax = false;
                 _nextPos = P + 1;
                 return;
             }
@@ -265,6 +272,7 @@ public sealed class MtpDecoder
             {
                 _fwd.LastHidden.CopyTo(_savedHidden);
                 mainLogits.CopyTo(_savedMainLogits);
+                _hasSavedArgmax = false;
                 _nextPos = P + 1;
                 return;
             }
@@ -287,6 +295,7 @@ public sealed class MtpDecoder
             // "previous hidden" the next iter's MTP draft will want.
             _fwd.LastHidden.CopyTo(_savedHidden);
             mainLogitsAfter.CopyTo(_savedMainLogits);
+            _hasSavedArgmax = false;
             _nextPos = P + 2;
         }
     }
@@ -342,7 +351,7 @@ public sealed class MtpDecoder
             }
 
             // ── Token 1: argmax of last main logits (greedy correctness) ──
-            int t1 = ArgMax(_savedMainLogits);
+            int t1 = _hasSavedArgmax ? _savedMainArgmax : ArgMax(_savedMainLogits);
             if (IsStop(t1, stopTokenIds)) return;
             emitToken(t1); generated++;
 
@@ -373,9 +382,19 @@ public sealed class MtpDecoder
             DraftMs += _phaseSw.Elapsed.TotalMilliseconds;
 
             // ── ONE batched main verify over tokens[0..kEff) ──────────
+            // #219: a pure-greedy verify (pMin >= 1.0) on a GPU pass fetches only the per-position
+            // argmaxes (k*8 bytes) instead of k full-vocab logits vectors. pMin < 1.0 still needs
+            // the distributions (AcceptDraft's softmax branch), so it keeps the full download.
+            bool argmaxFast = pMin >= 1.0f && _fwd.SupportsBatchVerifyArgmax;
             _phaseSw.Restart();
-            float[][] batch = _fwd.BatchVerify(tokens, P);
+            float[][]? batch = null;
+            (int Index, float Value)[]? verifyArgmax = null;
+            if (argmaxFast) verifyArgmax = _fwd.BatchVerifyArgmax(tokens, P);
+            else            batch = _fwd.BatchVerify(tokens, P);
             VerifyMs += _phaseSw.Elapsed.TotalMilliseconds;
+
+            // Verifier's greedy correction at draft position `pos` (argmax of the logits there).
+            int Target(int pos) => argmaxFast ? verifyArgmax![pos].Index : ArgMax(batch![pos]);
 
             // ── Greedy accept: count leading agreeing drafts ──────────
             // An accepted STOP draft also ends the chain here, EXCLUDED from `a`:
@@ -388,8 +407,11 @@ public sealed class MtpDecoder
             bool stopHit = false;
             for (int i = 1; i < kEff; i++)
             {
-                int target = ArgMax(batch[i - 1]);
-                if (!AcceptDraft(tokens[i], target, batch[i - 1], pMin, out _)) break;
+                int target = Target(i - 1);
+                bool accept = argmaxFast
+                    ? tokens[i] == target                              // pMin>=1.0: argmax-match only
+                    : AcceptDraft(tokens[i], target, batch![i - 1], pMin, out _);
+                if (!accept) break;
                 if (IsStop(tokens[i], stopTokenIds)) { stopHit = true; break; }
                 a++;
             }
@@ -400,7 +422,7 @@ public sealed class MtpDecoder
                 Console.Error.WriteLine(
                     $"[mtp-batch] P={P} k={kEff} t1={t1} " +
                     $"drafts=[{string.Join(",", tokens[1..])}] accepted={a}/{kEff - 1}" +
-                    (a < kEff - 1 ? $" correction={ArgMax(batch[a])}" : ""));
+                    (a < kEff - 1 ? $" correction={Target(a)}" : ""));
 
             _phaseSw.Restart();
             // ── Roll back the rejected tail (no-op when fully accepted) ──
@@ -433,7 +455,8 @@ public sealed class MtpDecoder
             // the correction on a reject, the chain continuation on full accept,
             // or the (un-emitted, un-committed) stop on stopHit. All caches sit
             // exactly at newPos, so a follow-up call resumes consistently.
-            batch[a].CopyTo(_savedMainLogits, 0);
+            if (argmaxFast) { _savedMainArgmax = verifyArgmax![a].Index; _hasSavedArgmax = true; }
+            else            { batch![a].CopyTo(_savedMainLogits, 0); _hasSavedArgmax = false; }
             HiddenAtChecked(newPos - 1).CopyTo(_savedHidden);
             _nextPos = newPos;
             if (stopHit) return;

--- a/tests/SharpInference.Tests.ForwardPass/CudaGpuArgmaxParityTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaGpuArgmaxParityTests.cs
@@ -1,0 +1,243 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using Xunit;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #219: GPU-side greedy argmax. Two layers of coverage:
+///   1. Kernel bit-exact parity (model-free) — <see cref="CudaBackend.Argmax"/> must match a
+///      left-to-right strict-<c>&gt;</c> host scan (the <c>Sampler.Greedy</c> contract: highest
+///      value wins, lowest index on an exact tie), including the winning value bit-for-bit.
+///   2. Decode equivalence (model-gated) — greedy decode via <c>ForwardArgmax</c> emits the exact
+///      same token stream as the legacy <c>Forward</c> + host argmax, on both the dense
+///      (<c>Forward</c>) and Gemma-4 (<c>ForwardGemma4</c>) paths.
+/// All tests silently no-op on hosts without CUDA (or, for the gated tests, without the model).
+/// </summary>
+public sealed class CudaGpuArgmaxParityTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static string? FindModel(params string[] candidates)
+    {
+        foreach (var c in candidates)
+            if (File.Exists(c)) return c;
+        return null;
+    }
+
+    // Host reference == Sampler.Greedy's scan (strict >, lowest-index tie-break) + the winning value.
+    private static (int idx, float val) CpuArgmax(ReadOnlySpan<float> logits)
+    {
+        int idx = 0;
+        float max = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > max) { max = logits[i]; idx = i; }
+        return (idx, max);
+    }
+
+    private static void AssertArgmaxMatches(CudaBackend gpu, float[] logits)
+    {
+        var g = gpu.Upload(logits, TensorShape.D1(logits.Length));
+        try
+        {
+            var (gIdx, gVal) = gpu.Argmax(g);
+            var (cIdx, cVal) = CpuArgmax(logits);
+            Assert.Equal(cIdx, gIdx);
+            // The kernel only compares/forwards the original float values — no arithmetic — so the
+            // winning value must be bit-identical to the host's, and equal to logits[idx].
+            Assert.Equal(BitConverter.SingleToInt32Bits(cVal), BitConverter.SingleToInt32Bits(gVal));
+            Assert.Equal(BitConverter.SingleToInt32Bits(logits[gIdx]), BitConverter.SingleToInt32Bits(gVal));
+        }
+        finally { gpu.Free(g); }
+    }
+
+    [Fact]
+    public void Argmax_MaxAtVariousPositions_AndSizes()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        // Span block boundaries (256 threads × 256 blocks) and real vocab sizes (Qwen3 152064,
+        // Gemma 4 262144) so the multi-block grid-stride + two-pass reduction is exercised.
+        foreach (int n in new[] { 1, 2, 3, 255, 256, 257, 1000, 65536, 152064, 262144 })
+        {
+            var rng = new Random(1234 + n);
+            var a = new float[n];
+            for (int i = 0; i < n; i++) a[i] = (float)(rng.NextDouble() * 20 - 10);
+            AssertArgmaxMatches(gpu, a);                       // random — max anywhere
+            foreach (int pos in new[] { 0, n / 2, n - 1 })
+            {
+                var b = (float[])a.Clone();
+                b[pos] = 1000f + pos;                          // a unique clear max at pos
+                AssertArgmaxMatches(gpu, b);
+            }
+        }
+    }
+
+    [Fact]
+    public void Argmax_TieBreak_LowestIndexWins()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        var a = new float[5000];
+        Array.Fill(a, -1f);
+        a[700] = 5f;
+        a[300] = 5f;   // equal maxima — index 300 (lower) must win, matching strict-> host scan
+        AssertArgmaxMatches(gpu, a);
+        var g = gpu.Upload(a, TensorShape.D1(a.Length));
+        try { Assert.Equal(300, gpu.Argmax(g).Index); }
+        finally { gpu.Free(g); }
+    }
+
+    [Fact]
+    public void Argmax_AllEqual_ReturnsIndexZero()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var a = new float[8192];
+        Array.Fill(a, 3.5f);
+        AssertArgmaxMatches(gpu, a);   // no element beats another -> index 0
+    }
+
+    [Fact]
+    public void Argmax_AllNegative()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var a = new float[4096];
+        var rng = new Random(99);
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(-rng.NextDouble() * 50 - 1);
+        AssertArgmaxMatches(gpu, a);
+    }
+
+    [Fact]
+    public void Argmax_KernelIndependentOfEngineKillSwitch()
+    {
+        // The SHARPI_GPU_ARGMAX gate only decides whether the engine takes the fast path; the
+        // kernel itself is always correct. Toggling the backend flag must not change Argmax's result.
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var a = new float[2048];
+        var rng = new Random(7);
+        for (int i = 0; i < a.Length; i++) a[i] = (float)rng.NextDouble();
+        a[123] = 9f;
+
+        bool prev = gpu.GpuArgmaxEnabled;
+        try
+        {
+            gpu.GpuArgmaxEnabled = false; AssertArgmaxMatches(gpu, a);
+            gpu.GpuArgmaxEnabled = true;  AssertArgmaxMatches(gpu, a);
+        }
+        finally { gpu.GpuArgmaxEnabled = prev; }
+    }
+
+    [Fact]
+    public void ArgmaxRows_BatchedParity()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        // Packed [rows × vocab] verify logits — each row reduced independently. Cover a few row
+        // counts (k for MTP verify) and a real vocab, with a distinct max placed per row.
+        foreach (int vocab in new[] { 1024, 152064 })
+        foreach (int rows in new[] { 1, 2, 4, 8 })
+        {
+            var rng = new Random(555 + rows * 31 + vocab);
+            var flat = new float[rows * vocab];
+            for (int i = 0; i < flat.Length; i++) flat[i] = (float)(rng.NextDouble() * 10 - 5);
+            // Put a unique, clear max in each row at a row-dependent position (incl. ties within a row).
+            for (int r = 0; r < rows; r++)
+            {
+                int pos = (r * 37) % vocab;
+                flat[r * vocab + pos] = 50f + r;
+                if (vocab > 100) flat[r * vocab + (pos + 50) % vocab] = 50f + r; // tie -> lower index wins
+            }
+
+            var g = gpu.Upload(flat, TensorShape.D1(flat.Length));
+            try
+            {
+                var rowsRes = gpu.ArgmaxRows(g, rows, vocab, vocab);
+                Assert.Equal(rows, rowsRes.Length);
+                for (int r = 0; r < rows; r++)
+                {
+                    var (cIdx, cVal) = CpuArgmax(flat.AsSpan(r * vocab, vocab));
+                    Assert.Equal(cIdx, rowsRes[r].Index);
+                    Assert.Equal(BitConverter.SingleToInt32Bits(cVal),
+                                 BitConverter.SingleToInt32Bits(rowsRes[r].Value));
+                }
+            }
+            finally { gpu.Free(g); }
+        }
+    }
+
+    // ── Decode equivalence (model-gated) ──────────────────────────────────────
+
+    private static void AssertDecodeEquivalence(string path, int steps = 24)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        int ctx = Math.Min(hp.ContextLength, 512);
+        var tokens = tokenizer.Encode("The quick brown fox jumps over the lazy dog.").ToArray();
+
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: ctx);
+        Assert.True(fwd.SupportsGpuArgmax, "CudaForwardPass should support GPU argmax by default.");
+
+        // Reference: legacy full-download Forward + host Sampler.Greedy.
+        var refTokens = new int[steps];
+        var logits = fwd.Prefill(tokens).ToArray();
+        int next = Sampler.Greedy(logits);
+        for (int i = 0; i < steps; i++)
+        {
+            refTokens[i] = next;
+            logits = fwd.Forward(next, tokens.Length + i).ToArray();
+            next = Sampler.Greedy(logits);
+        }
+
+        // Candidate: the on-device argmax fast path. Fresh cache, same prompt.
+        fwd.ResetCache();
+        var gpuTokens = new int[steps];
+        var pl = fwd.Prefill(tokens).ToArray();
+        next = Sampler.Greedy(pl);                     // first token still comes from prefill logits
+        for (int i = 0; i < steps; i++)
+        {
+            gpuTokens[i] = next;
+            var (tok, val) = fwd.ForwardArgmax(next, tokens.Length + i);
+            next = tok;
+        }
+
+        Assert.Equal(refTokens, gpuTokens);
+    }
+
+    [Fact]
+    public void Decode_DensePath_MatchesHostArgmax()   // SmolLM2 / Qwen3 -> Forward
+    {
+        var path = FindModel(
+            @"C:\p\sharpi\models\SmolLM2-1.7B-Instruct-Q4_K_M.gguf",
+            @"E:\models\SmolLM2-1.7B-Instruct-Q4_K_M.gguf",
+            @"C:\p\sharpi\models\Qwen3-8B-Q4_K_M.gguf",
+            @"E:\models\Qwen3-8B-Q4_K_M.gguf");
+        if (path is null) return;
+        AssertDecodeEquivalence(path);
+    }
+
+    [Fact]
+    public void Decode_Gemma4Path_MatchesHostArgmax()   // Gemma 4 E4B -> ForwardGemma4 (+ softcap)
+    {
+        var path = FindModel(
+            @"E:\models\gemma-4-E4B-it-Q8_0.gguf",
+            @"C:\p\sharpi\models\gemma-4-E4B-it-Q8_0.gguf");
+        if (path is null) return;
+        AssertDecodeEquivalence(path);
+    }
+}


### PR DESCRIPTION
Implements #219 (items 1 + 2).

## What
Decode steps on the CUDA passes ended with a synchronous full-vocab logits D2H (0.6–1 MB) only to
take a host argmax on the greedy (`temp 0`) path; the MTP self-spec verify downloaded k full-vocab
vectors per step only to compare k argmaxes. This adds an on-device argmax so those become an
**8-byte** (single token) / **k×8-byte** (verify) download.

- **Kernels:** `llm_argmax_partial` + `llm_argmax_final` (single row, two-pass) and `llm_argmax_rows`
  (one block per row, packed verify logits). Tie-break matches `Sampler.Greedy` exactly — highest
  value, lowest index on a tie — so the result is **bit-exact** with the host scan for finite logits.
- **Backend:** `CudaBackend.Argmax` / `ArgmaxRows`; kill switch `SHARPI_GPU_ARGMAX` (default on).
- **Item 1:** `IForwardPass.SupportsGpuArgmax`/`ForwardArgmax`; `CudaForwardPass` override (dense +
  Gemma-4 paths); `InferenceEngine` carries the next token id on the greedy/no-bias path.
- **Item 2:** `IForwardPass.SupportsBatchVerifyArgmax`/`BatchVerifyArgmax`; `CudaHybridGdnForwardPass`
  override; `MtpDecoder` uses it when `pMin >= 1.0` (full-distribution path stays for `pMin < 1.0`).

## Tests
Kernel bit-exact parity (single + batched, all sizes/ties/edge cases); decode equivalence on the
dense (SmolLM2) and Gemma-4 (E4B+softcap) paths; the existing 27B-MTP batch-verify suite (now
exercises `BatchVerifyArgmax` by default — 12 pass). Byte-identical greedy output verified with the
path on vs off on Qwen3-8B, Gemma 4 E4B, and Qwen3.6-27B-MTP. Full Release build clean.

## Honest perf finding
**Within run-to-run noise** on a 4070 Ti (PCIe 4.0) for these models. The region profiler shows the
logits download is only **0.084 ms = 0.6%** of the 14 ms/token on E4B (device compute dominates at
96%); ~0.1% on the 27B-MTP verify. The issue's 1–2% estimate was optimistic. The change is
correctness-preserving and frees host-CPU argmax + PCIe D2H — the win is larger on **PCIe 3.0**
boards, smaller/faster models, and concurrent/batched loads. (Bonus #162 datapoint: the non-matvec
remainder is dominated by embed+PLE at 0.5 ms, not the download.)

## Deferred (no current consumer benefits)
Dense `CudaForwardPass.BatchVerifyArgmax` (shared with continuous batching, needs a non-trivial
`BatchForwardMulti` variant) + `SpeculativeDecoder` wiring (its targets are dense; GDN models use
`MtpDecoder`). Item 3 (top-k pre-reduction) is profiling-gated and not pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)