### PR TITLE
perf(mtp): fused-scan ring capture for batched verify (#290)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -311,6 +311,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // Issue #114-B: batched GDN trunk + batched-query SDPA kernels.
     private nint   _gdnConv1dDecodeBatchedKernel;
     private nint   _gdnConv1dStateUpdateBatchedKernel;
+    private nint   _gdnConv1dStateCaptureRingKernel;   // #290
     private nint   _gdnL2NormPerHeadBatchedKernel;
     private nint   _gdnTileHeadsBatchedKernel;
     private nint   _gdnRecurrenceScanKernel;
@@ -6003,7 +6004,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         Tensor alphaAll, Tensor betaAll, Tensor ssmA, Tensor dtBias,
         Tensor normWeight, Tensor zAll, Tensor outputAll,
         int numVHeads, int headDim, float normEps,
-        int qStride, int kStride, int vStride, int vHeadOff, int zStride, int oStride, int nTok)
+        int qStride, int kStride, int vStride, int vHeadOff, int zStride, int oStride, int nTok,
+        Tensor? ringScan = null, long ringScanFloatOffset = 0, int ringSlotStride = 0, int nCapture = 0)
     {
         EnsureImageKernels();
         if (!_imageKernelsAvailable)
@@ -6017,18 +6019,53 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         int pHV = numVHeads, pD = headDim;
         float pE = normEps;
         int pQS = qStride, pKS = kStride, pVS = vStride, pVO = vHeadOff, pZS = zStride, pOS = oStride, pN = nTok;
-        nint* args = stackalloc nint[21]
+        // #290 ring capture: null tensor → null pointer + 0 captures (no-op).
+        nint rsP = ringScan is null ? 0 : GetDevPtr(ringScan) + (nint)(ringScanFloatOffset * sizeof(float));
+        int pRSS = ringSlotStride, pNC = ringScan is null ? 0 : nCapture;
+        nint* args = stackalloc nint[24]
         {
             (nint)(&sP), (nint)(&qP), (nint)(&kP), (nint)(&vP),
             (nint)(&aP), (nint)(&bP), (nint)(&aaP), (nint)(&dbP),
             (nint)(&nwP), (nint)(&zP), (nint)(&oP),
             (nint)(&pHV), (nint)(&pD), (nint)(&pE),
-            (nint)(&pQS), (nint)(&pKS), (nint)(&pVS), (nint)(&pVO), (nint)(&pZS), (nint)(&pOS), (nint)(&pN)
+            (nint)(&pQS), (nint)(&pKS), (nint)(&pVS), (nint)(&pVO), (nint)(&pZS), (nint)(&pOS), (nint)(&pN),
+            (nint)(&rsP), (nint)(&pRSS), (nint)(&pNC)
         };
         uint sharedBytes = (uint)(8 * headDim * sizeof(float));
         int r = NvrtcInterop.LaunchKernel(_gdnRecurrenceScanKernel,
             (uint)numVHeads, 1, 1, (uint)headDim, 1, 1, sharedBytes, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(gdn_recurrence_scan) failed: {r}");
+    }
+
+    /// <summary>
+    /// #290: capture the per-token conv1d states of a batched-verify chunk into the
+    /// device snapshot ring in a single launch. Slot <c>i</c> (i ∈ [0,
+    /// <paramref name="nCapture"/>)) receives the conv state the sequential decode
+    /// loop would hold after token <c>i</c> — byte-identical to
+    /// <see cref="GdnConv1dStateUpdateBatched"/> with <c>nTok = i+1</c>. Reads the
+    /// PRE-update <paramref name="state"/>, so call it BEFORE advancing the live
+    /// conv state. <paramref name="ring"/> points to this layer's region in slot 0;
+    /// <paramref name="ringFloatOffset"/> offsets to it; <paramref name="ringSlotStride"/>
+    /// is the float stride between consecutive slots.
+    /// </summary>
+    public void GdnConv1dStateCaptureRing(Tensor x, Tensor state, Tensor ring, long ringFloatOffset,
+                                          int channels, int kernelSize, int ringSlotStride, int nCapture)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (nCapture <= 0) return;
+
+        nint xP = GetDevPtr(x), sP = GetDevPtr(state);
+        nint rP = GetDevPtr(ring) + (nint)(ringFloatOffset * sizeof(float));
+        int pC = channels, pK = kernelSize, pRSS = ringSlotStride, pNC = nCapture;
+        nint* args = stackalloc nint[7]
+        {
+            (nint)(&xP), (nint)(&sP), (nint)(&rP), (nint)(&pC), (nint)(&pK), (nint)(&pRSS), (nint)(&pNC)
+        };
+        uint grid = (uint)((channels + 255) / 256);
+        int r = NvrtcInterop.LaunchKernel(_gdnConv1dStateCaptureRingKernel, grid, (uint)nCapture, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(gdn_conv1d_state_capture_ring) failed: {r}");
     }
 
     /// <summary>GDN_CHUNK in <c>llm_gdn_chunked_prefill</c> — must match the kernel #define.</summary>
@@ -6412,6 +6449,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _siluInplaceKernel, _gdnConv1dDecodeKernel, _gdnL2NormPerHeadKernel,
             _gdnTileHeadsKernel, _gdnRecurrenceDecodeKernel,
             _gdnConv1dDecodeBatchedKernel, _gdnConv1dStateUpdateBatchedKernel,
+            _gdnConv1dStateCaptureRingKernel,   // #290
             _gdnL2NormPerHeadBatchedKernel, _gdnTileHeadsBatchedKernel, _gdnRecurrenceScanKernel,
             _gdnChunkedPrefillKernel,
             _kvAppendBatchedKernel, _kvAppendBatchedBf16Kernel,
@@ -6625,6 +6663,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         // qwen35moe GDN batched trunk + batched-query SDPA kernels (issue #114-B).
         _gdnConv1dDecodeBatchedKernel      = GetKernelFunc("llm_gdn_conv1d_decode_batched");
         _gdnConv1dStateUpdateBatchedKernel = GetKernelFunc("llm_gdn_conv1d_state_update_batched");
+        _gdnConv1dStateCaptureRingKernel   = GetKernelFunc("llm_gdn_conv1d_state_capture_ring");   // #290
         _gdnL2NormPerHeadBatchedKernel     = GetKernelFunc("llm_gdn_l2_norm_per_head_batched");
         _gdnTileHeadsBatchedKernel         = GetKernelFunc("llm_gdn_tile_heads_batched");
         _gdnRecurrenceScanKernel           = GetKernelFunc("llm_gdn_recurrence_scan");

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -8273,6 +8273,39 @@ extern ""C"" __global__ void llm_gdn_conv1d_state_update_batched(
         state[(long)r * channels + c] = tmp[r];
 }
 
+// ── GDN #290: capture intermediate conv1d states into the verify ring ───────
+// One launch writes every batched-verify ring slot's conv state. grid =
+// (ceil(channels/256), n_capture); block (c, slot) writes the conv state AFTER
+// token `slot` (i.e. the state the per-token loop held once it had advanced over
+// the first slot+1 tokens) into ring slot `slot`. Byte-identical to invoking
+// `llm_gdn_conv1d_state_update_batched` with n_tok = slot+1: the per-slot window
+// is [slot+1-retained .. slot], drawing from the carried pre-chunk `state` for the
+// early-token (p < 0) padding. Reads the PRE-update state (the caller must run
+// this BEFORE the in-place state advance). `ring` points to this layer's region
+// in slot 0; `ring_slot_stride` is the float stride between consecutive slots.
+extern ""C"" __global__ void llm_gdn_conv1d_state_capture_ring(
+    const float* __restrict__ x,        // [n_tok, channels] chunk inputs
+    const float* __restrict__ state,    // [(K-1), channels] oldest-first, pre-chunk
+    float* __restrict__ ring,           // layer region in slot 0
+    int channels, int kernel_size, int ring_slot_stride, int n_capture)
+{
+    int c = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int slot = (int)blockIdx.y;
+    if (c >= channels || slot >= n_capture) return;
+
+    int retained = kernel_size - 1;
+    int n_eff = slot + 1;               // state after processing tokens [0, n_eff)
+    float* dst = ring + (long)slot * ring_slot_stride;
+    #pragma unroll 4
+    for (int r = 0; r < retained; r++) {
+        int p = n_eff - retained + r;
+        float v = (p >= 0)
+            ? x[(long)p * channels + c]
+            : state[(long)(p + retained) * channels + c];
+        dst[(long)r * channels + c] = v;
+    }
+}
+
 // ── GDN: L2-norm per head, batched over n_tok rows ──────────────────────────
 // Bit-identical to n_tok sequential `llm_gdn_l2_norm_per_head` calls. grid =
 // (num_heads, n_tok); `data` is the region base (already offset to the Q or K
@@ -8355,7 +8388,17 @@ extern ""C"" __global__ void llm_gdn_recurrence_scan(
     float* __restrict__ output_all,       // [n_tok, o_stride]; head h at h*d
     int hv, int d, float norm_eps,
     int q_stride, int k_stride, int v_stride, int v_head_off,
-    int z_stride, int o_stride, int n_tok)
+    int z_stride, int o_stride, int n_tok,
+    // ── #290 batched-verify ring capture (nullable) ──────────────────────────
+    // When ring_scan != null, the post-token-i state (after Pass B, i.e. exactly
+    // what the live `state` holds at that boundary) is also written into ring
+    // slot i for i ∈ [0, n_capture). ring_scan points to this layer's region in
+    // slot 0; ring_slot_stride is the float stride between consecutive slots
+    // (= numGdnLayers * scanStateFloatsPerLayer). Disjoint from `state`, so the
+    // scan arithmetic and the live `state` evolution stay byte-unchanged — the
+    // capture is purely additional stores to a separate buffer.
+    float* __restrict__ ring_scan,
+    int ring_slot_stride, int n_capture)
 {
     int h = (int)blockIdx.x;
     int j = (int)threadIdx.x;
@@ -8406,11 +8449,17 @@ extern ""C"" __global__ void llm_gdn_recurrence_scan(
         __syncthreads();
 
         // Pass B: rank-1 update S[i,j] += k[i]·d[j], fused with readout o[j].
+        // #290: when capturing, mirror each post-update element into ring slot i
+        // (same value the live `state` now holds → byte-identical to the device
+        // CopyDeviceRegion the per-position loop used to issue).
+        bool capture = ring_scan != nullptr && i < n_capture;
+        float* ring_i = capture ? ring_scan + (long)i * ring_slot_stride + state_base : nullptr;
         float o_local = 0.f;
         for (int ii = 0; ii < d; ii++) {
             long off = state_base + (long)ii * d + j;
             float sij = state[off] + sK[ii] * d_j;
             state[off] = sij;
+            if (capture) ring_i[(long)ii * d + j] = sij;
             o_local += sQ[ii] * sij;
         }
         o_local *= rsqrtf((float)d);

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -417,18 +417,22 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private int _batchStartPos;        // startPos of the most recent batched verify
     private int _batchK;               // token count of the most recent batched verify
 
-    // ── Device-side GDN snapshot ring (issues #30/#207 goal 4) ──────────
+    // ── Device-side GDN snapshot ring (issues #30/#207 goal 4, #290) ────
     // On the GPU-GDN trunk (!_cpuGdn) the live recurrent state is the per-layer
     // _gpuGdnScanState/_gpuGdnConvState device tensors, so rollback snapshots must
     // be captured on-device: ring slot j holds every GDN layer's (scan, conv) state
     // AFTER batch token j, packed per layer at offset gdnIdx × per-layer-floats.
-    // Allocated in the constructor BEFORE TryUploadDenseFfnLayers fills VRAM
-    // (~100 MB/slot for 27B; landing it in WDDM-paged memory would 5-10× the
-    // verify). _gdnRingSlots is the achieved slot count (alloc stops on OOM);
+    // #290: the ring is one flat contiguous tensor per (scan, conv) — slot j sits
+    // at j × (numGdn × per-layer-floats) — so the fused #114-B scan kernel can
+    // stride across slots and dump each token's state in place (dropping the
+    // per-position relaunch + the bulk CopyDeviceRegion fan-out). Allocated in the
+    // constructor BEFORE TryUploadDenseFfnLayers fills VRAM (~60 MB/slot for 27B;
+    // landing it in WDDM-paged memory would 5-10× the verify). _gdnRingSlots is
+    // the achieved slot count (alloc retries with fewer slots on OOM);
     // SupportsBatchVerify requires ≥ 1 slot on this trunk. The host
     // _batchSnapshotBuf above serves the SHARPI_CPU_GDN=1 debug trunk only.
-    private readonly Tensor?[]? _gpuGdnRingScan;
-    private readonly Tensor?[]? _gpuGdnRingConv;
+    private readonly Tensor? _gpuGdnRingScan;   // [slots × numGdn × scanFloatsPerLayer]
+    private readonly Tensor? _gpuGdnRingConv;   // [slots × numGdn × convFloatsPerLayer]
     private readonly int _gdnRingSlots;
 
     // Batched-verify scratch (exact-k; reallocated when the batch size changes the
@@ -681,8 +685,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // sequential GdnRecurrenceScan. The chunked form is numerically equal to the scan
     // only up to FP reduction order (NOT byte-exact), so it is OFF by default — the
     // bit-parity oracles keep validating the byte-exact scan — and only engages on the
-    // prefill (clean state-carry) path: it lives inside the BatchedGdnScanEnabled &&
-    // !snapRing branch, so decode and batched-verify ring capture stay on the scan.
+    // prefill (clean state-carry) path: GdnBlockBatched short-circuits to the byte-exact
+    // ring-capturing scan whenever snapRing is set (if (snapRing) … else if
+    // (GdnChunkedPrefillEnabled) …), so decode and batched-verify ring capture stay on the scan.
     // Mirrors HybridGdnForwardPass.GdnChunkedPrefillEnabled. SHARPI_GDN_CHUNKED_PREFILL=1
     // opts in; CudaHybridGdnChunkedPrefillTests A/B-toggles it.
     internal static bool GdnChunkedPrefillEnabled =
@@ -1220,31 +1225,39 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             int scanF = _gdnStateCache.ScanStateFloatsPerLayer;
             int convF = _gdnStateCache.ConvStateFloatsPerLayer;
             int want = _mtpBatchMax - 1;
-            var ringScan = new Tensor?[want];
-            var ringConv = new Tensor?[want];
+            // #290: one flat contiguous tensor per (scan, conv) sized for `got`
+            // slots, so the fused scan/conv-capture kernels can stride across slots.
+            // A single allocation can't partially succeed, so retry with fewer slots
+            // on OOM — total footprint matches the old slot-by-slot sum, preserving
+            // the graceful-degradation semantics.
+            Tensor? scanFlat = null, convFlat = null;
             int got = 0;
-            for (int s = 0; s < want; s++)
+            for (int trySlots = want; trySlots >= 1; trySlots--)
             {
+                Tensor? s = null, c = null;
                 try
                 {
-                    ringScan[s] = gpu.Allocate(TensorShape.D1((long)numGdn * scanF));
+                    s = gpu.Allocate(TensorShape.D1((long)trySlots * numGdn * scanF));
                     if (convF > 0)
-                        ringConv[s] = gpu.Allocate(TensorShape.D1((long)numGdn * convF));
-                    got = s + 1;
+                        c = gpu.Allocate(TensorShape.D1((long)trySlots * numGdn * convF));
+                    scanFlat = s;
+                    convFlat = c;
+                    got = trySlots;
+                    break;
                 }
                 catch (Exception ex)
                 {
-                    // VRAM exhausted (or backend fault) — keep the slots we already
-                    // have; MaxBatchVerifyTokens shrinks to match.
-                    if (ringScan[s] is { } partial) { gpu.Free(partial); ringScan[s] = null; }
+                    // Free any partial allocation (e.g. scan succeeded but conv threw)
+                    // before retrying with fewer slots.
+                    if (s is { } ps) gpu.Free(ps);
+                    if (c is { } pc) gpu.Free(pc);
                     Console.Error.WriteLine(
-                        $"[CudaHybridGdnForwardPass] GDN ring slot {s} allocation failed ({ex.GetType().Name}); " +
-                        $"continuing with {got} slot(s).");
-                    break;
+                        $"[CudaHybridGdnForwardPass] GDN ring allocation for {trySlots} slot(s) failed " +
+                        $"({ex.GetType().Name}); retrying with fewer.");
                 }
             }
-            _gpuGdnRingScan = ringScan;
-            _gpuGdnRingConv = ringConv;
+            _gpuGdnRingScan = scanFlat;
+            _gpuGdnRingConv = convFlat;
             _gdnRingSlots = got;
             long slotBytes = (long)numGdn * (scanF + convF) * sizeof(float);
             Console.Error.WriteLine(
@@ -1938,12 +1951,17 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// <summary>Batched GDN block: projections over N tokens; fused sequential-scan
     /// recurrence + batched conv1d/L2norm/tile by default (issue #114-B), or the
     /// per-position View loop under <c>SHARPI_BATCHED_GDN_SCAN=0</c>.
-    /// <para><paramref name="snapRing"/> (issue #30 batched verify) forces the
-    /// per-position loop — the fused scan only materialises the final state, but
-    /// rollback needs the state after EVERY non-final token — and captures each
-    /// boundary into device ring slot i via <see cref="CaptureGdnRingSlot"/>.
-    /// The per-position loop is the documented bit-identical fallback, so the
-    /// verify trunk stays in the same precision class as prefill/Forward.</para></summary>
+    /// <para><paramref name="snapRing"/> (issues #30/#290 batched verify) keeps the
+    /// fused path and captures the post-token-i (scan, conv) state into device ring
+    /// slot i AS IT SCANS: the sequential-scan kernel mirrors each token's
+    /// post-update state into the ring (zero extra launches), and a single
+    /// conv-capture launch dumps the per-token conv states. This replaces the old
+    /// per-position relaunch (k×8 launches/layer) + the per-slot
+    /// <see cref="CaptureGdnRingSlot"/> CopyDeviceRegion fan-out. Verify always uses
+    /// the byte-exact scan (never the chunked prefill form), so it stays in the same
+    /// precision class as prefill/Forward. The per-position View loop below remains
+    /// the <c>SHARPI_BATCHED_GDN_SCAN=0</c> fallback and keeps its CopyDeviceRegion
+    /// capture.</para></summary>
     private void GdnBlockBatched(int layer, int N, Tensor norm, Tensor blockOut, bool snapRing = false)
     {
         int convCh = _gdnConvChannels, valDim = _gdnValueDim, nVH = _gdnNumVHeads;
@@ -1963,16 +1981,31 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // Issue #114-B: fuse the per-position conv1d + delta-net recurrence into
         // one batched launch per stage + a single sequential-scan kernel. Output is
         // bit-identical to the per-position View loop below (same per-position math,
-        // same reduction order; only the host launch overhead is removed).
-        if (BatchedGdnScanEnabled && !snapRing)
+        // same reduction order; only the host launch overhead is removed). Issue
+        // #290: this path also serves batched verify (snapRing) — the scan/conv
+        // captures dump each token's state into the ring during the fused pass.
+        if (BatchedGdnScanEnabled)
         {
             var qkvConvAll = _gpuBtQkvConv!;
             var qHeadAll = _gpuBtQHead!;
             var kHeadAll = _gpuBtKHead!;
 
-            // conv1d over all tokens (read-only state), then advance the state.
+            // #290 ring geometry (only when capturing): this layer's dense GDN index,
+            // per-layer float counts, and the inter-slot stride (= numGdn × per-layer
+            // floats). gdnIdx ≥ 0 here — GdnBlockBatched only runs for GDN layers.
+            int gdnIdx = snapRing ? _gdnStateCache.GdnLayerOf(layer) : -1;
+            int numGdn = _gdnStateCache.NumGdnLayers;
+            int scanF = _gdnStateCache.ScanStateFloatsPerLayer;
+            int convF = _gdnStateCache.ConvStateFloatsPerLayer;
+            int nCapture = N - 1;   // slots [0, N-1): state after each non-final token
+
+            // conv1d over all tokens (read-only state), capture the per-token conv
+            // states (BEFORE advancing the live state), then advance the state.
             _gpu.GdnConv1dDecodeBatched(qkvAll, convState, _gpuSsmConv1d[layer], qkvConvAll,
                 convCh, _gdnConvKernel, N);
+            if (snapRing && nCapture > 0 && convF > 0 && _gpuGdnRingConv is { } ringConv)
+                _gpu.GdnConv1dStateCaptureRing(qkvAll, convState, ringConv, (long)gdnIdx * convF,
+                    convCh, _gdnConvKernel, numGdn * convF, nCapture);
             _gpu.GdnConv1dStateUpdateBatched(qkvAll, convState, convCh, _gdnConvKernel, N);
             // SiLU over the whole [N × convCh] (matches the per-token full-convCh SiLU).
             _gpu.SiLUInPlace(qkvConvAll);
@@ -1984,10 +2017,19 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             _gpu.GdnTileHeadsBatched(qkvConvAll, kDim, kHeadAll, 0, _gdnNumKHeads, _gdnKvRepeat, hd, convCh, valDim, N);
             // Recurrence: v read straight from the silu'd conv output's V region
             // (vHeadOff = 2*kDim, stride convCh); q/k from the tiled head buffers.
-            // GdnChunkedPrefill is a signature-identical drop-in for the sequential
-            // GdnRecurrenceScan — the FlashQLA chunk-parallel form (opt-in, not
-            // byte-exact) vs the byte-exact per-token-equivalent scan (default).
-            if (GdnChunkedPrefillEnabled)
+            // Verify (snapRing) always uses the byte-exact scan with ring capture;
+            // GdnChunkedPrefill (opt-in, NOT byte-exact) only serves clean prefill.
+            if (snapRing)
+                _gpu.GdnRecurrenceScan(
+                    scanState, qHeadAll, kHeadAll, qkvConvAll,
+                    alphaAll, betaAll, _gpuSsmA[layer], _gpuSsmDtBias[layer], _gpuSsmNormW[layer],
+                    zAll, gdnOutAll,
+                    nVH, hd, normEps: 1e-6f,
+                    qStride: valDim, kStride: valDim, vStride: convCh, vHeadOff: 2 * kDim,
+                    zStride: valDim, oStride: valDim, nTok: N,
+                    ringScan: _gpuGdnRingScan, ringScanFloatOffset: (long)gdnIdx * scanF,
+                    ringSlotStride: numGdn * scanF, nCapture: nCapture);
+            else if (GdnChunkedPrefillEnabled)
                 _gpu.GdnChunkedPrefill(
                     scanState, qHeadAll, kHeadAll, qkvConvAll,
                     alphaAll, betaAll, _gpuSsmA[layer], _gpuSsmDtBias[layer], _gpuSsmNormW[layer],
@@ -3580,12 +3622,17 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             throw new InvalidOperationException(
                 $"CaptureGdnRingSlot({slot}): the GDN snapshot ring has {_gdnRingSlots} slot(s). " +
                 "Callers must clamp the batch to MaxBatchVerifyTokens.");
-        long scanBytes = (long)_gdnStateCache.ScanStateFloatsPerLayer * sizeof(float);
-        long convBytes = (long)_gdnStateCache.ConvStateFloatsPerLayer * sizeof(float);
+        long scanF = _gdnStateCache.ScanStateFloatsPerLayer;
+        long convF = _gdnStateCache.ConvStateFloatsPerLayer;
+        long numGdn = _gdnStateCache.NumGdnLayers;
+        long scanBytes = scanF * sizeof(float);
+        long convBytes = convF * sizeof(float);
         if (_gpuGdnScanState[layer] is { } scanT && scanBytes > 0)
-            _gpu.CopyDeviceRegion(_gpuGdnRingScan[slot]!, gdnIdx * scanBytes, scanT, 0, scanBytes);
-        if (_gpuGdnConvState[layer] is { } convT && convBytes > 0 && _gpuGdnRingConv?[slot] is { } convRing)
-            _gpu.CopyDeviceRegion(convRing, gdnIdx * convBytes, convT, 0, convBytes);
+            _gpu.CopyDeviceRegion(_gpuGdnRingScan, ((long)slot * numGdn * scanF + gdnIdx * scanF) * sizeof(float),
+                scanT, 0, scanBytes);
+        if (_gpuGdnConvState[layer] is { } convT && convBytes > 0 && _gpuGdnRingConv is { } convRing)
+            _gpu.CopyDeviceRegion(convRing, ((long)slot * numGdn * convF + gdnIdx * convF) * sizeof(float),
+                convT, 0, convBytes);
     }
 
     /// <summary>Inverse of <see cref="CaptureGdnRingSlot"/>: ring slot → live device state.</summary>
@@ -3596,12 +3643,17 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         if (_gpuGdnRingScan is null || slot >= _gdnRingSlots)
             throw new InvalidOperationException(
                 $"RestoreGdnRingSlot({slot}): the GDN snapshot ring has {_gdnRingSlots} slot(s).");
-        long scanBytes = (long)_gdnStateCache.ScanStateFloatsPerLayer * sizeof(float);
-        long convBytes = (long)_gdnStateCache.ConvStateFloatsPerLayer * sizeof(float);
+        long scanF = _gdnStateCache.ScanStateFloatsPerLayer;
+        long convF = _gdnStateCache.ConvStateFloatsPerLayer;
+        long numGdn = _gdnStateCache.NumGdnLayers;
+        long scanBytes = scanF * sizeof(float);
+        long convBytes = convF * sizeof(float);
         if (_gpuGdnScanState[layer] is { } scanT && scanBytes > 0)
-            _gpu.CopyDeviceRegion(scanT, 0, _gpuGdnRingScan[slot]!, gdnIdx * scanBytes, scanBytes);
-        if (_gpuGdnConvState[layer] is { } convT && convBytes > 0 && _gpuGdnRingConv?[slot] is { } convRing)
-            _gpu.CopyDeviceRegion(convT, 0, convRing, gdnIdx * convBytes, convBytes);
+            _gpu.CopyDeviceRegion(scanT, 0, _gpuGdnRingScan, ((long)slot * numGdn * scanF + gdnIdx * scanF) * sizeof(float),
+                scanBytes);
+        if (_gpuGdnConvState[layer] is { } convT && convBytes > 0 && _gpuGdnRingConv is { } convRing)
+            _gpu.CopyDeviceRegion(convT, 0, convRing, ((long)slot * numGdn * convF + gdnIdx * convF) * sizeof(float),
+                convBytes);
     }
 
     /// <summary>
@@ -6114,10 +6166,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             }
             // Issue #30/#207-goal-4 k-token batched verify: device GDN snapshot
             // ring + exact-k verify scratch + the MTP self-chaining hidden.
-            if (_gpuGdnRingScan is not null)
-                foreach (var t in _gpuGdnRingScan) if (t is { } rs) _gpu.Free(rs);
-            if (_gpuGdnRingConv is not null)
-                foreach (var t in _gpuGdnRingConv) if (t is { } rc) _gpu.Free(rc);
+            if (_gpuGdnRingScan is { } ringScan) _gpu.Free(ringScan);
+            if (_gpuGdnRingConv is { } ringConv) _gpu.Free(ringConv);
             if (_gpuBvLogitsAll is { } bvl) _gpu.Free(bvl);
             if (_gpuBvFfnAll is { } bvf) _gpu.Free(bvf);
             if (_bvNormHost != null) CudaBackend.FreePinnedHost((nint)_bvNormHost);

--- a/tests/SharpInference.Tests.ForwardPass/CudaGdnBatchedTrunkTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaGdnBatchedTrunkTests.cs
@@ -237,6 +237,150 @@ public sealed unsafe class CudaGdnBatchedTrunkTests
         }
     }
 
+    // ── #290 fused-scan ring capture: each slot == a fresh scan over the prefix ──
+    // The capturing scan must (a) leave its output/final-state byte-unchanged (the
+    // ring writes are disjoint stores) and (b) write into ring slot i exactly the
+    // state a scan over the first i+1 tokens produces. A non-zero target layer in a
+    // multi-layer ring exercises the per-layer float offset + inter-slot stride.
+    [Fact]
+    public void GdnRecurrenceScan_RingCapture_BitwiseMatchesPerSlotState()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int hv = 4, d = 128, scanF = hv * d * d, hd = hv * d;
+        const int numGdn = 3, gdnIdx = 1;
+        foreach (int N in new[] { 2, 4, 8 })
+        {
+            int nCapture = N - 1;
+            var rng = new Random(900 + N);
+            var state0 = Rand(scanF, rng);
+            var qAll = Rand(N * hd, rng); var kAll = Rand(N * hd, rng);
+            var vAll = Rand(N * hd, rng); var zAll = Rand(N * hd, rng);
+            var alphaAll = Rand(N * hv, rng); var betaAll = Rand(N * hv, rng);
+            var ssmA = Rand(hv, rng); var dtBias = Rand(hv, rng); var normW = Rand(d, rng);
+
+            var gpuSsmA = gpu.Upload(ssmA, TensorShape.D1(hv));
+            var gpuDt = gpu.Upload(dtBias, TensorShape.D1(hv));
+            var gpuNw = gpu.Upload(normW, TensorShape.D1(d));
+            var gQ = gpu.Upload(qAll, TensorShape.D1((long)N * hd));
+            var gK = gpu.Upload(kAll, TensorShape.D1((long)N * hd));
+            var gV = gpu.Upload(vAll, TensorShape.D1((long)N * hd));
+            var gZ = gpu.Upload(zAll, TensorShape.D1((long)N * hd));
+            var gA = gpu.Upload(alphaAll, TensorShape.D1((long)N * hv));
+            var gB = gpu.Upload(betaAll, TensorShape.D1((long)N * hv));
+
+            // Capturing scan over all N tokens into a zero-cleared multi-layer ring.
+            var gState = gpu.Upload(state0, TensorShape.D1(scanF));
+            var gOut = gpu.Allocate(TensorShape.D1((long)N * hd));
+            long ringFloats = (long)nCapture * numGdn * scanF;
+            var gRing = gpu.Allocate(TensorShape.D1(ringFloats));
+            gpu.Clear(gRing);
+            gpu.GdnRecurrenceScan(gState, gQ, gK, gV, gA, gB, gpuSsmA, gpuDt, gpuNw, gZ, gOut,
+                hv, d, 1e-6f, qStride: hd, kStride: hd, vStride: hd, vHeadOff: 0, zStride: hd, oStride: hd, nTok: N,
+                ringScan: gRing, ringScanFloatOffset: (long)gdnIdx * scanF,
+                ringSlotStride: numGdn * scanF, nCapture: nCapture);
+            gpu.Synchronize();
+            var ring = new float[ringFloats]; gpu.Download(gRing, ring);
+            var capFinalState = new float[scanF]; gpu.Download(gState, capFinalState);
+            var capOut = new float[(long)N * hd]; gpu.Download(gOut, capOut);
+
+            // (a) A non-capturing scan over all N must match the capturing one byte-for-byte.
+            var gStateRef = gpu.Upload(state0, TensorShape.D1(scanF));
+            var gOutRef = gpu.Allocate(TensorShape.D1((long)N * hd));
+            gpu.GdnRecurrenceScan(gStateRef, gQ, gK, gV, gA, gB, gpuSsmA, gpuDt, gpuNw, gZ, gOutRef,
+                hv, d, 1e-6f, qStride: hd, kStride: hd, vStride: hd, vHeadOff: 0, zStride: hd, oStride: hd, nTok: N);
+            gpu.Synchronize();
+            var refFinalState = new float[scanF]; gpu.Download(gStateRef, refFinalState);
+            var refOut = new float[(long)N * hd]; gpu.Download(gOutRef, refOut);
+            AssertBitId($"capture-must-not-perturb final state N={N}", capFinalState, refFinalState);
+            AssertBitId($"capture-must-not-perturb output N={N}", capOut, refOut);
+            gpu.Free(gStateRef); gpu.Free(gOutRef);
+
+            // (b) Each slot i == a fresh scan over the first i+1 tokens; other layers untouched.
+            for (int slot = 0; slot < nCapture; slot++)
+            {
+                var gStateS = gpu.Upload(state0, TensorShape.D1(scanF));
+                var gOutS = gpu.Allocate(TensorShape.D1((long)(slot + 1) * hd));
+                gpu.GdnRecurrenceScan(gStateS, gQ, gK, gV, gA, gB, gpuSsmA, gpuDt, gpuNw, gZ, gOutS,
+                    hv, d, 1e-6f, qStride: hd, kStride: hd, vStride: hd, vHeadOff: 0, zStride: hd, oStride: hd, nTok: slot + 1);
+                gpu.Synchronize();
+                var expState = new float[scanF]; gpu.Download(gStateS, expState);
+                gpu.Free(gStateS); gpu.Free(gOutS);
+
+                var slotLayer = new float[scanF];
+                Array.Copy(ring, (long)slot * numGdn * scanF + (long)gdnIdx * scanF, slotLayer, 0, scanF);
+                AssertBitId($"ring slot {slot} (N={N})", slotLayer, expState);
+
+                for (int g = 0; g < numGdn; g++)
+                {
+                    if (g == gdnIdx) continue;
+                    long baseOff = (long)slot * numGdn * scanF + (long)g * scanF;
+                    for (long e = 0; e < scanF; e++)
+                        if (ring[baseOff + e] != 0f)
+                            Assert.Fail($"ring slot {slot} layer {g} elem {e} = {ring[baseOff + e]} (expected untouched 0).");
+                }
+            }
+
+            gpu.Free(gpuSsmA); gpu.Free(gpuDt); gpu.Free(gpuNw);
+            gpu.Free(gQ); gpu.Free(gK); gpu.Free(gV); gpu.Free(gZ); gpu.Free(gA); gpu.Free(gB);
+            gpu.Free(gState); gpu.Free(gOut); gpu.Free(gRing);
+        }
+    }
+
+    // ── #290 conv-state ring capture: each slot == state-update over the prefix ──
+    [Fact]
+    public void GdnConv1dStateCaptureRing_BitwiseMatchesPerSlotUpdate()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int channels = 8192, kernelSize = 4, retained = kernelSize - 1, convF = retained * channels;
+        const int numGdn = 3, gdnIdx = 2;
+        foreach (int N in new[] { 2, 4, 8 })
+        {
+            int nCapture = N - 1;
+            var rng = new Random(950 + N);
+            var xAll = Rand(N * channels, rng);
+            var state0 = Rand(retained * channels, rng);
+
+            var gX = gpu.Upload(xAll, TensorShape.D1((long)N * channels));
+            var gState = gpu.Upload(state0, TensorShape.D1(retained * channels));
+            long ringFloats = (long)nCapture * numGdn * convF;
+            var gRing = gpu.Allocate(TensorShape.D1(ringFloats));
+            gpu.Clear(gRing);
+            gpu.GdnConv1dStateCaptureRing(gX, gState, gRing, (long)gdnIdx * convF,
+                channels, kernelSize, numGdn * convF, nCapture);
+            gpu.Synchronize();
+            var ring = new float[ringFloats]; gpu.Download(gRing, ring);
+
+            for (int slot = 0; slot < nCapture; slot++)
+            {
+                // Reference: in-place state-update over the first slot+1 tokens.
+                var gStateRef = gpu.Upload(state0, TensorShape.D1(retained * channels));
+                gpu.GdnConv1dStateUpdateBatched(gX, gStateRef, channels, kernelSize, slot + 1);
+                gpu.Synchronize();
+                var expState = new float[convF]; gpu.Download(gStateRef, expState);
+                gpu.Free(gStateRef);
+
+                var slotLayer = new float[convF];
+                Array.Copy(ring, (long)slot * numGdn * convF + (long)gdnIdx * convF, slotLayer, 0, convF);
+                AssertBitId($"conv ring slot {slot} (N={N})", slotLayer, expState);
+
+                for (int g = 0; g < numGdn; g++)
+                {
+                    if (g == gdnIdx) continue;
+                    long baseOff = (long)slot * numGdn * convF + (long)g * convF;
+                    for (long e = 0; e < convF; e++)
+                        if (ring[baseOff + e] != 0f)
+                            Assert.Fail($"conv ring slot {slot} layer {g} elem {e} touched.");
+                }
+            }
+
+            gpu.Free(gX); gpu.Free(gState); gpu.Free(gRing);
+        }
+    }
+
     // ── Batched KV-append + SDPA (fp32) ─────────────────────────────────────
     [Fact]
     public void AttentionBatched_F32_BitwiseMatchesSequential()


### PR DESCRIPTION
Closes #290. Follow-up to #209 (work item #4).

## Problem
`BatchVerify` set `gdnSnapRing=true`, forcing `GdnBlockBatched` into the per-position View loop (k×8 launches/layer via `GdnRecurrenceDecode`) **plus** ~2×(k−1)×numGdn `CopyDeviceRegion` launches (≈96×(k−1) on the 27B-MTP) — just to snapshot each token's GDN `(scan, conv)` state into the rollback ring, instead of the #114-B fused `GdnRecurrenceScan` path the prefill trunk uses.

## Change
Keep the fused path for verify and capture the state **during** the scan:

1. **`llm_gdn_recurrence_scan`** — optional `ring_scan`/`ring_slot_stride`/`n_capture`. In Pass B, where each thread already writes the post-update `state[off] = sij`, it also mirrors `sij` into ring slot `i` for `i < n_capture`. **Zero extra launches**; the scan arithmetic and the live-state evolution stay byte-unchanged (the ring is a disjoint `__restrict__` buffer).
2. **New `llm_gdn_conv1d_state_capture_ring`** — one launch writes every ring slot's conv state (slot `i` = `state_update` with `nTok = i+1`), run **before** the in-place conv state advance so it reads the pre-batch state.
3. **Flat ring** — the snapshot ring is now two contiguous tensors `[slots × numGdn × perLayerFloats]` so the kernels can stride across slots; OOM degrades by retrying fewer slots. `Capture/RestoreGdnRingSlot` re-point to the flat buffer (still used by the `SHARPI_BATCHED_GDN_SCAN=0` fallback + all restores).

Verify always uses the byte-exact scan (never the opt-in chunked-prefill form), so it stays in the same precision class as prefill/`Forward` — **bit-identity holds by composition** over the already-proven #114-B fused path. Rollback correctness is preserved (`RestoreBatchSnapshot` reads slot `lengthAfter − startPos − 1`).

## Tests
- New model-free bit-exactness oracles: `GdnRecurrenceScan_RingCapture_BitwiseMatchesPerSlotState`, `GdnConv1dStateCaptureRing_BitwiseMatchesPerSlotUpdate` (multi-layer ring, non-zero target layer; asserts capture doesn't perturb the scan and that untouched layers stay zero).
- All 10 `CudaGdnBatchedTrunkTests` pass.
- All 3 `CudaMtpBatchVerifyTests` (27B-MTP parity / junk-draft rollback / e2e decode) pass in **both** default and `SHARPI_BATCHED_GDN_SCAN=0` modes.
- Build clean (0 warnings, TreatWarningsAsErrors).

## Perf (RTX 4070 Ti, Qwen3.6-27B-MTP-Q4_K_M, `-g -1`, temp 0)
Warm A/B with greedy decode (identical trajectory ⇒ identical verify workload, isolating the GDN launch overhead): **11.0 vs 10.9 t/s, ~+1–2% e2e**, consistent across runs, never regresses. The e2e delta is small because this config is **CPU-FFN-bound** (44/64 dense FFN layers on CPU mmap); the structural win is **~4× fewer GDN-verify launches** (k=4, 48 layers: ~1824 → ~432), which matters more on GPU-FFN-resident GDN models or higher k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)