### PR TITLE
feat(cuda): SnapKV-aware continuous batching — per-sequence eviction + prefer-batching (#196)

### DIFF
--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -3336,14 +3336,17 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// Whether the dense packed multi-prompt prefill trunk (issue #193) can run this model: the
     /// single-sequence batched-trunk prefill is supported AND none of the Gemma-4 / softcap
     /// features the dense packed trunk omits (PLE, SWA rings, per-layer head_dim, shared-KV,
-    /// softcap) are present. Gemma 4 batches its DECODE (#195) but keeps the Gemma-4-capable
-    /// single-sequence batched trunk for prefill, so it returns false here and
-    /// <see cref="PrefillPackedMulti"/> uses the sequential loop for it. This is exactly the
-    /// negation of the dense-only assertion in <see cref="PrefillPackedTrunkMulti"/>.
+    /// softcap) are present, AND SnapKV is not active. Gemma 4 batches its DECODE (#195) but keeps
+    /// the Gemma-4-capable single-sequence batched trunk for prefill; SnapKV (#196) needs the
+    /// per-token eviction the packed trunk doesn't run. Both fall back to <see cref="PrefillPacked
+    /// Multi"/>'s sequential <see cref="PrefillWithCache"/> loop — which IS SnapKV-aware — instead
+    /// of the dense-only assertion in <see cref="PrefillPackedTrunkMulti"/> (kept as a last-resort
+    /// guard). This is the negation of that assertion.
     /// </summary>
     private bool IsDensePackablePrefill() =>
         !_isGemma4Like && !_hp.HasPerLayerTokenEmbd && _hp.LayerHeadDim is null
         && _hp.SlidingWindowSize <= 0 && _hp.KvSourceLayer is null && _hp.FinalLogitSoftcap == 0f
+        && _snapKvEffectiveBudget == 0
         && IsBatchedPrefillSupported();
 
     private bool AllChunksPackable(ReadOnlyMemory<int>[] chunks, int[] startPos)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -603,7 +603,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     public CudaForwardPass(GgufModel model, CudaBackend gpu, ModelHyperparams hp,
         int maxContextLength = 0,
         bool enableTurboQuant = false, int tqFp32Window = 256, int tqBits = 3,
-        bool? mmqSoa = null)
+        bool? mmqSoa = null, bool preferBatchingOverAutoSnapKv = false)
     {
         _model = model;
         _gpu = gpu;
@@ -816,6 +816,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         if (_snapKvCfg.IsBudgetExplicit)
         {
             _snapKvEffectiveBudget = _snapKvCfg.Budget;
+            // Issue #196 (Option 1): an explicit budget is honored even under continuous batching —
+            // per-sequence eviction composes with the batched decode (each CudaSequenceKvCache is
+            // scored + compacted at the end of its own prefill). Non-Gemma-4, fp32-KV only (the
+            // guards above force the budget off for narrowed KV / TQ / Gemma 4).
+            if (preferBatchingOverAutoSnapKv && _snapKvEffectiveBudget > 0)
+                Console.Error.WriteLine(
+                    $"[CudaForwardPass] SnapKV (budget={_snapKvEffectiveBudget}) composes with " +
+                    "continuous batching via per-sequence eviction (issue #196 Option 1).");
         }
         else if (_tqEnabled)
         {
@@ -848,6 +856,21 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 "[CudaForwardPass] SnapKV auto-enable suppressed for the multi-slot prefix cache " +
                 "(SHARPI_PREFIX_SLOTS=2, issue #212). Set an explicit SHARPI_SNAPKV_BUDGET>0 to " +
                 "use SnapKV instead (disables multi-slot).");
+        }
+        else if (preferBatchingOverAutoSnapKv)
+        {
+            // Issue #196 (Option 2): continuous batching is requested (MaxBatchSize>1). Prefer
+            // pure batching — the ragged-decode fast path with no lossy eviction — over the
+            // VRAM-scaled SnapKV auto-enable, which would otherwise route every sequence through
+            // the slower per-sequence-eviction decode (Option 1). The operator can still opt INTO
+            // per-sequence eviction with an explicit SHARPI_SNAPKV_BUDGET>0 (handled above; it
+            // composes with batching via #196 Option 1), or shrink the KV footprint without
+            // eviction via --kv-type bf16/q8_0.
+            _snapKvEffectiveBudget = 0;
+            Console.Error.WriteLine(
+                "[CudaForwardPass] SnapKV auto-enable suppressed because continuous batching is " +
+                "enabled (MaxBatchSize>1, issue #196). Set SHARPI_SNAPKV_BUDGET>0 for per-sequence " +
+                "eviction that composes with batching, or --kv-type bf16 to shrink KV without it.");
         }
         else
         {
@@ -3234,6 +3257,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             throw new InvalidOperationException(
                 "PrefillPackedTrunkMulti is dense-only; this model requires the Gemma-4 / softcap " +
                 "path that ThrowIfBatchingUnsupported should have rejected before reaching here.");
+        // The packed trunk does NOT run SnapKV eviction (it never sets EvictedCount), so it must
+        // never be used with an active budget — the resulting full-length cache would mismatch the
+        // evicted decode's physical mapping. The engine disables chunking when SnapKvEnabled, so
+        // packed prefill is unreachable under SnapKV; assert it loudly if that ever changes (#196).
+        if (_snapKvEffectiveBudget > 0)
+            throw new InvalidOperationException(
+                "PrefillPackedTrunkMulti does not run SnapKV eviction; an active budget must use the " +
+                "unchunked per-sequence PrefillWithCache path (the engine disables chunking when SnapKvEnabled).");
 
         int S = chunks.Length;
         var off = new int[S + 1];
@@ -3529,14 +3560,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// <summary>
     /// Whether this instance can be driven by the continuous-batching engine (issue #190 dense,
     /// #195 Gemma 4). Single source of truth for the loader gate and the runtime guard, so they
-    /// can't diverge: no TurboQuant, no active SnapKV, every trunk + output weight in a GEMM-N-
-    /// batchable dtype (excludes Q4_0), and EITHER a dense transformer
-    /// (<see cref="DenseBatchedDecodeSupported"/>) OR a Gemma-4 model
-    /// (<see cref="Gemma4BatchedDecodeSupported"/> — the batched decode applies its per-layer
-    /// head_dim / SWA rings / shared-KV / k_eq_v / PLE / sandwich norms / final softcap).
+    /// can't diverge: no TurboQuant, every trunk + output weight in a GEMM-N-batchable dtype
+    /// (excludes Q4_0), and EITHER a dense transformer (<see cref="DenseBatchedDecodeSupported"/>)
+    /// OR a Gemma-4 model (<see cref="Gemma4BatchedDecodeSupported"/> — the batched decode applies
+    /// its per-layer head_dim / SWA rings / shared-KV / k_eq_v / PLE / sandwich norms / final
+    /// softcap). An active SnapKV budget no longer disqualifies batching (issue #196): a budget is
+    /// only ever set for dense fp32 KV (the constructor forces it off for Gemma 4 / narrowed KV /
+    /// TQ), and there it composes with batching via per-sequence eviction (Option 1).
     /// </summary>
     public bool SupportsContinuousBatching =>
-        _snapKvEffectiveBudget == 0 && (DenseBatchedDecodeSupported() || Gemma4BatchedDecodeSupported());
+        DenseBatchedDecodeSupported() || Gemma4BatchedDecodeSupported();
 
     /// <summary>
     /// The arch/dtype gate shared by <see cref="SupportsContinuousBatching"/> and
@@ -3602,9 +3635,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
     /// <summary>
     /// Guards the batched-serving entry points: continuous batching on the CUDA path is
-    /// implemented for dense transformers (#190) and Gemma-4 models (#195). Anything that needs
-    /// the owned-cache state machine (TQ ring, SnapKV eviction), or a weight dtype the GEMM-N
-    /// matvec can't drive (Q4_0), is out of scope.
+    /// implemented for dense transformers (#190) and Gemma-4 models (#195), and now composes with
+    /// a SnapKV budget via per-sequence eviction (#196). Anything that needs the TurboQuant ring
+    /// state machine, or a weight dtype the GEMM-N matvec can't drive (Q4_0), is out of scope.
     /// </summary>
     private void ThrowIfBatchingUnsupported(bool decodeOnly = false)
     {
@@ -3614,15 +3647,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         if (_tqEnabled)
             throw new NotSupportedException(
                 "CUDA continuous batching is not supported with the TurboQuant KV cache.");
-        // Prefill-capable entry points (CreateCache / PrefillWithCache / PrefillPackedMulti)
-        // reject any configured SnapKV budget — a whole-prompt prefill into a bound cache
-        // could evict. Decode-only batching (BatchForwardMulti, incl. the issue-#207
-        // BatchVerify wrapper) never evicts, so it only rejects an ALREADY-compacted owned
-        // cache, where logical position != physical slot.
-        if (decodeOnly ? _kvEvictedCount > 0 : _snapKvEffectiveBudget > 0)
-            throw new NotSupportedException(decodeOnly
-                ? "CUDA batched decode is not supported on a SnapKV-compacted cache (physical slot != logical position)."
-                : "CUDA continuous batching is not supported with an active SnapKV budget (eviction runs only on a whole-prompt prefill of the owned cache).");
+        // A configured SnapKV budget now composes with batching: prefill into a per-sequence cache
+        // evicts THAT cache and records the delta in CudaSequenceKvCache.EvictedCount (#196 Option
+        // 1), so CreateCache / PrefillWithCache no longer reject it. The decode-only path still
+        // rejects an ALREADY-compacted OWNED cache (e.g. after a single-user SnapKV prefill on this
+        // instance) — the batched decode never touches the owned cache, so its _kvEvictedCount must
+        // be 0; a non-zero value means physical slot != logical position on a cache the batched
+        // kernels would mis-index.
+        if (decodeOnly && _kvEvictedCount > 0)
+            throw new NotSupportedException(
+                "CUDA batched decode is not supported on a SnapKV-compacted OWNED cache (physical slot != logical position).");
         // Dense (#190) and Gemma 4 (#195) are the two supported families; both require every
         // trunk + output (+ Gemma PLE) weight in a GEMM-N-batchable dtype. A dense softcap arch
         // is excluded (the dense decode finisher applies no softcap); the Gemma-4 finisher does.
@@ -3754,6 +3788,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// <see cref="Prefill"/> (its batched trunk is both correct and weight-amortized; prefill
     /// captures no per-token graph, so the rebind is safe), writes the advanced length back,
     /// and always restores the owned cache. Returns the logits at the chunk's final token.
+    ///
+    /// <para>SnapKV (issue #196 Option 1): when a budget is active, <see cref="Prefill"/> runs
+    /// per-token + scores + compacts the BOUND cache in place. The eviction state lives on the
+    /// instance (<c>_kvEvictedCount</c> / <c>_kvLength</c>), so this binds the cache's own
+    /// eviction delta in, captures the post-eviction physical length + delta back onto the cache,
+    /// and restores the owned-cache state — keeping per-sequence eviction isolated from the owned
+    /// cache and from other sequences. For a non-evicting prefill (no budget, or prompt below the
+    /// budget) the delta stays 0 and physical == logical, exactly as before.</para>
     /// </summary>
     internal ReadOnlySpan<float> PrefillWithCache(IReadOnlyList<int> tokens, CudaSequenceKvCache cache, int startPos = 0)
     {
@@ -3763,17 +3805,25 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             throw new ArgumentException("Token list is empty", nameof(tokens));
 
         int savedKvLength = _kvLength;
+        int savedEvicted = _kvEvictedCount;
         BindCache(cache);
+        // Bind this sequence's eviction delta so the per-token SnapKV prefill appends at the right
+        // physical slot (pos - delta); a fresh cache has delta 0. A chunked resume can't co-occur
+        // with SnapKV (the engine disables chunking when SnapKvEnabled), so on the SnapKV path this
+        // is always a fresh whole-prompt prefill at startPos 0.
+        _kvEvictedCount = cache.EvictedCount;
         try
         {
             var logits = Prefill(tokens, startPos);
-            cache.Length = _kvLength;
+            cache.Length = _kvLength;            // physical rows (post-eviction K, or full length)
+            cache.EvictedCount = _kvEvictedCount; // logical-minus-physical delta (0 if not evicted)
             return logits;
         }
         finally
         {
             RestoreOwned();
             _kvLength = savedKvLength;
+            _kvEvictedCount = savedEvicted;
         }
     }
 
@@ -4011,6 +4061,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // [N×vocab] logits in _decodeLogitsAll, so both BatchForwardMulti tails work unchanged.
         if (_isGemma4Like)
         {
+            // Defense-in-depth: the Gemma-4 decode uses positions[n] directly as the physical slot
+            // (no SnapKV physical/logical mapping). The constructor forces the SnapKV budget off
+            // for Gemma 4, so no Gemma-4 cache is ever evicted — assert it loudly rather than
+            // silently mis-index if that invariant is ever broken (#196).
+            for (int n = 0; n < N; n++)
+                if (caches[n].EvictedCount > 0)
+                    throw new InvalidOperationException(
+                        "Gemma-4 batched decode reached a SnapKV-evicted cache; the constructor forces " +
+                        "the SnapKV budget off for Gemma 4, so this means that invariant was broken.");
             RunBatchedTrunkGemma4(tokens, positions, caches);
             return;
         }
@@ -4022,12 +4081,31 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         EnsureBatchedTrunkScratch(N);
         EnsureDecodeLogits(N);
 
+        // SnapKV-evicted caches (issue #196): a sequence whose prompt was compacted maps a logical
+        // position p to the physical slot p - EvictedCount for KV append + attention (RoPE keeps p).
+        // The ragged kernels take positions[] for BOTH append slot and attention range, so they'd
+        // mis-index an evicted cache — force the per-sequence loop, which threads the physical slot
+        // and logical RoPE position separately, when any cache in the batch carries an eviction.
+        bool anyEvicted = false;
+        for (int n = 0; n < N; n++)
+        {
+            if (caches[n].EvictedCount == 0) continue;
+            anyEvicted = true;
+            // EvictedCount is a public field; a value exceeding the logical position would make the
+            // physical slot negative → out-of-range device access. Fail fast instead (matches the
+            // owned-cache decode's implicit pos - _kvEvictedCount ≥ 0 expectation).
+            if (caches[n].EvictedCount > positions[n])
+                throw new InvalidOperationException(
+                    $"Sequence {n}: EvictedCount {caches[n].EvictedCount} exceeds position {positions[n]} " +
+                    "(negative physical slot); the SnapKV eviction delta is inconsistent.");
+        }
+
         // Ragged path (#197, default): the per-layer QK-norm/RoPE/KV-append/attention run as
         // O(1) ragged-batched launches over all N sequences. Build the [layer][seq] cache
         // tensor table once per batch composition (identity-compared; steps within a stable
         // batch reuse it) and grab the spill scratch only if some sequence is past the
         // 4096-slot shared-memory fast path.
-        bool ragged = _batchDecodeRagged;
+        bool ragged = _batchDecodeRagged && !anyEvicted;
         Tensor? raggedScores = null;
         if (ragged)
         {
@@ -4092,8 +4170,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                     // (bias → QK-norm/RoPE, #157 order → KV append → attention), each op one
                     // launch whose grid covers all N rows at positions[n] against caches[n].
                     // Every kernel keeps its per-token counterpart's reduction chain, so per
-                    // sequence this is bit-identical to the loop it replaces. _kvEvictedCount
-                    // is 0 (SnapKV is rejected for batching), so the physical slot is pos.
+                    // sequence this is bit-identical to the loop it replaces. Reached only when no
+                    // cache in the batch is SnapKV-evicted (the anyEvicted gate above routes an
+                    // evicted batch to the per-sequence loop), so every cache's physical slot
+                    // equals its logical pos — the ragged kernels can take positions[] directly.
                     if (_hasAttnBias)
                     {
                         _gpu.AddBiasBatched(_bpQ!, _bq![layer], qDim, N);
@@ -4123,13 +4203,16 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                     // caches[n].Length is advanced once after the pass completes (below).
                 }
                 else
-                // Per-sequence (#190, SHARPI_BATCH_DECODE_RAGGED=0): bias → QK-norm/RoPE (same
-                // order as RunDeviceRegion, #157) → KV append into that sequence's own cache →
-                // single-query attention over its [0, pos+1). _kvEvictedCount is 0 (SnapKV is
-                // rejected for batching), so the physical slot is simply pos.
+                // Per-sequence (#190, SHARPI_BATCH_DECODE_RAGGED=0; also forced when any cache is
+                // SnapKV-evicted, #196): bias → QK-norm/RoPE (same order as RunDeviceRegion, #157)
+                // → KV append into that sequence's own cache → single-query attention. RoPE uses
+                // the LOGICAL position; KV append + the attention range use the PHYSICAL slot
+                // pos - EvictedCount (== pos when the sequence was never evicted), matching the
+                // owned-cache SnapKV decode (Forward's kvSlot = position - _kvEvictedCount).
                 for (int n = 0; n < N; n++)
                 {
                     int pos = positions[n];
+                    int physSlot = pos - caches[n].EvictedCount;
                     Tensor qv = qViews[n], kv = kViews[n], vv = vViews[n], av = aViews[n];
 
                     if (_hasAttnBias)
@@ -4156,9 +4239,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                     }
 
                     Tensor kc = caches[n].K[layer], vc = caches[n].V[layer];
-                    KvAppendKv(kv, vv, kc, vc, kvDim, pos, _maxSeqLen);
+                    KvAppendKv(kv, vv, kc, vc, kvDim, physSlot, _maxSeqLen);
                     AttentionKv(qv, kc, vc, av, _attnScoresScratch,
-                        _numHeads, _numKvHeads, _headDim, pos + 1, _maxSeqLen, _attnScale);
+                        _numHeads, _numKvHeads, _headDim, physSlot + 1, _maxSeqLen, _attnScale);
                     // caches[n].Length is advanced once after the pass completes (below), not
                     // here — a mid-pass throw then leaves the logical length unadvanced.
                 }
@@ -4430,10 +4513,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         {
             result[n] = new float[vocab];
             Array.Copy(_decodeLogitsHost!, (long)n * vocab, result[n], 0, vocab);
-            // Advance each sequence's logical length now that the append + attention for this
-            // token have completed and synchronized (transactional: a mid-pass throw above
-            // leaves Length untouched).
-            caches[n].Length = positions[n] + 1;
+            // Advance each sequence's PHYSICAL length now that the append + attention for this
+            // token have completed and synchronized (transactional: a mid-pass throw above leaves
+            // Length untouched). Physical = logical position - EvictedCount + 1 (== position + 1
+            // when the sequence was never SnapKV-evicted, #196).
+            caches[n].Length = positions[n] - caches[n].EvictedCount + 1;
         }
         return result;
     }
@@ -4458,7 +4542,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // rows*8-byte D2H (index+value per row) with its own internal sync — completes the pass.
         var am = _gpu.ArgmaxRows(_decodeLogitsAll!, N, _hp.VocabSize, _hp.VocabSize);
         for (int n = 0; n < N; n++)
-            caches[n].Length = positions[n] + 1;
+            caches[n].Length = positions[n] - caches[n].EvictedCount + 1; // physical (#196)
         return am;
     }
 

--- a/src/SharpInference.Engine/CudaSequenceKvCache.cs
+++ b/src/SharpInference.Engine/CudaSequenceKvCache.cs
@@ -30,8 +30,17 @@ internal sealed class CudaSequenceKvCache : ISequenceKvCache
     /// <summary>Layers whose K/V alias a source layer (Gemma 4 shared-KV tail) — never freed here.</summary>
     private readonly IReadOnlySet<int> _aliasedLayers;
 
-    /// <summary>Logical KV positions stored so far (the forward pass reads/advances this).</summary>
+    /// <summary>Physical KV rows stored so far (the forward pass reads/advances this). Equals the
+    /// logical token count unless SnapKV evicted this sequence's prompt, in which case it is the
+    /// post-compaction count and <see cref="EvictedCount"/> bridges back to logical positions.</summary>
     public int Length;
+
+    /// <summary>Logical-minus-physical delta from a SnapKV prefill eviction (issue #196): the
+    /// number of prompt positions dropped during compaction. The batched decode maps a logical
+    /// position <c>p</c> to the physical slot <c>p - EvictedCount</c> for KV append + attention,
+    /// while RoPE keeps the logical <c>p</c> (the kept K rows retain their original RoPE phase).
+    /// 0 for a sequence that was never evicted (physical slot == logical position).</summary>
+    public int EvictedCount;
 
     private bool _disposed;
 

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -79,7 +79,7 @@ public static class InferenceEngineLoader
         try
         {
             (fwd, batchingSupported) = BuildForwardPass(model, hp, arch, ctxSize, nGpuLayers, opts.Backend, turboQuant, owned,
-                DequantCacheBytes(opts.PrefillDequantCacheMb));
+                DequantCacheBytes(opts.PrefillDequantCacheMb), preferBatchingOverAutoSnapKv: opts.MaxBatchSize > 1);
             owned.Add(model);
         }
         catch
@@ -175,7 +175,8 @@ public static class InferenceEngineLoader
 
     private static (IForwardPass Fwd, bool BatchingSupported) BuildForwardPass(
         GgufModel model, ModelHyperparams hp, string arch, int ctxSize, int nGpuLayers,
-        ServerBackend backend, bool turboQuant, List<IDisposable> owned, long prefillDequantCacheBytes)
+        ServerBackend backend, bool turboQuant, List<IDisposable> owned, long prefillDequantCacheBytes,
+        bool preferBatchingOverAutoSnapKv = false)
     {
         // Resolve "auto" first so the rest of the method can treat backend as concrete.
         if (nGpuLayers != 0 && backend == ServerBackend.Auto)
@@ -265,16 +266,31 @@ public static class InferenceEngineLoader
 
             if (gpuLayers >= hp.NumLayers)
             {
-                var cfwd = new CudaForwardPass(model, cuda, hp, ctxSize, enableTurboQuant: turboQuant);
+                // #196 Option 2: when batching is requested, suppress the VRAM-scaled SnapKV
+                // auto-enable (prefer pure batching over routing every sequence through the slower
+                // per-sequence-eviction decode). An explicit SHARPI_SNAPKV_BUDGET>0 still wins and
+                // composes with batching via #196 Option 1.
+                var cfwd = new CudaForwardPass(model, cuda, hp, ctxSize, enableTurboQuant: turboQuant,
+                    preferBatchingOverAutoSnapKv: preferBatchingOverAutoSnapKv);
                 owned.Add(cfwd);
                 // Issue #190 (dense) / #195 (Gemma 4): CUDA full-offload supports continuous
                 // batching (per-sequence GPU KV caches + true batched decode). SupportsContinuous-
                 // Batching is the single source of truth shared with CudaForwardPass's runtime
                 // guard, so the loader gate can't diverge from what the batched methods accept — it
-                // admits dense AND Gemma-4 models and folds OUT MoE, TurboQuant, an auto/explicit
-                // SnapKV budget, a dense final-logit softcap, and any non-GEMM-N-batchable
-                // trunk/output weight dtype (Q4_0).
-                return (cfwd, cfwd.SupportsContinuousBatching);
+                // admits dense AND Gemma-4 models and folds OUT MoE, TurboQuant, a dense final-logit
+                // softcap, and any non-GEMM-N-batchable trunk/output weight dtype (Q4_0). A SnapKV
+                // budget no longer disqualifies batching (#196 — it composes via per-sequence eviction).
+                bool batches = cfwd.SupportsContinuousBatching;
+                // #196 footgun guard: we suppressed the SnapKV auto-enable because batching was
+                // requested, but this model can't actually batch (e.g. dense softcap / Q4_0) — so it
+                // would fall back to single-user with NO auto-SnapKV either. Warn so the operator can
+                // restore the memory savings with an explicit budget or a narrowed --kv-type.
+                if (preferBatchingOverAutoSnapKv && !batches && !cfwd.SnapKvEnabled)
+                    Console.Error.WriteLine(
+                        "[InferenceEngineLoader] MaxBatchSize>1 suppressed SnapKV auto-enable, but this " +
+                        "model does not support continuous batching (it will run single-user). Set an " +
+                        "explicit SHARPI_SNAPKV_BUDGET>0 or a narrowed --kv-type to keep KV memory bounded.");
+                return (cfwd, batches);
             }
 
             // pinGpuLayers (not a `with { GpuLayers = }` override) so the expert-cache budget the

--- a/tests/SharpInference.Tests.ForwardPass/CudaSnapKvBatchingTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaSnapKvBatchingTests.cs
@@ -1,0 +1,349 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #196: SnapKV-aware CUDA continuous batching. Before #196, an active SnapKV budget made
+/// <see cref="CudaForwardPass.SupportsContinuousBatching"/> false (long-context concurrent serving
+/// silently fell back to single-user). #196 ships two things:
+/// <list type="bullet">
+///   <item><b>Option 1</b> — per-sequence eviction: <see cref="CudaForwardPass.PrefillWithCache"/>
+///     scores + compacts each <see cref="CudaSequenceKvCache"/> at the end of its own prefill and
+///     records the logical-minus-physical delta on the cache; the batched decode maps a logical
+///     position to the physical slot <c>pos - EvictedCount</c> (RoPE keeps the logical pos), so
+///     eviction composes with batching.</item>
+///   <item><b>Option 2</b> — when batching is preferred (<c>preferBatchingOverAutoSnapKv</c>), the
+///     VRAM-scaled SnapKV AUTO-enable is suppressed so a server doesn't silently route every
+///     sequence through the slower per-sequence-eviction decode; an explicit budget still wins.</item>
+/// </list>
+///
+/// Oracle: the batched decode of an evicted per-sequence cache must reproduce the single-user
+/// SnapKV decode (owned cache) on dense <b>Qwen3-8B Q4_K</b>. Silent-skips when CUDA / the GGUF is
+/// absent. Mirrors <see cref="CudaForwardPassSnapKvTests"/> + <see cref="CudaBatchForwardMultiTests"/>.
+/// </summary>
+public sealed class CudaSnapKvBatchingTests
+{
+    private const string ModelFile = "Qwen3-8B-Q4_K_M.gguf";
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); } catch { return null; }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absolute = { $@"C:\p\sharpi\models\{ModelFile}", $@"E:\models\{ModelFile}" };
+        foreach (var p in absolute)
+            if (File.Exists(p)) return p;
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int[] LongPrompt(GgufTokenizer tokenizer, int approxTokenCount)
+    {
+        const string seed =
+            "The quick brown fox jumps over the lazy dog. " +
+            "Sphinx of black quartz, judge my vow. " +
+            "Pack my box with five dozen liquor jugs. ";
+        var sb = new System.Text.StringBuilder();
+        while (true)
+        {
+            sb.Append(seed);
+            var attempt = tokenizer.Encode(sb.ToString());
+            if (attempt.Count >= approxTokenCount) return attempt.ToArray();
+            if (sb.Length > 100_000)
+                throw new InvalidOperationException("Tokenizer not packing enough — unexpected for Qwen3.");
+        }
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    private static (float maxAbs, int overlap) Compare(float[] reference, float[] candidate)
+    {
+        Assert.Equal(reference.Length, candidate.Length);
+        float maxAbs = 0f;
+        for (int i = 0; i < reference.Length; i++)
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(reference[i] - candidate[i]));
+        var refTop = new HashSet<int>();
+        {
+            var idx = new int[reference.Length];
+            for (int i = 0; i < idx.Length; i++) idx[i] = i;
+            Array.Sort(idx, (a, b) => reference[b].CompareTo(reference[a]));
+            for (int i = 0; i < 5 && i < idx.Length; i++) refTop.Add(idx[i]);
+        }
+        int overlap = 0;
+        {
+            var idx = new int[candidate.Length];
+            for (int i = 0; i < idx.Length; i++) idx[i] = i;
+            Array.Sort(idx, (a, b) => candidate[b].CompareTo(candidate[a]));
+            for (int i = 0; i < 5 && i < idx.Length; i++) if (refTop.Contains(idx[i])) overlap++;
+        }
+        return (maxAbs, overlap);
+    }
+
+    private static IDisposable SnapKvEnv(int budget, int window)
+    {
+        return new EnvScope(
+            ("SHARPI_SNAPKV_BUDGET", budget.ToString()),
+            ("SHARPI_SNAPKV_WINDOW", window.ToString()),
+            ("SHARPI_PREFIX_SLOTS", null)); // ensure multi-slot doesn't suppress the budget
+    }
+
+    private sealed class EnvScope : IDisposable
+    {
+        private readonly (string Key, string? Prev)[] _saved;
+        public EnvScope(params (string Key, string? Value)[] vars)
+        {
+            _saved = new (string, string?)[vars.Length];
+            for (int i = 0; i < vars.Length; i++)
+            {
+                _saved[i] = (vars[i].Key, Environment.GetEnvironmentVariable(vars[i].Key));
+                Environment.SetEnvironmentVariable(vars[i].Key, vars[i].Value);
+            }
+        }
+        public void Dispose()
+        {
+            foreach (var (key, prev) in _saved)
+                Environment.SetEnvironmentVariable(key, prev);
+        }
+    }
+
+    /// <summary>
+    /// Option 1 gate: with an explicit SnapKV budget, the model now supports continuous batching
+    /// (it was disqualified before #196). SnapKvEnabled stays true (the budget is honored).
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_ExplicitSnapKv_SupportsContinuousBatching()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var env = SnapKvEnv(budget: 512, window: 32);
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048);
+
+        Assert.True(fwd.SnapKvEnabled, "explicit SHARPI_SNAPKV_BUDGET should keep SnapKV active.");
+        Assert.True(fwd.SupportsContinuousBatching,
+            "SnapKV + dense should now support continuous batching via per-sequence eviction (#196).");
+    }
+
+    /// <summary>
+    /// Option 1 oracle (N=1): a prompt long enough to trigger SnapKV eviction, prefilled into a
+    /// per-sequence cache, then a batched decode step — must reproduce the single-user SnapKV
+    /// decode (owned cache). Asserts the per-sequence cache actually evicted (EvictedCount &gt; 0,
+    /// physical Length &lt; prompt) and that physical+delta == logical.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_SnapKvBatchedDecode_N1_MatchesSingleUser()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+        using var env = SnapKvEnv(budget, window: 32);
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048);
+        Assert.True(fwd.SnapKvEnabled);
+
+        int[] prompt = LongPrompt(tokenizer, 700);
+
+        // Single-user reference: owned-cache SnapKV prefill (evicts) + one decode step.
+        fwd.ResetCache();
+        int tok = Argmax(fwd.Prefill(prompt));
+        Assert.True(fwd.KvLength < prompt.Length, "single-user prefill should have evicted.");
+        float[] refLogits = fwd.Forward(tok, prompt.Length).ToArray();
+        fwd.ResetCache(); // clear the owned-cache eviction state so the batched decode guard passes
+
+        // Batched: per-sequence cache SnapKV prefill (evicts THIS cache) + batched decode step.
+        using var cache = fwd.CreateCache();
+        int tok2 = Argmax(fwd.PrefillWithCache(prompt, cache));
+        Assert.Equal(tok, tok2); // identical eviction + prefill
+        Assert.True(cache.EvictedCount > 0, "per-sequence prefill should have evicted.");
+        Assert.True(cache.Length < prompt.Length);
+        Assert.Equal(prompt.Length, cache.Length + cache.EvictedCount); // physical + delta == logical
+
+        float[][] batch = fwd.BatchForwardMulti([tok2], [prompt.Length], [cache]);
+        Assert.Single(batch);
+        var (maxAbs, overlap) = Compare(refLogits, batch[0]);
+        Assert.Equal(Argmax(refLogits), Argmax(batch[0]));
+        Assert.True(overlap >= 4, $"SnapKV batched decode top-5 overlap {overlap}/5 (maxAbs={maxAbs}).");
+        Assert.True(maxAbs < 1.0f, $"SnapKV batched decode vs single-user maxAbs={maxAbs}.");
+    }
+
+    /// <summary>
+    /// Option 1 oracle (N=2): two prompts of DIFFERENT lengths evict to the same budget but with
+    /// DIFFERENT deltas, so this exercises per-sequence eviction state (each cache's own
+    /// EvictedCount drives its physical-slot mapping). Both sequences' batched decode must match
+    /// their single-user references.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_SnapKvBatchedDecode_N2_PerSequenceEviction()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+        using var env = SnapKvEnv(budget, window: 32);
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048);
+
+        int[] promptA = LongPrompt(tokenizer, 600);
+        int[] promptB = LongPrompt(tokenizer, 1000);
+        Assert.True(promptB.Length > promptA.Length);
+
+        // Single-user references.
+        fwd.ResetCache();
+        int tokA = Argmax(fwd.Prefill(promptA));
+        float[] refA = fwd.Forward(tokA, promptA.Length).ToArray();
+        fwd.ResetCache();
+        int tokB = Argmax(fwd.Prefill(promptB));
+        float[] refB = fwd.Forward(tokB, promptB.Length).ToArray();
+        fwd.ResetCache();
+
+        using var cacheA = fwd.CreateCache();
+        using var cacheB = fwd.CreateCache();
+        int tokA2 = Argmax(fwd.PrefillWithCache(promptA, cacheA));
+        int tokB2 = Argmax(fwd.PrefillWithCache(promptB, cacheB));
+        Assert.Equal(tokA, tokA2);
+        Assert.Equal(tokB, tokB2);
+        Assert.True(cacheA.EvictedCount > 0 && cacheB.EvictedCount > 0);
+        Assert.NotEqual(cacheA.EvictedCount, cacheB.EvictedCount); // different prompt lengths
+
+        float[][] batch = fwd.BatchForwardMulti(
+            [tokA2, tokB2], [promptA.Length, promptB.Length], [cacheA, cacheB]);
+        Assert.Equal(2, batch.Length);
+
+        var (maxAbsA, overlapA) = Compare(refA, batch[0]);
+        Assert.Equal(Argmax(refA), Argmax(batch[0]));
+        Assert.True(overlapA >= 4, $"Seq A SnapKV batched top-5 {overlapA}/5 (maxAbs={maxAbsA}).");
+        Assert.True(maxAbsA < 1.0f, $"Seq A SnapKV batched maxAbs={maxAbsA}.");
+
+        var (maxAbsB, overlapB) = Compare(refB, batch[1]);
+        Assert.Equal(Argmax(refB), Argmax(batch[1]));
+        Assert.True(overlapB >= 4, $"Seq B SnapKV batched top-5 {overlapB}/5 (maxAbs={maxAbsB}).");
+        Assert.True(maxAbsB < 1.0f, $"Seq B SnapKV batched maxAbs={maxAbsB}.");
+    }
+
+    /// <summary>
+    /// Option 1 mixed batch: one SnapKV-evicted sequence (long prompt) and one un-evicted sequence
+    /// (short prompt below the budget) in the SAME <see cref="CudaForwardPass.BatchForwardMulti"/>
+    /// call. The forced per-sequence loop must apply <c>physSlot = pos - EvictedCount</c> per cache
+    /// — the evicted one offset, the un-evicted one at <c>pos</c> — and both must match their
+    /// single-user references.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_SnapKvBatchedDecode_MixedEvictedAndNot()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+        using var env = SnapKvEnv(budget, window: 32);
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048);
+
+        int[] longPrompt = LongPrompt(tokenizer, 900);          // > budget → evicts
+        int[] shortPrompt = { 9707, 11, 1879, 0, 358, 1079 };   // << budget → no eviction
+
+        fwd.ResetCache();
+        int tokL = Argmax(fwd.Prefill(longPrompt));
+        float[] refL = fwd.Forward(tokL, longPrompt.Length).ToArray();
+        fwd.ResetCache();
+        int tokS = Argmax(fwd.Prefill(shortPrompt));
+        float[] refS = fwd.Forward(tokS, shortPrompt.Length).ToArray();
+        fwd.ResetCache();
+
+        using var cacheL = fwd.CreateCache();
+        using var cacheS = fwd.CreateCache();
+        int tokL2 = Argmax(fwd.PrefillWithCache(longPrompt, cacheL));
+        int tokS2 = Argmax(fwd.PrefillWithCache(shortPrompt, cacheS));
+        Assert.True(cacheL.EvictedCount > 0, "long prompt should have evicted.");
+        Assert.Equal(0, cacheS.EvictedCount);   // short prompt below budget — never evicted
+        Assert.Equal(shortPrompt.Length, cacheS.Length);
+
+        float[][] batch = fwd.BatchForwardMulti(
+            [tokL2, tokS2], [longPrompt.Length, shortPrompt.Length], [cacheL, cacheS]);
+        Assert.Equal(2, batch.Length);
+
+        var (maxAbsL, overlapL) = Compare(refL, batch[0]);
+        Assert.Equal(Argmax(refL), Argmax(batch[0]));
+        Assert.True(overlapL >= 4, $"Evicted seq top-5 {overlapL}/5 (maxAbs={maxAbsL}).");
+        Assert.True(maxAbsL < 1.0f, $"Evicted seq maxAbs={maxAbsL}.");
+
+        var (maxAbsS, overlapS) = Compare(refS, batch[1]);
+        Assert.Equal(Argmax(refS), Argmax(batch[1]));
+        Assert.True(overlapS >= 4, $"Un-evicted seq top-5 {overlapS}/5 (maxAbs={maxAbsS}).");
+        Assert.True(maxAbsS < 1.0f, $"Un-evicted seq maxAbs={maxAbsS}.");
+    }
+
+    /// <summary>
+    /// Option 2: when continuous batching is preferred (<c>preferBatchingOverAutoSnapKv</c>), the
+    /// VRAM-scaled SnapKV AUTO-enable is suppressed — so a batching server gets the ragged-decode
+    /// fast path, not silent lossy eviction. Verified at a context where auto-SnapKV WOULD engage.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_PreferBatching_SuppressesAutoSnapKv()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        // Unset the explicit budget so the auto-enable path is exercised.
+        using var env = new EnvScope(
+            ("SHARPI_SNAPKV_BUDGET", null),
+            ("SHARPI_PREFIX_SLOTS", null),
+            ("SHARPI_KV_DTYPE", null));
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        // ctx 4096 makes the fp32 KV cache exceed the auto-enable threshold (and maxSeqLen/4 lands
+        // in the auto-budget band), so auto-SnapKV engages by default.
+        bool autoEngaged;
+        using (var autoFwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 4096,
+            preferBatchingOverAutoSnapKv: false))
+            autoEngaged = autoFwd.SnapKvEnabled;
+
+        using (var preferFwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 4096,
+            preferBatchingOverAutoSnapKv: true))
+            Assert.False(preferFwd.SnapKvEnabled,
+                "preferBatchingOverAutoSnapKv should suppress the SnapKV auto-enable (#196 Option 2).");
+
+        Assert.True(autoEngaged,
+            "expected auto-SnapKV to engage at ctx 4096 for Qwen3-8B; if not, the suppression test " +
+            "needs a larger context to be meaningful.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #196. **Stacked on #195** (PR #273, which is stacked on #193/PR #272) — base is `feat/195-gemma4-cuda-batching`; rebase down the stack as each merges.

`CudaForwardPass.SupportsContinuousBatching` returned false when SnapKV was active, and auto-SnapKV is VRAM-scaled (engages at ctx ≳ 2048 on a 12 GB 4070 Ti) — so long-context concurrent serving on CUDA **silently** fell back to single-user decode. This implements **both** options from the issue.

## Option 1 — per-sequence eviction (the real feature)

`PrefillWithCache` runs the existing owned-cache SnapKV scoring + compaction against the **bound** per-sequence cache (`Prefill` → `ApplySnapKvEviction`), then captures the logical-minus-physical delta onto `CudaSequenceKvCache.EvictedCount` and the post-compaction physical length onto `.Length`, restoring the instance eviction state (isolated per sequence and from the owned cache). The batched decode maps a logical position `p` to the physical slot `p - EvictedCount` for KV append + attention while RoPE keeps `p` — mirroring the single-user owned-cache decode (`kvSlot = position - _kvEvictedCount`). Any evicted cache in a batch forces the per-sequence decode loop (the ragged kernels take `positions[]` for the append slot, so they can't index a compacted cache).

## Option 2 — prefer batching (the safe default)

A new constructor flag `preferBatchingOverAutoSnapKv` (loader passes `MaxBatchSize > 1`) suppresses the VRAM-scaled SnapKV **auto**-enable, so a batching server gets the ragged fast path instead of silent lossy eviction. An explicit `SHARPI_SNAPKV_BUDGET>0` still wins and composes via Option 1. Both modes log clearly.

## Gates

`SupportsContinuousBatching` drops the `budget==0` term — a budget only ever survives for **dense fp32 KV** (the constructor forces it off for Gemma 4 / narrowed KV / TQ), so per-sequence eviction is always wireable there. `ThrowIfBatchingUnsupported` drops the prefill-time SnapKV throw but keeps the decode-only guard against a compacted **owned** cache. Defense-in-depth from review: Gemma-4 decode + packed prefill assert no eviction reached them; the decode guards a negative physical slot; the loader warns when batching was preferred but the model can't actually batch (dense softcap / Q4_0) so the operator can restore KV bounds with an explicit budget or `--kv-type`.

## Testing (Qwen3-8B Q4_K, RTX 4070 Ti)

New `CudaSnapKvBatchingTests`:
- explicit-budget gate flip (`SupportsContinuousBatching` now true),
- N=1 and N=2 (distinct per-sequence deltas) batched decode of evicted caches vs single-user SnapKV decode (argmax-stable; asserts `Length + EvictedCount == prompt.Length`),
- **mixed** batch (one evicted + one un-evicted in the same call),
- Option-2 auto-suppression (with a sanity assert that auto-SnapKV would otherwise engage).

Regressions: dense batched + #193 packed (15) and single-user SnapKV (3) pass; #195 Gemma 4 batched decode (4) still green.

## Review

Two passes (code-reviewer + silent-failure-hunter). Both HIGH latent items hardened: the Gemma-4 decode `anyEvicted` bypass (now a loud assert) and the loader auto-SnapKV-suppressed-but-not-batching footgun (now warns), plus the negative-`physSlot` and packed-prefill SnapKV guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)