### PR TITLE
perf(cuda): ragged batched decode for SnapKV-evicted caches (#277)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -4205,23 +4205,27 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// <summary>
     /// Ragged-batched KV append (issue #197): row <c>t</c> of the fp32
     /// <paramref name="kInputAll"/>/<paramref name="vInputAll"/> (<c>[N × kvDim]</c>)
-    /// is stored into <c>kCaches[t]</c>/<c>vCaches[t]</c> at slot
-    /// <c>positions[t] % maxSeqLen</c>. Per sequence bit-identical to the matching
+    /// is stored into <c>kCaches[t]</c>/<c>vCaches[t]</c> at physical slot
+    /// <c>slots[t] % maxSeqLen</c>. Per sequence bit-identical to the matching
     /// per-token append (<see cref="KvAppend"/> / <see cref="KvAppendBf16"/> /
     /// <see cref="KvAppendQ8_0"/> per <paramref name="kvDType"/>).
+    /// <para><paramref name="slots"/> is the PHYSICAL cache slot, not the logical token position:
+    /// for a SnapKV-compacted cache (#277) the caller passes <c>position - EvictedCount</c> so the
+    /// new token lands in the compacted cache (RoPE still rotates at the logical position). When no
+    /// sequence is evicted slot == position and this is the plain #197 append.</para>
     /// </summary>
     public void KvAppendBatchedRagged(
         Tensor kInputAll, Tensor vInputAll,
         ReadOnlySpan<Tensor> kCaches, ReadOnlySpan<Tensor> vCaches,
-        ReadOnlySpan<int> positions, int kvDim, int maxSeqLen, DType kvDType = DType.Float32)
+        ReadOnlySpan<int> slots, int kvDim, int maxSeqLen, DType kvDType = DType.Float32)
     {
         EnsureImageKernels();
         if (!_imageKernelsAvailable)
             throw new NotSupportedException("NVRTC kernels are not available.");
-        int nTok = positions.Length;
+        int nTok = slots.Length;
         if (nTok == 0) return;
         if (kCaches.Length != nTok || vCaches.Length != nTok)
-            throw new ArgumentException("KvAppendBatchedRagged: kCaches/vCaches/positions lengths must match.");
+            throw new ArgumentException("KvAppendBatchedRagged: kCaches/vCaches/slots lengths must match.");
         nint kernel = kvDType switch
         {
             DType.Float32  => _kvAppendRaggedKernel,
@@ -4252,7 +4256,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             {
                 kPtrs[t] = GetDevPtr(kCaches[s + t]);
                 vPtrs[t] = GetDevPtr(vCaches[s + t]);
-                pos[t]   = positions[s + t];
+                pos[t]   = slots[s + t];
             }
             kIn = kBase + (nint)((long)s * rowBytes);
             vIn = vBase + (nint)((long)s * rowBytes);
@@ -4265,13 +4269,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// <summary>
     /// Ragged-batched single-query attention (issue #197): query row <c>t</c> of
     /// <paramref name="qAll"/> (<c>[N × numHeads*headDim]</c>) attends over
-    /// <c>kCaches[t]</c>/<c>vCaches[t]</c> positions <c>[0, positions[t] + 1)</c> into
+    /// <c>kCaches[t]</c>/<c>vCaches[t]</c> slots <c>[0, slots[t] + 1)</c> into
     /// row <c>t</c> of <paramref name="outputAll"/>. Grid is (numHeads, N): all N
     /// sequences' attention blocks run concurrently in one launch. Each (head, sequence)
     /// block keeps the per-token <see cref="Attention"/> kernel's exact reduction chain,
     /// so per sequence the output is bit-identical to the sequential call.
     ///
-    /// When every <c>positions[t] + 1 ≤ 4096</c> scores stay in shared memory and
+    /// <para><paramref name="slots"/> is the PHYSICAL last-slot index: the attended range is
+    /// <c>[0, slots[t] + 1)</c>. For a SnapKV-compacted cache (#277) the caller passes
+    /// <c>position - EvictedCount</c>, so each sequence attends over exactly its compacted length;
+    /// when no sequence is evicted slot == position and this is the plain #197 attention.</para>
+    ///
+    /// When every <c>slots[t] + 1 ≤ 4096</c> scores stay in shared memory and
     /// <paramref name="scoresScratch"/> may be null; above that it must hold
     /// <c>N × numHeads × maxSeqLen</c> floats (per-sequence rows of the per-token
     /// kernel's <c>numHeads × maxSeqLen</c> layout).
@@ -4280,15 +4289,15 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         Tensor qAll, ReadOnlySpan<Tensor> kCaches, ReadOnlySpan<Tensor> vCaches,
         Tensor outputAll, Tensor? scoresScratch,
         int numHeads, int numKvHeads, int headDim,
-        ReadOnlySpan<int> positions, int maxSeqLen, float attnScale = -1f, DType kvDType = DType.Float32)
+        ReadOnlySpan<int> slots, int maxSeqLen, float attnScale = -1f, DType kvDType = DType.Float32)
     {
         EnsureImageKernels();
         if (!_imageKernelsAvailable)
             throw new NotSupportedException("NVRTC kernels are not available.");
-        int nTok = positions.Length;
+        int nTok = slots.Length;
         if (nTok == 0) return;
         if (kCaches.Length != nTok || vCaches.Length != nTok)
-            throw new ArgumentException("AttentionBatchedRagged: kCaches/vCaches/positions lengths must match.");
+            throw new ArgumentException("AttentionBatchedRagged: kCaches/vCaches/slots lengths must match.");
         nint kernel = kvDType switch
         {
             DType.Float32  => _attentionRaggedKernel,
@@ -4299,7 +4308,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
 
         nint ssBase = scoresScratch is { } sv ? GetDevPtr(sv) : nint.Zero;
         int maxLen = 0;
-        for (int i = 0; i < nTok; i++) maxLen = Math.Max(maxLen, positions[i] + 1);
+        for (int i = 0; i < nTok; i++) maxLen = Math.Max(maxLen, slots[i] + 1);
         if (maxLen > 4096)
         {
             // Fail loud, not corrupt: a too-small/absent scratch would make the kernel
@@ -4336,7 +4345,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             {
                 kPtrs[t] = GetDevPtr(kCaches[s + t]);
                 vPtrs[t] = GetDevPtr(vCaches[s + t]);
-                pos[t]   = positions[s + t];
+                pos[t]   = slots[s + t];
             }
             qPtr  = qBase + (nint)((long)s * qRowBytes);
             oPtr  = oBase + (nint)((long)s * qRowBytes);

--- a/src/SharpInference.Cuda/CudaRaggedKernels.cs
+++ b/src/SharpInference.Cuda/CudaRaggedKernels.cs
@@ -111,6 +111,8 @@ extern ""C"" __global__ void llm_rope_interleaved_ragged(
 // N distinct caches per launch via the pointer table. Same ring-slot convention
 // as llm_kv_append (`position % max_seq_len`; identity for the full-context
 // dense caches batched decode uses). Pure copy — bit-identical trivially.
+// `positions.v[t]` is the PHYSICAL slot the caller chose: position for an
+// uncompacted cache, position - EvictedCount for a SnapKV-compacted one (#277).
 extern ""C"" __global__ void llm_kv_append_ragged(
     const float* __restrict__ k_in_all,
     const float* __restrict__ v_in_all,
@@ -186,6 +188,8 @@ extern ""C"" __global__ void llm_kv_append_ragged_q8_0(
 // reductions, same sequential phase-3 V sum — against that sequence's own
 // cache over its own ragged length seq_len = positions.v[t] + 1, so per
 // sequence the output is bit-identical to the per-token llm_attention call.
+// positions.v[t] is the PHYSICAL last slot (position - EvictedCount for a
+// SnapKV-compacted cache, #277), so seq_len is the compacted length.
 // Spill scratch (seq_len > 4096) is per-(sequence, head):
 // scores_scratch[((t*num_heads)+h) * max_seq_len].
 template<typename KV>

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -468,9 +468,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     // back-to-back) to O(1) ragged kernels whose grid covers all N sequences at their own
     // positions against their own caches (CudaBackend.*BatchedRagged). Bit-identical per
     // sequence to the per-sequence loop (same kernels' reduction chains, batched grid).
-    // SHARPI_BATCH_DECODE_RAGGED=0 restores the #190 per-sequence loop.
-    private readonly bool _batchDecodeRagged =
+    // SHARPI_BATCH_DECODE_RAGGED=0 restores the #190 per-sequence loop. Not readonly only so the
+    // #277 test seam below can A/B both paths on one instance; production sets it once from the env.
+    private bool _batchDecodeRagged =
         Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_RAGGED") != "0";
+
+    /// <summary>Test seam (#277): flip the ragged-vs-per-sequence decode path at runtime so a single
+    /// instance can A/B both on the SAME caches at the SAME positions. A batched decode step is
+    /// idempotent there (it overwrites its own next slot with identical K/V and never reads
+    /// <c>Length</c> to bound attention), and both paths share every GEMM, so the two outputs are
+    /// bit-identical when the ragged attention block matches the per-sequence loop. A cross-instance
+    /// compare can't assert that — prefill is not bit-exact across instances.</summary>
+    internal bool BatchDecodeRaggedForTest { get => _batchDecodeRagged; set => _batchDecodeRagged = value; }
 
     // Per-batch-composition cache pointer table for the ragged kernels: [layer][seq]
     // K/V cache tensors, rebuilt only when the caches array composition changes
@@ -502,6 +511,14 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     // actually occurs (43 MB at N=8 / 40K ctx — don't pay it for short decodes).
     private Tensor? _raggedAttnScores;
     private int _raggedAttnScoresCapacity;
+
+    // Physical cache slots for the ragged KV-append + attention range when some sequence in the
+    // batch is SnapKV-evicted (issue #277): slots[n] = positions[n] - EvictedCount[n]. RoPE keeps
+    // the LOGICAL position, so the ragged path threads these two apart exactly like the per-sequence
+    // loop (KvAppendKv/AttentionKv at physSlot, RoPE at pos). Reused across decode steps and grown
+    // on demand; only built when an eviction is actually present (the common no-eviction batch
+    // passes positions straight through, allocation-free and byte-identical to pre-#277).
+    private int[]? _raggedPhysSlots;
 
     // Empty (no-aliasing) layer set shared by every dense per-sequence cache CreateCache
     // hands out — dense models never share KV across layers (that's the Gemma 4 tail,
@@ -4086,9 +4103,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
         // SnapKV-evicted caches (issue #196): a sequence whose prompt was compacted maps a logical
         // position p to the physical slot p - EvictedCount for KV append + attention (RoPE keeps p).
-        // The ragged kernels take positions[] for BOTH append slot and attention range, so they'd
-        // mis-index an evicted cache — force the per-sequence loop, which threads the physical slot
-        // and logical RoPE position separately, when any cache in the batch carries an eviction.
+        // Issue #277: the ragged kernels now take that physical slot for BOTH the append slot and the
+        // attention range (built into `slots` below), so an evicted cache no longer forces the
+        // per-sequence loop — the ragged fast path handles eviction too.
         bool anyEvicted = false;
         for (int n = 0; n < N; n++)
         {
@@ -4108,12 +4125,24 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // tensor table once per batch composition (identity-compared; steps within a stable
         // batch reuse it) and grab the spill scratch only if some sequence is past the
         // 4096-slot shared-memory fast path.
-        bool ragged = _batchDecodeRagged && !anyEvicted;
+        bool ragged = _batchDecodeRagged;
+        // Physical slots for KV append + attention range (#277): pos - EvictedCount per sequence.
+        // RoPE keeps the logical positions[]. When nothing is evicted these are identical, so reuse
+        // positions[] directly — the common batch stays allocation-free and byte-identical to #197.
+        ReadOnlySpan<int> slots = positions;
+        if (ragged && anyEvicted)
+        {
+            if (_raggedPhysSlots is null || _raggedPhysSlots.Length < N)
+                _raggedPhysSlots = new int[N];
+            for (int n = 0; n < N; n++)
+                _raggedPhysSlots[n] = positions[n] - caches[n].EvictedCount;
+            slots = _raggedPhysSlots.AsSpan(0, N);
+        }
         Tensor? raggedScores = null;
         if (ragged)
         {
             EnsureRaggedCacheTable(caches);
-            raggedScores = EnsureRaggedAttnScores(N, positions);
+            raggedScores = EnsureRaggedAttnScores(N, slots);
         }
 
         // Per-sequence views into the batched Q/K/V/attnOut scratch — only the legacy
@@ -4171,12 +4200,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 {
                     // Ragged-batched (#197): same op sequence as the per-sequence loop below
                     // (bias → QK-norm/RoPE, #157 order → KV append → attention), each op one
-                    // launch whose grid covers all N rows at positions[n] against caches[n].
-                    // Every kernel keeps its per-token counterpart's reduction chain, so per
-                    // sequence this is bit-identical to the loop it replaces. Reached only when no
-                    // cache in the batch is SnapKV-evicted (the anyEvicted gate above routes an
-                    // evicted batch to the per-sequence loop), so every cache's physical slot
-                    // equals its logical pos — the ragged kernels can take positions[] directly.
+                    // launch whose grid covers all N rows against caches[n]. Every kernel keeps its
+                    // per-token counterpart's reduction chain, so per sequence this is bit-identical
+                    // to the loop it replaces. RoPE rotates at the LOGICAL positions[n]; KV append +
+                    // the attention range use the PHYSICAL `slots[n]` (= positions[n] - EvictedCount,
+                    // == positions[n] when unevicted) — so a SnapKV-compacted cache (#277) lands its
+                    // new token at the right slot and attends over its compacted length, exactly like
+                    // the per-sequence loop's physSlot threading.
                     if (_hasAttnBias)
                     {
                         _gpu.AddBiasBatched(_bpQ!, _bq![layer], qDim, N);
@@ -4199,10 +4229,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                     }
 
                     _gpu.KvAppendBatchedRagged(_bpK!, _bpV!, _raggedKLayers![layer], _raggedVLayers![layer],
-                        positions, kvDim, _maxSeqLen, _kvDType);
+                        slots, kvDim, _maxSeqLen, _kvDType);
                     _gpu.AttentionBatchedRagged(_bpQ!, _raggedKLayers[layer], _raggedVLayers[layer],
                         _bpAttnOut!, raggedScores,
-                        _numHeads, _numKvHeads, _headDim, positions, _maxSeqLen, _attnScale, _kvDType);
+                        _numHeads, _numKvHeads, _headDim, slots, _maxSeqLen, _attnScale, _kvDType);
                     // caches[n].Length is advanced once after the pass completes (below).
                 }
                 else
@@ -4698,10 +4728,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// [N × numHeads × maxSeqLen] buffer of per-(sequence, head) score rows, lazily
     /// allocated and re-sized only when the decode batch capacity changes.
     /// </summary>
-    private Tensor? EnsureRaggedAttnScores(int n, int[] positions)
+    private Tensor? EnsureRaggedAttnScores(int n, ReadOnlySpan<int> slots)
     {
         int maxLen = 0;
-        for (int i = 0; i < positions.Length; i++) maxLen = Math.Max(maxLen, positions[i] + 1);
+        for (int i = 0; i < slots.Length; i++) maxLen = Math.Max(maxLen, slots[i] + 1);
         if (maxLen <= 4096) return null;
 
         if (_raggedAttnScoresCapacity != n)

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
@@ -199,11 +199,15 @@ public sealed class CudaBatchedDecodeBench
         var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
         var tokenizer = GgufTokenizer.FromGgufModel(model);
 
-        // Long prompt that exceeds the SnapKV budget so every per-sequence cache evicts.
+        // Long prompt that exceeds the SnapKV budget so every per-sequence cache evicts. Tokenize the
+        // seed ONCE and repeat the tokens (the exact token stream is irrelevant for the bench — only
+        // the length matters) rather than re-encoding a growing string each iteration (O(n²) on the
+        // SPM tokenizer; see the "SPM O(n²)" fix in #214).
         const string seed = "The quick brown fox jumps over the lazy dog. Sphinx of black quartz, judge my vow. ";
-        var sb = new System.Text.StringBuilder();
-        while (tokenizer.Encode(sb.ToString()).Count < 1200) sb.Append(seed);
-        int[] prompt = tokenizer.Encode(sb.ToString()).ToArray();
+        var seedTokens = tokenizer.Encode(seed);
+        var promptList = new List<int>();
+        while (promptList.Count < 1200) promptList.AddRange(seedTokens);
+        int[] prompt = promptList.ToArray();
 
         var prevBudget = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
         var prevWindow = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_WINDOW");

--- a/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaBatchedDecodeBench.cs
@@ -174,4 +174,95 @@ public sealed class CudaBatchedDecodeBench
             }
         }
     }
+
+    /// <summary>
+    /// Issue #277: aggregate decode throughput for a SnapKV-EVICTED batch on the ragged fast path
+    /// vs the #190 per-sequence loop it used to be forced onto. Before #277 any evicted cache in the
+    /// batch routed the whole batch through O(N) per-op launches; #277 keeps it on the O(1) ragged
+    /// kernels (physical-slot threaded). The per-sequence loop is reachable here via the
+    /// <see cref="CudaForwardPass.BatchDecodeRaggedForTest"/> seam, so this A/Bs both on one warm
+    /// instance. Long prompts force eviction (budget 512). Surfaces t/s, asserts no threshold.
+    ///
+    /// Opt-in: $env:SHARPI_BENCH_BATCH=1; dotnet test ... --filter
+    ///   "FullyQualifiedName~Decode_Throughput_SnapKvEvicted_Ragged_vs_PerSeq"
+    /// </summary>
+    [Fact]
+    public void Decode_Throughput_SnapKvEvicted_Ragged_vs_PerSeq()
+    {
+        if (!BenchEnabled) return;
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+        // Long prompt that exceeds the SnapKV budget so every per-sequence cache evicts.
+        const string seed = "The quick brown fox jumps over the lazy dog. Sphinx of black quartz, judge my vow. ";
+        var sb = new System.Text.StringBuilder();
+        while (tokenizer.Encode(sb.ToString()).Count < 1200) sb.Append(seed);
+        int[] prompt = tokenizer.Encode(sb.ToString()).ToArray();
+
+        var prevBudget = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        var prevWindow = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_WINDOW");
+        var prevSlots = Environment.GetEnvironmentVariable("SHARPI_PREFIX_SLOTS");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "512");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_WINDOW", "32");
+        Environment.SetEnvironmentVariable("SHARPI_PREFIX_SLOTS", null);
+        CudaForwardPass fwdTmp;
+        try { fwdTmp = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048); }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevBudget);
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_WINDOW", prevWindow);
+            Environment.SetEnvironmentVariable("SHARPI_PREFIX_SLOTS", prevSlots);
+        }
+        using var fwd = fwdTmp;
+
+        int decodeSteps = DecodeSteps;
+        const int warmup = 8;
+        foreach (int n in BatchSizesToRun)
+        {
+            var caches = new CudaSequenceKvCache[n];
+            try
+            {
+                var toks = new int[n];
+                var poss = new int[n];
+                for (int s = 0; s < n; s++)
+                {
+                    caches[s] = fwd.CreateCache();
+                    toks[s] = Argmax(fwd.PrefillWithCache(prompt, caches[s]));
+                    poss[s] = prompt.Length;
+                }
+                if (caches[0].EvictedCount == 0)
+                    throw new InvalidOperationException("bench expects SnapKV eviction; prompt too short for the budget.");
+
+                double Run(bool ragged)
+                {
+                    fwd.BatchDecodeRaggedForTest = ragged;
+                    var t = (int[])toks.Clone();
+                    var p = (int[])poss.Clone();
+                    // Idempotent re-decode at fixed positions keeps the timed window pinned to one
+                    // cache geometry (no cache growth across steps) — a clean per-op A/B.
+                    for (int i = 0; i < warmup; i++) fwd.BatchForwardMulti(t, p, caches);
+                    var sw = Stopwatch.StartNew();
+                    for (int i = 0; i < decodeSteps; i++) fwd.BatchForwardMulti(t, p, caches);
+                    sw.Stop();
+                    return (double)n * decodeSteps / sw.Elapsed.TotalSeconds;
+                }
+
+                double perSeq = Run(ragged: false);
+                double raggedTps = Run(ragged: true);
+                Log($"[bench-277] evicted N={n}: ragged {raggedTps:F1} t/s vs per-seq {perSeq:F1} t/s " +
+                    $"({raggedTps / perSeq:F2}× ragged, EvictedCount={caches[0].EvictedCount})");
+            }
+            finally
+            {
+                fwd.BatchDecodeRaggedForTest = true;
+                foreach (var c in caches) c?.Dispose();
+            }
+        }
+    }
 }

--- a/tests/SharpInference.Tests.ForwardPass/CudaSnapKvBatchingTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaSnapKvBatchingTests.cs
@@ -310,6 +310,124 @@ public sealed class CudaSnapKvBatchingTests
     }
 
     /// <summary>
+    /// Issue #277: a SnapKV-evicted batch now stays on the #197 ragged fast path (the
+    /// <c>anyEvicted</c> → per-sequence-loop forcing is gone). The ragged KV-append + attention
+    /// take the PHYSICAL slot <c>pos - EvictedCount</c> while RoPE keeps the logical position — so
+    /// the ragged-evicted decode must be BIT-IDENTICAL to the per-sequence-loop decode it replaces.
+    ///
+    /// A batched decode step is idempotent on the same caches at the same positions (it overwrites
+    /// its own next slot with identical K/V and bounds attention by <c>pos - EvictedCount</c>, never
+    /// by <c>Length</c>), and both paths share every GEMM — so running one instance's ragged path
+    /// then flipping to the per-sequence loop on the SAME caches isolates the attention block and
+    /// asserts exact equality. Two different-length prompts give two different eviction deltas, so a
+    /// physical-slot mis-index would diverge here. (A cross-instance compare can't assert bit-
+    /// identity — prefill isn't bit-exact across instances.)
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_RaggedEvictedDecode_BitIdentical_To_PerSequenceLoop_N2()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+        using var env = SnapKvEnv(budget, window: 32);
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048);
+        Assert.True(fwd.SnapKvEnabled);
+        Assert.True(fwd.BatchDecodeRaggedForTest, "ragged decode must be enabled to exercise #277.");
+
+        int[] promptA = LongPrompt(tokenizer, 600);
+        int[] promptB = LongPrompt(tokenizer, 1000);
+
+        using var cacheA = fwd.CreateCache();
+        using var cacheB = fwd.CreateCache();
+        int tokA = Argmax(fwd.PrefillWithCache(promptA, cacheA));
+        int tokB = Argmax(fwd.PrefillWithCache(promptB, cacheB));
+        Assert.True(cacheA.EvictedCount > 0 && cacheB.EvictedCount > 0);
+        Assert.NotEqual(cacheA.EvictedCount, cacheB.EvictedCount); // different deltas
+
+        int[] toks = { tokA, tokB };
+        int[] poss = { promptA.Length, promptB.Length };
+
+        // Ragged path (default): handles eviction via the physical-slot array (#277).
+        fwd.BatchDecodeRaggedForTest = true;
+        float[][] ragged = fwd.BatchForwardMulti(toks, poss, [cacheA, cacheB]);
+
+        // Per-sequence loop (#190) on the SAME caches at the SAME positions — idempotent re-run.
+        fwd.BatchDecodeRaggedForTest = false;
+        float[][] perSeq = fwd.BatchForwardMulti(toks, poss, [cacheA, cacheB]);
+
+        for (int n = 0; n < 2; n++)
+        {
+            float maxAbs = MaxAbs(ragged[n], perSeq[n]);
+            Assert.Equal(Argmax(perSeq[n]), Argmax(ragged[n]));
+            Assert.True(maxAbs == 0f,
+                $"Seq {n}: ragged-evicted decode must be bit-identical to the per-sequence loop " +
+                $"(maxAbs={maxAbs}); a nonzero delta means the physical-slot threading diverged.");
+        }
+    }
+
+    /// <summary>
+    /// Issue #277, mixed batch: one SnapKV-evicted sequence and one un-evicted sequence in the same
+    /// ragged decode. The physical-slot array must offset only the evicted one (<c>pos - delta</c>)
+    /// and leave the un-evicted one at <c>pos</c>; the ragged path must still be bit-identical to the
+    /// per-sequence loop for BOTH. Guards the per-sequence <c>slots[n]</c> construction.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_RaggedEvictedDecode_BitIdentical_To_PerSequenceLoop_MixedEvictedAndNot()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int budget = 512;
+        using var env = SnapKvEnv(budget, window: 32);
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048);
+
+        int[] longPrompt = LongPrompt(tokenizer, 900);          // > budget → evicts
+        int[] shortPrompt = { 9707, 11, 1879, 0, 358, 1079 };   // << budget → no eviction
+
+        using var cacheL = fwd.CreateCache();
+        using var cacheS = fwd.CreateCache();
+        int tokL = Argmax(fwd.PrefillWithCache(longPrompt, cacheL));
+        int tokS = Argmax(fwd.PrefillWithCache(shortPrompt, cacheS));
+        Assert.True(cacheL.EvictedCount > 0);
+        Assert.Equal(0, cacheS.EvictedCount);
+
+        int[] toks = { tokL, tokS };
+        int[] poss = { longPrompt.Length, shortPrompt.Length };
+
+        fwd.BatchDecodeRaggedForTest = true;
+        float[][] ragged = fwd.BatchForwardMulti(toks, poss, [cacheL, cacheS]);
+        fwd.BatchDecodeRaggedForTest = false;
+        float[][] perSeq = fwd.BatchForwardMulti(toks, poss, [cacheL, cacheS]);
+
+        for (int n = 0; n < 2; n++)
+        {
+            float maxAbs = MaxAbs(ragged[n], perSeq[n]);
+            Assert.Equal(Argmax(perSeq[n]), Argmax(ragged[n]));
+            Assert.True(maxAbs == 0f,
+                $"Seq {n} (mixed): ragged decode must be bit-identical to the per-sequence loop (maxAbs={maxAbs}).");
+        }
+    }
+
+    private static float MaxAbs(float[] a, float[] b)
+    {
+        Assert.Equal(a.Length, b.Length);
+        float m = 0f;
+        for (int i = 0; i < a.Length; i++) m = MathF.Max(m, MathF.Abs(a[i] - b[i]));
+        return m;
+    }
+
+    /// <summary>
     /// Option 2: when continuous batching is preferred (<c>preferBatchingOverAutoSnapKv</c>), the
     /// VRAM-scaled SnapKV AUTO-enable is suppressed — so a batching server gets the ragged-decode
     /// fast path, not silent lossy eviction. Verified at a context where auto-SnapKV WOULD engage.


### PR DESCRIPTION
Closes #277. Follow-up to #196 (PR #274) CUDA continuous batching.

## Problem
Before this, the `RunBatchedTrunk` gate `ragged = _batchDecodeRagged && !anyEvicted` forced **any** batch containing a SnapKV-evicted cache off the #197 O(1) ragged batched-decode path onto the #190 per-sequence loop (O(N) per-op launches). That sacrifices the ragged speedup exactly in the long-context serving regime SnapKV is meant to accelerate.

## Fix
The ragged CUDA kernels already index the KV-append slot as `pos % maxSeqLen` and the attention range as `[0, pos + 1)` — there is no position-based masking inside them. So feeding them the **physical** slot `positions[n] - EvictedCount[n]` (while RoPE keeps the **logical** `positions[]`) is exactly the per-sequence loop's `physSlot` / `pos` split. No kernel-source change.

- `RunBatchedTrunk` builds a `slots[]` physical-slot span **only when an eviction is present**; the common no-eviction batch reuses `positions[]` directly (allocation-free, byte-identical to #197).
- `KvAppendBatchedRagged` / `AttentionBatchedRagged` rename `positions` → `slots` + docs to make the physical-slot contract explicit. `RoPEBatchedRagged` stays on logical positions.
- The `EvictedCount > position` (negative-slot) guard is retained and still runs unconditionally for both paths.

## Correctness
`CudaSnapKvBatchingTests` now asserts the ragged-evicted decode is **bit-identical** (`maxAbs == 0f`) to the per-sequence loop on the same caches — a batched decode step is idempotent at fixed positions (overwrites its own next slot with identical K/V, bounds attention by `slots[t]+1` not `Length`), so a single warm instance A/Bs both paths via the new internal `BatchDecodeRaggedForTest` seam. Two cases: N=2 with different eviction deltas, and a mixed evicted/un-evicted batch. The existing oracle tests (vs single-user) now also exercise the ragged-evicted path.

## Performance
Opt-in bench `Decode_Throughput_SnapKvEvicted_Ragged_vs_PerSeq` (Qwen3-8B Q4_K, RTX 4070 Ti, evicted batch, ragged vs per-sequence loop):

| N | ragged | per-seq | speedup |
|---|--------|---------|---------|
| 2 | 104.7  | 102.1   | 1.03×   |
| 4 | 165.3  | 145.2   | 1.14×   |
| 8 | 304.4  | 228.6   | 1.33×   |

Non-evicted path unchanged (byte-identical).

## Validation
- Builds clean (Release, `TreatWarningsAsErrors`, 0 warnings).
- GPU: full `CudaSnapKvBatchingTests` (7/7), `CudaBatchForwardMultiTests` + `Gemma4CudaBatchForwardMultiTests` + `CudaSpecBatchVerifyTests` (20/20) pass — no regression on the non-evicted / spec-verify paths.
- Two review passes (code-reviewer + silent-failure-hunter): no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)