### PR TITLE
perf(cuda): GPU-side argmax for batched decode + BM=32 MMQ tile (#205, #203)

### DIFF
--- a/src/SharpInference.Cuda/CuBlasInterop.cs
+++ b/src/SharpInference.Cuda/CuBlasInterop.cs
@@ -192,4 +192,6 @@ internal static partial class CuBlasInterop
     // cudaDeviceAttr: compute capability
     internal const int CudaDevAttrComputeCapabilityMajor = 75;
     internal const int CudaDevAttrComputeCapabilityMinor = 76;
+    // cudaDeviceAttr: number of SMs (cudaDevAttrMultiProcessorCount)
+    internal const int CudaDevAttrMultiProcessorCount = 16;
 }

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -29,6 +29,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private readonly nint _handle;
     private readonly SgemmPrecision _precision;
     private readonly int _smVersion;
+    private readonly int _smCount;   // SM (multiprocessor) count — decode-MMQ tile-size routing (#205)
     private readonly nint _stream;
     private readonly ConcurrentDictionary<nint, (nint devPtr, nuint byteSize)> _devPtrs = new();
     // Issue #111: handles registered by View() — non-owning slices into another
@@ -195,6 +196,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // #201: scale-word Q6_K WS variant + Q4_K decode MMQ (BN=16 int8 mma).
     private readonly nint[] _matvecQ6KWsSwKernels    = new nint[CudaWsKernels.Variants.Length];
     private nint _mmqQ4kSoaActsN16Kernel;
+    private nint _mmqQ4kSoaActsN16Bm32Kernel;   // #205: BM=32 tile for grid-starved low-row shapes
+    // #205 kill-switch: SHARPI_DECODE_MMQ_BM32=0 forces the BM=64 decode-MMQ tile for all
+    // shapes (BM=32 is default-on for grid-starved low-row shapes; output is bit-identical).
+    private readonly bool _decodeMmqBm32Enabled =
+        Environment.GetEnvironmentVariable("SHARPI_DECODE_MMQ_BM32") != "0";
     // Issue #141: compute-bound prefill GEMM — dequant Q8_0 weight + convert
     // activations to fp16, then one cublasGemmEx (weight read once per batch).
     private nint   _dequantQ80F16Kernel;
@@ -590,12 +596,13 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             throw new InvalidOperationException($"cudaMemcpyAsync (D2D region) failed: {r}");
     }
 
-    private CudaBackend(nint handle, SgemmPrecision precision, int smVersion, nint stream,
+    private CudaBackend(nint handle, SgemmPrecision precision, int smVersion, int smCount, nint stream,
                         nint pinnedBuf, nuint pinnedBufSize)
     {
         _handle        = handle;
         _precision     = precision;
         _smVersion     = smVersion;
+        _smCount       = smCount;
         _stream        = stream;
         _pinnedBuf     = pinnedBuf;
         _pinnedBufSize = pinnedBufSize;
@@ -632,6 +639,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             CuBlasInterop.DeviceGetAttribute(out int minor, CuBlasInterop.CudaDevAttrComputeCapabilityMinor, 0) == 0)
             smVersion = major * 10 + minor;
 
+        // SM count drives decode-MMQ tile-size routing (#205): a row tile that yields fewer
+        // than ~2 full waves of blocks starves the grid, so those shapes take the BM=32 tile.
+        int smCount = 0;
+        CuBlasInterop.DeviceGetAttribute(out smCount, CuBlasInterop.CudaDevAttrMultiProcessorCount, 0);
+
         // Dedicated CUDA stream — all memcpy and GEMM are enqueued on this stream,
         // so cudaStreamSynchronize(stream) waits only for our work (not the whole device).
         if (CuBlasInterop.StreamCreate(out nint stream) != 0)
@@ -655,7 +667,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         CuBlasInterop.MallocHost(out nint pinnedBuf, InitialPinnedSize);
 
         var resolvedPrecision = precision ?? DetectBestPrecision(smVersion);
-        var backend = new CudaBackend(handle, resolvedPrecision, smVersion, stream, pinnedBuf, InitialPinnedSize);
+        var backend = new CudaBackend(handle, resolvedPrecision, smVersion, smCount, stream, pinnedBuf, InitialPinnedSize);
 
         // The 2.5 GiB im2col tile buffer is allocated lazily on the first Conv2d call.
         // Pre-allocating it here used to push LLM contexts that estimated max-context based
@@ -2249,10 +2261,22 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
                 (nint)(&wPtr), (nint)(&qsPtr), (nint)(&dsPtr), (nint)(&yPtr),
                 (nint)(&pRows), (nint)(&pCols), (nint)(&pN)
             };
-            uint gx = (uint)((rows + 63) / 64), gy = (uint)((nTok + 15) / 16);
-            int rm = NvrtcInterop.LaunchKernel(_mmqQ4kSoaActsN16Kernel, gx, gy, 1,
-                                               256, 1, 1, 0, _stream, args, null);
-            if (rm != 0) throw new InvalidOperationException($"cuLaunchKernel(mmq_q4k_soa_acts_n16) failed: {rm}");
+            uint gy = (uint)((nTok + 15) / 16);
+            // #205: the BM=64 tile yields ceil(rows/64) blocks. When that's below ~2 full SM
+            // waves the grid starves (e.g. rows≈4096 → 64 blocks on a 60-SM 4070 Ti — Q/O
+            // proj + the Q4_K ffn_down half), so route those low-row shapes to the BM=32 tile
+            // (ceil(rows/32) blocks, 128 threads). High-row shapes (gate/up 12288, lm-head
+            // 151936) keep BM=64 — they already fill the grid and BM=32 would double the
+            // per-block activation re-staging. Output is bit-identical between the two tiles.
+            // _smCount == 0 (attribute query failed) disables the BM=32 route (keeps BM=64).
+            bool useBm32 = _decodeMmqBm32Enabled && _mmqQ4kSoaActsN16Bm32Kernel != nint.Zero
+                           && _smCount > 0 && (rows + 63) / 64 < 2 * _smCount;
+            nint kernel = useBm32 ? _mmqQ4kSoaActsN16Bm32Kernel : _mmqQ4kSoaActsN16Kernel;
+            uint gx = useBm32 ? (uint)((rows + 31) / 32) : (uint)((rows + 63) / 64);
+            uint block = useBm32 ? 128u : 256u;
+            int rm = NvrtcInterop.LaunchKernel(kernel, gx, gy, 1,
+                                               block, 1, 1, 0, _stream, args, null);
+            if (rm != 0) throw new InvalidOperationException($"cuLaunchKernel(mmq_q4k_soa_acts_n16{(useBm32 ? "_bm32" : "")}) failed: {rm}");
         }
     }
 
@@ -6222,7 +6246,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _kvAppendRaggedKernel, _kvAppendRaggedBf16Kernel, _kvAppendRaggedQ8Kernel,
             _attentionRaggedKernel, _attentionRaggedBf16Kernel, _attentionRaggedQ8Kernel,
             _addBiasRowsKernel,
-            _mmqQ4kSoaActsN16Kernel,   // #201
+            _mmqQ4kSoaActsN16Kernel,       // #201
+            _mmqQ4kSoaActsN16Bm32Kernel,   // #205
         ];
         foreach (nint k in kernels)
         {
@@ -6318,6 +6343,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _matvecQ6KWsSwKernels[v]    = GetKernelFunc($"llm_matvec_q6k_ws_sw_n{nt}");      // #201
         }
         _mmqQ4kSoaActsN16Kernel = GetKernelFunc("llm_mmq_q4k_soa_acts_n16");   // #201
+        _mmqQ4kSoaActsN16Bm32Kernel = GetKernelFunc("llm_mmq_q4k_soa_acts_n16_bm32");   // #205
         _dequantQ80F16Kernel   = GetKernelFunc("llm_dequant_q8_0_to_f16");
         _dequantQ4KF16Kernel   = GetKernelFunc("llm_dequant_q4k_to_f16");
         _dequantQ4KF16SoaKernel = GetKernelFunc("llm_dequant_q4k_to_f16_soa");

--- a/src/SharpInference.Cuda/CudaWsKernels.cs
+++ b/src/SharpInference.Cuda/CudaWsKernels.cs
@@ -49,16 +49,33 @@ internal static class CudaWsKernels
     internal static readonly int[] Variants = [2, 4, 8, 16];
 
     /// <summary>All weight-stationary kernels (one instantiation per variant) plus the
-    /// once-only #201 decode-MMQ kernel.</summary>
+    /// #201/#205 decode-MMQ kernel at both row-tile sizes (BM=64 default, BM=32 for
+    /// grid-starved low-row shapes).</summary>
     public static string Source { get; } = Build();
 
     private static string Build()
     {
-        var sb = new System.Text.StringBuilder(Template.Length * Variants.Length + DecodeMmq.Length);
+        var sb = new System.Text.StringBuilder(Template.Length * Variants.Length + DecodeMmqTemplate.Length * 2);
         foreach (int nt in Variants)
             sb.Append(Template.Replace("__NT__", nt.ToString(System.Globalization.CultureInfo.InvariantCulture)));
-        sb.Append(DecodeMmq);
+        // Decode MMQ, two row-tile sizes (#205). BM/16 row-strips: BM=64 → wr = warp & 3,
+        // wc = warp >> 2; BM=32 → wr = warp & 1, wc = warp >> 1. Quant staging is 8 iters
+        // either way (MMQ_BM*32 == 8*threads); act staging is (16*64)/threads = 4 / 8 iters.
+        sb.Append(EmitDecodeMmq(bm: 64, threads: 256, actJ: 4, wrMask: 3, wcShift: 2, suffix: ""));
+        sb.Append(EmitDecodeMmq(bm: 32, threads: 128, actJ: 8, wrMask: 1, wcShift: 1, suffix: "_bm32"));
         return sb.ToString();
+    }
+
+    private static string EmitDecodeMmq(int bm, int threads, int actJ, int wrMask, int wcShift, string suffix)
+    {
+        static string S(int v) => v.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return DecodeMmqTemplate
+            .Replace("__BM__", S(bm))
+            .Replace("__NTHREADS__", S(threads))
+            .Replace("__ACTJ__", S(actJ))
+            .Replace("__WRMASK__", S(wrMask))
+            .Replace("__WCSHIFT__", S(wcShift))
+            .Replace("__SUF__", suffix);
     }
 
     private const string Template = @"
@@ -745,13 +762,21 @@ extern ""C"" __global__ void llm_matvec_q6k_ws_sw_n__NT__(
     /// while the m16n8k32 int8 mma replaces the per-token dp4a chains. Identical
     /// K-order accumulation and {d,s} fixup math to the prefill kernel — only the
     /// tile shape changes (one n-tile per warp, scalar acc0..3 instead of acc[8][4]).
+    ///
+    /// <para><b>#205:</b> emitted at two row-tile sizes from one template. BM=64 (256
+    /// threads, 8 warps) is the default. BM=32 (<c>_bm32</c>, 128 threads, 4 warps)
+    /// doubles the grid to ceil(rows/32) blocks — the dispatcher routes the grid-starved
+    /// low-row shapes (Q/O proj, the Q4_K ffn_down half: rows≈4096 → only 64 blocks on a
+    /// 60-SM card) there so they fill ≥2 waves instead of stalling at ~1. Output is
+    /// bit-identical to BM=64 (same fragments / mma / accumulation order; only the
+    /// block→row mapping changes), so both share the argmax-stable oracle.</para>
     /// </summary>
-    private const string DecodeMmq = @"
-// ── #201 decode MMQ: Q4_K SoA weights × SoA Q8_1 activations, BN=16 ─────────
-// grid = (ceil(rows/64), ceil(n_tok/16)), block = 256 (8 warps: 4 row-strips ×
-// 2 token-strips). The K-step is one 256-element SUPER-block: the block stages
-// the raw tile (64×32 quant words + 64 scale tails + 16×64 act words + 16×8
-// act {d,s}) with linear fully-coalesced copies, then runs 8 m16n8k32 s8 mma
+    private const string DecodeMmqTemplate = @"
+// ── #201/#205 decode MMQ: Q4_K SoA weights × SoA Q8_1 activations, BN=16 ─────
+// grid = (ceil(rows/MMQ_BM), ceil(n_tok/16)), block = __NTHREADS__ ((MMQ_BM/16)
+// row-strips × 2 token-strips). The K-step is one 256-element SUPER-block: the
+// block stages the raw tile (MMQ_BM×32 quant words + scale tails + 16×64 act
+// words + 16×8 act {d,s}) with linear fully-coalesced copies, then runs 8 m16n8k32 s8 mma
 // per warp between one barrier pair — nibble/scale decode happens at
 // fragment-read time from shared. A sub-block-sized K-step (one mma per
 // barrier pair) was measured 1.4-1.7× SLOWER than the WS matvec it replaces:
@@ -760,9 +785,9 @@ extern ""C"" __global__ void llm_matvec_q6k_ws_sw_n__NT__(
 // issues ~14 independent loads per thread per epoch and amortizes it 8×.
 // Argmax-stable, not bit-exact: both operands int8-quantized, min-bias via the
 // fp16 s = d·Σq field (same contract and K-order as the prefill MMQ).
-#define MMQ_BM 64
+#define MMQ_BM __BM__
 #define MMQ_BN 16
-extern ""C"" __global__ void __launch_bounds__(256) llm_mmq_q4k_soa_acts_n16(
+extern ""C"" __global__ void __launch_bounds__(__NTHREADS__) llm_mmq_q4k_soa_acts_n16__SUF__(
     const unsigned int*  __restrict__ weights,   // SoA [Q][S][D]
     const unsigned int*  __restrict__ y_qs,      // SoA Q8_1 quants [n_tok × sub_total × 32 B]
     const unsigned int*  __restrict__ y_ds,      // SoA Q8_1 scales [n_tok × sub_total] {d,s}
@@ -792,8 +817,8 @@ extern ""C"" __global__ void __launch_bounds__(256) llm_mmq_q4k_soa_acts_n16(
     int lane = tid & 31;
     int grp  = lane >> 2;
     int tig  = lane & 3;
-    int wr   = warp & 3;
-    int wc   = warp >> 2;
+    int wr   = warp & __WRMASK__;
+    int wc   = warp >> __WCSHIFT__;
     int mrow0 = wr * 16;
     int ncol0 = wc * 8;
 
@@ -809,7 +834,7 @@ extern ""C"" __global__ void __launch_bounds__(256) llm_mmq_q4k_soa_acts_n16(
         // 128-B-coalesced in global (one row / token segment per warp-instruction).
         #pragma unroll
         for (int j = 0; j < 8; j++) {            // 64 rows × 32 quant words
-            int k = tid + j * 256;
+            int k = tid + j * __NTHREADS__;
             int r = row_block + (k >> 5);
             sWq[(k >> 5) * 33 + (k & 31)] =
                 (r < rows) ? qReg[((long)r * nb_super + ksb) * 32L + (k & 31)] : 0u;
@@ -825,8 +850,8 @@ extern ""C"" __global__ void __launch_bounds__(256) llm_mmq_q4k_soa_acts_n16(
             sWd[tid] = (r < rows) ? dReg[(long)r * nb_super + ksb] : 0u;
         }
         #pragma unroll
-        for (int j = 0; j < 4; j++) {            // 16 tokens × 64 act words (256 B)
-            int k = tid + j * 256;
+        for (int j = 0; j < __ACTJ__; j++) {     // 16 tokens × 64 act words (256 B)
+            int k = tid + j * __NTHREADS__;
             int t = tok_block + (k >> 6);
             sYq[(k >> 6) * 65 + (k & 63)] =
                 (t < n_tok) ? y_qs[((long)t * sub_total + ksb * 8) * 8L + (k & 63)] : 0u;

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -296,9 +296,26 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 cacheBuf[i] = active[i].Cache;
             }
 
-            // Batched decode step (shares weight reads across N sequences)
-            float[][] logitsBatch = _fwd.BatchForwardMulti(
-                tokensBuf[..n], posBuf[..n], cacheBuf[..n]);
+            // Batched decode step (shares weight reads across N sequences). When EVERY active
+            // sequence is plain greedy this step (temp ≤ 0, not force-closing </think>), take the
+            // on-device argmax tail (#205/#206): it returns just the per-seq (token, logit) and
+            // skips the full N×vocab logits D2H + host split. A single sampled or force-closing
+            // seq reverts the whole step to the full-logits path (the argmax buffer can't sample).
+            bool allGreedy = _fwd.SupportsBatchedGpuArgmax;
+            for (int i = 0; i < n && allGreedy; i++)
+            {
+                var s = active[i];
+                bool forcedClose = _thinkingEnabled && s.InThinking && s.Sp.MaxThinkingTokens > 0
+                                   && s.ThinkingCount >= s.Sp.MaxThinkingTokens && _endThinkTokenId > 0;
+                if (s.Sp.Temperature > 0f || forcedClose) allGreedy = false;
+            }
+
+            float[][]? logitsBatch = null;
+            (int Token, float Logit)[]? argmaxBatch = null;
+            if (allGreedy)
+                argmaxBatch = _fwd.BatchForwardMultiArgmax(tokensBuf[..n], posBuf[..n], cacheBuf[..n]);
+            else
+                logitsBatch = _fwd.BatchForwardMulti(tokensBuf[..n], posBuf[..n], cacheBuf[..n]);
 
             // Process results in reverse order so RemoveAt indices stay valid
             for (int i = n - 1; i >= 0; i--)
@@ -310,7 +327,13 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 // boundary branch below and is fed back as the next CurrentToken so the
                 // model continues from its post-think state on the next batched step.
                 int next;
-                if (_thinkingEnabled && seq.InThinking && seq.Sp.MaxThinkingTokens > 0
+                if (argmaxBatch is not null)
+                {
+                    // All-greedy fast path: the on-device argmax already picked each token (the
+                    // gate above excluded any sampled / force-closing seq from this branch).
+                    next = argmaxBatch[i].Token;
+                }
+                else if (_thinkingEnabled && seq.InThinking && seq.Sp.MaxThinkingTokens > 0
                     && seq.ThinkingCount >= seq.Sp.MaxThinkingTokens && _endThinkTokenId > 0)
                 {
                     next = _endThinkTokenId;
@@ -318,8 +341,8 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 else
                 {
                     next = seq.Sp.Temperature <= 0f
-                        ? Sampler.Greedy(logitsBatch[i])
-                        : Sampler.Sample(logitsBatch[i], seq.Sp, seq.Rng);
+                        ? Sampler.Greedy(logitsBatch![i])
+                        : Sampler.Sample(logitsBatch![i], seq.Sp, seq.Rng);
                 }
 
                 bool done = seq.StopIds.Contains(next)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -3501,7 +3501,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     }
 
     /// <summary>
-    /// Ragged batched decode (issue #190): one token per sequence, each at its own position
+    /// Ragged batched decode trunk (issue #190): one token per sequence, each at its own position
     /// against its own per-sequence cache, with the dense weight reads amortized N× across
     /// the batch. This is a TRUE batched pass — it issues direct launches and never replays
     /// the per-token CUDA graph (which would bake in owned-cache pointers). It adapts the
@@ -3511,28 +3511,32 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// batched O-proj + batched FFN} → per-row final norm + one batched output GEMM. The
     /// per-sequence attention block mirrors the dense <see cref="RunDeviceRegion"/> ordering
     /// exactly (QK-norm before RoPE, #157), so it is argmax-stable vs the single-user loop.
+    ///
+    /// <para>Leaves the [N×vocab] logits in <see cref="_decodeLogitsAll"/> on the stream (not
+    /// downloaded/synced) and does NOT advance cache lengths — the caller's tail does both:
+    /// <see cref="BatchForwardMulti"/> downloads + splits the full logits, while
+    /// <see cref="BatchForwardMultiArgmax"/> runs the on-device argmax (#205/#206 follow-up).</para>
     /// </summary>
     /// <param name="allowDecodeMmq">When true (multi-user continuous-batching decode) the big
     /// Q4_K matmuls may use the #201/#206 argmax-stable decode MMQ tile (default-on, the
     /// +11–28% win); when false (the spec-decode <see cref="BatchVerify"/> wrapper) they stay on
     /// the bit-exact WS path so greedy spec-decode output is byte-stable. SHARPI_BATCH_DECODE_MMQ
     /// =0/1 overrides both to off/on everywhere.</param>
-    internal float[][] BatchForwardMulti(int[] tokens, int[] positions, CudaSequenceKvCache[] caches,
-                                         bool allowDecodeMmq = true)
+    private void RunBatchedTrunk(int[] tokens, int[] positions, CudaSequenceKvCache[] caches,
+                                 bool allowDecodeMmq)
     {
         ArgumentNullException.ThrowIfNull(tokens);
         ArgumentNullException.ThrowIfNull(positions);
         ArgumentNullException.ThrowIfNull(caches);
         ThrowIfBatchingUnsupported(decodeOnly: true);
         int N = tokens.Length;
-        if (N == 0) return Array.Empty<float[]>();
+        if (N == 0) return;
         if (positions.Length != N || caches.Length != N)
             throw new ArgumentException("tokens/positions/caches lengths must match.");
 
         int embDim = _embDim;
         int qDim = _numHeads * _headDim;
         int kvDim = _numKvHeads * _headDim;
-        int vocab = _hp.VocabSize;
 
         EnsureBatchedTrunkScratch(N);
         EnsureDecodeLogits(N);
@@ -3711,20 +3715,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             //    single matmul, so amortizing its read across N is the main throughput win).
             _gpu.RmsNormBatched(_bpHidden!, _bpHidden!, _wOutputNorm, N, embDim, _hp.RmsNormEps);
             BatchDecodeMatMul(_decodeLogitsAll!, _wOutput, _bpHidden!, N, allowDecodeMmq);
-            _gpu.Download(_decodeLogitsAll!, _decodeLogitsHost.AsSpan(0, N * vocab));
-            _gpu.Synchronize();
-
-            var result = new float[N][];
-            for (int n = 0; n < N; n++)
-            {
-                result[n] = new float[vocab];
-                Array.Copy(_decodeLogitsHost!, (long)n * vocab, result[n], 0, vocab);
-                // Advance each sequence's logical length now that the append + attention for
-                // this token have completed and synchronized (transactional: a mid-pass throw
-                // leaves Length untouched).
-                caches[n].Length = positions[n] + 1;
-            }
-            return result;
+            // Logits are now in _decodeLogitsAll on the stream (NOT yet downloaded/synced). The
+            // caller's tail completes the pass: BatchForwardMulti downloads + splits the full
+            // N×vocab logits, while BatchForwardMultiArgmax runs the on-device argmax and copies
+            // back only rows*8 bytes (#205/#206 follow-up). Each tail advances caches[n].Length
+            // after its download synchronizes (transactional: a mid-pass throw leaves it untouched).
         }
         finally
         {
@@ -3739,6 +3734,63 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
             }
         }
     }
+
+    /// <summary>Ragged batched decode returning the full per-sequence next-token logits
+    /// (issue #190). Runs the <see cref="RunBatchedTrunk"/> then downloads + splits the
+    /// [N×vocab] logits.</summary>
+    /// <param name="allowDecodeMmq">See <see cref="RunBatchedTrunk"/>.</param>
+    internal float[][] BatchForwardMulti(int[] tokens, int[] positions, CudaSequenceKvCache[] caches,
+                                         bool allowDecodeMmq = true)
+    {
+        RunBatchedTrunk(tokens, positions, caches, allowDecodeMmq);
+        int N = tokens.Length;
+        if (N == 0) return Array.Empty<float[]>();
+        int vocab = _hp.VocabSize;
+
+        _gpu.Download(_decodeLogitsAll!, _decodeLogitsHost.AsSpan(0, N * vocab));
+        _gpu.Synchronize();
+
+        var result = new float[N][];
+        for (int n = 0; n < N; n++)
+        {
+            result[n] = new float[vocab];
+            Array.Copy(_decodeLogitsHost!, (long)n * vocab, result[n], 0, vocab);
+            // Advance each sequence's logical length now that the append + attention for this
+            // token have completed and synchronized (transactional: a mid-pass throw above
+            // leaves Length untouched).
+            caches[n].Length = positions[n] + 1;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Greedy counterpart of <see cref="BatchForwardMulti"/> (#205/#206 follow-up): runs the same
+    /// trunk, then computes the per-sequence argmax ON-DEVICE (<see cref="CudaBackend.ArgmaxRows"/>,
+    /// the #219 kernel) and copies back only rows*8 bytes — eliminating the full N×vocab logits
+    /// D2H (4.86 MB at N=8 / vocab 151936), the host buffer copy, and the N per-row allocations.
+    /// The argmax is bit-exact to a host scan of the same <see cref="_decodeLogitsAll"/> with
+    /// lowest-index tie-break (matches <c>Sampler.Greedy</c>), so greedy output is identical to
+    /// taking <c>Argmax</c> over <see cref="BatchForwardMulti"/>'s logits. Valid only when every
+    /// sequence is greedy — the engine gates on <see cref="SupportsBatchedGpuArgmax"/>.
+    /// </summary>
+    internal (int Token, float Logit)[] BatchForwardMultiArgmax(
+        int[] tokens, int[] positions, CudaSequenceKvCache[] caches)
+    {
+        RunBatchedTrunk(tokens, positions, caches, allowDecodeMmq: true);
+        int N = tokens.Length;
+        if (N == 0) return Array.Empty<(int, float)>();
+
+        // rows*8-byte D2H (index+value per row) with its own internal sync — completes the pass.
+        var am = _gpu.ArgmaxRows(_decodeLogitsAll!, N, _hp.VocabSize, _hp.VocabSize);
+        for (int n = 0; n < N; n++)
+            caches[n].Length = positions[n] + 1;
+        return am;
+    }
+
+    /// <summary>#205/#206: the batched greedy-argmax tail elides the full logits download when the
+    /// on-device argmax kernel is enabled (mirrors <see cref="SupportsGpuArgmax"/>; the profiling
+    /// variants keep the full download so their region timings stay meaningful).</summary>
+    public bool SupportsBatchedGpuArgmax => _gpu.GpuArgmaxEnabled && !s_profile && !s_regionProfile;
 
     // ── Speculative-decode batched verify (issue #207) ──────────────────────────────────
 
@@ -3913,6 +3965,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
 
     float[][] IBatchedForwardPass.BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches)
         => BatchForwardMulti(tokens, positions, Cast(caches));
+
+    (int Token, float Logit)[] IBatchedForwardPass.BatchForwardMultiArgmax(
+        int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        => BatchForwardMultiArgmax(tokens, positions, Cast(caches));
 
     private static CudaSequenceKvCache[] Cast(ISequenceKvCache[] caches)
     {

--- a/src/SharpInference.Engine/IBatchedForwardPass.cs
+++ b/src/SharpInference.Engine/IBatchedForwardPass.cs
@@ -48,6 +48,25 @@ public interface IBatchedForwardPass
     float[][] BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches);
 
     /// <summary>
+    /// Whether <see cref="BatchForwardMultiArgmax"/> avoids the full per-row logits download by
+    /// running the greedy argmax on-device (mirrors <see cref="IForwardPass.SupportsGpuArgmax"/>,
+    /// issue #219). Default false — backends without a GPU tail to elide use the full path.
+    /// </summary>
+    bool SupportsBatchedGpuArgmax => false;
+
+    /// <summary>
+    /// Greedy counterpart of <see cref="BatchForwardMulti"/>: returns only the per-sequence
+    /// (argmax token, its logit) instead of the full N×vocab logits — a rows*8-byte device→host
+    /// copy in place of the N×vocab download + host split (issue #205/#206 follow-up). Valid only
+    /// when <see cref="SupportsBatchedGpuArgmax"/> and every sequence in the batch is greedy
+    /// (temp ≤ 0, no forced-token override); the caller gates on those before invoking. Default
+    /// throws — callers must check <see cref="SupportsBatchedGpuArgmax"/> first.
+    /// </summary>
+    (int Token, float Logit)[] BatchForwardMultiArgmax(int[] tokens, int[] positions, ISequenceKvCache[] caches) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not implement BatchForwardMultiArgmax. Check SupportsBatchedGpuArgmax first.");
+
+    /// <summary>
     /// Whether SnapKV prefill eviction is configured. The engine disables chunked/packed prefill
     /// when true (SnapKV scoring only runs on a fresh full-prompt prefill).
     /// </summary>

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchForwardMultiTests.cs
@@ -312,6 +312,64 @@ public sealed class CudaBatchForwardMultiTests
     }
 
     /// <summary>
+    /// #205/#206: the on-device greedy argmax tail (<see cref="CudaForwardPass.BatchForwardMultiArgmax"/>,
+    /// reusing the #219 <c>ArgmaxRows</c> kernel) must return exactly what a host argmax of the full
+    /// <see cref="CudaForwardPass.BatchForwardMulti"/> logits would — the whole point is to elide the
+    /// N×vocab download without changing the greedy token. Run a batched step both ways on two
+    /// identically-prefilled cache sets (the trunk is deterministic, so their logits are bit-identical)
+    /// at N=6 (so the decode MMQ engages) and assert, per sequence, the argmax token equals the host
+    /// Argmax of the full logits AND the returned logit equals that row's value at that token.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_BatchForwardMultiArgmax_MatchesBatchForwardMulti_N6()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        using var fwd = NewFwd(model, gpu, hp);
+
+        const int N = 6;
+        int[][] prompts = { PromptA, PromptB };
+        var cachesFull = new CudaSequenceKvCache[N];
+        var cachesArg = new CudaSequenceKvCache[N];
+        try
+        {
+            var toks = new int[N];
+            var poss = new int[N];
+            for (int i = 0; i < N; i++)
+            {
+                int[] p = i < 3 ? prompts[0] : prompts[1];
+                cachesFull[i] = fwd.CreateCache();
+                cachesArg[i] = fwd.CreateCache();
+                int t = Argmax(fwd.PrefillWithCache(p, cachesFull[i]));
+                fwd.PrefillWithCache(p, cachesArg[i]);   // identical prefill into the second set
+                toks[i] = t;
+                poss[i] = p.Length;
+            }
+
+            var full = fwd.BatchForwardMulti(toks, poss, cachesFull);
+            var am = fwd.BatchForwardMultiArgmax(toks, poss, cachesArg);
+
+            Assert.Equal(N, am.Length);
+            for (int i = 0; i < N; i++)
+            {
+                int hostArg = Argmax(full[i]);
+                Assert.Equal(hostArg, am[i].Token);
+                Assert.Equal(full[i][am[i].Token], am[i].Logit);
+            }
+        }
+        finally
+        {
+            foreach (var c in cachesFull) c?.Dispose();
+            foreach (var c in cachesArg) c?.Dispose();
+        }
+    }
+
+    /// <summary>
     /// A second batched decode step (positions advance by one) must still track the single-user
     /// continuation — catches a per-sequence cache-append / position-indexing bug that a single
     /// decode step would miss (the first step's KV is reused, a second token is appended).

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
@@ -131,21 +131,41 @@ public sealed class CudaBatchedDecodeBench
                     poss[s] = Prompt.Length;
                 }
 
+                // #205/#206: SHARPI_BENCH_ARGMAX=1 measures the on-device argmax tail
+                // (BatchForwardMultiArgmax — rows*8-byte D2H instead of the full N×vocab download).
+                // All sequences here are greedy, so this is the all-greedy upper bound of the win.
+                bool useArgmax = Environment.GetEnvironmentVariable("SHARPI_BENCH_ARGMAX") == "1";
                 for (int i = 0; i < warmup; i++)
                 {
-                    var lg = fwd.BatchForwardMulti(toks, poss, caches);
-                    for (int s = 0; s < n; s++) { toks[s] = Argmax(lg[s]); poss[s]++; }
+                    if (useArgmax)
+                    {
+                        var am = fwd.BatchForwardMultiArgmax(toks, poss, caches);
+                        for (int s = 0; s < n; s++) { toks[s] = am[s].Token; poss[s]++; }
+                    }
+                    else
+                    {
+                        var lg = fwd.BatchForwardMulti(toks, poss, caches);
+                        for (int s = 0; s < n; s++) { toks[s] = Argmax(lg[s]); poss[s]++; }
+                    }
                 }
                 var sw2 = Stopwatch.StartNew();
                 for (int i = 0; i < decodeSteps; i++)
                 {
-                    var lg = fwd.BatchForwardMulti(toks, poss, caches);
-                    for (int s = 0; s < n; s++) { toks[s] = Argmax(lg[s]); poss[s]++; }
+                    if (useArgmax)
+                    {
+                        var am = fwd.BatchForwardMultiArgmax(toks, poss, caches);
+                        for (int s = 0; s < n; s++) { toks[s] = am[s].Token; poss[s]++; }
+                    }
+                    else
+                    {
+                        var lg = fwd.BatchForwardMulti(toks, poss, caches);
+                        for (int s = 0; s < n; s++) { toks[s] = Argmax(lg[s]); poss[s]++; }
+                    }
                 }
                 sw2.Stop();
                 double aggTps = (double)n * decodeSteps / sw2.Elapsed.TotalSeconds;
                 double perSeq = (double)decodeSteps / sw2.Elapsed.TotalSeconds;
-                Log($"[bench-190] batched N={n}: aggregate {aggTps:F1} t/s ({perSeq:F1} t/s/seq), " +
+                Log($"[bench-190] batched N={n}{(useArgmax ? " [argmax]" : "")}: aggregate {aggTps:F1} t/s ({perSeq:F1} t/s/seq), " +
                     $"{aggTps / singleTps:F2}× single-user");
             }
             finally

--- a/tests/SharpInference.Tests.ForwardPass/CudaDecodeMmqTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDecodeMmqTests.cs
@@ -102,10 +102,13 @@ public sealed unsafe class CudaDecodeMmqTests
         using var gpu = TryCreate();
         if (gpu is null) return;
 
-        // rows ≥ 2048 (eligible) with non-multiple-of-64 coverage via the second case;
-        // batch sizes cover partial token tiles (2, 5, 11), the full tile (16), and the
-        // grid.y = 2 round-up (17).
-        foreach ((int rows, int cols) in new[] { (2048, 512), (2112, 256) })
+        // rows ≥ 2048 (eligible). #205: the dispatcher routes low-row shapes
+        // (ceil(rows/64) < 2·SM) to the BM=32 tile and high-row shapes to BM=64, so the
+        // cases span both kernels on a ≤64-SM card: 2048 (BM=32, no tail), 2096 (BM=32 with
+        // a non-multiple-of-32 row tail + non-multiple-of-64), 8192 (BM=64). Both tiles are
+        // bit-identical and tracked against the same fp32 CPU reference. Batch sizes cover
+        // partial token tiles (2, 5, 11), the full tile (16), and the grid.y = 2 round-up (17).
+        foreach ((int rows, int cols) in new[] { (2048, 512), (2096, 256), (8192, 512) })
         {
             var rng = new Random(20260610 + rows * 13 + cols * 5);
             byte[] weightBytes = BuildQ4KMatrix(rows, cols, rng);


### PR DESCRIPTION
## Summary

Pushes multi-user batched decode **clearly over the 3-4% bar** by stacking two **orthogonal** levers. Measured on Qwen3-8B Q4_K_M @ RTX 4070 Ti (aggregate t/s vs baseline, all-greedy):

| N | baseline | +BM=32 | +argmax | **+both** |
|---|---|---|---|---|
| 6 | 264.3 | 271.1 (+2.6%) | 273.6 (+3.5%) | **281.7 (+6.6%)** |
| 7 | 298.6 | 306.4 (+2.6%) | 310.0 (+3.8%) | **317.3 (+6.3%)** |
| 8 | 321.1 | 328.9 (+2.4%) | 332.9 (+3.7%) | **342.3 (+6.6%)** |

The levers target different constraints (host/PCIe tail vs device matmul), so they add.

## Lever 1 — GPU-side argmax for batched decode (the larger one, +3.5–3.8% alone)

`BatchForwardMulti` downloaded the full `[N×vocab]` logits **every step** (4.86 MB at N=8, vocab 151936), host-copied it, and allocated N per-row `float[]`. New `BatchForwardMultiArgmax` reuses the already-shipped #219 `ArgmaxRows` kernel to compute the per-sequence argmax **on-device** and copy back only `rows*8` bytes.

- #219 found single-user GPU argmax "within noise" because the 1-row download is tiny — but the **batched** download is N× larger, so eliding it is a real win here.
- The trunk is hoisted into `RunBatchedTrunk`; `BatchForwardMulti` keeps the full-logits tail unchanged.
- **Bit-exact** to a host argmax of the same logits (lowest-index tie-break == `Sampler.Greedy`).
- `ContinuousBatchingEngine` takes it only when **every** active sequence is greedy this step (temp≤0, not force-closing `</think>`); any sampled/forced seq reverts the whole step to the full path.
- Gated by `SupportsBatchedGpuArgmax` (the existing `SHARPI_GPU_ARGMAX` kill-switch; off under the profiling variants). Single-user spec-decode `BatchVerify` is untouched (stays bit-exact WS).

## Lever 2 — BM=32 decode-MMQ tile (#205 item 1, +2.4–2.6% alone)

Emits `llm_mmq_q4k_soa_acts_n16` at a second row-tile size from one template; the dispatcher routes grid-starved shapes (`ceil(rows/64) < 2·SM`: Q/O proj + the Q4_K ffn_down half — 64 blocks on a 60-SM card) to the BM=32/128-thread tile. High-row shapes (gate/up, lm-head) keep BM=64. Bit-identical to BM=64. SM count from `cudaDevAttrMultiProcessorCount`; `SHARPI_DECODE_MMQ_BM32=0` kill-switch.

**#205 item 2 (cp.async) dropped** — an adversarial design panel plus the #176/#152 prefill precedent rate it ~0–1% / e2e-neutral on decode; not worth the kernel complexity.

## Validation

- New `Qwen3_8B_BatchForwardMultiArgmax_MatchesBatchForwardMulti_N6`: GPU argmax token == host `Argmax` of the full logits, and the returned logit == that row's value (exact).
- `CudaDecodeMmqTests` covers **both** MMQ tiles vs the fp32 CPU reference (`SimdKernels.DotQ4K`).
- N=6 MMQ oracle + all `CudaBatchForwardMultiTests` (N=2, two-step, empty-batch, prefill) green — guard the trunk refactor.
- Release build clean (0 warnings, TreatWarningsAsErrors). All 10 relevant CUDA tests green on the 4070 Ti.

Closes #205. Refs #203 (umbrella), #219 (extends GPU argmax to the batched path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)