### PR TITLE
perf(engine): 2-slot prefix cache so short agentic aux requests don't evict the long prefix (#212)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -830,6 +830,25 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             // isn't wired here yet (#179). Don't auto-enable eviction on top.
             _snapKvEffectiveBudget = 0;
         }
+        else if (MultiSlotPrefixRequested())
+        {
+            // Issue #212: the operator opted into the multi-slot prefix cache
+            // (SHARPI_PREFIX_SLOTS=2), which keeps a long prefix resident for cross-request
+            // reuse — the opposite of SnapKV's prefill eviction, and incompatible with its
+            // compaction (which discards prefix positions and reindexes the cache so logical
+            // position != physical slot). For the agentic workload #212 targets (a huge system
+            // prefix re-sent every turn) prefix reuse beats SnapKV's memory savings, so let the
+            // multi-slot request suppress the SnapKV AUTO-enable; SupportsMultiSlotPrefix can
+            // then see budget==0 and engage. An explicit SHARPI_SNAPKV_BUDGET>0 still wins above
+            // (IsBudgetExplicit) and keeps SnapKV (with multi-slot disabled). Memory-safe: auto
+            // context sizes _maxSeqLen to fit a full KV cache, so dropping the auto-compaction
+            // can't OOM the base cache (the bounded scratch slot has its own OOM fallback).
+            _snapKvEffectiveBudget = 0;
+            Console.Error.WriteLine(
+                "[CudaForwardPass] SnapKV auto-enable suppressed for the multi-slot prefix cache " +
+                "(SHARPI_PREFIX_SLOTS=2, issue #212). Set an explicit SHARPI_SNAPKV_BUDGET>0 to " +
+                "use SnapKV instead (disables multi-slot).");
+        }
         else
         {
             long fullCacheBytes = (long)_hp.NumLayers * _maxSeqLen
@@ -3521,6 +3540,17 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
     /// <inheritdoc/>
     public bool SupportsMultiSlotPrefix => _snapKvEffectiveBudget == 0 && DenseBatchedDecodeSupported();
+
+    /// <summary>
+    /// Issue #212: whether the operator requested the multi-slot prefix cache via
+    /// <c>SHARPI_PREFIX_SLOTS=2</c>. Read in the constructor so the SnapKV auto-enable can defer
+    /// to it (the two are mutually exclusive — SnapKV compaction destroys the positional cache
+    /// invariant prefix reuse relies on). Mirrors the engine's own parse of the same var.
+    /// </summary>
+    private static bool MultiSlotPrefixRequested() =>
+        int.TryParse(Environment.GetEnvironmentVariable("SHARPI_PREFIX_SLOTS"),
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out int s) && s == 2;
 
     /// <inheritdoc/>
     public ISequenceKvCache OwnedSlot

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -38,7 +38,7 @@ namespace SharpInference.Engine;
 ///   • MoE + TurboQuant combination not validated (no test model has both;
 ///     should compose but the dispatch never sees the combination today).
 /// </summary>
-public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
+public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, IMultiSlotKvCache
 {
     private readonly CudaBackend _gpu;
     private readonly GgufModel _model;
@@ -485,6 +485,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     // against the owned cache. Never disposed (the owned tensors are freed by Dispose);
     // every layer is marked aliased so even an accidental Dispose can't free them.
     private CudaSequenceKvCache? _ownedCacheView;
+
+    // Issue #212: multi-slot prefix cache (single-user). The engine binds a non-owned
+    // "scratch" slot via ActivateSlot to serve a short interleaved request without evicting
+    // the long resident prefix in the owned cache (slot 0). _activeSlot is the bound slot
+    // (null = owned/no active bind); _savedKvLengthForSlot restores the owned _kvLength on
+    // DeactivateSlot; _activeSlotIsOwned gates the per-token CUDA graph (a captured graph
+    // bakes the owned pointers, so replay is only valid while slot 0 is active).
+    private ISequenceKvCache? _activeSlot;
+    private int _savedKvLengthForSlot;
+    private bool _activeSlotIsOwned = true;
 
     // Ragged attention spill scratch [N × numHeads × maxSeqLen] — the ragged kernel
     // spills per-(sequence, head) score rows when a sequence's length exceeds the
@@ -1662,6 +1672,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         if (_tqEnabled || _kvEvictedCount > 0 || _snapKvCaptureSlot >= 0 || _isMoE)
             return false;
 
+        // Issue #212: a captured graph bakes the OWNED cache's device pointers, so replaying
+        // it while a non-owned scratch slot is bound would touch a stale (foreign) pointer.
+        // Scratch-slot decode therefore uses direct launches; slot 0 keeps the captured graph.
+        if (!_activeSlotIsOwned)
+            return false;
+
         // Steady state: graph already captured — just replay at the new position.
         if (_graphCaptured && _gpu.GraphReady)
         {
@@ -2004,6 +2020,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
         // sequentially — so gate on an actual eviction (_kvEvictedCount > 0), not on the
         // budget being set.
         if (_kvEvictedCount > 0 || _tqEnabled)
+            return false;
+
+        // Issue #212: a captured graph bakes the OWNED cache's device pointers, so a non-owned
+        // scratch slot bind must run direct launches (mirrors the dense twin above).
+        if (!_activeSlotIsOwned)
             return false;
 
         // Steady state: graph already captured — just replay at the new position.
@@ -3487,6 +3508,110 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass
     /// (the engine always builds chunks from <c>int[].AsMemory</c>).</summary>
     private static IReadOnlyList<int> AsList(ReadOnlyMemory<int> mem) =>
         MemoryMarshal.TryGetArray(mem, out ArraySegment<int> seg) ? seg : mem.ToArray();
+
+    // ── IMultiSlotKvCache (issue #212): single-user 2-slot prefix cache ──────────────────
+    //
+    // The single-user InferenceEngine binds a bounded non-owned "scratch" slot to serve a
+    // short interleaved request (Claude Code's auxiliary calls) without evicting the long
+    // resident prefix in the owned cache (slot 0). Only the dense rewindable path participates;
+    // the gate below reuses DenseBatchedDecodeSupported so TQ/SnapKV/MoE/Gemma-4/softcap stay
+    // single-slot. Unlike the batching engine's CreateCache, allocating a scratch slot does NOT
+    // disable CUDA graphs — graphs stay valid for slot 0 via the per-slot _activeSlotIsOwned
+    // gate in TryRunDeviceRegionViaGraph; scratch decode runs direct launches.
+
+    /// <inheritdoc/>
+    public bool SupportsMultiSlotPrefix => _snapKvEffectiveBudget == 0 && DenseBatchedDecodeSupported();
+
+    /// <inheritdoc/>
+    public ISequenceKvCache OwnedSlot
+    {
+        get
+        {
+            if (_ownedCacheView is null)
+            {
+                // Every layer marked aliased so even an accidental Dispose frees nothing — the
+                // owned tensors are freed by CudaForwardPass.Dispose (mirrors the #207 view).
+                var all = new HashSet<int>();
+                for (int l = 0; l < _hp.NumLayers; l++) all.Add(l);
+                _ownedCacheView = new CudaSequenceKvCache(_gpu, _ownedKCache, _ownedVCache, all);
+            }
+            // Hand out the owned region's current logical length so the engine's prefix logic
+            // sees what's actually resident.
+            _ownedCacheView.Length = _kvLength;
+            return _ownedCacheView;
+        }
+    }
+
+    /// <inheritdoc/>
+    public ISequenceKvCache AllocateScratchSlot(int capacityTokens)
+    {
+        if (!SupportsMultiSlotPrefix)
+            throw new NotSupportedException(
+                "AllocateScratchSlot requires the dense single-slot-capable configuration " +
+                "(no MoE / Gemma-4 / TurboQuant / SnapKV / softcap, GEMM-N-batchable weights). " +
+                "Check SupportsMultiSlotPrefix first.");
+
+        int cap = Math.Min(Math.Max(1, capacityTokens), _maxSeqLen);
+        int kvDim = _numKvHeads * _headDim;
+        // q8_0 KV packs 32 elements/block; the store kernels assume each layer's kvDim is a
+        // multiple of 32 (mirrors CreateCache + the owned-cache guard in the constructor).
+        if (_kvDType == DType.Q8_0 && (kvDim & 31) != 0)
+            throw new NotSupportedException(
+                $"SHARPI_KV_DTYPE=q8_0 requires kvDim % 32 == 0 (block_q8_0 = 32 elements/block); kvDim={kvDim}.");
+
+        int L = _hp.NumLayers;
+        var k = new Tensor[L];
+        var v = new Tensor[L];
+        // Free the partial allocations on OOM so a failed scratch alloc doesn't strand VRAM
+        // (mirrors CreateCache); the caller can fall back to single-slot on the throw.
+        try
+        {
+            for (int i = 0; i < L; i++)
+            {
+                k[i] = _gpu.Allocate(TensorShape.D1((long)cap * kvDim), _kvDType);
+                v[i] = _gpu.Allocate(TensorShape.D1((long)cap * kvDim), _kvDType);
+            }
+        }
+        catch
+        {
+            for (int i = 0; i < L; i++)
+            {
+                if (k[i] is { } ki) _gpu.Free(ki);
+                if (v[i] is { } vi) _gpu.Free(vi);
+            }
+            throw;
+        }
+        return new CudaSequenceKvCache(_gpu, k, v, s_noAliasedLayers);
+    }
+
+    /// <inheritdoc/>
+    public void ActivateSlot(ISequenceKvCache slot)
+    {
+        ArgumentNullException.ThrowIfNull(slot);
+        var c = (CudaSequenceKvCache)slot;
+        _savedKvLengthForSlot = _kvLength;
+        _gpuKCache = c.K;
+        _gpuVCache = c.V;
+        // c.Length seeds the position counter, but the engine always follows ActivateSlot with a
+        // TruncateTo (prefix reuse) or ResetCache (fresh) before any KV append, so this seed is
+        // provisional and never drives an append on its own — don't rely on it elsewhere.
+        _kvLength = c.Length;
+        // Slot 0 (the owned region) keeps the captured CUDA graph; any other slot forces
+        // direct launches for the duration of the bind.
+        _activeSlotIsOwned = ReferenceEquals(c, _ownedCacheView) || ReferenceEquals(c.K, _ownedKCache);
+        _activeSlot = slot;
+    }
+
+    /// <inheritdoc/>
+    public void DeactivateSlot()
+    {
+        if (_activeSlot is null) return;
+        ((CudaSequenceKvCache)_activeSlot).Length = _kvLength;
+        RestoreOwned();
+        _kvLength = _savedKvLengthForSlot;
+        _activeSlotIsOwned = true;
+        _activeSlot = null;
+    }
 
     /// <summary>One batched-decode matmul. Default: the weight-stationary small-N matvec
     /// (#194 — weight HBM read amortized across the batch, bit-identical reduction to the

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -3606,9 +3606,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     public void DeactivateSlot()
     {
         if (_activeSlot is null) return;
+        // Persist the advanced length into the slot so the NEXT ActivateSlot of this slot reloads
+        // it (this is what actually preserves per-slot resident length across requests, including
+        // the owned slot's growth — not _savedKvLengthForSlot).
         ((CudaSequenceKvCache)_activeSlot).Length = _kvLength;
         RestoreOwned();
-        _kvLength = _savedKvLengthForSlot;
+        // Only a non-owned (scratch) bind needs _kvLength rewound to the owned value it displaced;
+        // when the owned slot itself was active, _kvLength already reflects its (advanced) resident
+        // length and must be kept so a follow-up read before the next ActivateSlot sees it.
+        if (!_activeSlotIsOwned)
+            _kvLength = _savedKvLengthForSlot;
         _activeSlotIsOwned = true;
         _activeSlot = null;
     }

--- a/src/SharpInference.Engine/IMultiSlotKvCache.cs
+++ b/src/SharpInference.Engine/IMultiSlotKvCache.cs
@@ -1,0 +1,27 @@
+namespace SharpInference.Engine;
+
+/// <summary>
+/// Optional capability: a forward pass that can hold more than one resident KV region
+/// (the native "owned" cache plus extra "scratch" regions) so a short interleaved request
+/// can be served without evicting a long resident prefix in the owned cache. Issue #212.
+/// Implemented by the dense CudaForwardPass; null/absent for backends that don't support it.
+/// </summary>
+internal interface IMultiSlotKvCache
+{
+    /// <summary>True when extra KV slots are allocatable (dense, non-TQ/SnapKV/MoE/Gemma-shared, etc.).</summary>
+    bool SupportsMultiSlotPrefix { get; }
+
+    /// <summary>The native owned KV region as a slot handle (slot 0). Never disposed by the engine.</summary>
+    ISequenceKvCache OwnedSlot { get; }
+
+    /// <summary>Allocate one extra resident KV region capped at <paramref name="capacityTokens"/> positions.
+    /// Engine owns/disposes it.</summary>
+    ISequenceKvCache AllocateScratchSlot(int capacityTokens);
+
+    /// <summary>Bind <paramref name="slot"/> as the active KV region for the whole request
+    /// (prefill + decode + truncate). Subsequent Prefill/Forward/TruncateTo/ResetCache operate on it.</summary>
+    void ActivateSlot(ISequenceKvCache slot);
+
+    /// <summary>Write the active slot's advanced length back and restore the owned region. Idempotent.</summary>
+    void DeactivateSlot();
+}

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -172,11 +172,18 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
             && fwd.SupportsPartialRewind
             && fwd is IMultiSlotKvCache ms && ms.SupportsMultiSlotPrefix)
         {
+            // The scratch tensor is clamped to the model's max context (AllocateScratchSlot caps at
+            // _maxSeqLen); clamp the routing cap to match so SelectSlot's footprint gate can't pass
+            // a request the (clamped) scratch allocation couldn't actually hold.
+            _scratchCap = Math.Min(_scratchCap, fwd.MaxSeqLen);
+
             // Allocating the extra scratch KV region can OOM: auto-context sizes _maxSeqLen to
             // fit exactly one full KV cache in VRAM and doesn't budget the scratch slot. Since
-            // the feature is opt-in, degrade to single-slot on failure rather than aborting
-            // engine construction. (Logger is DI-set after construction, so it's unavailable
-            // here — emit to stderr like the other SHARPI_* opt-in traces.)
+            // the feature is opt-in, degrade to single-slot on a device-allocation failure rather
+            // than aborting engine construction. (Logger is DI-set after construction, so it's
+            // unavailable here — emit to stderr like the other SHARPI_* opt-in traces.) A
+            // NotSupportedException means the capability checks above disagree with
+            // AllocateScratchSlot — a real bug, not an allocation failure — so let it propagate.
             try
             {
                 var scratch = ms.AllocateScratchSlot(_scratchCap);
@@ -184,7 +191,8 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 _slots = [ms.OwnedSlot, scratch];
                 _slotTokens = new int[]?[2];
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not NotSupportedException and not OutOfMemoryException
+                                       and not OperationCanceledException)
             {
                 Console.Error.WriteLine(
                     $"[InferenceEngine] SHARPI_PREFIX_SLOTS=2: could not allocate the " +
@@ -193,6 +201,14 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
             }
         }
     }
+
+    /// <summary>
+    /// Issue #212: whether the 2-slot prefix cache is active for this engine. False when
+    /// <c>SHARPI_PREFIX_SLOTS</c> wasn't 2, the backend can't multi-slot, or the scratch
+    /// allocation failed and the engine degraded to single-slot. Lets a host observe the
+    /// degraded fallback (which otherwise only writes a one-shot stderr line at construction).
+    /// </summary>
+    public bool MultiSlotPrefixActive => _slots is not null;
 
     /// <summary>
     /// Back-compat constructor preserving the original positional signature
@@ -724,6 +740,15 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             reusedTokens = prefixLen;
                             Interlocked.Add(ref _prefillTokensReused, prefixLen);
                         }
+
+                        // Issue #212: from here the active slot's KV is mutated (ResetCache wiped
+                        // it, or the upcoming prefill overwrites positions >= prefixLen). _prevTokens
+                        // was already read above for the prefix match, so null the active slot's
+                        // shadow now — a mid-decode throw/cancel skips the end-of-decode shadow
+                        // write, and a stale shadow would let the next request SelectSlot-match a
+                        // prefix whose KV was destroyed. Re-populated only on a complete decode.
+                        if (_slotTokens is not null && activeSlotIdx >= 0)
+                            _slotTokens[activeSlotIdx] = null;
 
                         // Prefill: process all prompt tokens (or just the suffix after the cached prefix).
                         //

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -38,6 +38,17 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     // Prefix caching state (guarded by _gate — only accessed during generation).
     private int[]? _prevTokens;
 
+    // Multi-slot prefix cache (issue #212), opt-in via SHARPI_PREFIX_SLOTS=2. Non-null only
+    // when the dense rewindable pass supports it AND the env requested 2 slots; otherwise the
+    // engine stays exactly single-slot (byte-identical default path). Slot 0 = the pass's owned
+    // cache (legacy _prevTokens semantics); slot 1 = a bounded scratch cache for short
+    // interleaved requests so an aux call doesn't evict the long resident prefix in slot 0.
+    // _slotTokens[s] mirrors _prevTokens for slot s. Engine owns/disposes the scratch slot(s).
+    private readonly IMultiSlotKvCache? _multiSlot;
+    private ISequenceKvCache[]? _slots;
+    private int[]?[]? _slotTokens;
+    private readonly int _scratchCap;
+
     // Image input (issue #253). Set once at load via EnableImageInput; the VisionModel is
     // owned/disposed elsewhere (in _owned). Image requests splice projected soft tokens at
     // each placeholder during a fresh (no-prefix-reuse) prefill.
@@ -139,6 +150,46 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 Console.Error.WriteLine(
                     $"[InferenceEngine] prefix cache disabled — {fwd.GetType().Name} reports SupportsPartialRewind == false " +
                     "and exposes no snapshot facility. Multi-turn requests will re-prefill the full prompt.");
+            }
+        }
+
+        // Multi-slot prefix cache (issue #212): opt-in via SHARPI_PREFIX_SLOTS=2, dense
+        // rewindable path only. A bounded scratch slot (SHARPI_PREFIX_SCRATCH_TOKENS, default
+        // 4096) holds short interleaved requests so they don't evict slot 0's long prefix.
+        // Default (env unset / != 2) leaves _multiSlot null → exact single-slot behavior.
+        _scratchCap = 4096;
+        if (int.TryParse(
+                Environment.GetEnvironmentVariable("SHARPI_PREFIX_SCRATCH_TOKENS"),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out int sc) && sc > 0)
+            _scratchCap = sc;
+
+        if (int.TryParse(
+                Environment.GetEnvironmentVariable("SHARPI_PREFIX_SLOTS"),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out int slots)
+            && slots == 2
+            && fwd.SupportsPartialRewind
+            && fwd is IMultiSlotKvCache ms && ms.SupportsMultiSlotPrefix)
+        {
+            // Allocating the extra scratch KV region can OOM: auto-context sizes _maxSeqLen to
+            // fit exactly one full KV cache in VRAM and doesn't budget the scratch slot. Since
+            // the feature is opt-in, degrade to single-slot on failure rather than aborting
+            // engine construction. (Logger is DI-set after construction, so it's unavailable
+            // here — emit to stderr like the other SHARPI_* opt-in traces.)
+            try
+            {
+                var scratch = ms.AllocateScratchSlot(_scratchCap);
+                _multiSlot = ms;
+                _slots = [ms.OwnedSlot, scratch];
+                _slotTokens = new int[]?[2];
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[InferenceEngine] SHARPI_PREFIX_SLOTS=2: could not allocate the " +
+                    $"{_scratchCap}-token scratch KV slot ({ex.GetType().Name}: {ex.Message}); " +
+                    "falling back to single-slot prefix cache.");
             }
         }
     }
@@ -293,21 +344,76 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     /// Finds the longest page-aligned prefix shared between the new token array and the cached
     /// previous token array, returning its length (0 if no reusable prefix exists).
     /// </summary>
-    private int FindCacheablePrefix(int[] tokens)
+    private int FindCacheablePrefix(int[] tokens) => PageAlignedSharedPrefix(tokens, _prevTokens, tokens.Length);
+
+    /// <summary>
+    /// Longest page-aligned token prefix shared between <paramref name="a"/> and a cached
+    /// <paramref name="prev"/> array (0 if none). Factored out of <see cref="FindCacheablePrefix"/>
+    /// so the issue-#212 multi-slot selector can score each resident slot with identical logic.
+    /// </summary>
+    private static int PageAlignedSharedPrefix(int[] a, int[]? prev, int newLen)
     {
-        if (_prevTokens == null || tokens.Length <= PagedKvCache.PageSize)
+        if (prev == null || newLen <= PagedKvCache.PageSize)
             return 0;
 
         // Compare up to all-but-last-page tokens (need at least one page to bother).
-        int maxCompare = Math.Min(tokens.Length - 1, _prevTokens.Length);
+        int maxCompare = Math.Min(newLen - 1, prev.Length);
         int match = 0;
-        while (match < maxCompare && tokens[match] == _prevTokens[match])
+        while (match < maxCompare && a[match] == prev[match])
             match++;
 
         // Align down to page boundary (must be at least one full page).
-        int aligned = (match / PagedKvCache.PageSize) * PagedKvCache.PageSize;
-        return aligned;
+        return (match / PagedKvCache.PageSize) * PagedKvCache.PageSize;
     }
+
+    /// <summary>
+    /// Issue #212 multi-slot selection: pick the resident slot to serve <paramref name="tokens"/>.
+    /// Scores each slot's page-aligned shared prefix; reuses the slot with the largest match.
+    /// On no match, picks a victim — the bounded scratch slot when the prompt fits its capacity
+    /// (so a short interleaved request leaves slot 0's long prefix intact), otherwise the
+    /// full-size owned slot. Returns the chosen slot index and the prefix length to reuse
+    /// (0 for the victim). Only called when <see cref="_slots"/> is non-null.
+    /// </summary>
+    private (int SlotIdx, int PrefixLen) SelectSlot(int[] tokens, int maxNewTokens)
+    {
+        int[]?[] slotTokens = _slotTokens!;
+
+        // Worst-case absolute positions this request will occupy: prompt + every decoded token
+        // (decode appends KV at startPos+i for i in [0, maxNewTokens), so the highest written
+        // offset is (footprint-1)*kvDim). A request may bind the BOUNDED scratch slot only if
+        // its whole footprint fits the allocation — otherwise decode would append KV past the
+        // scratch tensor (out-of-bounds VRAM write). The owned slot 0 is full-size (_maxSeqLen),
+        // so it always fits and needs no such gate. Issue #212.
+        long footprint = (long)tokens.Length + Math.Max(0, maxNewTokens);
+        bool scratchFits = footprint <= _scratchCap;
+
+        int bestSlot = -1, bestPrefix = 0;
+        for (int s = 0; s < slotTokens.Length; s++)
+        {
+            // Skip a prefix match against the scratch slot when the request can't safely live
+            // there — fall through to (re-prefilling on) the owned slot instead.
+            if (s == ScratchSlotIdx && !scratchFits) continue;
+            int p = PageAlignedSharedPrefix(tokens, slotTokens[s], tokens.Length);
+            if (p > bestPrefix)
+            {
+                bestPrefix = p;
+                bestSlot = s;
+            }
+        }
+        if (bestSlot >= 0)
+            return (bestSlot, bestPrefix);
+
+        // No reusable prefix: pick a victim. Prefer the bounded scratch slot when the footprint
+        // fits (so a short interleaved request leaves slot 0's long prefix intact); otherwise the
+        // full-size owned slot absorbs it.
+        int victim = scratchFits ? ScratchSlotIdx : OwnedSlotIdx;
+        return (victim, 0);
+    }
+
+    // Issue #212 slot indices: slot 0 is the pass's owned (full-size) cache; slot 1 is the
+    // bounded scratch cache. Named for clarity in SelectSlot's footprint gating.
+    private const int OwnedSlotIdx = 0;
+    private const int ScratchSlotIdx = 1;
 
     /// <summary>
     /// Back-compat string-stream view of <see cref="GenerateChunksAsync"/>: yields only
@@ -406,6 +512,10 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 bool logReq = logger?.IsEnabled(LogLevel.Debug) == true;
                 int promptTokenCount = 0, reusedTokens = 0, decodeTokens = 0;
                 long encodeMs = 0, prefillMs = 0, ttftMs = -1;
+                // Issue #212: index of the multi-slot prefix slot bound for this request, or -1
+                // when no non-owned slot is active (single-slot mode, or this request stayed on
+                // the owned slot). -1 keeps the finally's DeactivateSlot a no-op.
+                int activeSlotIdx = -1;
                 try
                 {
                     var tokens = _tokenizer.Encode(prompt).ToArray();
@@ -544,12 +654,40 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         // which leaves the cache partially written (the end-of-decode snapshot below
                         // is already skipped for image requests).
                         _prevTokens = null;
+                        // Issue #212: the image path runs on the owned cache (slot 0, no slot
+                        // bind) and ResetCache wipes its KV — invalidate slot 0's token shadow so
+                        // a later text request can't SelectSlot-match the now-overwritten prefix.
+                        // (The bounded scratch slot 1 is untouched and stays valid.)
+                        if (_slotTokens is not null) _slotTokens[0] = null;
                         _fwd.ResetCache();
                         suffixTokens = tokens;
                         logits = SplicePrefillImages(tokens, imageBytes, ct, out startPos);
                     }
                     else
                     {
+                        // Issue #212: multi-slot prefix cache. On the dense rewindable path, pick
+                        // the resident slot (owned slot 0 or bounded scratch slot 1) with the best
+                        // page-aligned prefix, bind it as the active KV region, and point the
+                        // engine's working _prevTokens at that slot's cached tokens so the existing
+                        // FindCacheablePrefix/TruncateTo block below operates on it unchanged. The
+                        // bind is released in this request's finally (DeactivateSlot).
+                        if (_slots is not null && _fwd.SupportsPartialRewind)
+                        {
+                            if (useMtp)
+                            {
+                                // MTP stays single-slot (slot 0 / owned cache) — no slot bind. But
+                                // _prevTokens may still mirror a prior scratch request, so realign
+                                // it to slot 0's shadow so prefix reuse matches the owned KV.
+                                _prevTokens = _slotTokens![0];
+                            }
+                            else
+                            {
+                                (activeSlotIdx, _) = SelectSlot(tokens, sp.MaxNewTokens);
+                                _multiSlot!.ActivateSlot(_slots[activeSlotIdx]);
+                                _prevTokens = _slotTokens![activeSlotIdx];
+                            }
+                        }
+
                         if (_fwd.SupportsPartialRewind)
                         {
                             int candidate = FindCacheablePrefix(tokens);
@@ -679,7 +817,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         if (!useCanonicalSnapshot && !ct.IsCancellationRequested)
                         {
                             _fwd.CaptureSnapshot();
-                            _prevTokens = fullSeq.ToArray();
+                            var snapMtp = fullSeq.ToArray();
+                            _prevTokens = snapMtp;
+                            // Issue #212: MTP ran single-slot on slot 0 (owned) — record the
+                            // transcript against slot 0 so the next turn's SelectSlot can rematch.
+                            if (_slotTokens is not null) _slotTokens[0] = snapMtp;
                         }
                         channel.Writer.TryComplete();
                         return;
@@ -821,7 +963,13 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     if (!useCanonicalSnapshot && !ct.IsCancellationRequested && imageBytes is null)
                     {
                         _fwd.CaptureSnapshot();
-                        _prevTokens = fullSeq.ToArray();
+                        var snap = fullSeq.ToArray();
+                        _prevTokens = snap;
+                        // Issue #212: record the transcript against the active slot so the next
+                        // turn's SelectSlot can rematch it (slot 0 = owned long prefix, slot 1 =
+                        // scratch). When no non-owned slot is bound (single-slot, MTP), this is
+                        // skipped and _prevTokens carries the state as before.
+                        if (activeSlotIdx >= 0) _slotTokens![activeSlotIdx] = snap;
                     }
 
                     channel.Writer.TryComplete();
@@ -832,6 +980,10 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 }
                 finally
                 {
+                    // Issue #212: always release a bound non-owned slot, even on exception or
+                    // cancellation, so a scratch bind can't leak into the next request's
+                    // owned-cache state (mirrors how RestoreOwned is always in a finally).
+                    if (activeSlotIdx >= 0) _multiSlot!.DeactivateSlot();
                     if (logReq)
                     {
                         long totalMs = swReq.ElapsedMilliseconds;
@@ -944,6 +1096,13 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 "live worker. Ensure consumers dispose their generation enumerators and that the backend is responsive.");
             return;
         }
+        // Issue #212: dispose the scratch slot(s) the engine allocated (slot 0 is the pass's
+        // OwnedSlot — owned/freed by _fwd.Dispose, never disposed here). Done before _fwd.Dispose
+        // so the scratch tensors free while the backend is still live.
+        if (_slots is not null)
+            for (int s = 1; s < _slots.Length; s++)
+                _slots[s].Dispose();
+
         _fwd.Dispose();
         foreach (var d in _owned)
             d.Dispose();

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
@@ -413,6 +413,71 @@ public sealed class InferenceEnginePrefixCacheTests
         Assert.Equal(33, fwd.CaptureSnapshotCalls[0]);
     }
 
+    /// <summary>
+    /// Issue #212: with the 2-slot prefix cache enabled (SHARPI_PREFIX_SLOTS=2), a short
+    /// interleaved auxiliary request is served from the bounded scratch slot (slot 1) and does
+    /// NOT evict the long resident prefix in the owned slot (slot 0) — so the next long request
+    /// still reuses it. This is the exact agentic-client (Claude Code) pattern #212 targets.
+    /// Slot activations: long → owned, aux → scratch, long → owned; the second long reuses 48
+    /// (3-page-aligned) tokens of the first long's prefix.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_TwoSlot_ShortAuxRequestDoesNotEvictLongPrefix()
+    {
+        using var _ = new EnvScope(("SHARPI_PREFIX_SLOTS", "2"), ("SHARPI_PREFIX_SCRATCH_TOKENS", "48"));
+
+        var tokenizer = new InterleavedAgenticTokenizer();
+        var fwd = new MultiSlotForwardPass();
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        Assert.True(engine.PrefixCacheEnabled);
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+
+        await Drain(engine.GenerateAsync("long", sp));   // cold → owned slot 0
+        await Drain(engine.GenerateAsync("aux", sp));    // short, no match → scratch slot 1
+        await Drain(engine.GenerateAsync("long", sp));   // matches slot 0 → reuse
+
+        // The three requests bound owned, scratch, owned in order.
+        Assert.Equal([0, 1, 0], fwd.ActivatedIds);
+
+        // The aux turn never touched the owned slot: it was reset/prefilled exactly once (the
+        // first long turn), then truncated+prefilled for the third (reuse) turn — never by aux.
+        Assert.Equal(1, fwd.Owned.Resets);
+        Assert.Equal([(64, 0), (16, 48)], fwd.Owned.Prefills);
+        Assert.Contains(48, fwd.Owned.Truncates);
+
+        // The aux request lived entirely in the scratch slot.
+        Assert.Single(fwd.Scratch);
+        Assert.Equal([(16, 0)], fwd.Scratch[0].Prefills);
+
+        // Only the third turn reused a prefix (48 page-aligned tokens of the long prefix).
+        Assert.Equal(48, engine.PrefillTokensReused);
+    }
+
+    /// <summary>
+    /// Issue #212 contrast (the bug being fixed): with the default single-slot cache, the short
+    /// interleaved aux request overwrites the one resident sequence, so the next long request
+    /// finds no reusable prefix and re-prefills from scratch — 0 reuse.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_SingleSlot_ShortAuxRequestEvictsLongPrefix()
+    {
+        var tokenizer = new InterleavedAgenticTokenizer();
+        var fwd = new MultiSlotForwardPass();
+        // No SHARPI_PREFIX_SLOTS env → single-slot (default) behavior, even though fwd CAN do 2.
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 1 };
+        await Drain(engine.GenerateAsync("long", sp));
+        await Drain(engine.GenerateAsync("aux", sp));
+        await Drain(engine.GenerateAsync("long", sp));
+
+        // Single-slot: the engine never binds a non-owned slot...
+        Assert.Empty(fwd.ActivatedIds);
+        // ...and the aux turn evicted the long prefix, so the second long turn reused nothing.
+        Assert.Equal(0, engine.PrefillTokensReused);
+    }
+
     private static IAsyncEnumerable<string> GenerateAsync(
         InferenceEngine engine, string prompt, string canonical, SamplingParams sp)
     {
@@ -862,6 +927,149 @@ public sealed class InferenceEnginePrefixCacheTests
             Array.Clear(_logits);
             _logits[Eos] = 1.0f;
             return _logits;
+        }
+    }
+
+    /// <summary>
+    /// Issue #212 tokenizer modelling the agentic interleave: a long stable request, a short
+    /// auxiliary request with disjoint tokens, then the long request again.
+    ///   "long" → [0..64)                 (64 tokens; the stable system-prefix-like sequence)
+    ///   "aux"  → [500..516)              (16 tokens; disjoint, no shared prefix with "long")
+    /// </summary>
+    private sealed class InterleavedAgenticTokenizer : ITokenizer
+    {
+        public int VocabSize => 600;
+        public int BosTokenId => 0;
+        public int EosTokenId => Eos;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => Eos;
+        public bool AddBosToken => false;
+
+        public IReadOnlyList<int> Encode(string text) => text switch
+        {
+            "long" => Enumerable.Range(0, 64).ToArray(),
+            "aux"  => Enumerable.Range(500, 16).ToArray(),
+            _      => throw new ArgumentException($"unknown prompt: {text}", nameof(text)),
+        };
+
+        public string Decode(IEnumerable<int> tokens) => string.Empty;
+        public byte[] DecodeBytes(int token) => [];
+    }
+
+    /// <summary>
+    /// Rewind-capable forward pass that ALSO implements <see cref="IMultiSlotKvCache"/> (issue
+    /// #212). Each <see cref="Slot"/> records the Prefill/TruncateTo/ResetCache calls routed to it
+    /// while it is the active (bound) slot, so a test can assert which slot served each request and
+    /// that a scratch-bound request never touched the owned slot. Slot 0 is the owned cache; each
+    /// <see cref="AllocateScratchSlot"/> hands out the next id.
+    /// </summary>
+    private sealed class MultiSlotForwardPass : IForwardPass, IMultiSlotKvCache
+    {
+        private readonly float[] _logits = new float[600];
+        private readonly Slot _owned = new(0);
+        private readonly List<Slot> _scratch = [];
+        private Slot _active;
+
+        public MultiSlotForwardPass() => _active = _owned;
+
+        public sealed class Slot(int id) : ISequenceKvCache
+        {
+            public int Id { get; } = id;
+            public int Length;
+            public int Capacity = int.MaxValue;
+            public List<(int Length, int StartPos)> Prefills { get; } = [];
+            public List<int> Truncates { get; } = [];
+            public int Resets;
+            public void Dispose() { }
+        }
+
+        public Slot Owned => _owned;
+        public IReadOnlyList<Slot> Scratch => _scratch;
+        /// <summary>Ids of slots bound via ActivateSlot, in order (empty in single-slot mode).</summary>
+        public List<int> ActivatedIds { get; } = [];
+
+        // ── IForwardPass: route to the active slot ──
+        public bool SupportsPartialRewind => true;
+        public int VocabSize => 600;
+        public int MaxSeqLen => 100_000;
+
+        public ReadOnlySpan<float> Forward(int token, int position)
+        {
+            _active.Length = position + 1;
+            return EosLogits();
+        }
+
+        public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0)
+        {
+            _active.Prefills.Add((tokens.Count, startPos));
+            _active.Length = startPos + tokens.Count;
+            return EosLogits();
+        }
+
+        public void TruncateTo(int length)
+        {
+            _active.Truncates.Add(length);
+            _active.Length = length;
+        }
+
+        public void ResetCache()
+        {
+            _active.Resets++;
+            _active.Length = 0;
+        }
+
+        public void Dispose() { }
+
+        // ── IMultiSlotKvCache ──
+        public bool SupportsMultiSlotPrefix => true;
+        public ISequenceKvCache OwnedSlot => _owned;
+
+        public ISequenceKvCache AllocateScratchSlot(int capacityTokens)
+        {
+            var s = new Slot(_scratch.Count + 1) { Capacity = capacityTokens };
+            _scratch.Add(s);
+            return s;
+        }
+
+        public void ActivateSlot(ISequenceKvCache slot)
+        {
+            _active = (Slot)slot;
+            ActivatedIds.Add(_active.Id);
+        }
+
+        public void DeactivateSlot() => _active = _owned;
+
+        private ReadOnlySpan<float> EosLogits()
+        {
+            Array.Clear(_logits);
+            _logits[Eos] = 1.0f;
+            return _logits;
+        }
+    }
+
+    /// <summary>
+    /// Sets environment variables for the duration of a test and restores their prior values on
+    /// dispose. The engine reads SHARPI_PREFIX_* only in its constructor; other engine tests use
+    /// non-multi-slot fakes, so a stray concurrent read of these vars is inert.
+    /// </summary>
+    private sealed class EnvScope : IDisposable
+    {
+        private readonly (string Key, string? Prior)[] _saved;
+
+        public EnvScope(params (string Key, string? Value)[] vars)
+        {
+            _saved = new (string, string?)[vars.Length];
+            for (int i = 0; i < vars.Length; i++)
+            {
+                _saved[i] = (vars[i].Key, Environment.GetEnvironmentVariable(vars[i].Key));
+                Environment.SetEnvironmentVariable(vars[i].Key, vars[i].Value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var (key, prior) in _saved)
+                Environment.SetEnvironmentVariable(key, prior);
         }
     }
 }

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEnginePrefixCacheTests.cs
@@ -478,6 +478,40 @@ public sealed class InferenceEnginePrefixCacheTests
         Assert.Equal(0, engine.PrefillTokensReused);
     }
 
+    /// <summary>
+    /// Issue #212 (review follow-up): a scratch request that resets+overwrites its slot's KV but
+    /// fails mid-decode must NOT leave the slot's token shadow describing the destroyed KV — else
+    /// the next request could SelectSlot-match that stale prefix and TruncateTo into mismatched KV
+    /// (silent garbage). The engine nulls the active slot's shadow before mutating its KV and only
+    /// re-writes it on a complete decode, so the post-failure request reuses nothing.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_TwoSlot_ScratchFailedMidDecode_DoesNotReuseDestroyedPrefix()
+    {
+        using var _ = new EnvScope(("SHARPI_PREFIX_SLOTS", "2"), ("SHARPI_PREFIX_SCRATCH_TOKENS", "48"));
+
+        var tokenizer = new InterleavedAgenticTokenizer();
+        var fwd = new MultiSlotForwardPass { EmitNonStopFirst = true }; // force a decode Forward
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 2 };
+
+        // B1: completes on the scratch slot; its transcript becomes scratch's shadow.
+        await Drain(engine.GenerateAsync("aux32", sp));
+
+        // B2: a disjoint short request resets the scratch KV, then throws mid-decode.
+        fwd.FailNextDecode = true;
+        await Assert.ThrowsAnyAsync<Exception>(async () => await Drain(engine.GenerateAsync("aux2", sp)));
+
+        long reusedBefore = engine.PrefillTokensReused;
+
+        // B3: same prompt as B1. If B2's failure had left the stale B1 shadow in place, B3 would
+        // reuse a 16-token page of it — into KV that B2 reset+overwrote. The shadow-null fix makes
+        // B3 reuse nothing.
+        await Drain(engine.GenerateAsync("aux32", sp));
+
+        Assert.Equal(reusedBefore, engine.PrefillTokensReused);
+    }
+
     private static IAsyncEnumerable<string> GenerateAsync(
         InferenceEngine engine, string prompt, string canonical, SamplingParams sp)
     {
@@ -947,9 +981,13 @@ public sealed class InferenceEnginePrefixCacheTests
 
         public IReadOnlyList<int> Encode(string text) => text switch
         {
-            "long" => Enumerable.Range(0, 64).ToArray(),
-            "aux"  => Enumerable.Range(500, 16).ToArray(),
-            _      => throw new ArgumentException($"unknown prompt: {text}", nameof(text)),
+            "long"  => Enumerable.Range(0, 64).ToArray(),
+            "aux"   => Enumerable.Range(500, 16).ToArray(),
+            // 32-token (>1 page) scratch-sized prompts for the mid-decode-failure test, where a
+            // reusable prefix requires length > PageSize. "aux2" is disjoint from "aux32".
+            "aux32"  => Enumerable.Range(500, 32).ToArray(),
+            "aux2"   => Enumerable.Range(600, 32).ToArray(),
+            _       => throw new ArgumentException($"unknown prompt: {text}", nameof(text)),
         };
 
         public string Decode(IEnumerable<int> tokens) => string.Empty;
@@ -988,6 +1026,13 @@ public sealed class InferenceEnginePrefixCacheTests
         /// <summary>Ids of slots bound via ActivateSlot, in order (empty in single-slot mode).</summary>
         public List<int> ActivatedIds { get; } = [];
 
+        /// <summary>When set, Prefill returns a non-stop token so the decode loop runs at least
+        /// one Forward (the EOS-on-prefill default breaks before any Forward).</summary>
+        public bool EmitNonStopFirst;
+        /// <summary>One-shot: the next Forward throws, simulating a mid-decode failure/cancel.</summary>
+        public bool FailNextDecode;
+        private const int NonStopToken = 5;
+
         // ── IForwardPass: route to the active slot ──
         public bool SupportsPartialRewind => true;
         public int VocabSize => 600;
@@ -995,6 +1040,11 @@ public sealed class InferenceEnginePrefixCacheTests
 
         public ReadOnlySpan<float> Forward(int token, int position)
         {
+            if (FailNextDecode)
+            {
+                FailNextDecode = false;
+                throw new InvalidOperationException("simulated mid-decode failure");
+            }
             _active.Length = position + 1;
             return EosLogits();
         }
@@ -1003,7 +1053,7 @@ public sealed class InferenceEnginePrefixCacheTests
         {
             _active.Prefills.Add((tokens.Count, startPos));
             _active.Length = startPos + tokens.Count;
-            return EosLogits();
+            return EmitNonStopFirst ? OneHot(NonStopToken) : EosLogits();
         }
 
         public void TruncateTo(int length)
@@ -1039,10 +1089,12 @@ public sealed class InferenceEnginePrefixCacheTests
 
         public void DeactivateSlot() => _active = _owned;
 
-        private ReadOnlySpan<float> EosLogits()
+        private ReadOnlySpan<float> EosLogits() => OneHot(Eos);
+
+        private ReadOnlySpan<float> OneHot(int token)
         {
             Array.Clear(_logits);
-            _logits[Eos] = 1.0f;
+            _logits[token] = 1.0f;
             return _logits;
         }
     }


### PR DESCRIPTION
## Problem (#212)

Under an agentic client (Claude Code), the single-user `InferenceEngine` got **0 prefix reuse**. Live server trace:

```
request prompt=335tok   (reused=0 ...)            # Claude Code auxiliary request
request prompt=23678tok  (reused=0) prefill=27755ms (853 tok/s) ttft=27958ms
```

The engine keeps **one** previous-sequence slot (`_prevTokens`) and the dense `CudaForwardPass` KV cache holds **one** contiguous sequence. Short interleaved auxiliary requests (topic/title/quota checks, ~335 tokens) overwrite the KV that held the long stable system prefix (~23.7k tokens), so every real turn re-prefills the whole system prompt → **~28 s TTFT on every turn**.

## Fix

An **opt-in 2-slot prefix cache**:
- **Slot 0** = the dense `CudaForwardPass`'s native owned KV cache (full `_maxSeqLen`).
- **Slot 1** = a **bounded scratch** cache (`SHARPI_PREFIX_SCRATCH_TOKENS`, default 4096).

A short aux request is routed to scratch and **leaves slot 0's long prefix intact**, so the next real turn reuses it (TTFT → decode-only). Per request the engine picks the slot with the longest page-aligned shared prefix; on no match, a request whose worst-case footprint (`prompt + maxNewTokens`) fits the scratch cap goes to scratch, otherwise to the full-size owned slot.

### Mechanism (Engine-internal; no `SharpInference.Core` changes)
- New internal `IMultiSlotKvCache` capability; `CudaForwardPass` implements it by reusing the existing owned-cache view + `BindCache` machinery. The only per-slot state on the dense path is `(_gpuKCache, _gpuVCache, _kvLength)` — `_kvCache` is write-only bookkeeping — so a scoped owned-pointer swap is bit-safe.
- **CUDA graphs** bake the owned cache's device pointers, so the captured graph is valid only while slot 0 is active: `_activeSlotIsOwned` gates both graph paths to direct launches during scratch decode. No permanent graph disable → slot 0 keeps its ~9% graph win.
- Gated to the dense `SupportsPartialRewind` path; **GDN/snapshot, MTP, image (#253), TurboQuant, SnapKV, and MoE all stay single-slot**, exactly as before.

### Safety
- **Default OFF** (`SHARPI_PREFIX_SLOTS` unset / ≠ 2) → byte-identical to current behavior; every new branch is guarded by a null/`-1` sentinel.
- A scratch-routed request can never append KV past the scratch allocation: `SelectSlot` bounds routing by `prompt + maxNewTokens ≤ scratchCap` (caught in review — would otherwise be an OOB VRAM write).
- Scratch-alloc OOM degrades to single-slot rather than failing engine construction (auto-context doesn't budget the extra region).

## Knobs
- `SHARPI_PREFIX_SLOTS=2` — enable (default 1 = single-slot).
- `SHARPI_PREFIX_SCRATCH_TOKENS=N` — scratch capacity (default 4096).

## Tests
`InferenceEnginePrefixCacheTests` gains a before/after pair:
- **single-slot**: the aux request evicts the long prefix → **0 reuse** on the next long turn (the bug).
- **2-slot**: the aux request is served from scratch → the next long turn **reuses 48 tokens** of slot 0's prefix.

14/14 green; full solution builds clean under `TreatWarningsAsErrors`.

## Scope / follow-ups (this is the "cheaper mitigation" from #212)
- This is the bounded 2-slot mitigation, not the full vLLM-style paged/multi-prefix cache (two interleaved *large* conversations still thrash slot 0).
- Not GPU-validated end-to-end here (no-CPU-inference / no-GPU-run dev constraint); the default path is inert and shipping-default. A 4070 Ti A/B (slot-0 reuse hits the graph; scratch decode correct via direct launches; multi-turn `reused=` under a real Claude Code session) is the recommended validation before flipping default-on or adding a `SharpInferenceServerOptions` field (mirrors #93).

Closes #212 (mitigation tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)