### PR TITLE
Default VibeThinker to Q8_0, drop f16 (#282)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,13 @@ dotnet run --project src/SharpInference.Cli -c Release -- \
   -m models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf -p "prompt" --temp 0 -g -1
 
 # VibeThinker-1.5B (Qwen2-based math/reasoning, issue #282). Loads as a standard
-# qwen2 GGUF (QKV bias, no QK-norm, 28 layers / 2 KV heads, ChatML, tied embeddings).
-# Recommended sampling: temp 0.6, top_p 0.95, top_k 0, and NO system prompt for math.
-# Output is long plain-text chain-of-thought (not <think> tags).
+# qwen2 GGUF (QKV bias but no output-projection bias, no QK-norm, 28 layers / 2 KV
+# heads, ChatML, tied embeddings). Default download is Q8_0 (near-lossless; `-Model
+# vibethinker-q4` for the smaller quant). Recommended sampling: temp 0.6, top_p 0.95,
+# top_k 0, and no system prompt (the chat template supplies the math one). Emits a long
+# <think> chain-of-thought then a \boxed{} answer (handled by the generic think machinery).
 dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/VibeThinker-1.5B.Q4_K_M.gguf -g -1 \
+  -m models/VibeThinker-1.5B.Q8_0.gguf -g -1 \
   --temp 0.6 --top-p 0.95 --top-k 0 \
   -p "If 5x + 3 = 2x + 18, what is x? Show your reasoning."
 

--- a/scripts/bench-allrows-1k.ps1
+++ b/scripts/bench-allrows-1k.ps1
@@ -171,9 +171,9 @@ $jobs = @(
   @{ Tag="smol-vulkan";     M="$C\SmolLM2-1.7B-Instruct-Q4_K_M.gguf"; A=@("-g","-1","--backend","vulkan");                 Temp="0.7"; Samp=$sSmol;  T=300 }
   @{ Tag="smol-cuda";       M="$C\SmolLM2-1.7B-Instruct-Q4_K_M.gguf"; A=@("-g","-1","--backend","cuda");                   Temp="0.7"; Samp=$sSmol;  T=300 }
 
-  @{ Tag="vibe-cpu";        M="$C\VibeThinker-1.5B.Q4_K_M.gguf"; A=@();                                                    Temp="0.6"; Samp=$sVibe;  T=300 }
-  @{ Tag="vibe-vulkan";     M="$C\VibeThinker-1.5B.Q4_K_M.gguf"; A=@("-g","-1","--backend","vulkan");                      Temp="0.6"; Samp=$sVibe;  T=300 }
-  @{ Tag="vibe-cuda";       M="$C\VibeThinker-1.5B.Q4_K_M.gguf"; A=@("-g","-1","--backend","cuda");                        Temp="0.6"; Samp=$sVibe;  T=300 }
+  @{ Tag="vibe-cpu";        M="$C\VibeThinker-1.5B.Q8_0.gguf"; A=@();                                                      Temp="0.6"; Samp=$sVibe;  T=300 }
+  @{ Tag="vibe-vulkan";     M="$C\VibeThinker-1.5B.Q8_0.gguf"; A=@("-g","-1","--backend","vulkan");                        Temp="0.6"; Samp=$sVibe;  T=300 }
+  @{ Tag="vibe-cuda";       M="$C\VibeThinker-1.5B.Q8_0.gguf"; A=@("-g","-1","--backend","cuda");                          Temp="0.6"; Samp=$sVibe;  T=300 }
 
   @{ Tag="qwen3-cpu";       M="$C\Qwen3-8B-Q4_K_M.gguf"; A=@();                                                            Temp="0.6"; Samp=$sQwen;  T=400 }
   @{ Tag="qwen3-cpu-tq";    M="$C\Qwen3-8B-Q4_K_M.gguf"; A=@("--tq");                                                      Temp="0.6"; Samp=$sQwen;  T=400 }

--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -12,9 +12,8 @@
 .EXAMPLE
     .\download-model.ps1                                # All text models
     .\download-model.ps1 -Model smollm2                 # SmolLM2 1.7B (1.1 GB)
-    .\download-model.ps1 -Model vibethinker             # VibeThinker-1.5B Q4_K_M (1.1 GB) — Qwen2-based math/reasoning, issue #282
-    .\download-model.ps1 -Model vibethinker-q8          # VibeThinker-1.5B Q8_0 (1.76 GB) — near-lossless quant for the math-sensitive path
-    .\download-model.ps1 -Model vibethinker-f16         # VibeThinker-1.5B f16 (3.32 GB) — full-precision (non-quantized) GGUF
+    .\download-model.ps1 -Model vibethinker             # VibeThinker-1.5B Q8_0 (1.76 GB) — Qwen2-based math/reasoning (default), issue #282
+    .\download-model.ps1 -Model vibethinker-q4          # VibeThinker-1.5B Q4_K_M (1.1 GB) — smaller/faster, slightly lossy
     .\download-model.ps1 -Model qwen3-8b                # Qwen3 8B (4.9 GB)
     .\download-model.ps1 -Model olmoe-1b-7b             # OLMoE 1B-7B Instruct Q4_K_M (~4.4 GB) — small MoE for kernel validation
     .\download-model.ps1 -Model llama31-70b             # Llama 3.1 70B (40.8 GB)
@@ -33,7 +32,7 @@
     .\download-model.ps1 -Model realesrgan-x4           # Real-ESRGAN x4plus upscaler (67 MB)
 #>
 param(
-    [ValidateSet("smollm2", "vibethinker", "vibethinker-q8", "vibethinker-f16", "qwen3-8b", "qwen3-0.6b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
+    [ValidateSet("smollm2", "vibethinker", "vibethinker-q4", "qwen3-8b", "qwen3-0.6b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
                  "qwen36-27b-mtp", "qwen36-27b-mtp-q5", "qwen36-35b-a3b-mtp", "carnice-35b-a3b-mtp",
                  "gemma4-12b-qat", "gemma4-12b-q4km", "gemma4-e4b-qat",
                  "llama4-scout", "z-image-turbo", "z-image-turbo-q8", "realesrgan-x4")]
@@ -56,33 +55,23 @@ $Models = @{
     # chain-of-thought then a \boxed{} answer (handled by the generic think machinery).
     # Recommended sampling: temp 0.6, top_p 0.95, top_k 0; the chat template supplies the
     # math system prompt so none is needed. Verification target for issue #282.
+    #
+    # Default is Q8_0 (~1.76 GB) — near-lossless, the right call for a 1.5B math model and
+    # an easy full-offload fit on a 12 GB card. The smaller Q4_K_M is available as
+    # `vibethinker-q4` (slightly lossy, ~0.7 GB less VRAM, faster decode).
     "vibethinker" = @{
-        Files = @("VibeThinker-1.5B.Q4_K_M.gguf")
-        Urls  = @("https://huggingface.co/mradermacher/VibeThinker-1.5B-GGUF/resolve/main/VibeThinker-1.5B.Q4_K_M.gguf")
-        Size  = "1.1 GB"
-        SizeGB = 1.1
-        Phase = "issue #282 (Qwen2-based math/reasoning verification)"
-    }
-    # Near-lossless Q8_0 of the same model (~1.76 GB). Best answer quality for the
-    # math-sensitive path; fits full-offload on a 12 GB card with room to spare. Same
-    # qwen2 arch / load path as the Q4_K_M above.
-    "vibethinker-q8" = @{
         Files = @("VibeThinker-1.5B.Q8_0.gguf")
         Urls  = @("https://huggingface.co/mradermacher/VibeThinker-1.5B-GGUF/resolve/main/VibeThinker-1.5B.Q8_0.gguf")
         Size  = "1.76 GB"
         SizeGB = 1.76
-        Phase = "issue #282 (Qwen2 math/reasoning — near-lossless Q8_0)"
+        Phase = "issue #282 (Qwen2 math/reasoning — near-lossless Q8_0, default)"
     }
-    # Full-precision (non-quantized) f16 GGUF (~3.32 GB) — the highest-fidelity build
-    # mradermacher ships (upstream WeiboAI weights are bf16; the GGUF is f16). Same
-    # qwen2 arch / load path. Use as the quality reference; Q8_0 is near-identical at
-    # half the bytes.
-    "vibethinker-f16" = @{
-        Files = @("VibeThinker-1.5B.f16.gguf")
-        Urls  = @("https://huggingface.co/mradermacher/VibeThinker-1.5B-GGUF/resolve/main/VibeThinker-1.5B.f16.gguf")
-        Size  = "3.32 GB"
-        SizeGB = 3.32
-        Phase = "issue #282 (Qwen2 math/reasoning — full-precision f16 reference)"
+    "vibethinker-q4" = @{
+        Files = @("VibeThinker-1.5B.Q4_K_M.gguf")
+        Urls  = @("https://huggingface.co/mradermacher/VibeThinker-1.5B-GGUF/resolve/main/VibeThinker-1.5B.Q4_K_M.gguf")
+        Size  = "1.1 GB"
+        SizeGB = 1.1
+        Phase = "issue #282 (Qwen2 math/reasoning — smaller Q4_K_M)"
     }
     "qwen3-8b" = @{
         Files = @("Qwen3-8B-Q4_K_M.gguf")

--- a/tests/SharpInference.Tests.Core/Qwen2BiasModelTests.cs
+++ b/tests/SharpInference.Tests.Core/Qwen2BiasModelTests.cs
@@ -62,7 +62,7 @@ public sealed class Qwen2BiasModelTests
     }
 
     /// <summary>
-    /// Integration test against the real VibeThinker-1.5B Q4_K_M GGUF. Gated on the file
+    /// Integration test against the real VibeThinker-1.5B Q8_0 GGUF. Gated on the file
     /// being present (downloaded via <c>scripts/download-model.ps1 -Model vibethinker</c>),
     /// like the other model-dependent tests in this project — returns early (skips) when the
     /// file is absent so CI without the weights stays green. Exercises the real tensor-probe
@@ -71,7 +71,7 @@ public sealed class Qwen2BiasModelTests
     [Fact]
     public void VibeThinkerGguf_ParsesAsQwen2WithBiasNoQkNorm()
     {
-        var path = FindModelPath("models/VibeThinker-1.5B.Q4_K_M.gguf");
+        var path = FindModelPath("models/VibeThinker-1.5B.Q8_0.gguf");
         if (path is null) return; // Model file not available — skip.
 
         using var model = GgufModel.Open(path);


### PR DESCRIPTION
Follow-up to #292. Makes **Q8_0 the default VibeThinker quant** and removes the f16 build.

### Why
Decode is memory-bandwidth-bound, so speed tracks bytes/param (CUDA `-g -1`: Q4 ≈ 214, Q8 ≈ 163, f16 ≈ 66 t/s). f16 can't use the int8 dp4a/MMQ fast path that the Q-quants do — routing it through that path would mean quantizing to int8, i.e. just using Q8_0. For a 1.5B math model Q8_0 is effectively lossless, so it's the sweet spot; f16 buys nothing but bytes.

### Changes
- `download-model.ps1`: `vibethinker` now downloads **Q8_0**; Q4_K_M kept as `vibethinker-q4` (smaller/faster); removed the `vibethinker-q8` alias and the `vibethinker-f16` entry.
- `CLAUDE.md`: example points at the Q8_0 file; comment corrected (emits `<think>` CoT; Qwen2 has no output-projection bias).
- `Tests.Core/Qwen2BiasModelTests`: the gated integration test loads the Q8_0 GGUF.
- `bench-allrows-1k.ps1`: vibe rows point at Q8_0.

No engine/runtime changes. `Tests.Core` green (`Qwen2BiasModelTests`: 2 passed against the on-disk Q8_0), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)