### PR TITLE
perf(mtp): 4-input CPU MatVec4In for k>2 batched verify (#209)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ sharpi-cli -m models/Qwen3.6-27B-MTP-Q4_K_M.gguf -g -1 \
 
 | Backend | Size | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | 16 GB | **10.0** | **10.4** | 22/64 dense FFN on GPU + GDN/attn KV resident, rest CPU mmap. 90% acceptance; folded k-token batched verify + GDN snapshot ring — **1.68× over MTP-off (6.4)** |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | 16 GB | **10.0** | **12.3** | GDN/attn KV resident on GPU, dense FFN on CPU mmap (the k=4 ring reclaims the VRAM the old k=2 default spent on 22 GPU FFN layers). 84% acceptance; 4-input CPU-FFN `MatVec4In` (#209) moves the verify optimum from k=2 → k=4 — **1.9× over MTP-off (6.5)**, +22% over the old k=2 default (10.1) |
 | **CUDA** `-g -1 --no-thinking` `Q5_K_M` (hybrid) | 19 GB | 6.2 | **5.5** | 13/64 FFN on GPU, 51/64 CPU mmap. 98% acceptance; batched trunk (#119) bit-identical |
 | CPU `--no-thinking` | 16 GB | 3.0 | **3.6** | dense 27B GDN/attn + native MTP head; auto MTP self-spec (#25) at greedy + `--no-thinking`. 90% draft acceptance; folded k-token batched verify (#30/#207) — 1.2× over MTP-off (3.0) |
 | CPU `--no-thinking` `Q5_K_M` | 19 GB | 2.8 | **3.5** | ~10% slower than Q4_K_M; 100% acceptance |

--- a/scripts/bench-27b-mtp.ps1
+++ b/scripts/bench-27b-mtp.ps1
@@ -1,6 +1,12 @@
 # One-shot bench harness for Qwen3.6-27B-MTP (issue #28). Runs both MTP-on (default)
 # and MTP-off (SHARPI_DISABLE_MTP=1) on CPU and CUDA-hybrid for one or more quants,
 # so the README can quote both numbers and the no-speedup gap is visible.
+#
+# Issue #209: the MTP-on rows now exercise the k=4 verify batch (the new default:
+# SHARPI_MTP_BATCH_MAX=4 / SHARPI_MTP_DRAFT_N=3) — the 4-input CPU-FFN MatVec4In
+# amortizes the dominant CPU mmap weight read four ways, moving the optimum out from
+# the old pairwise k=2. Measured Q4_K_M CUDA-hybrid: k=4 12.3 vs k=2 10.1 vs k=6 10.4
+# vs MTP-off 6.5 t/s. Set SHARPI_MTP_BATCH_MAX / SHARPI_MTP_DRAFT_N to sweep other k.
 param(
     [string[]]$Quants = @("Q4_K_M", "Q5_K_M"),
     [int]$NTokens = 80,

--- a/src/SharpInference.Core/IForwardPass.cs
+++ b/src/SharpInference.Core/IForwardPass.cs
@@ -272,19 +272,12 @@ public interface IForwardPass : IDisposable
     int MaxBatchVerifyTokens => int.MaxValue;
 
     /// <summary>
-    /// Last completed <see cref="BatchForward2"/>'s token-1 pre-output-norm hidden.
-    /// Used by the MTP commit step on the batched verify path. Empty when no batched
-    /// forward has been run.
-    /// </summary>
-    ReadOnlySpan<float> LastHiddenT1 => default;
-
-    /// <summary>
     /// Two-token batched forward (issue #30). On entry both caches must be at length
     /// <paramref name="startPos"/>. On return both caches are at length
-    /// <c>startPos + 2</c>, <see cref="LastHidden"/> holds h@startPos+1, and
-    /// <see cref="LastHiddenT1"/> holds h@startPos. A per-layer GDN snapshot is
-    /// captured at the "between t1 and t2" point so a rejected draft can be rolled
-    /// back via <see cref="RestoreBatchSnapshot"/>.
+    /// <c>startPos + 2</c> and <see cref="LastHidden"/> holds h@startPos+1. A per-layer
+    /// GDN snapshot is captured at the "between t1 and t2" point so a rejected draft can
+    /// be rolled back via <see cref="RestoreBatchSnapshot"/>. Both tokens' pre-output-
+    /// norm hiddens are written to the MTP hidden history for later draft chaining.
     /// </summary>
     void BatchForward2(int t1, int t2, int startPos,
         out ReadOnlySpan<float> logits1, out ReadOnlySpan<float> logits2) =>

--- a/src/SharpInference.Cpu/SimdKernels.cs
+++ b/src/SharpInference.Cpu/SimdKernels.cs
@@ -484,6 +484,155 @@ public static unsafe class SimdKernels
         }
     }
 
+    /// <summary>
+    /// Four-input fused mat-vec (issue #209): for each weight row
+    /// <c>output{0..3}[r] = weights[r] · input{0..3}</c>. Decodes each weight row
+    /// ONCE and dots it against four token columns in the same pass — one weight
+    /// HBM/L2 read per four tokens versus <see cref="MatVec2In"/>'s one-per-two. This
+    /// is the dominant lever on the 27B-MTP CUDA-hybrid decode path, where 46/64 dense
+    /// FFN layers are CPU-mmap'd and re-read once per draft token. Per-token
+    /// accumulation order is identical to <see cref="MatVec2In"/> / single
+    /// <see cref="MatVec"/>, so each position's bits are independent of the batch width
+    /// k (the duplicated-input-tail contract — see the BatchVerify callers, which fill
+    /// past-the-end lanes with a duplicate token routed to a sink).
+    /// </summary>
+    public static void MatVec4In(
+        float* output0, float* output1, float* output2, float* output3,
+        byte* weights,
+        float* input0, float* input1, float* input2, float* input3,
+        int rows, int cols, DType dtype)
+    {
+        switch (dtype)
+        {
+            case DType.Q4_K:
+            {
+                int bpr = (cols / 256) * 144;
+                if (rows >= MinRowsForParallel)
+                {
+                    var w = weights; var i0 = input0; var i1 = input1; var i2 = input2; var i3 = input3;
+                    var o0 = output0; var o1 = output1; var o2 = output2; var o3 = output3; int c = cols;
+                    Parallel.For(0, rows, s_parallelOpts, r =>
+                    {
+                        byte* row = w + (long)r * bpr;
+                        DotQ4K_4In(row, i0, i1, i2, i3, c, out float s0, out float s1, out float s2, out float s3);
+                        o0[r] = s0; o1[r] = s1; o2[r] = s2; o3[r] = s3;
+                    });
+                }
+                else
+                {
+                    for (int r = 0; r < rows; r++)
+                    {
+                        byte* row = weights + (long)r * bpr;
+                        DotQ4K_4In(row, input0, input1, input2, input3, cols, out float s0, out float s1, out float s2, out float s3);
+                        output0[r] = s0; output1[r] = s1; output2[r] = s2; output3[r] = s3;
+                    }
+                }
+                break;
+            }
+            case DType.Q5_K:
+            {
+                int bpr = (cols / 256) * 176;
+                if (rows >= MinRowsForParallel)
+                {
+                    var w = weights; var i0 = input0; var i1 = input1; var i2 = input2; var i3 = input3;
+                    var o0 = output0; var o1 = output1; var o2 = output2; var o3 = output3; int c = cols;
+                    Parallel.For(0, rows, s_parallelOpts, r =>
+                    {
+                        byte* row = w + (long)r * bpr;
+                        DotQ5K_4In(row, i0, i1, i2, i3, c, out float s0, out float s1, out float s2, out float s3);
+                        o0[r] = s0; o1[r] = s1; o2[r] = s2; o3[r] = s3;
+                    });
+                }
+                else
+                {
+                    for (int r = 0; r < rows; r++)
+                    {
+                        byte* row = weights + (long)r * bpr;
+                        DotQ5K_4In(row, input0, input1, input2, input3, cols, out float s0, out float s1, out float s2, out float s3);
+                        output0[r] = s0; output1[r] = s1; output2[r] = s2; output3[r] = s3;
+                    }
+                }
+                break;
+            }
+            case DType.Q6_K:
+            {
+                int bpr = (cols / 256) * 210;
+                int scratchBytes = Q8KScratchBytes(cols);
+                // One Q8_K scratch per input; same stack-alloc discipline as MatVec2In.
+                byte* sc0 = stackalloc byte[scratchBytes];
+                byte* sc1 = stackalloc byte[scratchBytes];
+                byte* sc2 = stackalloc byte[scratchBytes];
+                byte* sc3 = stackalloc byte[scratchBytes];
+                QuantizeRowToQ8K(input0, cols, sc0);
+                QuantizeRowToQ8K(input1, cols, sc1);
+                QuantizeRowToQ8K(input2, cols, sc2);
+                QuantizeRowToQ8K(input3, cols, sc3);
+
+                if (rows >= MinRowsForParallel)
+                {
+                    var w = weights; var s0 = sc0; var s1 = sc1; var s2 = sc2; var s3 = sc3;
+                    var o0 = output0; var o1 = output1; var o2 = output2; var o3 = output3; int c = cols;
+                    Parallel.For(0, rows, s_parallelOpts, r =>
+                    {
+                        byte* row = w + (long)r * bpr;
+                        DotQ6K_Q8K_4In(row, s0, s1, s2, s3, c, out float v0, out float v1, out float v2, out float v3);
+                        o0[r] = v0; o1[r] = v1; o2[r] = v2; o3[r] = v3;
+                    });
+                }
+                else
+                {
+                    for (int r = 0; r < rows; r++)
+                    {
+                        byte* row = weights + (long)r * bpr;
+                        DotQ6K_Q8K_4In(row, sc0, sc1, sc2, sc3, cols, out float v0, out float v1, out float v2, out float v3);
+                        output0[r] = v0; output1[r] = v1; output2[r] = v2; output3[r] = v3;
+                    }
+                }
+                break;
+            }
+            case DType.Float32:
+            {
+                var m = (float*)weights;
+                if (rows >= MinRowsForParallel)
+                {
+                    var i0 = input0; var i1 = input1; var i2 = input2; var i3 = input3;
+                    var o0 = output0; var o1 = output1; var o2 = output2; var o3 = output3; int c = cols;
+                    Parallel.For(0, rows, s_parallelOpts, r =>
+                    {
+                        float* row = m + (long)r * c;
+                        o0[r] = DotF32(row, i0, c);
+                        o1[r] = DotF32(row, i1, c);
+                        o2[r] = DotF32(row, i2, c);
+                        o3[r] = DotF32(row, i3, c);
+                    });
+                }
+                else
+                {
+                    for (int r = 0; r < rows; r++)
+                    {
+                        float* row = m + (long)r * cols;
+                        output0[r] = DotF32(row, input0, cols);
+                        output1[r] = DotF32(row, input1, cols);
+                        output2[r] = DotF32(row, input2, cols);
+                        output3[r] = DotF32(row, input3, cols);
+                    }
+                }
+                break;
+            }
+            default:
+                // Fallback: two MatVec2In pairs (each falls back per-dtype as needed).
+                // Never worse than the prior pairwise path, still correct. Q8_0 lands
+                // here deliberately — the single-token dense FFN decode (MatVec /
+                // MatVecDual) and the old MatVec2In path both take the dequant→DotF32
+                // fallback for Q8_0, so routing the quad here keeps the verify path
+                // bit-identical to single-token decode (specialising it would also
+                // require moving the single-token path to DotQ8_0 and re-validating).
+                MatVec2In(output0, output1, weights, input0, input1, rows, cols, dtype);
+                MatVec2In(output2, output3, weights, input2, input3, rows, cols, dtype);
+                break;
+        }
+    }
+
     private static void MatVecDequantFallback(float* output, byte* weights, float* input,
         int rows, int cols, DType dtype)
     {
@@ -853,6 +1002,115 @@ public static unsafe class SimdKernels
 
                 qIdx += 32;
                 scIdx += 2;
+            }
+            elemOff += 256;
+        }
+
+        sum0 = HSum512(Avx512F.Add(accLo0, accHi0));
+        sum1 = HSum512(Avx512F.Add(accLo1, accHi1));
+        sum2 = HSum512(Avx512F.Add(accLo2, accHi2));
+        sum3 = HSum512(Avx512F.Add(accLo3, accHi3));
+    }
+
+    // ================================================================
+    //  Q5_K Fused four-input dot (issue #209) — register-tiled extension
+    //  of DotQ5K_2In: decode each block ONCE and FMA against FOUR inputs.
+    //  Each input's lo/hi accumulator chain matches the single-input order
+    //  exactly, so the result is bit-identical to four DotQ5K calls.
+    // ================================================================
+
+    public static void DotQ5K_4In(byte* row,
+        float* input0, float* input1, float* input2, float* input3, int cols,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        int numBlocks = cols / 256;
+
+        if (Avx512F.IsSupported)
+        {
+            DotQ5K_4In_Avx512(row, input0, input1, input2, input3, numBlocks,
+                out sum0, out sum1, out sum2, out sum3);
+            return;
+        }
+        sum0 = DotQ5K(row, input0, cols);
+        sum1 = DotQ5K(row, input1, cols);
+        sum2 = DotQ5K(row, input2, cols);
+        sum3 = DotQ5K(row, input3, cols);
+    }
+
+    private static void DotQ5K_4In_Avx512(byte* row,
+        float* input0, float* input1, float* input2, float* input3, int numBlocks,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        var accLo0 = Vector512<float>.Zero; var accHi0 = Vector512<float>.Zero;
+        var accLo1 = Vector512<float>.Zero; var accHi1 = Vector512<float>.Zero;
+        var accLo2 = Vector512<float>.Zero; var accHi2 = Vector512<float>.Zero;
+        var accLo3 = Vector512<float>.Zero; var accHi3 = Vector512<float>.Zero;
+        var mask0F = Vector512.Create(0x0F);
+        var bit16  = Vector512.Create(16);
+        int elemOff = 0;
+
+        for (int b = 0; b < numBlocks; b++)
+        {
+            byte* x = row + b * 176;
+            float d = HalfToFloat(x[0], x[1]);
+            float dmin = HalfToFloat(x[2], x[3]);
+            byte* sc = x + 4;
+            byte* qh = x + 16;
+            byte* ql = x + 48;
+
+            int qIdx = 0, scIdx = 0;
+            byte u1 = 1, u2 = 2;
+
+            for (int chunk = 0; chunk < 4; chunk++)
+            {
+                GetScaleMinK4(scIdx, sc, out byte sc1, out byte m1);
+                GetScaleMinK4(scIdx + 1, sc, out byte sc2, out byte m2);
+
+                var d1     = Vector512.Create(d * sc1);
+                var negDm1 = Vector512.Create(-(dmin * m1));
+                var d2     = Vector512.Create(d * sc2);
+                var negDm2 = Vector512.Create(-(dmin * m2));
+
+                int bo = elemOff + chunk * 64;
+
+                for (int l = 0; l < 32; l += 16)
+                {
+                    var qlBytes = Vector128.LoadUnsafe(ref *(ql + qIdx + l));
+                    var qlInts = Avx512F.ConvertToVector512Int32(qlBytes);
+                    var qhBytes = Vector128.LoadUnsafe(ref *(qh + l));
+                    var qhInts = Avx512F.ConvertToVector512Int32(qhBytes);
+
+                    // Low nibble + high bit u1 → q5Lo, dequant once.
+                    var loNib = Avx512F.And(qlInts, mask0F);
+                    var hLoMask = Avx512F.And(qhInts, Vector512.Create((int)u1));
+                    var hLo = Avx512F.And(
+                        Avx512F.CompareGreaterThan(hLoMask, Vector512<int>.Zero).AsInt32(),
+                        bit16);
+                    var q5Lo = Avx512F.Add(loNib, hLo);
+                    var deqLo = Avx512F.FusedMultiplyAdd(d1, Avx512F.ConvertToVector512Single(q5Lo), negDm1);
+                    accLo0 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input0 + bo + l)), accLo0);
+                    accLo1 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input1 + bo + l)), accLo1);
+                    accLo2 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input2 + bo + l)), accLo2);
+                    accLo3 = Avx512F.FusedMultiplyAdd(deqLo, Vector512.LoadUnsafe(ref *(input3 + bo + l)), accLo3);
+
+                    // High nibble + high bit u2 → q5Hi, dequant once.
+                    var hiNib = Avx512F.And(Avx512F.ShiftRightLogical(qlInts, 4), mask0F);
+                    var hHiMask = Avx512F.And(qhInts, Vector512.Create((int)u2));
+                    var hHi = Avx512F.And(
+                        Avx512F.CompareGreaterThan(hHiMask, Vector512<int>.Zero).AsInt32(),
+                        bit16);
+                    var q5Hi = Avx512F.Add(hiNib, hHi);
+                    var deqHi = Avx512F.FusedMultiplyAdd(d2, Avx512F.ConvertToVector512Single(q5Hi), negDm2);
+                    accHi0 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input0 + bo + 32 + l)), accHi0);
+                    accHi1 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input1 + bo + 32 + l)), accHi1);
+                    accHi2 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input2 + bo + 32 + l)), accHi2);
+                    accHi3 = Avx512F.FusedMultiplyAdd(deqHi, Vector512.LoadUnsafe(ref *(input3 + bo + 32 + l)), accHi3);
+                }
+
+                qIdx += 32;
+                scIdx += 2;
+                u1 <<= 2;
+                u2 <<= 2;
             }
             elemOff += 256;
         }
@@ -3249,6 +3507,173 @@ public static unsafe class SimdKernels
         }
         sum1 = HSum256(acc1);
         sum2 = HSum256(acc2);
+    }
+
+    // ================================================================
+    //  Q6_K · Q8_K Fused four-input dot (issue #209) — register-tiled
+    //  extension of DotQ6K_Q8K_2In: decode each Q6_K super-block ONCE and
+    //  inner-int-product it against FOUR pre-quantized Q8_K inputs. Each
+    //  input's sumi/acc chain matches the single-input order exactly, so the
+    //  result is bit-identical to four DotQ6K_Q8K calls.
+    // ================================================================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void DotQ6K_Q8K_4In(byte* row, byte* scratch0, byte* scratch1,
+                                       byte* scratch2, byte* scratch3, int cols,
+                                       out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        int numBlocks = cols / 256;
+
+        if (Avx2.IsSupported && Fma.IsSupported)
+        {
+            DotQ6K_Q8K_4In_Avx2(row, scratch0, scratch1, scratch2, scratch3, numBlocks,
+                out sum0, out sum1, out sum2, out sum3);
+            return;
+        }
+        sum0 = DotQ6K_Q8K_Scalar(row, scratch0, numBlocks);
+        sum1 = DotQ6K_Q8K_Scalar(row, scratch1, numBlocks);
+        sum2 = DotQ6K_Q8K_Scalar(row, scratch2, numBlocks);
+        sum3 = DotQ6K_Q8K_Scalar(row, scratch3, numBlocks);
+    }
+
+    private static void DotQ6K_Q8K_4In_Avx2(byte* row,
+        byte* scratch0, byte* scratch1, byte* scratch2, byte* scratch3, int numBlocks,
+        out float sum0, out float sum1, out float sum2, out float sum3)
+    {
+        float* dArr0 = (float*)scratch0;
+        sbyte* qsArr0 = (sbyte*)(scratch0 + numBlocks * 4);
+        short* bsumsArr0 = (short*)(scratch0 + numBlocks * 4 + numBlocks * 256);
+        float* dArr1 = (float*)scratch1;
+        sbyte* qsArr1 = (sbyte*)(scratch1 + numBlocks * 4);
+        short* bsumsArr1 = (short*)(scratch1 + numBlocks * 4 + numBlocks * 256);
+        float* dArr2 = (float*)scratch2;
+        sbyte* qsArr2 = (sbyte*)(scratch2 + numBlocks * 4);
+        short* bsumsArr2 = (short*)(scratch2 + numBlocks * 4 + numBlocks * 256);
+        float* dArr3 = (float*)scratch3;
+        sbyte* qsArr3 = (sbyte*)(scratch3 + numBlocks * 4);
+        short* bsumsArr3 = (short*)(scratch3 + numBlocks * 4 + numBlocks * 256);
+
+        var m3 = Vector256.Create((byte)0x03);
+        var m12 = Vector256.Create((byte)0x0C);
+        var m48 = Vector256.Create((byte)0x30);
+        var m192 = Vector256.Create((byte)0xC0);
+        var m15 = Vector256.Create((byte)0x0F);
+        var acc0 = Vector256<float>.Zero;
+        var acc1 = Vector256<float>.Zero;
+        var acc2 = Vector256<float>.Zero;
+        var acc3 = Vector256<float>.Zero;
+
+        for (int i = 0; i < numBlocks; i++)
+        {
+            byte* x = row + i * 210;
+            byte* ql = x;
+            byte* qh = x + 128;
+            sbyte* sc = (sbyte*)(x + 192);
+            float dw = HalfToFloat(x[208], x[209]);
+            float dSuper0 = dw * dArr0[i];
+            float dSuper1 = dw * dArr1[i];
+            float dSuper2 = dw * dArr2[i];
+            float dSuper3 = dw * dArr3[i];
+
+            // Scales (int16) — shared between all inputs.
+            var scales128 = Vector128.LoadUnsafe(ref *(byte*)sc).AsSByte();
+            var scales16 = Avx2.ConvertToVector256Int16(scales128);
+
+            // Per-input offset corrections.
+            var q8sums0 = Vector256.LoadUnsafe(ref *(bsumsArr0 + i * 16));
+            var q8sclsub0 = Avx2.ShiftLeftLogical(Avx2.MultiplyAddAdjacent(q8sums0, scales16), 5);
+            var q8sums1 = Vector256.LoadUnsafe(ref *(bsumsArr1 + i * 16));
+            var q8sclsub1 = Avx2.ShiftLeftLogical(Avx2.MultiplyAddAdjacent(q8sums1, scales16), 5);
+            var q8sums2 = Vector256.LoadUnsafe(ref *(bsumsArr2 + i * 16));
+            var q8sclsub2 = Avx2.ShiftLeftLogical(Avx2.MultiplyAddAdjacent(q8sums2, scales16), 5);
+            var q8sums3 = Vector256.LoadUnsafe(ref *(bsumsArr3 + i * 16));
+            var q8sclsub3 = Avx2.ShiftLeftLogical(Avx2.MultiplyAddAdjacent(q8sums3, scales16), 5);
+
+            var sumi0 = Vector256<int>.Zero;
+            var sumi1 = Vector256<int>.Zero;
+            var sumi2 = Vector256<int>.Zero;
+            var sumi3 = Vector256<int>.Zero;
+            sbyte* q8a = (sbyte*)(qsArr0 + i * 256);
+            sbyte* q8b = (sbyte*)(qsArr1 + i * 256);
+            sbyte* q8c = (sbyte*)(qsArr2 + i * 256);
+            sbyte* q8d = (sbyte*)(qsArr3 + i * 256);
+
+            for (int j = 0; j < 2; j++)
+            {
+                var q4bits1 = Vector256.LoadUnsafe(ref *(ql + j * 64));
+                var q4bits2 = Vector256.LoadUnsafe(ref *(ql + j * 64 + 32));
+                var q4bitsH = Vector256.LoadUnsafe(ref *(qh + j * 32));
+
+                // Reconstruct 4 sets of 32 unsigned 6-bit values — shared across inputs.
+                var q4h_0 = Avx2.ShiftLeftLogical(Avx2.And(q4bitsH, m3).AsInt16(), 4).AsByte();
+                var q4h_1 = Avx2.ShiftLeftLogical(Avx2.And(q4bitsH, m12).AsInt16(), 2).AsByte();
+                var q4h_2 = Avx2.And(q4bitsH, m48);
+                var q4h_3 = Avx2.ShiftRightLogical(Avx2.And(q4bitsH, m192).AsInt16(), 2).AsByte();
+
+                var q4_0 = Avx2.Or(Avx2.And(q4bits1, m15), q4h_0);
+                var q4_1 = Avx2.Or(Avx2.And(q4bits2, m15), q4h_1);
+                var q4_2 = Avx2.Or(
+                    Avx2.And(Avx2.ShiftRightLogical(q4bits1.AsInt16(), 4).AsByte(), m15), q4h_2);
+                var q4_3 = Avx2.Or(
+                    Avx2.And(Avx2.ShiftRightLogical(q4bits2.AsInt16(), 4).AsByte(), m15), q4h_3);
+
+                int isc = j * 8;
+                var sc16_0 = Vector256.Create(
+                    Vector128.Create((short)sc[isc + 0]), Vector128.Create((short)sc[isc + 1]));
+                var sc16_1 = Vector256.Create(
+                    Vector128.Create((short)sc[isc + 2]), Vector128.Create((short)sc[isc + 3]));
+                var sc16_2 = Vector256.Create(
+                    Vector128.Create((short)sc[isc + 4]), Vector128.Create((short)sc[isc + 5]));
+                var sc16_3 = Vector256.Create(
+                    Vector128.Create((short)sc[isc + 6]), Vector128.Create((short)sc[isc + 7]));
+
+                Q6KAccumInput(q8a, j, q4_0, q4_1, q4_2, q4_3, sc16_0, sc16_1, sc16_2, sc16_3, ref sumi0);
+                Q6KAccumInput(q8b, j, q4_0, q4_1, q4_2, q4_3, sc16_0, sc16_1, sc16_2, sc16_3, ref sumi1);
+                Q6KAccumInput(q8c, j, q4_0, q4_1, q4_2, q4_3, sc16_0, sc16_1, sc16_2, sc16_3, ref sumi2);
+                Q6KAccumInput(q8d, j, q4_0, q4_1, q4_2, q4_3, sc16_0, sc16_1, sc16_2, sc16_3, ref sumi3);
+            }
+
+            acc0 = Fma.MultiplyAdd(Vector256.Create(dSuper0),
+                Avx.ConvertToVector256Single(Avx2.Subtract(sumi0, q8sclsub0)), acc0);
+            acc1 = Fma.MultiplyAdd(Vector256.Create(dSuper1),
+                Avx.ConvertToVector256Single(Avx2.Subtract(sumi1, q8sclsub1)), acc1);
+            acc2 = Fma.MultiplyAdd(Vector256.Create(dSuper2),
+                Avx.ConvertToVector256Single(Avx2.Subtract(sumi2, q8sclsub2)), acc2);
+            acc3 = Fma.MultiplyAdd(Vector256.Create(dSuper3),
+                Avx.ConvertToVector256Single(Avx2.Subtract(sumi3, q8sclsub3)), acc3);
+        }
+        sum0 = HSum256(acc0);
+        sum1 = HSum256(acc1);
+        sum2 = HSum256(acc2);
+        sum3 = HSum256(acc3);
+    }
+
+    /// <summary>One Q8_K input's contribution to a Q6_K super-block half-pair, using
+    /// the already-decoded weight sextets (<paramref name="q4_0"/>..<c>q4_3</c>) and
+    /// per-group scales. Matches the inline input pass of <see cref="DotQ6K_Q8K_2In_Avx2"/>
+    /// exactly so the 4-input path stays bit-identical to the single/pair paths.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Q6KAccumInput(sbyte* q8, int j,
+        Vector256<byte> q4_0, Vector256<byte> q4_1, Vector256<byte> q4_2, Vector256<byte> q4_3,
+        Vector256<short> sc16_0, Vector256<short> sc16_1, Vector256<short> sc16_2, Vector256<short> sc16_3,
+        ref Vector256<int> sumi)
+    {
+        var qa0 = Vector256.LoadUnsafe(ref *(q8 + j * 128)).AsSByte();
+        var qa1 = Vector256.LoadUnsafe(ref *(q8 + j * 128 + 32)).AsSByte();
+        var qa2 = Vector256.LoadUnsafe(ref *(q8 + j * 128 + 64)).AsSByte();
+        var qa3 = Vector256.LoadUnsafe(ref *(q8 + j * 128 + 96)).AsSByte();
+
+        var pa0 = Avx2.MultiplyAddAdjacent(q4_0, qa0);
+        var pa1 = Avx2.MultiplyAddAdjacent(q4_1, qa1);
+        var pa2 = Avx2.MultiplyAddAdjacent(q4_2, qa2);
+        var pa3 = Avx2.MultiplyAddAdjacent(q4_3, qa3);
+
+        var sa0 = Avx2.MultiplyAddAdjacent(sc16_0, pa0);
+        var sa1 = Avx2.MultiplyAddAdjacent(sc16_1, pa1);
+        var sa2 = Avx2.MultiplyAddAdjacent(sc16_2, pa2);
+        var sa3 = Avx2.MultiplyAddAdjacent(sc16_3, pa3);
+
+        sumi = Avx2.Add(sumi, Avx2.Add(Avx2.Add(sa0, sa1), Avx2.Add(sa2, sa3)));
     }
 
     // ================================================================

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -398,11 +398,16 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private readonly Tensor _gpuResidual2;        // [embDim]
     private readonly Tensor _gpuNormBuf2;         // [embDim]
     private readonly Tensor _gpuLogits2;          // [vocabSize]
-    private readonly Tensor _gpuLastHiddenT1;     // [embDim] — h@startPos for the MTP commit
+    // BatchForward2 (SHARPI_CPU_GDN=1 debug trunk) snapshots t1's pre-norm hidden into
+    // these so it can ride the queued DownloadAsync alongside t2's _gpuLastHidden, then
+    // copies it into the MTP hidden history. Internal scratch for that path only — the
+    // production k-token BatchVerify path writes the history straight from the device
+    // stream (the dead public LastHiddenT1 accessor was removed in issue #209).
+    private readonly Tensor _gpuLastHiddenT1;     // [embDim] — t1 hidden device snapshot
     private readonly float[] _logitsBuf2;         // host download for token 2 logits
     private readonly float* _cpuNormBuf2;         // [embDim] — t2's norm download for CPU FFN path
     private readonly float* _cpuMoeHidden2;       // [embDim] — t2's CPU FFN output
-    private readonly float* _lastHiddenT1;        // [embDim] — host span for the t1 hidden
+    private readonly float* _lastHiddenT1;        // [embDim] — pinned t1 hidden host target
 
     private byte* _batchSnapshotBuf;
     private long _batchSnapshotCap;
@@ -441,14 +446,22 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     // Max tokens per BatchVerify call = ring slots + 1. Each slot costs ~149 MiB
     // of VRAM that TryUploadDenseFfnLayers would otherwise fill with ~2 dense FFN
-    // layers, hence the conservative default; deeper chains only pay once the CPU
-    // FFN amortizes more than pairwise (4-input MatVec follow-up). Instance-resolved
-    // at construction so tests can override per instance; the knob semantics live
-    // in one place (GdnStateCache.ResolveMtpBatchMax) shared with the CPU pass.
+    // layers, so the default (4 → 3 slots) is the smallest ring that reaches the
+    // measured k=4 optimum now that the 4-input CPU FFN kernel (issue #209) amortizes
+    // the dominant mmap weight read four ways. Instance-resolved at construction so
+    // tests can override per instance; the knob semantics live in one place
+    // (GdnStateCache.ResolveMtpBatchMax) shared with the CPU pass.
     private readonly int _mtpBatchMax = GdnStateCache.ResolveMtpBatchMax();
     // Token-2 host FFN scratch (intermediate gate/up post-MatVec2In, pre-SiLuMul).
     private readonly float* _cpuFfnGateBuf2;
     private readonly float* _cpuFfnUpBuf2;
+    // Lane-3/4 host FFN scratch (issue #209): CpuDenseFfn4 dots one CPU mmap weight
+    // read against four draft tokens via MatVec4In, so it needs four distinct
+    // gate/up scratch slabs (SiLU reads them per-lane before the down projection).
+    private readonly float* _cpuFfnGateBuf3;
+    private readonly float* _cpuFfnUpBuf3;
+    private readonly float* _cpuFfnGateBuf4;
+    private readonly float* _cpuFfnUpBuf4;
 
     // Host-side hidden history; see HybridGdnForwardPass field-level doc.
     private float* _mtpPrefillHiddens;     // [_mtpPrefillHiddensCap × embDim], slot p = h_p
@@ -1393,6 +1406,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 _gpuFfnUpBufDense2   = gpu.Allocate(TensorShape.D1(_intermDim));
                 _cpuFfnGateBuf2  = Alloc(_intermDim);
                 _cpuFfnUpBuf2    = Alloc(_intermDim);
+                _cpuFfnGateBuf3  = Alloc(_intermDim);
+                _cpuFfnUpBuf3    = Alloc(_intermDim);
+                _cpuFfnGateBuf4  = Alloc(_intermDim);
+                _cpuFfnUpBuf4    = Alloc(_intermDim);
             }
 
             // Host snapshot buffer for BatchForward2's between-token capture — only
@@ -3295,10 +3312,6 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         _mtpSelfHidden != null ? new ReadOnlySpan<float>(_mtpSelfHidden, _embDim) : default;
 
     /// <inheritdoc />
-    public ReadOnlySpan<float> LastHiddenT1 =>
-        _lastHiddenT1 != null ? new ReadOnlySpan<float>(_lastHiddenT1, _embDim) : default;
-
-    /// <inheritdoc />
     public void BatchForward2(int t1, int t2, int startPos,
         out ReadOnlySpan<float> logits1, out ReadOnlySpan<float> logits2)
     {
@@ -3701,19 +3714,22 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             else if (!isMoe && !denseGpuLayer)
             {
                 // CPU mmap dense FFN — the 27B/12GB decode cost center (~8.6 GB
-                // weight reads per token). Pair-batched MatVec2In reads each weight
-                // row once per pair; the odd tail re-runs as a duplicated-input
-                // pair (second output → sink) so every token's bits match the pair
-                // kernel regardless of k parity.
+                // weight reads per token). Quad-batched MatVec4In reads each weight
+                // row once per four tokens (issue #209); the final partial group's
+                // duplicated-tail lanes re-run the last real token with their output
+                // routed to a shared sink, so every token's bits match the quad
+                // kernel regardless of k parity (per-position k-parity independence).
                 _gpu.Download(moeNorm, (nint)_bvNormHost, k * embDim);
-                for (int i = 0; i < k; i += 2)
+                for (int i = 0; i < k; i += 4)
                 {
-                    bool tail = i + 1 >= k;
-                    int j = tail ? i : i + 1;
-                    CpuDenseFfn2(layer,
-                        _bvNormHost + (long)i * embDim, _bvNormHost + (long)j * embDim,
-                        _bvFfnHost + (long)i * embDim,
-                        tail ? _cpuMoeHidden2 : _bvFfnHost + (long)j * embDim);
+                    MtpBatchTail.Group4(i, k, out int j0, out int j1, out int j2, out int j3, out int nReal);
+                    CpuDenseFfn4(layer,
+                        _bvNormHost + (long)j0 * embDim, _bvNormHost + (long)j1 * embDim,
+                        _bvNormHost + (long)j2 * embDim, _bvNormHost + (long)j3 * embDim,
+                        _bvFfnHost + (long)j0 * embDim,
+                        nReal > 1 ? _bvFfnHost + (long)j1 * embDim : _cpuMoeHidden2,
+                        nReal > 2 ? _bvFfnHost + (long)j2 * embDim : _cpuMoeHidden2,
+                        nReal > 3 ? _bvFfnHost + (long)j3 * embDim : _cpuMoeHidden2);
                 }
                 _gpu.UploadInto(_gpuBvFfnAll!, (nint)_bvFfnHost, k * embDim);
                 _gpu.AddInPlace(_gpuBvFfnAll!, blockOut);
@@ -4583,6 +4599,40 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // down: silu'd gate buffers are the inputs, output dim = embDim.
         SimdKernels.MatVec2In(cpuHiddenOut1, cpuHiddenOut2, wDown.DataPtr,
             _cpuFfnGateBuf, _cpuFfnGateBuf2, _embDim, _intermDim, wDown.DType);
+    }
+
+    /// <summary>
+    /// Batched four-token CPU dense FFN (issue #209). Each gate/up/down weight row is
+    /// read once from the CPU mmap and dotted against all four tokens via
+    /// <see cref="SimdKernels.MatVec4In"/> — one weight HBM read per four draft tokens
+    /// versus <see cref="CpuDenseFfn2"/>'s one-per-two, halving the dominant decode
+    /// cost on the 27B-MTP CUDA-hybrid path at k = 4. Per-token bits are identical to
+    /// <see cref="CpuDenseFfn2"/> and single-token decode (MatVec4In is bit-identical
+    /// per slot). Lanes that are duplicated-tail fillers point their <c>out</c> at a
+    /// shared sink — the value is recomputed-but-discarded; the four gate/up scratch
+    /// slabs stay distinct because SiLU consumes each lane before the down projection.
+    /// </summary>
+    private void CpuDenseFfn4(int layer,
+        float* n0, float* n1, float* n2, float* n3,
+        float* out0, float* out1, float* out2, float* out3)
+    {
+        var wGate = _cpuWFfnGate![layer];
+        var wUp   = _cpuWFfnUp![layer];
+        var wDown = _cpuWFfnDown![layer];
+
+        SimdKernels.MatVec4In(_cpuFfnGateBuf, _cpuFfnGateBuf2, _cpuFfnGateBuf3, _cpuFfnGateBuf4,
+            wGate.DataPtr, n0, n1, n2, n3, _intermDim, _embDim, wGate.DType);
+        SimdKernels.MatVec4In(_cpuFfnUpBuf, _cpuFfnUpBuf2, _cpuFfnUpBuf3, _cpuFfnUpBuf4,
+            wUp.DataPtr, n0, n1, n2, n3, _intermDim, _embDim, wUp.DType);
+
+        SimdKernels.SiLuMul(_cpuFfnGateBuf,  _cpuFfnUpBuf,  _intermDim);
+        SimdKernels.SiLuMul(_cpuFfnGateBuf2, _cpuFfnUpBuf2, _intermDim);
+        SimdKernels.SiLuMul(_cpuFfnGateBuf3, _cpuFfnUpBuf3, _intermDim);
+        SimdKernels.SiLuMul(_cpuFfnGateBuf4, _cpuFfnUpBuf4, _intermDim);
+
+        SimdKernels.MatVec4In(out0, out1, out2, out3, wDown.DataPtr,
+            _cpuFfnGateBuf, _cpuFfnGateBuf2, _cpuFfnGateBuf3, _cpuFfnGateBuf4,
+            _embDim, _intermDim, wDown.DType);
     }
 
     // =================================================================
@@ -6052,6 +6102,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 if (_gpuFfnUpBufDense2   is { } uB2) _gpu.Free(uB2);
                 if (_cpuFfnGateBuf2 != null) NativeMemory.Free(_cpuFfnGateBuf2);
                 if (_cpuFfnUpBuf2   != null) NativeMemory.Free(_cpuFfnUpBuf2);
+                if (_cpuFfnGateBuf3 != null) NativeMemory.Free(_cpuFfnGateBuf3);
+                if (_cpuFfnUpBuf3   != null) NativeMemory.Free(_cpuFfnUpBuf3);
+                if (_cpuFfnGateBuf4 != null) NativeMemory.Free(_cpuFfnGateBuf4);
+                if (_cpuFfnUpBuf4   != null) NativeMemory.Free(_cpuFfnUpBuf4);
                 if (_batchSnapshotBuf != null)
                 {
                     NativeMemory.Free(_batchSnapshotBuf);

--- a/src/SharpInference.Engine/GdnStateCache.cs
+++ b/src/SharpInference.Engine/GdnStateCache.cs
@@ -386,15 +386,19 @@ public sealed unsafe class GdnStateCache : IDisposable
     /// <summary>
     /// Resolve the SHARPI_MTP_BATCH_MAX knob: max tokens per batched-verify call
     /// (= 1 + max MTP draft-chain length), which sizes the per-token-boundary GDN
-    /// snapshot ring at <c>value − 1</c> slots. Clamped to [2, 8]; default 2 — one
-    /// ring slot (~149 MB for 27B on either side of the PCIe bus), the measured
-    /// k=2 optimum until the CPU FFN amortizes more than pairwise. Shared by both
-    /// hybrid GDN passes so the knob means the same thing on every backend.
+    /// snapshot ring at <c>value − 1</c> slots. Clamped to [2, 8]; default 4 (three
+    /// ring slots, ~149 MB each for 27B on either side of the PCIe bus) — the measured
+    /// k=4 optimum once the 4-input CPU FFN kernel (issue #209) amortizes the dominant
+    /// CPU mmap weight read across four draft tokens (27B Q4_K_M CUDA-hybrid: k=4 12.2
+    /// vs k=2 10.1 vs k=6 10.4 t/s; the GPU-trunk matvec re-stream and lower acceptance
+    /// erode deeper chains). The ring alloc stops on OOM and SupportsBatchVerify clamps
+    /// MaxBatchVerifyTokens to what fit, so a tight-VRAM card degrades gracefully.
+    /// Shared by both hybrid GDN passes so the knob means the same thing on every backend.
     /// </summary>
     public static int ResolveMtpBatchMax()
     {
         var s = Environment.GetEnvironmentVariable("SHARPI_MTP_BATCH_MAX");
-        return s is not null && int.TryParse(s, out var v) ? Math.Clamp(v, 2, 8) : 2;
+        return s is not null && int.TryParse(s, out var v) ? Math.Clamp(v, 2, 8) : 4;
     }
 
     /// <summary>

--- a/src/SharpInference.Engine/HybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/HybridGdnForwardPass.cs
@@ -116,7 +116,15 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
     private readonly float* _ffnGate2;       // [intermDim]
     private readonly float* _ffnUp2;         // [intermDim]
     private readonly float* _logits2;        // [vocabSize]
-    private readonly float* _lastHiddenT1;   // [embDim] — t1's pre-output-norm hidden after BatchForward2
+    // Lane-3/4 batched-verify scratch (issue #209): DenseFfn4 / the quad lm_head dot
+    // amortize one CPU mmap weight read across four draft tokens via MatVec4In, so they
+    // need four distinct gate/up FFN slabs and four distinct vocab-sized logits sinks.
+    private readonly float* _ffnGate3;       // [intermDim]
+    private readonly float* _ffnUp3;         // [intermDim]
+    private readonly float* _ffnGate4;       // [intermDim]
+    private readonly float* _ffnUp4;         // [intermDim]
+    private readonly float* _logits3;        // [vocabSize]
+    private readonly float* _logits4;        // [vocabSize]
 
     // Per-token-boundary GDN snapshot ring used by the batched verify paths
     // (issues #30 / #207-goal-4). Slot j holds every GDN layer's state AFTER the
@@ -646,19 +654,26 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
             _mtpSelfHidden = Alloc(_embDim);
 
             // Issue #30 / #45: batched verify scratch. _hidden2/_residual2/_normBuf2/
-            // _logits2/_lastHiddenT1 are needed for any MTP-bearing model. The dense
-            // FFN intermediate buffers (_ffnGate2/_ffnUp2) are only used on the dense
-            // path; the MoE path runs MoeFfnCore sequentially per token and shares
-            // _expertGate / _expertUp / _expertGateAll / _expertUpAll between t1 and t2.
+            // _logits2 are needed for any MTP-bearing model. The dense FFN intermediate
+            // buffers (_ffnGate2/_ffnUp2) are only used on the dense path; the MoE path
+            // runs MoeFfnCore sequentially per token and shares _expertGate / _expertUp
+            // / _expertGateAll / _expertUpAll between t1 and t2.
             _hidden2 = Alloc(_embDim);
             _residual2 = Alloc(_embDim);
             _normBuf2 = Alloc(_embDim);
             _logits2 = Alloc(hp.VocabSize);
-            _lastHiddenT1 = Alloc(_embDim);
+            // Lane-3/4 lm_head sinks (issue #209) — the quad lm_head dot runs for both
+            // dense and MoE MTP models, so the logits sinks live outside the !IsMoE gate.
+            _logits3 = Alloc(hp.VocabSize);
+            _logits4 = Alloc(hp.VocabSize);
             if (!hp.IsMoE)
             {
                 _ffnGate2 = Alloc(_intermDim);
                 _ffnUp2 = Alloc(_intermDim);
+                _ffnGate3 = Alloc(_intermDim);
+                _ffnUp3 = Alloc(_intermDim);
+                _ffnGate4 = Alloc(_intermDim);
+                _ffnUp4 = Alloc(_intermDim);
             }
 
             long perLayerBytes = _gdnStateCache.LayerSnapshotBytes;
@@ -1192,7 +1207,7 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
     //   <c>_kvCache.Length == startPos + 2</c>,
     //   <c>_gdnStateCache.Length == startPos + 2</c>,
     //   <c>_lastHidden</c> = h@startPos+1 (t2's pre-output-norm hidden),
-    //   <c>LastHiddenT1</c> = h@startPos (t1's pre-output-norm hidden),
+    //   both tokens' pre-output-norm hiddens written to the MTP hidden history,
     //   per-layer GDN snapshot captured at "after t1, before t2" — available for
     //   <see cref="RestoreBatchSnapshot"/>.</para>
     // <para><b>Return:</b> two logit slices (predict-startPos+1, predict-startPos+2).</para>
@@ -1227,14 +1242,6 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         _hasMtp
         && !KvCacheCompacted
         && Environment.GetEnvironmentVariable("SHARPI_DISABLE_BATCH_VERIFY") != "1";
-
-    /// <summary>
-    /// Last completed <see cref="BatchForward2"/>'s token-1 pre-output-norm hidden.
-    /// Used by the <see cref="MtpDecoder"/> commit step to drive the next MTP forward
-    /// at <c>startPos + 1</c>.
-    /// </summary>
-    public ReadOnlySpan<float> LastHiddenT1 =>
-        _lastHiddenT1 != null ? new ReadOnlySpan<float>(_lastHiddenT1, _embDim) : default;
 
     /// <summary>
     /// Run two adjacent tokens (t1 at <paramref name="startPos"/>, t2 at
@@ -1356,8 +1363,7 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         // 5. Snapshot the pre-output-norm hiddens before final norm overwrites them.
         var h1Span = new ReadOnlySpan<float>(_hidden,  _embDim);
         var h2Span = new ReadOnlySpan<float>(_hidden2, _embDim);
-        h1Span.CopyTo(new Span<float>(_lastHiddenT1, _embDim));
-        h2Span.CopyTo(new Span<float>(_lastHidden,   _embDim));
+        h2Span.CopyTo(new Span<float>(_lastHidden, _embDim));
 
         // Issue #106: also write the absolute-position slots in the hidden history
         // buffer so future snapshot-restore + PrefillMtp(startPos = past decode
@@ -1569,17 +1575,20 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
             }
             else
             {
-                // MatVec2In pairs; the odd tail duplicates its input into both pair
-                // slots (second output → _hidden2 sink) so EVERY token goes through
-                // the identical kernel — per-position bits don't depend on k parity.
-                for (int i = 0; i < k; i += 2)
+                // MatVec4In quads (issue #209); the final partial group duplicates its
+                // last real token into the empty lanes (output → _hidden2 sink) so EVERY
+                // token goes through the identical kernel — per-position bits don't
+                // depend on k parity.
+                for (int i = 0; i < k; i += 4)
                 {
-                    bool tail = i + 1 >= k;
-                    int j = tail ? i : i + 1;
-                    DenseFfn2(layer,
-                        _bvNormAll + (long)i * embDim, _bvNormAll + (long)j * embDim,
-                        _bvHiddenAll + (long)i * embDim,
-                        tail ? _hidden2 : _bvHiddenAll + (long)j * embDim);
+                    MtpBatchTail.Group4(i, k, out int j0, out int j1, out int j2, out int j3, out int nReal);
+                    DenseFfn4(layer,
+                        _bvNormAll + (long)j0 * embDim, _bvNormAll + (long)j1 * embDim,
+                        _bvNormAll + (long)j2 * embDim, _bvNormAll + (long)j3 * embDim,
+                        _bvHiddenAll + (long)j0 * embDim,
+                        nReal > 1 ? _bvHiddenAll + (long)j1 * embDim : _hidden2,
+                        nReal > 2 ? _bvHiddenAll + (long)j2 * embDim : _hidden2,
+                        nReal > 3 ? _bvHiddenAll + (long)j3 * embDim : _hidden2);
                 }
             }
 
@@ -1609,8 +1618,9 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
             Copy(_lastHidden, _bvHiddenAll + (long)(k - 1) * embDim, embDim);
         }
 
-        // 5. Final norm + lm_head, MatVec2In pairs (vocab-sized weight read once per
-        //    pair). Odd tail uses the duplicated-input pair with _logits2 as sink.
+        // 5. Final norm + lm_head, MatVec4In quads (vocab-sized weight read once per
+        //    four tokens — issue #209). The final partial group's duplicated-tail lanes
+        //    re-run the last real token into the _logits{2..4} sinks and are discarded.
         var outNormW = GetNormWeight(_outputNorm);
         for (int i = 0; i < k; i++)
         {
@@ -1619,16 +1629,17 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         }
 
         var result = new float[k][];
-        for (int i = 0; i < k; i += 2)
+        for (int i = 0; i < k; i += 4)
         {
-            bool tail = i + 1 >= k;
-            int j = tail ? i : i + 1;
-            SimdKernels.MatVec2In(_logits, _logits2, _outputWeight.DataPtr,
-                _bvHiddenAll + (long)i * embDim, _bvHiddenAll + (long)j * embDim,
+            MtpBatchTail.Group4(i, k, out int j0, out int j1, out int j2, out int j3, out int nReal);
+            SimdKernels.MatVec4In(_logits, _logits2, _logits3, _logits4, _outputWeight.DataPtr,
+                _bvHiddenAll + (long)j0 * embDim, _bvHiddenAll + (long)j1 * embDim,
+                _bvHiddenAll + (long)j2 * embDim, _bvHiddenAll + (long)j3 * embDim,
                 _hp.VocabSize, embDim, _outputWeight.DType);
-            result[i] = new ReadOnlySpan<float>(_logits, _hp.VocabSize).ToArray();
-            if (!tail)
-                result[i + 1] = new ReadOnlySpan<float>(_logits2, _hp.VocabSize).ToArray();
+            result[j0] = new ReadOnlySpan<float>(_logits, _hp.VocabSize).ToArray();
+            if (nReal > 1) result[j1] = new ReadOnlySpan<float>(_logits2, _hp.VocabSize).ToArray();
+            if (nReal > 2) result[j2] = new ReadOnlySpan<float>(_logits3, _hp.VocabSize).ToArray();
+            if (nReal > 3) result[j3] = new ReadOnlySpan<float>(_logits4, _hp.VocabSize).ToArray();
         }
 
         _batchSnapshotValid = true;
@@ -1691,6 +1702,39 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
         SimdKernels.MatVec2In(
             hiddenOut1, hiddenOut2,
             _wFfnDown[layer].DataPtr, _ffnGate, _ffnGate2,
+            _embDim, _intermDim, _wFfnDown[layer].DType);
+    }
+
+    /// <summary>
+    /// Batched gate × up → down dense FFN for four tokens sharing the same weight
+    /// matrices (issue #209). Each weight row is touched once and dotted against all
+    /// four inputs via <see cref="SimdKernels.MatVec4In"/> — one weight read per four
+    /// tokens versus <see cref="DenseFfn2"/>'s one-per-two. The four gate/up scratch
+    /// slabs stay distinct because SiLU consumes each lane before the down projection;
+    /// duplicated-tail filler lanes point their <c>hiddenOut</c> at a shared sink.
+    /// Per-token bits are identical to <see cref="DenseFfn2"/> / single-token decode.
+    /// </summary>
+    private void DenseFfn4(int layer,
+        float* n0, float* n1, float* n2, float* n3,
+        float* out0, float* out1, float* out2, float* out3)
+    {
+        SimdKernels.MatVec4In(
+            _ffnGate, _ffnGate2, _ffnGate3, _ffnGate4,
+            _wFfnGate[layer].DataPtr, n0, n1, n2, n3,
+            _intermDim, _embDim, _wFfnGate[layer].DType);
+        SimdKernels.MatVec4In(
+            _ffnUp, _ffnUp2, _ffnUp3, _ffnUp4,
+            _wFfnUp[layer].DataPtr, n0, n1, n2, n3,
+            _intermDim, _embDim, _wFfnUp[layer].DType);
+
+        SimdKernels.SiLuMul(_ffnGate,  _ffnUp,  _intermDim);
+        SimdKernels.SiLuMul(_ffnGate2, _ffnUp2, _intermDim);
+        SimdKernels.SiLuMul(_ffnGate3, _ffnUp3, _intermDim);
+        SimdKernels.SiLuMul(_ffnGate4, _ffnUp4, _intermDim);
+
+        SimdKernels.MatVec4In(
+            out0, out1, out2, out3,
+            _wFfnDown[layer].DataPtr, _ffnGate, _ffnGate2, _ffnGate3, _ffnGate4,
             _embDim, _intermDim, _wFfnDown[layer].DType);
     }
 
@@ -3024,8 +3068,13 @@ public sealed unsafe class HybridGdnForwardPass : IForwardPass
             if (_normBuf2 != null) NativeMemory.Free(_normBuf2);
             if (_ffnGate2 != null) NativeMemory.Free(_ffnGate2);
             if (_ffnUp2 != null) NativeMemory.Free(_ffnUp2);
+            if (_ffnGate3 != null) NativeMemory.Free(_ffnGate3);
+            if (_ffnUp3 != null) NativeMemory.Free(_ffnUp3);
+            if (_ffnGate4 != null) NativeMemory.Free(_ffnGate4);
+            if (_ffnUp4 != null) NativeMemory.Free(_ffnUp4);
             if (_logits2 != null) NativeMemory.Free(_logits2);
-            if (_lastHiddenT1 != null) NativeMemory.Free(_lastHiddenT1);
+            if (_logits3 != null) NativeMemory.Free(_logits3);
+            if (_logits4 != null) NativeMemory.Free(_logits4);
             if (_mtpSelfHidden != null) NativeMemory.Free(_mtpSelfHidden);
             if (_bvHiddenAll != null) NativeMemory.Free(_bvHiddenAll);
             if (_bvResidAll != null) NativeMemory.Free(_bvResidAll);

--- a/src/SharpInference.Engine/MtpBatchTail.cs
+++ b/src/SharpInference.Engine/MtpBatchTail.cs
@@ -1,0 +1,35 @@
+namespace SharpInference.Engine;
+
+/// <summary>
+/// Lane→token mapping for the width-4 batched-verify (MTP) duplicated-input tail
+/// (issues #30/#209). The k draft tokens of a <c>BatchVerify</c> step are processed in
+/// groups of four sharing one CPU mmap weight read (<see cref="Cpu.SimdKernels.MatVec4In"/>).
+/// Only the final group can be partial; it duplicates its last real token into the
+/// empty lanes so the quad kernel always sees four valid inputs, and the duplicate
+/// lanes' outputs are routed to a sink and discarded by the caller. Because MatVec4In
+/// is bit-identical per token slot, every real token's bits are independent of the
+/// batch width k — the per-position k-parity-independence contract the MTP greedy
+/// parity test pins. Centralised here so the three former hand-copied tail idioms (the
+/// CUDA dense-FFN loop, and the CPU pass's FFN + lm_head loops) share one definition.
+/// </summary>
+internal static class MtpBatchTail
+{
+    /// <summary>
+    /// For the width-4 group starting at <paramref name="i"/> over a batch of
+    /// <paramref name="k"/> tokens (<c>0 ≤ i &lt; k</c>), yields the four lane→token
+    /// indices and <paramref name="nReal"/>, the count of real (non-duplicate) lanes
+    /// in this group (1..4). In-range lanes map to their own token; past-the-end lanes
+    /// clamp to the group's last real token (<c>k-1</c>) so the kernel reads valid
+    /// inputs and the caller can route the duplicate output to a sink.
+    /// </summary>
+    public static void Group4(int i, int k,
+        out int j0, out int j1, out int j2, out int j3, out int nReal)
+    {
+        int last = k - 1;
+        j0 = i;                              // i < k by the loop guard
+        j1 = i + 1 <= last ? i + 1 : last;
+        j2 = i + 2 <= last ? i + 2 : last;
+        j3 = i + 3 <= last ? i + 3 : last;
+        nReal = Math.Min(4, k - i);
+    }
+}

--- a/src/SharpInference.Engine/MtpDecoder.cs
+++ b/src/SharpInference.Engine/MtpDecoder.cs
@@ -146,11 +146,12 @@ public sealed class MtpDecoder
     /// <summary>
     /// Resolve the effective MTP draft-chain length (proposed tokens per step) from the
     /// llama.cpp-parity <c>--spec-draft-n-max</c> value. <c>&lt; 1</c> (unset) falls back
-    /// to <c>SHARPI_MTP_DRAFT_N</c>, then to the built-in default of 1 (a 2-token verify
-    /// batch — the measured 27B optimum: the GPU trunk's matvec re-stream scales linearly
-    /// with k while the CPU FFN only pair-amortizes, so deeper chains don't pay until a
-    /// 4-input CPU FFN kernel lands; see the issue #30 bench). Deeper chains also need
-    /// ring slots: raise <c>SHARPI_MTP_BATCH_MAX</c> alongside. The result is further
+    /// to <c>SHARPI_MTP_DRAFT_N</c>, then to the built-in default of 3 (a 4-token verify
+    /// batch — the measured 27B optimum once the 4-input CPU FFN kernel landed (issue
+    /// #209): the dominant CPU mmap FFN now amortizes its weight read across four draft
+    /// tokens, moving the optimum out from the old pairwise k=2 to k=4. Deeper chains
+    /// need ring slots too: <see cref="GdnStateCache.ResolveMtpBatchMax"/> defaults to 4
+    /// (raise <c>SHARPI_MTP_BATCH_MAX</c> together for k &gt; 4). The result is further
     /// clamped per step against <see cref="IForwardPass.MaxBatchVerifyTokens"/>.
     /// Shared by <see cref="InferenceEngine"/> and the CLI so both resolve identically.
     /// </summary>
@@ -159,7 +160,7 @@ public sealed class MtpDecoder
         if (specDraftNMax >= 1) return specDraftNMax;
         var s = Environment.GetEnvironmentVariable("SHARPI_MTP_DRAFT_N");
         if (s is not null && int.TryParse(s, out var v) && v >= 1) return v;
-        return 1;
+        return 3;
     }
 
     /// <summary>

--- a/tests/SharpInference.Tests.ForwardPass/MtpBatchTailTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/MtpBatchTailTests.cs
@@ -1,0 +1,59 @@
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Unit coverage for <see cref="MtpBatchTail.Group4"/> — the width-4 batched-verify
+/// lane→token mapping shared by the CUDA dense-FFN loop and the CPU pass's FFN +
+/// lm_head loops (issue #209). The mapping is what makes the duplicated-input tail
+/// correct: real lanes must hit their own token, past-the-end lanes must clamp onto
+/// the group's last real token (so the quad kernel reads valid inputs and the caller
+/// routes the duplicate output to a sink), and across all groups every token must
+/// appear exactly once as a real lane. A bug here silently corrupts a draft slot.
+/// </summary>
+public sealed class MtpBatchTailTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(9)]
+    public void Group4_RealLanesCoverEveryTokenOnce_TailClampsToLastReal(int k)
+    {
+        var realSeen = new List<int>();
+
+        for (int i = 0; i < k; i += 4)
+        {
+            MtpBatchTail.Group4(i, k, out int j0, out int j1, out int j2, out int j3, out int nReal);
+
+            Assert.Equal(Math.Min(4, k - i), nReal);
+            Assert.InRange(nReal, 1, 4);
+            Assert.Equal(i, j0); // lane 0 is always the real group start (i < k)
+
+            int[] lanes = { j0, j1, j2, j3 };
+            int last = k - 1;
+            for (int s = 0; s < 4; s++)
+            {
+                if (s < nReal)
+                {
+                    Assert.Equal(i + s, lanes[s]);   // real lane → its own token
+                    realSeen.Add(lanes[s]);
+                }
+                else
+                {
+                    Assert.Equal(last, lanes[s]);    // duplicate tail lane → last real token
+                }
+                Assert.InRange(lanes[s], 0, k - 1);  // every index is a valid token slot
+            }
+        }
+
+        // Every token 0..k-1 is produced exactly once as a real lane, in order.
+        realSeen.Sort();
+        Assert.Equal(Enumerable.Range(0, k).ToList(), realSeen);
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SimdKernelsQ8KSTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using SharpInference.Core;
 using SharpInference.Cpu;
@@ -388,6 +389,93 @@ public sealed unsafe class SimdKernelsQ8KSTests
                 for (int i = 0; i < 128; i++) bytes[off + 48 + i] = (byte)rng.Next(256);
             }
         return bytes;
+    }
+
+    private static byte[] BuildQ6KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256, bytesPerRow = blocksPerRow * 210;
+        var bytes = new byte[rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                int off = r * bytesPerRow + b * 210;
+                for (int i = 0; i < 128; i++) bytes[off + i] = (byte)rng.Next(256);          // ql
+                for (int i = 0; i < 64; i++) bytes[off + 128 + i] = (byte)rng.Next(256);      // qh
+                for (int i = 0; i < 16; i++) bytes[off + 192 + i] = (byte)(sbyte)(rng.Next(256) - 128); // int8 scales
+                float d = (float)(rng.NextDouble() * 0.05 + 0.005);
+                ushort dh = HalfToUshort((Half)d);
+                bytes[off + 208] = (byte)(dh & 0xFF); bytes[off + 209] = (byte)(dh >> 8);
+            }
+        return bytes;
+    }
+
+    /// <summary>
+    /// Issue #209: <see cref="SimdKernels.MatVec4In"/> — the four-input dense-FFN
+    /// mat-vec that amortizes the CPU mmap weight read across four MTP draft tokens
+    /// — must be <b>bit-identical</b>, per row and per token slot, to four single
+    /// <see cref="SimdKernels.MatVec"/> calls. This is the per-position
+    /// k-parity-independence contract the batched-verify duplicated-tail relies on:
+    /// a token's logits must not depend on whether it shared a weight read with one
+    /// other token (the old MatVec2In pairing) or three (MatVec4In). Covers every
+    /// dense-FFN dtype: Q4_K/Q5_K/Q6_K (register-tiled quad kernels), F32, and Q8_0
+    /// (which deliberately routes through the dequant fallback to stay identical to
+    /// single-token decode). Includes a rows ≥ 64 case to exercise the Parallel.For
+    /// path, and a deliberately mis-mappable token order so a swapped slot is caught.
+    /// </summary>
+    [Fact]
+    public void MatVec4In_BitwiseMatchesSingleMatVec()
+    {
+        foreach ((int rows, int cols) in new[] { (4, 256), (5, 512), (8, 2048), (3, 4096), (128, 512) })
+        {
+            var rng = new Random(unchecked((int)0x4209C0DE) ^ (rows * 131 + cols));
+            var inputs = new float[4][];
+            for (int t = 0; t < 4; t++)
+            {
+                inputs[t] = new float[cols];
+                for (int i = 0; i < cols; i++) inputs[t][i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+
+            byte[] q4 = BuildQ4KMatrix(rows, cols, rng);
+            byte[] q5 = BuildQ5KMatrix(rows, cols, rng);
+            byte[] q6 = BuildQ6KMatrix(rows, cols, rng);
+            byte[] q8 = BuildQ8_0Matrix(rows, cols, rng);
+            var f32 = new float[rows * cols];
+            for (int i = 0; i < f32.Length; i++) f32[i] = (float)(rng.NextDouble() * 0.2 - 0.1);
+
+            foreach ((byte[] w, DType dt) in new (byte[], DType)[]
+                     {
+                         (q4, DType.Q4_K), (q5, DType.Q5_K), (q6, DType.Q6_K),
+                         (q8, DType.Q8_0), (MemoryMarshal.AsBytes(f32.AsSpan()).ToArray(), DType.Float32),
+                     })
+            {
+                var o0 = new float[rows]; var o1 = new float[rows];
+                var o2 = new float[rows]; var o3 = new float[rows];
+                var refOut = new float[4][];
+                for (int t = 0; t < 4; t++) refOut[t] = new float[rows];
+
+                fixed (byte* wp = w)
+                fixed (float* i0 = inputs[0]) fixed (float* i1 = inputs[1])
+                fixed (float* i2 = inputs[2]) fixed (float* i3 = inputs[3])
+                fixed (float* p0 = o0) fixed (float* p1 = o1) fixed (float* p2 = o2) fixed (float* p3 = o3)
+                fixed (float* r0 = refOut[0]) fixed (float* r1 = refOut[1])
+                fixed (float* r2 = refOut[2]) fixed (float* r3 = refOut[3])
+                {
+                    SimdKernels.MatVec4In(p0, p1, p2, p3, wp, i0, i1, i2, i3, rows, cols, dt);
+                    SimdKernels.MatVec(r0, wp, i0, rows, cols, dt);
+                    SimdKernels.MatVec(r1, wp, i1, rows, cols, dt);
+                    SimdKernels.MatVec(r2, wp, i2, rows, cols, dt);
+                    SimdKernels.MatVec(r3, wp, i3, rows, cols, dt);
+                }
+
+                for (int r = 0; r < rows; r++)
+                {
+                    Assert.Equal(BitConverter.SingleToInt32Bits(refOut[0][r]), BitConverter.SingleToInt32Bits(o0[r]));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(refOut[1][r]), BitConverter.SingleToInt32Bits(o1[r]));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(refOut[2][r]), BitConverter.SingleToInt32Bits(o2[r]));
+                    Assert.Equal(BitConverter.SingleToInt32Bits(refOut[3][r]), BitConverter.SingleToInt32Bits(o3[r]));
+                }
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Implements **work item #1** of #209 (the scope chosen for this PR: the highest-leverage lever + the directly-coupled cleanups): a 4-input batched CPU mat-vec that amortizes the dominant CPU mmap dense-FFN weight read across four MTP draft tokens, plus the dead-code amputation and helper dedup the #208 review flagged. Items #2–#6 remain as follow-ups.

The 27B-MTP CUDA-hybrid decode cost center is the CPU-resident FFN layers (~6 GB/token). The prior `MatVec2In` only **pair**-amortized that weight read, pinning the verify optimum at k=2; deeper chains lost to the per-step re-stream. `MatVec4In` reads each weight row once per **four** tokens, moving the optimum to k=4.

## Changes

- **`SimdKernels.MatVec4In`** + register-tiled `DotQ5K_4In` (AVX-512) / `DotQ6K_Q8K_4In` (AVX2). Q4_K reuses the existing #114 `DotQ4K_4In`; F32 via 4× `DotF32`. Bit-identical **per output slot** to a single `MatVec` (so per-position bits are k-parity-independent). **Q8_0 deliberately uses the dequant fallback** to stay bit-identical to single-token dense-FFN decode (`MatVec`/`MatVecDual` never specialized it).
- **`CpuDenseFfn4` / `DenseFfn4` + 4-wide lm_head** replace the 2-wide loops in both GDN passes' `BatchVerify`. The three hand-copied duplicated-input-tail idioms collapse into one shared **`MtpBatchTail.Group4`** helper.
- **Default verify batch k=2 → k=4** (`ResolveMtpBatchMax` 2→4, `ResolveDraftN` 1→3). The GDN ring alloc stops on OOM and clamps `MaxBatchVerifyTokens`, so tight-VRAM cards degrade gracefully.
- **Amputate the dead public `IForwardPass.LastHiddenT1`** accessor (no consumers — `MtpDecoder` drives `BatchVerify`/`HiddenAt`). The CPU pass's backing buffer is removed; the CUDA pass keeps `_lastHiddenT1`/`_gpuLastHiddenT1` as internal `SHARPI_CPU_GDN=1` debug-trunk scratch.

## Acceptance

Bench — **27B Q4_K_M CUDA-hybrid, RTX 4070 Ti, `-g -1 --no-thinking`** (decode t/s):

| config | decode t/s | accept |
|---|---:|---:|
| MTP-off | 6.5 | — |
| k=2 (old default) | 10.1 | 90% |
| **k=4 (new default)** | **12.3** | 84% |
| k=6 | 10.4 | 83% |
| k=8 | 10.2 | 71% |

- [x] ≥ 12 t/s at the new optimum k (12.3 vs 10.4 today, 6.2 MTP-off) — **1.9× over MTP-off**, +22% over the old k=2 default
- [x] Per-position bit-identity across k parities preserved (`MatVec4In` ≡ single `MatVec`, proven by `MatVec4In_BitwiseMatchesSingleMatVec`)
- [x] `MtpDecoder_GreedyParity_LlamaCpp` untouched (both 2In and 4In are per-token bit-identical to single `MatVec`, so the CPU pass emits identical per-token logits — unaffected)
- [x] `bench-27b-mtp.ps1` + README row updated

## Tests

- `MatVec4In_BitwiseMatchesSingleMatVec` — Q4_K/Q5_K/Q6_K/Q8_0/F32, serial + `Parallel.For` (rows=128) paths.
- `MtpBatchTail` lane-mapping oracle — k=1..9: real lanes cover every token once, tail clamps to last real.
- CUDA k=4 batched-verify suite (`CudaMtpBatchVerifyTests`) stays green on the real 27B model; coherent e2e output confirmed on hardware with dense FFN on CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
