### PR TITLE
fix(server): stop tool-call content leak + populate prompt_tokens (#150)

### DIFF
--- a/src/SharpInference.Core/ToolCallAdapter.cs
+++ b/src/SharpInference.Core/ToolCallAdapter.cs
@@ -649,6 +649,13 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
     public const string CallPrefix  = "call:";
     /// <summary>Gemma's string-delimiter token; brackets a string literal on both sides.</summary>
     public const string Quote       = "<|\"|>";
+    /// <summary>
+    /// Turn-boundary control tokens that open/close a tool-result turn. The model frequently
+    /// emits the opening <c>&lt;|tool_response&gt;</c> immediately after a tool call (it is
+    /// starting the next, tool-role, turn) — these are special tokens, never user-facing
+    /// content, so they are scrubbed from the parsed plain text (issue #150).
+    /// </summary>
+    private static readonly string[] ResponseMarkers = ["<|tool_response>", "<tool_response|>"];
 
     public string Architecture => "gemma4";
     public int MaxOpenTagLength => OpenMarker.Length;
@@ -676,7 +683,7 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
                 // Model stopped mid-call (no <tool_call|>): surface the partial as text and flag
                 // truncation rather than emitting a half-parsed call. Matches the streaming path.
                 plain.Append(rawOutput, contentStart, rawOutput.Length - contentStart);
-                return new ToolCallParseResult(plain.ToString(), calls, Truncated: true);
+                return new ToolCallParseResult(ScrubResponseMarkers(plain), calls, Truncated: true);
             }
 
             string block = rawOutput[contentStart..end];
@@ -684,7 +691,20 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
             foreach (var c in ParseBlock(block)) calls.Add(c);
         }
 
-        return new ToolCallParseResult(plain.ToString(), calls, Truncated: false);
+        return new ToolCallParseResult(ScrubResponseMarkers(plain), calls, Truncated: false);
+    }
+
+    /// <summary>
+    /// Removes any orphan tool-response turn markers from the accumulated plain text so a
+    /// leftover <c>&lt;|tool_response&gt;</c> (emitted after a tool call) doesn't surface as
+    /// assistant content. Operates on the non-block text only — tool-call blocks were already
+    /// extracted — so a marker that legitimately appears inside a tool argument is untouched.
+    /// </summary>
+    private static string ScrubResponseMarkers(StringBuilder plain)
+    {
+        foreach (var marker in ResponseMarkers)
+            plain.Replace(marker, "");
+        return plain.ToString();
     }
 
     public int FindOpenMarker(string buffer, int startSearch, out int contentStart)

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -504,6 +504,10 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             }
 
             _committedTokens += projected;
+            // Surface the prompt-token count out-of-band so endpoints can report
+            // usage.prompt_tokens / input_tokens without re-tokenizing (issue #150).
+            // Emitted at admission, before any text/thinking chunk for this sequence.
+            req.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Usage, "", tokens.Length));
             prefilling.Add(new PrefillingSeq
             {
                 Req = req,

--- a/src/SharpInference.Engine/GenerateChunk.cs
+++ b/src/SharpInference.Engine/GenerateChunk.cs
@@ -13,6 +13,16 @@ public enum GenerateChunkKind
 
     /// <summary>Reasoning content emitted between <c>&lt;think&gt;</c> and <c>&lt;/think&gt;</c>.</summary>
     Thinking,
+
+    /// <summary>
+    /// Out-of-band usage metadata emitted once per request (not user-facing text). Its
+    /// <see cref="GenerateChunk.Text"/> is empty; <see cref="GenerateChunk.PromptTokens"/>
+    /// carries the encoded prompt-token count so endpoints can populate
+    /// <c>usage.prompt_tokens</c> / <c>usage.input_tokens</c> (issue #150) without
+    /// re-tokenizing. Consumers that only surface text (e.g. the default
+    /// <see cref="IInferenceEngine.GenerateAsync"/> adapter) ignore it.
+    /// </summary>
+    Usage,
 }
 
 /// <summary>
@@ -20,5 +30,9 @@ public enum GenerateChunkKind
 /// allocation-free (<c>readonly record struct</c>); only the inner string allocates.
 /// The boundary tokens themselves (<c>&lt;think&gt;</c> / <c>&lt;/think&gt;</c>) are
 /// never emitted as content — they're protocol markers consumed by the engine.
+/// <para>
+/// <see cref="PromptTokens"/> is meaningful only on a <see cref="GenerateChunkKind.Usage"/>
+/// chunk (0 on Text/Thinking chunks).
+/// </para>
 /// </summary>
-public readonly record struct GenerateChunk(GenerateChunkKind Kind, string Text);
+public readonly record struct GenerateChunk(GenerateChunkKind Kind, string Text, int PromptTokens = 0);

--- a/src/SharpInference.Engine/IInferenceEngine.cs
+++ b/src/SharpInference.Engine/IInferenceEngine.cs
@@ -35,8 +35,10 @@ public interface IInferenceEngine
 
     /// <summary>
     /// Generate typed chunks from a pre-formatted prompt string. Each chunk is tagged as
-    /// either user-facing <see cref="GenerateChunkKind.Text"/> or internal
-    /// <see cref="GenerateChunkKind.Thinking"/> reasoning. The boundary tokens
+    /// user-facing <see cref="GenerateChunkKind.Text"/>, internal
+    /// <see cref="GenerateChunkKind.Thinking"/> reasoning, or a single out-of-band
+    /// <see cref="GenerateChunkKind.Usage"/> metadata chunk (emitted once, before any text,
+    /// carrying the prompt-token count). The boundary tokens
     /// (<c>&lt;think&gt;</c> / <c>&lt;/think&gt;</c>) are consumed by the engine and never
     /// surface in chunk text. Requests are serialized — concurrent calls block until
     /// the current request finishes.

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -537,6 +537,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     var tokens = _tokenizer.Encode(prompt).ToArray();
                     promptTokenCount = tokens.Length;
                     encodeMs = swReq.ElapsedMilliseconds;
+                    // Surface the prompt-token count out-of-band so endpoints can report
+                    // usage.prompt_tokens / input_tokens without re-tokenizing (issue #150).
+                    // Emitted before any text/thinking chunk; consumers that only read text
+                    // ignore the Usage kind.
+                    channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Usage, "", promptTokenCount));
                     var rng = new Random();
                     System.Collections.Immutable.ImmutableArray<int> stopIds =
                         sp.StopTokenIds is { } userStops ? [.. userStops] : _tokenizer.EogTokenIds;

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -162,11 +162,17 @@ public static class AnthropicEndpoints
         var thinkingSb = new StringBuilder();
         var textSb = new StringBuilder();
         int totalOutputTokens = 0;
+        int promptTokens = 0;
 
         try
         {
             await foreach (var chunk in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
+                if (chunk.Kind == GenerateChunkKind.Usage)
+                {
+                    promptTokens = chunk.PromptTokens;
+                    continue;
+                }
                 totalOutputTokens++;
                 if (chunk.Kind == GenerateChunkKind.Thinking)
                     thinkingSb.Append(chunk.Text);
@@ -224,7 +230,7 @@ public static class AnthropicEndpoints
             msgId, "message", "assistant",
             contentList.ToArray(),
             modelId, stopReason,
-            new AUsage(0, totalOutputTokens));
+            new AUsage(promptTokens, totalOutputTokens));
 
         ctx.Response.ContentType = "application/json";
         await ctx.Response.WriteAsync(
@@ -257,6 +263,7 @@ public static class AnthropicEndpoints
         int nextBlockIndex = 0; // increments as blocks are opened
         var thinkingSb = new StringBuilder();
         int outputTokens = 0;
+        int promptTokens = 0;
         bool hasToolCalls = false;
 
         // Tool-call streaming state machine — adapter-driven so the open/close markers
@@ -404,6 +411,14 @@ public static class AnthropicEndpoints
         {
             await foreach (var chunk in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
+                // Out-of-band usage chunk (issue #150): not a generated token. Capture the
+                // prompt-token count for the terminal message_delta usage and skip the rest of
+                // the per-token handling.
+                if (chunk.Kind == GenerateChunkKind.Usage)
+                {
+                    promptTokens = chunk.PromptTokens;
+                    continue;
+                }
                 outputTokens++;
 
                 if (chunk.Kind == GenerateChunkKind.Thinking)
@@ -519,7 +534,7 @@ public static class AnthropicEndpoints
             ? "tool_use"
             : truncatedToolCall ? "max_tokens" : "end_turn";
         var msgDelta = new AMessageDeltaEvent("message_delta",
-            new AMessageDelta(stopReason, null), new AUsage(0, outputTokens));
+            new AMessageDelta(stopReason, null), new AUsage(promptTokens, outputTokens));
         await WriteAnthropicEvent(ctx.Response, "message_delta",
             JsonSerializer.Serialize(msgDelta, SharpInferenceJsonContext.Default.AMessageDeltaEvent));
 

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -278,6 +278,11 @@ public static class AnthropicEndpoints
         async Task FlushTextDelta(string text)
         {
             if (text.Length == 0) return;
+            // Once a tool_use block has been emitted, any trailing plain text is model control
+            // noise (e.g. Gemma's <|tool_response> turn marker) — not assistant content — so it
+            // must not open a stray text block (issue #150). Preamble before the first call is
+            // unaffected (hasToolCalls is still false then). Mirrors the OpenAI streaming guard.
+            if (hasToolCalls) return;
             if (!textOpen)
             {
                 // Close thinking block first if it was opened without a follow-up text block.

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -173,12 +173,17 @@ public static class OpenAiEndpoints
         var reasoningSb = new StringBuilder();
         int textTokens = 0;
         int reasoningTokens = 0;
+        int promptTokens = 0;
 
         try
         {
             await foreach (var c in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
-                if (c.Kind == GenerateChunkKind.Thinking)
+                if (c.Kind == GenerateChunkKind.Usage)
+                {
+                    promptTokens = c.PromptTokens;
+                }
+                else if (c.Kind == GenerateChunkKind.Thinking)
                 {
                     reasoningSb.Append(c.Text);
                     reasoningTokens++;
@@ -256,7 +261,7 @@ public static class OpenAiEndpoints
             reasoningSb.Length > 0 ? reasoningSb.ToString() : null,
             toolCalls);
         var usage = new ChatUsage(
-            0, completionTokens, completionTokens,
+            promptTokens, completionTokens, promptTokens + completionTokens,
             reasoningTokens > 0 ? new CompletionTokensDetails(reasoningTokens) : null);
 
         var response = new ChatCompletionResponse(
@@ -296,6 +301,11 @@ public static class OpenAiEndpoints
         async Task WriteContentDelta(string text)
         {
             if (text.Length == 0) return;
+            // OpenAI's wire shape carries the assistant's intent in tool_calls once a call has
+            // been emitted; any trailing plain text is model control noise (e.g. Gemma's
+            // <|tool_response> turn marker) and must not leak as a content delta (issue #150).
+            // Preamble before the first call is unaffected (hasToolCalls is still false then).
+            if (hasToolCalls) return;
             var chunk = new ChatCompletionChunk(
                 requestId, "chat.completion.chunk", created, engine.ModelId,
                 [new ChunkChoice(0, new ChunkDelta(null, text), null)]);
@@ -373,6 +383,10 @@ public static class OpenAiEndpoints
         {
             await foreach (var c in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
             {
+                // Out-of-band usage chunk (issue #150): not a generated token and carries no
+                // text. The streaming response doesn't emit a usage object (OpenAI gates that
+                // behind stream_options.include_usage, unsupported here), so just skip it.
+                if (c.Kind == GenerateChunkKind.Usage) continue;
                 tokenCount++;
                 if (c.Kind == GenerateChunkKind.Thinking)
                 {

--- a/tests/SharpInference.Tests.Core/ToolCallAdapterTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolCallAdapterTests.cs
@@ -333,6 +333,30 @@ public sealed class ToolCallAdapterTests
     }
 
     [Fact]
+    public void Gemma4_Parse_ScrubsTrailingToolResponseMarker()
+    {
+        // The model frequently emits the next-turn control token <|tool_response> immediately
+        // after a tool call. It is a special token, never assistant content (issue #150), so it
+        // must not survive in PlainText (which the endpoints surface as the message content).
+        var a = new Gemma4ToolCallAdapter();
+        var raw = "<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|><|tool_response>";
+        var (plain, calls) = a.Parse(raw);
+        Assert.Equal("", plain);
+        Assert.Single(calls);
+        Assert.Equal("get_weather", calls[0].Name);
+    }
+
+    [Fact]
+    public void Gemma4_Parse_KeepsGenuinePreambleButScrubsResponseMarker()
+    {
+        var a = new Gemma4ToolCallAdapter();
+        var raw = "Let me check.<|tool_call>call:a{k:1}<tool_call|><|tool_response>";
+        var (plain, calls) = a.Parse(raw);
+        Assert.Equal("Let me check.", plain);
+        Assert.Single(calls);
+    }
+
+    [Fact]
     public void Gemma4_FindMarkers_RoundTripsBlock()
     {
         var a = new Gemma4ToolCallAdapter();

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
@@ -39,8 +39,13 @@ public sealed class InferenceEngineChunkTests
         await foreach (var c in engine.GenerateChunksAsync("seed", sp))
             chunks.Add(c);
 
-        Assert.All(chunks, c => Assert.Equal(GenerateChunkKind.Text, c.Kind));
-        var joined = string.Concat(chunks.Select(c => c.Text));
+        // The engine leads with one out-of-band Usage chunk carrying the prompt-token count
+        // (issue #150) — ScriptedTokenizer.Encode returns a single token. The rest are Text.
+        var usage = Assert.Single(chunks, c => c.Kind == GenerateChunkKind.Usage);
+        Assert.Equal(1, usage.PromptTokens);
+        Assert.All(chunks.Where(c => c.Kind != GenerateChunkKind.Usage),
+            c => Assert.Equal(GenerateChunkKind.Text, c.Kind));
+        var joined = string.Concat(chunks.Where(c => c.Kind == GenerateChunkKind.Text).Select(c => c.Text));
         Assert.Equal("Hi there", joined);
     }
 

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -1142,6 +1142,13 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
     public long PrefillTokensReused => 0;
 
     /// <summary>
+    /// When set, a <see cref="GenerateChunkKind.Usage"/> chunk carrying this prompt-token count
+    /// is emitted before the scripted output — mirroring what the real engines do so endpoint
+    /// tests can assert <c>usage.prompt_tokens</c> / <c>input_tokens</c> (issue #150).
+    /// </summary>
+    public int PromptTokens { get; init; }
+
+    /// <summary>
     /// Captures the <see cref="SamplingParams"/> handed to the most recent
     /// <see cref="GenerateChunksAsync"/> call. Lets wire-level tests confirm that request
     /// fields (e.g. <c>thinking.budget_tokens</c>, <c>max_thinking_tokens</c>) reach the
@@ -1185,6 +1192,8 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
         LastSamplingParams = sp;
         LastCanonicalHistoryPrefix = canonicalHistoryPrefix;
         LastPrompt = prompt;
+        if (PromptTokens > 0)
+            yield return new GenerateChunk(GenerateChunkKind.Usage, "", PromptTokens);
         foreach (var (kind, text) in _script)
         {
             ct.ThrowIfCancellationRequested();
@@ -1203,6 +1212,8 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
         LastCanonicalHistoryPrefix = null;
         LastPrompt = prompt;
         LastImageCount = imageBytes.Count;
+        if (PromptTokens > 0)
+            yield return new GenerateChunk(GenerateChunkKind.Usage, "", PromptTokens);
         foreach (var (kind, text) in _script)
         {
             ct.ThrowIfCancellationRequested();

--- a/tests/SharpInference.Tests.Server/ToolCallEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/ToolCallEndpointTests.cs
@@ -438,6 +438,55 @@ public sealed class ToolCallEndpointTests
         Assert.Contains("\"finish_reason\":\"tool_calls\"", body);
     }
 
+    [Fact]
+    public async Task Anthropic_Gemma4_Streaming_ToolResponseMarkerNotLeakedAsTextBlock()
+    {
+        var fake = new FakeInferenceEngine("gemma-4", [
+            (GenerateChunkKind.Text, "<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>"),
+            (GenerateChunkKind.Text, "<|tool_response>"),
+        ]);
+        var client = CreateClient(fake, "gemma4");
+
+        var req = new
+        {
+            model = "gemma-4",
+            messages = new[] { new { role = "user", content = "Weather?" } },
+            max_tokens = 50,
+            stream = true,
+            tools = new[] { new { name = "get_weather", description = "w", input_schema = new { type = "object" } } }
+        };
+        var response = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+
+        // The leaked marker is JSON-escaped and may be split across multiple text_delta events,
+        // so a raw substring match would miss it — decode + concatenate the text_delta payloads.
+        var streamedText = ConcatTextDeltas(body);
+        Assert.DoesNotContain("tool_response", streamedText);
+        Assert.Contains("\"type\":\"tool_use\"", body);
+        Assert.Equal("tool_use", ExtractMessageDeltaStopReason(body));
+    }
+
+    /// <summary>Concatenates every Anthropic <c>text_delta</c> payload in an SSE body so an
+    /// assertion sees the full streamed text regardless of chunk splitting / JSON escaping.</summary>
+    private static string ConcatTextDeltas(string sseBody)
+    {
+        var sb = new System.Text.StringBuilder();
+        int i = 0;
+        while ((i = sseBody.IndexOf("\"text_delta\"", i, StringComparison.Ordinal)) >= 0)
+        {
+            int dataStart = sseBody.LastIndexOf("data: ", i, StringComparison.Ordinal);
+            int dataEnd = sseBody.IndexOf('\n', i);
+            if (dataStart < 0 || dataEnd < 0) break;
+            dataStart += "data: ".Length;
+            using var doc = JsonDocument.Parse(sseBody[dataStart..dataEnd]);
+            if (doc.RootElement.TryGetProperty("delta", out var d) && d.TryGetProperty("text", out var t))
+                sb.Append(t.GetString());
+            i = dataEnd;
+        }
+        return sb.ToString();
+    }
+
     // ── usage.prompt_tokens populated from the engine's Usage chunk (#150) ──────
 
     [Fact]

--- a/tests/SharpInference.Tests.Server/ToolCallEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/ToolCallEndpointTests.cs
@@ -376,6 +376,126 @@ public sealed class ToolCallEndpointTests
             "a truncated call must not be emitted as a tool_calls entry");
     }
 
+    // ── Gemma 4 tool-response marker leak (#150) ──────────────────────────────
+
+    [Fact]
+    public async Task OpenAi_Gemma4_NonStreaming_ToolResponseMarkerNotLeakedIntoContent()
+    {
+        // Gemma emits the next-turn control token <|tool_response> right after the call. It is
+        // a special token, not assistant content — content must be null, not "<|tool_response>".
+        var fake = new FakeInferenceEngine("gemma-4", [
+            (GenerateChunkKind.Text, "<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>"),
+            (GenerateChunkKind.Text, "<|tool_response>"),
+        ]);
+        var client = CreateClient(fake, "gemma4");
+
+        var req = new
+        {
+            model = "gemma-4",
+            messages = new[] { new { role = "user", content = "Weather?" } },
+            max_tokens = 50,
+            stream = false,
+            tools = new[] { new { type = "function", function = new { name = "get_weather", description = "w", parameters = new { type = "object" } } } }
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("tool_response", json);
+
+        using var doc = JsonDocument.Parse(json);
+        var choice = doc.RootElement.GetProperty("choices")[0];
+        Assert.Equal("tool_calls", choice.GetProperty("finish_reason").GetString());
+        var message = choice.GetProperty("message");
+        if (message.TryGetProperty("content", out var c))
+            Assert.True(c.ValueKind == JsonValueKind.Null, "content must be null, not the leaked marker");
+        Assert.Equal("get_weather", message.GetProperty("tool_calls")[0].GetProperty("function").GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task OpenAi_Gemma4_Streaming_ToolResponseMarkerNotLeakedAsContentDelta()
+    {
+        var fake = new FakeInferenceEngine("gemma-4", [
+            (GenerateChunkKind.Text, "<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>"),
+            (GenerateChunkKind.Text, "<|tool_response>"),
+        ]);
+        var client = CreateClient(fake, "gemma4");
+
+        var req = new
+        {
+            model = "gemma-4",
+            messages = new[] { new { role = "user", content = "Weather?" } },
+            max_tokens = 50,
+            stream = true,
+            tools = new[] { new { type = "function", function = new { name = "get_weather", description = "w", parameters = new { type = "object" } } } }
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+
+        // The leaked turn marker must never appear as a streamed content delta.
+        Assert.DoesNotContain("tool_response", body);
+        Assert.Contains("\"tool_calls\":[", body);
+        Assert.Contains("\"finish_reason\":\"tool_calls\"", body);
+    }
+
+    // ── usage.prompt_tokens populated from the engine's Usage chunk (#150) ──────
+
+    [Fact]
+    public async Task OpenAi_NonStreaming_PopulatesPromptTokensFromUsageChunk()
+    {
+        var fake = new FakeInferenceEngine("test-model", [
+            (GenerateChunkKind.Text, "Hello"),
+            (GenerateChunkKind.Text, " world"),
+        ]) { PromptTokens = 42 };
+        var client = CreateClient(fake);
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Hi" } },
+            max_tokens = 10,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+
+        var usage = doc.RootElement.GetProperty("usage");
+        Assert.Equal(42, usage.GetProperty("prompt_tokens").GetInt32());
+        // The Usage chunk must NOT inflate completion_tokens (2 scripted text chunks).
+        Assert.Equal(2, usage.GetProperty("completion_tokens").GetInt32());
+        Assert.Equal(44, usage.GetProperty("total_tokens").GetInt32());
+        // And it must not surface as content.
+        Assert.Equal("Hello world", doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task Anthropic_NonStreaming_PopulatesInputTokensFromUsageChunk()
+    {
+        var fake = new FakeInferenceEngine("test-model", [
+            (GenerateChunkKind.Text, "Hi"),
+        ]) { PromptTokens = 17 };
+        var client = CreateClient(fake);
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Hi" } },
+            max_tokens = 10,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+
+        var usage = doc.RootElement.GetProperty("usage");
+        Assert.Equal(17, usage.GetProperty("input_tokens").GetInt32());
+        Assert.Equal(1, usage.GetProperty("output_tokens").GetInt32());
+        Assert.Equal("Hi", doc.RootElement.GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
     [Fact]
     public async Task Anthropic_TruncatedToolCall_NonStreaming_ReportsMaxTokens()
     {


### PR DESCRIPTION
## Summary

Fixes the two OpenAI `/v1/chat/completions` wire-format deviations in #150 (and the equivalent gaps on the Anthropic surface):

1. **Tool-call response leaked `<|tool_response>` into `content`.** Gemma emits its next-turn control token `<|tool_response>` right after a tool call; it was surviving in the parsed plain text and surfacing as `message.content` (should be `null` per the OpenAI spec when `tool_calls` are present).
2. **`usage.prompt_tokens` always reported 0.**

## Changes

**Marker leak**
- `Gemma4ToolCallAdapter.Parse` scrubs orphan tool-response turn markers (`<|tool_response>` / `<tool_response|>`) from the accumulated plain text. Operates on non-block text only, so a marker inside a tool argument is untouched. Genuine preamble before a call is preserved (existing `TextBeforeCall` behaviour intact). This fixes **both** the OpenAI and Anthropic *non-streaming* paths (both route through `adapter.Parse`).
- OpenAI **streaming** (`WriteContentDelta`) and Anthropic **streaming** (`FlushTextDelta`) suppress trailing plain-text content once a tool call has been emitted, dropping the same leaked marker as a content delta/block. Preamble before the first call is unaffected.

**prompt_tokens**
- New `GenerateChunkKind.Usage` + `GenerateChunk.PromptTokens` field. `InferenceEngine` and `ContinuousBatchingEngine` emit one out-of-band `Usage` chunk carrying the already-computed prompt-token count (no re-tokenization).
- Endpoints capture it into `usage.prompt_tokens` (OpenAI) / `usage.input_tokens` (Anthropic) for non-streaming, plus the Anthropic streaming `message_delta`. Streaming OpenAI skips it (no usage object is emitted — OpenAI gates that behind `stream_options.include_usage`, unsupported here). All four endpoint loops skip it for output-token counting, so it never inflates `completion_tokens`/`output_tokens` or surfaces as content.

## Tests
- `ToolCallAdapterTests`: Gemma scrub units (trailing marker removed; genuine preamble kept).
- `ToolCallEndpointTests`: OpenAI non-streaming + streaming and Anthropic streaming marker-leak guards; OpenAI `prompt_tokens` + Anthropic `input_tokens` population. The Anthropic streaming test decodes + concatenates SSE `text_delta` payloads (the marker is JSON-escaped and split across deltas, so a raw substring match would miss it) — verified it fails without the guard.
- `InferenceEngineChunkTests`: asserts the engine emits exactly one `Usage` chunk with the prompt-token count.
- Full `SharpInference.Tests.Server` (118) + `SharpInference.Tests.Core` adapter (41) + engine chunk/prefix/concurrency/batching suites pass. Build clean under `TreatWarningsAsErrors`.

## Notes
- No perf-sensitive paths touched — the only runtime addition is one extra channel write per request (negligible).
- An internal `code-reviewer` pass caught the Anthropic-streaming gap (originally only OpenAI streaming was guarded); that's the second commit.

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
