### PR TITLE
perf(cuda): default-on int8 decode MMQ for multi-user batched serving (#206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ dotnet run --project src/SharpInference.Cli -c Release -- \
   -p "Write a binary search in Rust" --temp 0
 
 # API server (OpenAI /v1/chat/completions + Anthropic /v1/messages, port 5000)
-# Multi-user: SHARPI_MAX_BATCH=8 enables continuous batching (CPU backend). Long-prompt
-# admission prefills in SHARPI_PREFILL_CHUNK-token slices (default 256, 0 = blocking)
-# interleaved with decode, packed across prompts; SHARPI_KV_BUDGET_MB caps total KV
-# memory for admission backpressure (default: half of RAM). See issue #183.
+# Multi-user: SHARPI_MAX_BATCH=8 enables continuous batching (CPU or CUDA backend). On CUDA,
+# batched decode uses int8 tensor-core matmuls by default at N>=5 (Qwen3-8B Q4_K_M @ 4070 Ti:
+# +11% to +28% aggregate t/s from N=5 to N=8); SHARPI_BATCH_DECODE_MMQ=0 forces the bit-exact
+# path. Long-prompt admission prefills in SHARPI_PREFILL_CHUNK-token slices (default 256,
+# 0 = blocking) interleaved with decode, packed across prompts; SHARPI_KV_BUDGET_MB caps total
+# KV memory for admission backpressure (default: half of RAM). See issues #183 / #206.
 SHARPI_MODEL=models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf \
   dotnet run --project src/SharpInference.Server.Host -c Release
 ```

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -438,14 +438,27 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_GEMM") == "1";
     private readonly bool _batchDecodeWeightStationary =
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_WS") != "0";
-    // SHARPI_BATCH_DECODE_MMQ=1 (#201, opt-in): int8 tensor-core decode matmuls for the
-    // big Q4_K-SoA shapes (BN=16 mma tile, weight read once per step) — argmax-stable,
-    // not bit-exact; small/non-Q4_K shapes fall back to weight-stationary per tensor
-    // inside the backend. The bit-exact WS matvecs are L1TEX-bound ~3× above the weight
-    // floor at N=8 and their lane geometry is frozen by the bit-identity contract, so
-    // this toggle is where the remaining batched-decode headroom lives.
-    private readonly bool _batchDecodeMmq =
-        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ") == "1";
+    // SHARPI_BATCH_DECODE_MMQ (#201/#206): int8 tensor-core decode matmuls for the big
+    // Q4_K-SoA shapes (BN=16 mma tile, weight read once per step) — argmax-stable, not
+    // bit-exact; small/non-Q4_K shapes fall back to weight-stationary per tensor inside the
+    // backend. The bit-exact WS matvecs are L1TEX-bound ~3× above the weight floor at N=8
+    // and their lane geometry is frozen by the bit-identity contract, so this is where the
+    // remaining batched-decode headroom lives. Measured on Qwen3-8B Q4_K_M @ 4070 Ti
+    // (#206): aggregate t/s N=5 205→228 (+11%), N=6 225→263 (+17%), N=7 242→298 (+23%),
+    // N=8 250→319 (+28%) — all well above the bit-exact WS path it replaces.
+    //
+    // It is therefore DEFAULT-ON for ContinuousBatchingEngine multi-user decode, and
+    // DEFAULT-OFF for the single-user speculative-decode BatchVerify path: BatchVerify
+    // shares BatchForwardMulti but must stay bit-exact to preserve the 48-token greedy
+    // spec-decode parity guarantee (CudaSpecBatchVerifyTests). The decode call passes
+    // allowDecodeMmq; spec-verify passes false. The env var is a tri-state override:
+    //   unset → on for multi-user batched decode, off for spec-verify (default)
+    //   "0"   → off everywhere (bit-exact kill-switch)
+    //   "1"   → on everywhere incl. spec-verify (argmax-stable; perf A/B only)
+    private readonly string? _batchDecodeMmqEnv =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ");
+    private bool BatchDecodeMmqKill => _batchDecodeMmqEnv == "0";
+    private bool BatchDecodeMmqForceAll => _batchDecodeMmqEnv == "1";
 
     // Ragged-batched per-sequence attention ops (issue #197). Default on: the per-layer
     // QK-norm/RoPE/KV-append/attention launches collapse from O(N) per-sequence calls
@@ -3467,16 +3480,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// <summary>One batched-decode matmul. Default: the weight-stationary small-N matvec
     /// (#194 — weight HBM read amortized across the batch, bit-identical reduction to the
     /// GEMM-N matvec; N=1 / N&gt;16 delegate to GEMM-N inside the backend).
-    /// SHARPI_BATCH_DECODE_WS=0: the #190 GEMM-N matvec. SHARPI_BATCH_DECODE_MMQ=1: the
-    /// #201 int8 tensor-core decode tile for big Q4_K-SoA shapes (argmax-stable, WS
-    /// fallback per tensor). SHARPI_BATCH_DECODE_GEMM=1: the compute-bound GEMM/MMQ path
-    /// (the same routing <see cref="GpuMatMulBatchedCore"/> uses for prefill) —
-    /// argmax-stable only, kept as the A/B toggle for very high concurrency.</summary>
-    private void BatchDecodeMatMul(Tensor outAll, Tensor weights, Tensor inAll, int n)
+    /// SHARPI_BATCH_DECODE_WS=0: the #190 GEMM-N matvec. The #201/#206 int8 tensor-core
+    /// decode tile for big Q4_K-SoA shapes (argmax-stable, WS fallback per tensor) is
+    /// default-on for multi-user decode (<paramref name="allowMmq"/>) and off for the
+    /// bit-exact spec-verify path; SHARPI_BATCH_DECODE_MMQ=0/1 forces it off/on everywhere.
+    /// SHARPI_BATCH_DECODE_GEMM=1: the compute-bound GEMM/MMQ path (the same routing
+    /// <see cref="GpuMatMulBatchedCore"/> uses for prefill) — argmax-stable only, kept as
+    /// the A/B toggle for very high concurrency.</summary>
+    private void BatchDecodeMatMul(Tensor outAll, Tensor weights, Tensor inAll, int n, bool allowMmq)
     {
         if (_batchDecodeComputeBound)
             GpuMatMulBatchedCore(outAll, weights, inAll, n);
-        else if (_batchDecodeMmq)
+        else if (!BatchDecodeMmqKill && (allowMmq || BatchDecodeMmqForceAll))
             _gpu.MatMulBatchedDecodeMmq(outAll, weights, inAll, n, WDType(weights));
         else if (_batchDecodeWeightStationary)
             _gpu.MatMulBatchedWeightStationary(outAll, weights, inAll, n, WDType(weights));
@@ -3496,7 +3511,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// per-sequence attention block mirrors the dense <see cref="RunDeviceRegion"/> ordering
     /// exactly (QK-norm before RoPE, #157), so it is argmax-stable vs the single-user loop.
     /// </summary>
-    internal float[][] BatchForwardMulti(int[] tokens, int[] positions, CudaSequenceKvCache[] caches)
+    /// <param name="allowDecodeMmq">When true (multi-user continuous-batching decode) the big
+    /// Q4_K matmuls may use the #201/#206 argmax-stable decode MMQ tile (default-on, the
+    /// +11–28% win); when false (the spec-decode <see cref="BatchVerify"/> wrapper) they stay on
+    /// the bit-exact WS path so greedy spec-decode output is byte-stable. SHARPI_BATCH_DECODE_MMQ
+    /// =0/1 overrides both to off/on everywhere.</param>
+    internal float[][] BatchForwardMulti(int[] tokens, int[] positions, CudaSequenceKvCache[] caches,
+                                         bool allowDecodeMmq = true)
     {
         ArgumentNullException.ThrowIfNull(tokens);
         ArgumentNullException.ThrowIfNull(positions);
@@ -3568,13 +3589,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                 _gpu.CopyDevice(_bpResidual!, _bpHidden!);
                 _gpu.RmsNormBatched(_bpNorm!, _bpHidden!, _wAttnNorm[layer], N, embDim, _hp.RmsNormEps);
 
-                // Batched QKV. Default weight-stationary matvec (#194: weight read amortized
-                // across the batch, bit-identical reduction to the per-token oracle's kernels);
-                // SHARPI_BATCH_DECODE_WS=0 / SHARPI_BATCH_DECODE_GEMM=1 select the #190
-                // GEMM-N / compute-bound GEMM-MMQ alternatives (see BatchDecodeMatMul).
-                BatchDecodeMatMul(_bpQ!, _wq[layer], _bpNorm!, N);
-                BatchDecodeMatMul(_bpK!, _wk[layer], _bpNorm!, N);
-                BatchDecodeMatMul(_bpV!, _wv[layer]!, _bpNorm!, N);
+                // Batched QKV. For multi-user decode (allowDecodeMmq) the big Q4_K shapes
+                // default to the #201/#206 int8 MMQ tile (argmax-stable, +11–28% at N=5–8),
+                // small/non-Q4_K shapes to the #194 weight-stationary matvec; the bit-exact
+                // spec-verify path forces WS. SHARPI_BATCH_DECODE_WS=0 / _GEMM=1 / _MMQ=0|1
+                // override the routing (see BatchDecodeMatMul).
+                BatchDecodeMatMul(_bpQ!, _wq[layer], _bpNorm!, N, allowDecodeMmq);
+                BatchDecodeMatMul(_bpK!, _wk[layer], _bpNorm!, N, allowDecodeMmq);
+                BatchDecodeMatMul(_bpV!, _wv[layer]!, _bpNorm!, N, allowDecodeMmq);
 
                 bool useRoPE = _hp.NoRopeLayerStep == 0 || (layer + 1) % _hp.NoRopeLayerStep != 0;
 
@@ -3659,7 +3681,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                 // path adds it in one broadcast launch, the legacy loop via per-sequence hidden
                 // views created inline here (rare branch) to keep the common no-bias decode
                 // path free of unused per-row views.
-                BatchDecodeMatMul(_bpHidden!, _wo[layer], _bpAttnOut!, N);
+                BatchDecodeMatMul(_bpHidden!, _wo[layer], _bpAttnOut!, N, allowDecodeMmq);
                 if (_hasAttnBias)
                 {
                     if (ragged)
@@ -3677,17 +3699,17 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
                 // FFN (dense SwiGLU), batched across N.
                 _gpu.CopyDevice(_bpResidual!, _bpHidden!);
                 _gpu.RmsNormBatched(_bpNorm!, _bpHidden!, _wFfnNorm[layer], N, embDim, _hp.RmsNormEps);
-                BatchDecodeMatMul(_bpFfnGate!, _wGate[layer], _bpNorm!, N);
-                BatchDecodeMatMul(_bpFfnUp!,   _wUp[layer],   _bpNorm!, N);
+                BatchDecodeMatMul(_bpFfnGate!, _wGate[layer], _bpNorm!, N, allowDecodeMmq);
+                BatchDecodeMatMul(_bpFfnUp!,   _wUp[layer],   _bpNorm!, N, allowDecodeMmq);
                 _gpu.SiLuMul(_bpFfnGate!, _bpFfnUp!);
-                BatchDecodeMatMul(_bpHidden!, _wDown[layer], _bpFfnGate!, N);
+                BatchDecodeMatMul(_bpHidden!, _wDown[layer], _bpFfnGate!, N, allowDecodeMmq);
                 _gpu.AddInPlace(_bpHidden!, _bpResidual!);
             }
 
             // 3. Final norm + output projection, batched (the output weight is the largest
             //    single matmul, so amortizing its read across N is the main throughput win).
             _gpu.RmsNormBatched(_bpHidden!, _bpHidden!, _wOutputNorm, N, embDim, _hp.RmsNormEps);
-            BatchDecodeMatMul(_decodeLogitsAll!, _wOutput, _bpHidden!, N);
+            BatchDecodeMatMul(_decodeLogitsAll!, _wOutput, _bpHidden!, N, allowDecodeMmq);
             _gpu.Download(_decodeLogitsAll!, _decodeLogitsHost.AsSpan(0, N * vocab));
             _gpu.Synchronize();
 
@@ -3740,10 +3762,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// and row i attends over [0, startPos+i] — i.e. packed causal attention (the legacy
     /// per-sequence fallback loop appends-then-attends in ascending row order, equally
     /// causal). Every matmul routes through <see cref="BatchDecodeMatMul"/>, so the #194
-    /// weight-stationary kernels (or the opt-in #201 decode MMQ) amortize the weight HBM
-    /// reads k×. Each row keeps the per-token kernels' reduction chains (#194/#197), so the
-    /// default WS path is expected bit-identical to k sequential <see cref="Forward"/> calls;
-    /// the opt-in compute-bound/MMQ toggles are argmax-stable only. All k K/V entries land in
+    /// weight-stationary kernels amortize the weight HBM reads k×. This path passes
+    /// <c>allowDecodeMmq: false</c> so it stays on those bit-exact WS kernels even though the
+    /// #201/#206 decode MMQ is default-on for multi-user decode — each row keeps the per-token
+    /// kernels' reduction chains (#194/#197), so verify is bit-identical to k sequential
+    /// <see cref="Forward"/> calls and greedy spec-decode output is byte-stable. (Only the
+    /// SHARPI_BATCH_DECODE_MMQ=1 force-all override or SHARPI_BATCH_DECODE_GEMM=1 route this
+    /// through an argmax-stable-only path.) All k K/V entries land in
     /// the cache; the caller rewinds rejected tokens via <see cref="TruncateTo"/>. Issues
     /// direct launches only — the per-token decode CUDA graph (owned-cache pointers) stays
     /// valid for the surrounding Forward steps.
@@ -3786,7 +3811,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         var caches = new CudaSequenceKvCache[k];
         Array.Fill(caches, _ownedCacheView);
 
-        var result = BatchForwardMulti(tokens, positions, caches);
+        // allowDecodeMmq: false keeps the verify on the bit-exact WS matvecs so greedy
+        // spec-decode output stays byte-stable vs the non-spec baseline (the 48-token
+        // parity oracle in CudaSpecBatchVerifyTests). SHARPI_BATCH_DECODE_MMQ=1 still
+        // forces MMQ here for perf A/B (argmax-stable, not byte-stable).
+        var result = BatchForwardMulti(tokens, positions, caches, allowDecodeMmq: false);
         // Mirror what k sequential Forward calls would leave behind; the speculative
         // decoder's TruncateTo(startPos + accepted) then rewinds the rejected tail.
         _kvLength = Math.Max(_kvLength, startPos + k);

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -455,10 +455,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     //   unset → on for multi-user batched decode, off for spec-verify (default)
     //   "0"   → off everywhere (bit-exact kill-switch)
     //   "1"   → on everywhere incl. spec-verify (argmax-stable; perf A/B only)
-    private readonly string? _batchDecodeMmqEnv =
-        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ");
-    private bool BatchDecodeMmqKill => _batchDecodeMmqEnv == "0";
-    private bool BatchDecodeMmqForceAll => _batchDecodeMmqEnv == "1";
+    // Parsed once at construction — BatchDecodeMatMul reads these per matmul per layer per step.
+    private readonly bool _batchDecodeMmqKill =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ") == "0";
+    private readonly bool _batchDecodeMmqForceAll =
+        Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ") == "1";
 
     // Ragged-batched per-sequence attention ops (issue #197). Default on: the per-layer
     // QK-norm/RoPE/KV-append/attention launches collapse from O(N) per-sequence calls
@@ -3491,7 +3492,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     {
         if (_batchDecodeComputeBound)
             GpuMatMulBatchedCore(outAll, weights, inAll, n);
-        else if (!BatchDecodeMmqKill && (allowMmq || BatchDecodeMmqForceAll))
+        else if (!_batchDecodeMmqKill && (allowMmq || _batchDecodeMmqForceAll))
             _gpu.MatMulBatchedDecodeMmq(outAll, weights, inAll, n, WDType(weights));
         else if (_batchDecodeWeightStationary)
             _gpu.MatMulBatchedWeightStationary(outAll, weights, inAll, n, WDType(weights));

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
@@ -217,6 +217,101 @@ public sealed class CudaBatchForwardMultiTests
     }
 
     /// <summary>
+    /// #206 oracle for the decode MMQ at its real engagement size. The #201 tile only
+    /// dispatches at N≥5 (below that <see cref="CudaForwardPass.BatchForwardMulti"/> falls back
+    /// to the bit-exact WS matvecs per tensor), so the N=2 oracle above never actually runs the
+    /// int8 mma kernel — this one does. N=6 (3×PromptA, 3×PromptB) with SHARPI_BATCH_DECODE_MMQ=1
+    /// so every ≥2048-row Q4_K matmul (Q/O proj, gate/up, the Q4_K ffn_down half, lm-head) takes
+    /// the MMQ path, asserting each sequence reproduces its prompt's single-user argmax/top-5
+    /// across TWO decode steps — argmax-stable (not bit-exact), the contract #206 ships
+    /// default-on for multi-user serving. The second step also exercises the per-sequence KV
+    /// append / position indexing on the MMQ path.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_BatchForwardMulti_DecodeMmq_N6_MatchesSingleUser()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        var prevMmq = Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ");
+        Environment.SetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ", "1");
+        CudaForwardPass fwdTmp;
+        try { fwdTmp = NewFwd(model, gpu, hp); }
+        finally { Environment.SetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ", prevMmq); }
+        using var fwd = fwdTmp;
+
+        const int Steps = 2;
+        int[][] prompts = { PromptA, PromptB };
+
+        // Single-user reference per distinct prompt: prefill then Steps greedy decode logits,
+        // capturing the token fed at each step (the trajectory the batched run must reproduce).
+        var refLogits = new float[2][][];
+        var refToks = new int[2][];
+        for (int p = 0; p < 2; p++)
+        {
+            fwd.ResetCache();
+            int tok = Argmax(fwd.Prefill(prompts[p]));
+            refLogits[p] = new float[Steps][];
+            refToks[p] = new int[Steps];
+            for (int s = 0; s < Steps; s++)
+            {
+                refToks[p][s] = tok;
+                var lg = fwd.Forward(tok, prompts[p].Length + s).ToArray();
+                refLogits[p][s] = lg;
+                tok = Argmax(lg);
+            }
+        }
+
+        // Batched N=6: sequences 0-2 run PromptA, 3-5 run PromptB, each with its own cache.
+        const int N = 6;
+        var caches = new CudaSequenceKvCache[N];
+        var toks = new int[N];
+        var poss = new int[N];
+        var promptOf = new int[N];
+        try
+        {
+            for (int i = 0; i < N; i++)
+            {
+                int p = i < 3 ? 0 : 1;
+                promptOf[i] = p;
+                caches[i] = fwd.CreateCache();
+                toks[i] = Argmax(fwd.PrefillWithCache(prompts[p], caches[i]));
+                poss[i] = prompts[p].Length;
+            }
+
+            for (int s = 0; s < Steps; s++)
+            {
+                var batch = fwd.BatchForwardMulti(toks, poss, caches);
+                Assert.Equal(N, batch.Length);
+                for (int i = 0; i < N; i++)
+                {
+                    int p = promptOf[i];
+                    // Sanity: the token fed this step tracks the single-user trajectory (else the
+                    // sequences have diverged and the per-step logit comparison is meaningless).
+                    Assert.Equal(refToks[p][s], toks[i]);
+                    var (maxAbs, overlap) = Compare(refLogits[p][s], batch[i]);
+                    Assert.Equal(Argmax(refLogits[p][s]), Argmax(batch[i]));
+                    Assert.True(overlap >= 4,
+                        $"Seq {i} (prompt {p}) step {s}: MMQ top-5 overlaps single-user in only {overlap}/5 (maxAbs={maxAbs}).");
+                    Assert.True(maxAbs < 1.0f,
+                        $"Seq {i} (prompt {p}) step {s}: MMQ logits diverged beyond tolerance: maxAbs={maxAbs}.");
+                    toks[i] = Argmax(batch[i]);
+                    poss[i]++;
+                }
+            }
+        }
+        finally
+        {
+            foreach (var c in caches) c?.Dispose();
+        }
+    }
+
+    /// <summary>
     /// A second batched decode step (positions advance by one) must still track the single-user
     /// continuation — catches a per-sequence cache-append / position-indexing bug that a single
     /// decode step would miss (the first step's KV is reused, a second token is appended).


### PR DESCRIPTION
## Summary

Resolves #206 (umbrella #203). The #201 int8 tensor-core batched-decode MMQ tile (`SHARPI_BATCH_DECODE_MMQ=1`) shipped opt-in. Re-benched and flip it **default-on for multi-user continuous-batching decode**, while keeping single-user speculative-decode `BatchVerify` bit-exact.

## Why (measured, Qwen3-8B Q4_K_M @ RTX 4070 Ti)

Aggregate decode t/s, MMQ vs the bit-exact weight-stationary path it replaces:

| N | WS (was default) | MMQ (now default) | Δ |
|---|---|---|---|
| 5 | 204.9 | 227.6 | **+11.1%** |
| 6 | 225.4 | 262.7 | **+16.8%** |
| 7 | 242.3 | 297.3 | **+22.8%** |
| 8 | 249.7 | 318.9 | **+27.6%** |

The N=5 cell (the dispatch threshold) is a solid win, not a wash — confirms the existing `N≥5` gate. All cells are far above the 3–4% bar.

## Scoping (the load-bearing detail)

`BatchVerify` (single-user spec decode) shares `BatchForwardMulti`, and `CudaSpecBatchVerifyTests.Qwen3_8B_SpecDecode_GreedyParity_E2E` asserts **exact** token equality over 48 tokens. The MMQ path is argmax-stable, **not** bit-exact — a naive global default-flip would put that guarantee at risk. So:

- `BatchForwardMulti` gains `bool allowDecodeMmq = true`. Continuous batching (via the `IBatchedForwardPass` interface impl) uses the default → MMQ on. `BatchVerify` passes `false` → stays on the bit-exact WS kernels.
- `SHARPI_BATCH_DECODE_MMQ` becomes tri-state: **unset** = on for multi-user decode / off for spec-verify; **`0`** = off everywhere (bit-exact kill-switch); **`1`** = on everywhere incl. spec-verify (argmax-stable, perf A/B only).

## Test gap closed

The pre-existing #201 "MMQ oracle" ran at **N=2**, below the `N≥5` dispatch threshold, so it silently fell back to WS and never exercised the int8 mma kernel. New `Qwen3_8B_BatchForwardMulti_DecodeMmq_N6_MatchesSingleUser` runs N=6 (3×PromptA + 3×PromptB, two decode steps) so the big ≥2048-row Q4_K matmuls actually take the MMQ path, asserting per-sequence argmax/top-5 parity with the single-user reference + KV-append/position indexing.

## Verification (4070 Ti, Qwen3-8B-Q4_K_M)

- Default-on bench reproduces the win automatically (318.9 t/s @ N=8, no env var).
- `SHARPI_BATCH_DECODE_MMQ=0` reverts to 249.0 t/s (bit-exact WS).
- New N=6 MMQ oracle: green.
- All 5 `CudaSpecBatchVerifyTests` green, incl. the 48-token greedy parity E2E (spec-verify stayed bit-exact).
- `CudaBatchForwardMultiTests` (7 tests) green.
- Release build clean (0 warnings, TreatWarningsAsErrors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)