### PR TITLE
test(cuda): bench Gemma 4 batched decode-MMQ on a Q4_K 12B (#283)

### DIFF
--- a/tests/SharpInference.Tests.ForwardPass/Gemma4CudaBatchedDecodeBench.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4CudaBatchedDecodeBench.cs
@@ -7,18 +7,29 @@ using Xunit.Abstractions;
 namespace SharpInference.Tests.ForwardPass;
 
 /// <summary>
-/// Issue #275: aggregate decode-throughput measurement for the Gemma 4 batched decode. #195 shipped
-/// Gemma 4 continuous batching with every trunk matmul on the cuBLAS GEMM (<c>GpuMatMulBatched</c>);
-/// #275 routes the trunk matmuls (Q/K/V/O, gate/up/down, lm-head) through
+/// Issue #275/#283: aggregate decode-throughput measurement for the Gemma 4 batched decode. #195
+/// shipped Gemma 4 continuous batching with every trunk matmul on the cuBLAS GEMM
+/// (<c>GpuMatMulBatched</c>); #275 routes the trunk matmuls (Q/K/V/O, gate/up/down, lm-head) through
 /// <see cref="CudaForwardPass.BatchForwardMulti"/>'s decode router (<c>BatchDecodeMatMul</c> — the
-/// #194 weight-stationary matvec / #201 decode-MMQ), like the dense path, while the PLE matmuls stay
-/// on GEMM. cuBLAS GEMM is compute-bound and known to lose to WS/GEMM-N for small-N decode (#190),
-/// so this is the A/B that proves the win.
+/// #194 weight-stationary matvec / #201/#206 decode-MMQ), like the dense path, while the PLE matmuls
+/// stay on GEMM. cuBLAS GEMM is compute-bound and known to lose to WS/GEMM-N for small-N decode
+/// (#190), so this is the A/B that proves the win.
 ///
-/// Run on <b>Gemma 4 E4B Q8_0</b> (the only GEMM-N-batchable Gemma 4 that fits 12 GB). The routing
-/// is selected at construction by the ambient env, so A/B by running twice:
-///   # new WS routing (default):
+/// <para>Default model is <b>Gemma 4 E4B Q8_0</b> (per-layer head_dim / SWA / shared-KV / PLE). On
+/// Q8_0 the #201/#206 int8 decode-MMQ tile (Q4_K/Q6_K-only) always falls back to the WS matvec, so
+/// E4B Q8_0 only measures the WS path. <b>Issue #283</b>: point this at a GEMM-N-batchable
+/// <b>Q4_K 12B</b> (<c>SHARPI_BENCH_MODEL=gemma-4-12b-it-Q4_K_M.gguf</c>) so the decode-MMQ tile
+/// (N≥5, rows≥2048, cols%256) actually engages for the big Q4_K trunk shapes (q/o-proj, gate/up,
+/// down, lm-head), and confirm it beats the WS matvec at higher N. The 12B is the realistic
+/// k_eq_v-on-global + real-V-on-SWA model.</para>
+///
+/// The routing is selected at construction by the ambient env, so A/B by running twice:
+///   # default routing (WS for E4B Q8_0; WS for N&lt;5 + decode-MMQ for N≥5 big Q4_K shapes on the 12B):
 ///   $env:SHARPI_BENCH_BATCH=1; dotnet test ... --filter "FullyQualifiedName~Gemma4CudaBatchedDecodeBench"
+///   # decode-MMQ vs WS A/B on the Q4_K 12B (#283): force WS everywhere with SHARPI_BATCH_DECODE_MMQ=0
+///   $env:SHARPI_BENCH_BATCH=1; $env:SHARPI_BENCH_MODEL="gemma-4-12b-it-Q4_K_M.gguf";
+///   $env:SHARPI_BENCH_BATCH_N="2,4,5,6,8"; dotnet test ... (default = MMQ on, then re-run with
+///   $env:SHARPI_BATCH_DECODE_MMQ="0" = WS everywhere)
 ///   # old all-GEMM routing (#195 baseline):
 ///   $env:SHARPI_BENCH_BATCH=1; $env:SHARPI_BATCH_DECODE_GEMM=1; dotnet test ... (same filter)
 /// Surfaces t/s, asserts no threshold (mirrors <see cref="CudaBatchedDecodeBench"/>). Silent-skips
@@ -26,7 +37,12 @@ namespace SharpInference.Tests.ForwardPass;
 /// </summary>
 public sealed class Gemma4CudaBatchedDecodeBench
 {
-    private const string ModelFile = "gemma-4-E4B-it-Q8_0.gguf";
+    // Default E4B Q8_0; override with SHARPI_BENCH_MODEL (filename resolved against the model dirs,
+    // or an absolute path) to point at the Q4_K 12B for the #283 decode-MMQ validation.
+    private static string ModelFile =>
+        Environment.GetEnvironmentVariable("SHARPI_BENCH_MODEL") is { Length: > 0 } m
+            ? m
+            : "gemma-4-E4B-it-Q8_0.gguf";
     private readonly ITestOutputHelper _out;
     public Gemma4CudaBatchedDecodeBench(ITestOutputHelper outHelper) { _out = outHelper; }
 
@@ -40,6 +56,10 @@ public sealed class Gemma4CudaBatchedDecodeBench
         .Select(int.Parse).ToArray();
     private static int DecodeSteps =>
         int.TryParse(Environment.GetEnvironmentVariable("SHARPI_BENCH_STEPS"), out int s) && s > 0 ? s : 128;
+    // The decode loop only touches ~prompt+steps positions, so a smaller ctx is fine and lets the
+    // bigger-KV Q4_K 12B fit N=8 caches in 12 GB (SHARPI_BENCH_CTX, default 2048 — unchanged for E4B).
+    private static int MaxCtx =>
+        int.TryParse(Environment.GetEnvironmentVariable("SHARPI_BENCH_CTX"), out int c) && c > 0 ? c : 2048;
 
     private static readonly int[] Prompt =
         { 2, 651, 6037, 576, 6081, 603, 1234, 4567, 8901, 222, 333, 444, 555, 666, 777, 888 };
@@ -53,6 +73,9 @@ public sealed class Gemma4CudaBatchedDecodeBench
 
     private static string? FindModelPath()
     {
+        // SHARPI_BENCH_MODEL may be an absolute path; honor it directly.
+        if (Path.IsPathRooted(ModelFile)) return File.Exists(ModelFile) ? ModelFile : null;
+
         string[] absolute = { $@"E:\models\{ModelFile}", $@"C:\p\sharpi\models\{ModelFile}" };
         foreach (var p in absolute)
             if (File.Exists(p)) return p;
@@ -92,12 +115,16 @@ public sealed class Gemma4CudaBatchedDecodeBench
         var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
         Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0");
         CudaForwardPass fwdTmp;
-        try { fwdTmp = new CudaForwardPass(model, gpu, hp, maxContextLength: 2048); }
+        try { fwdTmp = new CudaForwardPass(model, gpu, hp, maxContextLength: MaxCtx); }
         finally { Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap); }
         using var fwd = fwdTmp;
 
         bool gemm = Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_GEMM") == "1";
-        Log($"[bench-275] routing = {(gemm ? "all-GEMM (#195 baseline)" : "WS/decode-MMQ (#275)")}");
+        bool mmqKill = Environment.GetEnvironmentVariable("SHARPI_BATCH_DECODE_MMQ") == "0";
+        string routing = gemm
+            ? "all-GEMM (#195 baseline)"
+            : mmqKill ? "WS only (decode-MMQ forced off)" : "WS + decode-MMQ@N≥5 (#275 default)";
+        Log($"[bench-275] model = {Path.GetFileName(path)} · routing = {routing}");
 
         int decodeSteps = DecodeSteps;
         const int warmup = 8;


### PR DESCRIPTION
Validates the #283 perf deliverable: the Gemma 4 batched decode-MMQ tile beats the WS matvec at N≥5 on a Q4_K 12B.

## Why
#275 routed the Gemma 4 batched decode through `BatchDecodeMatMul` (WS / decode-MMQ), but the only GEMM-N-batchable Gemma 4 on hand was E4B Q8_0, where the int8 decode-MMQ tile (Q4_K/Q6_K-only) **always falls back to the WS matvec** — so the #201/#206 decode-MMQ tile was never exercised on a Gemma 4 model. A Q4_K_M 12B engages it for the big Q4_K trunk shapes at N≥5.

## What
Parameterize `Gemma4CudaBatchedDecodeBench`'s model (`SHARPI_BENCH_MODEL`) and context (`SHARPI_BENCH_CTX`, default 2048 — **unchanged for E4B**) so it can target the larger-KV Q4_K 12B and fit N=8 caches in 12 GB, and make the routing log line report the effective WS / decode-MMQ / all-GEMM mode.

A/B by running twice (default = decode-MMQ on at N≥5; `SHARPI_BATCH_DECODE_MMQ=0` = WS everywhere).

## Validation (4070 Ti, `gemma-4-12b-it-Q4_K_M.gguf`, ctx 512, 128 steps)
| N | decode-MMQ (default) | WS only | speedup |
|---|---|---|---|
| 2 | 76.1 | 75.9 | 1.00× (N<5, both WS) |
| 4 | 113.7 | 113.4 | 1.00× (N<5, both WS) |
| 5 | 149.0 | 117.9 | **1.26×** |
| 6 | 166.3 | 126.8 | **1.31×** |
| 8 | 197.0 | 138.4 | **1.42×** |

The crossover sits exactly on the N≥5 decode-MMQ gate — a real win, not neutral/negative, and no regression below the gate (identical to WS). Build clean (0 warnings). Internal code review: no high-confidence findings; E4B default confirmed byte-for-byte unchanged.

Test-only / opt-in (`SHARPI_BENCH_BATCH=1`), asserts no thresholds, silent-skips without CUDA/model. Independent of the companion oracle PR (different file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)