### PR TITLE
fix(tokenizer,cuda): stop SmolLM2 CUDA crash on out-of-vocab whitespace tokens (#267)

### DIFF
--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -441,21 +441,29 @@ public sealed class GgufTokenizer : ITokenizer
             if ((uint)ids[i] >= (uint)VocabSize) { oob = i; break; }
         if (oob < 0) return ids; // common case: nothing to remap
 
+        // Last-resort id for a byte not found in the vocab. UnknownTokenId is normally 0 and
+        // in-vocab, but guard so a pathological model (unk = -1 or ≥ VocabSize) can't make the
+        // remap itself emit an out-of-range id — that would defeat the whole point.
+        int unk = (uint)UnknownTokenId < (uint)VocabSize ? UnknownTokenId : 0;
+
         var result = new List<int>(ids.Count + 4);
         for (int i = 0; i < ids.Count; i++)
         {
             int id = ids[i];
             if ((uint)id < (uint)VocabSize) { result.Add(id); continue; }
 
-            // Decode the offending token to its raw text, then re-map each UTF-8 byte to its
-            // single-byte GPT-2 vocab token (the base alphabet of a byte-level BPE — always
-            // in-vocab). Falls back to the unknown token if a byte somehow isn't present.
+            // Decode the offending token and map each GPT-2 byte-level char to its single-byte
+            // vocab token (the base alphabet of a byte-level BPE — always in-vocab). The two inner
+            // tokenizers decode differently (see Decode): CodeGenTokenizer returns clean UTF-8, so
+            // re-encode each byte to its GPT-2 char; the BpeTokenizer fallback already returns the
+            // GPT-2 byte-level form, so use it as-is (re-encoding would double-encode it).
             string piece = _inner.Decode(new[] { id }) ?? string.Empty;
-            foreach (char gpt2 in EncodeToGpt2Bytes(piece))
+            string gpt2 = _needsByteEncoding ? piece : EncodeToGpt2Bytes(piece);
+            foreach (char ch in gpt2)
             {
-                result.Add(_vocab.TryGetValue(gpt2.ToString(), out int byteId) && byteId < VocabSize
+                result.Add(_vocab.TryGetValue(ch.ToString(), out int byteId) && byteId < VocabSize
                     ? byteId
-                    : UnknownTokenId);
+                    : unk);
             }
         }
         return result;

--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -410,7 +410,7 @@ public sealed class GgufTokenizer : ITokenizer
 
         var ids = _inner.EncodeToIds(text);
 
-        if (ids.Count > 0) return ids;
+        if (ids.Count > 0) return RemapOutOfVocab(ids);
 
         var result = new List<int>(text.Length);
         foreach (char c in text)
@@ -419,6 +419,44 @@ public sealed class GgufTokenizer : ITokenizer
             char bpe = _needsByteEncoding ? c : EncodeByteToGpt2(c);
             if (_vocab.TryGetValue(bpe.ToString(), out int id))
                 result.Add(id);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Guarantees every emitted id is &lt; <see cref="VocabSize"/>, i.e. addressable in the
+    /// model's embedding table. <see cref="CodeGenTokenizer"/> injects model-independent
+    /// consecutive-whitespace tokens (ids beyond the supplied vocab — e.g. 2–8-space runs at
+    /// ids 49152+) that this GGUF has no embedding row for; feeding one to the GPU embedding
+    /// gather reads out of bounds and aborts the CUDA context with error 700 (issue #267), while
+    /// the CPU silently reads an adjacent tensor. Any such id is decomposed into its constituent
+    /// single-byte tokens (always present in a byte-level BPE vocab), so the whitespace is
+    /// preserved as in-vocab tokens rather than dropped. The fast path returns the input
+    /// unchanged when every id is already in range, so normal models pay only one scan.
+    /// </summary>
+    private IReadOnlyList<int> RemapOutOfVocab(IReadOnlyList<int> ids)
+    {
+        int oob = -1;
+        for (int i = 0; i < ids.Count; i++)
+            if ((uint)ids[i] >= (uint)VocabSize) { oob = i; break; }
+        if (oob < 0) return ids; // common case: nothing to remap
+
+        var result = new List<int>(ids.Count + 4);
+        for (int i = 0; i < ids.Count; i++)
+        {
+            int id = ids[i];
+            if ((uint)id < (uint)VocabSize) { result.Add(id); continue; }
+
+            // Decode the offending token to its raw text, then re-map each UTF-8 byte to its
+            // single-byte GPT-2 vocab token (the base alphabet of a byte-level BPE — always
+            // in-vocab). Falls back to the unknown token if a byte somehow isn't present.
+            string piece = _inner.Decode(new[] { id }) ?? string.Empty;
+            foreach (char gpt2 in EncodeToGpt2Bytes(piece))
+            {
+                result.Add(_vocab.TryGetValue(gpt2.ToString(), out int byteId) && byteId < VocabSize
+                    ? byteId
+                    : UnknownTokenId);
+            }
         }
         return result;
     }

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -4107,6 +4107,12 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         if (N == 0) return;
         if (positions.Length != N || caches.Length != N)
             throw new ArgumentException("tokens/positions/caches lengths must match.");
+        // Single choke point for batched decode + speculative verify (BatchForwardMulti /
+        // BatchVerify route here, and it dispatches to RunBatchedTrunkGemma4): a draft model
+        // with a mismatched vocab could hand an out-of-range token to the batched embed kernels,
+        // which would abort the CUDA context like the prefill path (issue #267).
+        for (int n = 0; n < N; n++)
+            EnsureTokenInVocab(tokens[n]);
 
         // Gemma 4 (issue #195): per-layer head_dim / SWA rings / shared-KV / k_eq_v / PLE /
         // sandwich norms / softcap need the dedicated batched decode. It leaves the same

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -3906,6 +3906,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 throw new ArgumentException(
                     $"Sequence {s}: startPos {startPos[s]} + chunk {chunks[s].Length} exceeds maxSeqLen {_maxSeqLen}.",
                     nameof(startPos));
+            // The packed-trunk path below embeds via batched kernels that never reach Forward's
+            // per-token guard, so validate token range up front here too (issue #267).
+            var span = chunks[s].Span;
+            for (int i = 0; i < span.Length; i++)
+                EnsureTokenInVocab(span[i]);
         }
 
         if (S >= 2 && IsDensePackablePrefill() && AllChunksPackable(chunks, startPos))

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -1456,9 +1456,27 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         return _lastArgmax;
     }
 
+    /// <summary>
+    /// Guards against a token id outside the model's embedding table (valid range
+    /// <c>0..VocabSize-1</c>). The GPU embedding gather kernels have no bounds check, so an
+    /// out-of-range id reads past the uploaded table and aborts the entire CUDA context with an
+    /// illegal-address error (700) — unrecoverable for the process. Surface it as a clear managed
+    /// exception instead (issue #267). The tokenizer normally guarantees in-range ids; this
+    /// catches a future tokenizer/model mismatch before it corrupts the context.
+    /// </summary>
+    private void EnsureTokenInVocab(int token)
+    {
+        if ((uint)token >= (uint)_hp.VocabSize)
+            throw new ArgumentOutOfRangeException(nameof(token), token,
+                $"Token id is outside the model vocabulary (0..{_hp.VocabSize - 1}); the GPU embedding " +
+                "gather would read out of bounds and abort the CUDA context. This indicates a " +
+                "tokenizer/model mismatch (issue #267).");
+    }
+
     /// <inheritdoc/>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
+        EnsureTokenInVocab(token);
         if (_isGemma4Like) return s_profile ? ForwardProfiledGemma4(token, position) : ForwardGemma4(token, position);
 
         if (s_profile) return ForwardProfiled(token, position);
@@ -2442,6 +2460,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             throw new ArgumentException("Token list is empty", nameof(tokens));
 
         int N = tokens.Count;
+        // Validate the whole prompt up front: the batched-trunk prefill path embeds via batched
+        // kernels that never reach Forward's per-token guard, so an out-of-range id would still
+        // abort the CUDA context there (issue #267).
+        for (int i = 0; i < N; i++)
+            EnsureTokenInVocab(tokens[i]);
         LastPrefillWasBatched = false;
 
         // Issue #142: pre-grow the dp4a Q8_1 input scratch to the widest decode

--- a/tests/SharpInference.Tests.Core/GgufTokenizerTests.cs
+++ b/tests/SharpInference.Tests.Core/GgufTokenizerTests.cs
@@ -75,6 +75,21 @@ public sealed class GgufTokenizerTests
     }
 
     [Fact]
+    public void Encode_IndentedCode_RoundTripsThroughDecode()
+    {
+        // Semantic guard for the #267 remap: the decomposed in-vocab tokens must still decode
+        // back to the original indented text. A remap that produced wrong-but-in-vocab ids would
+        // pass the in-range check but fail here.
+        var tokenizer = CreateTokenizer();
+        if (tokenizer is null) return;
+
+        var text = "    if (x) {\n        return 0;\n    }";
+        var ids = tokenizer.Encode(text);
+        Assert.All(ids, id => Assert.InRange(id, 0, tokenizer.VocabSize - 1));
+        Assert.Equal(text, tokenizer.Decode(ids));
+    }
+
+    [Fact]
     public void Encode_MultiSpaceRun_DecomposesToInVocabSpaceTokens()
     {
         // The 2–8-space CodeGenTokenizer tokens (ids 50280–50286) decompose into repeated

--- a/tests/SharpInference.Tests.Core/GgufTokenizerTests.cs
+++ b/tests/SharpInference.Tests.Core/GgufTokenizerTests.cs
@@ -51,6 +51,50 @@ public sealed class GgufTokenizerTests
     }
 
     [Fact]
+    public void Encode_IndentedCode_StaysWithinVocab()
+    {
+        // Issue #267: CodeGenTokenizer injects model-independent consecutive-whitespace tokens
+        // at ids beyond this GGUF's 49152-row embedding (e.g. an 8-space run → id 50280). Feeding
+        // one to the GPU embedding gather reads out of bounds and aborts the CUDA context (error
+        // 700). The tokenizer must decompose such tokens into in-vocab byte tokens so every id is
+        // addressable in the embedding table.
+        var tokenizer = CreateTokenizer();
+        if (tokenizer is null) return;
+
+        foreach (var text in new[]
+                 {
+                     "        private const int PageSize = 16;", // the original repro (8-space indent)
+                     "    if (x) {\n        return;\n    }",      // 4- and 8-space runs + newlines/tabs
+                     new string(' ', 8) + "x",
+                 })
+        {
+            var ids = tokenizer.Encode(text);
+            Assert.NotEmpty(ids);
+            Assert.All(ids, id => Assert.InRange(id, 0, tokenizer.VocabSize - 1));
+        }
+    }
+
+    [Fact]
+    public void Encode_MultiSpaceRun_DecomposesToInVocabSpaceTokens()
+    {
+        // The 2–8-space CodeGenTokenizer tokens (ids 50280–50286) decompose into repeated
+        // single-space in-vocab tokens (issue #267), preserving the whitespace rather than
+        // dropping it or emitting an unembeddable id.
+        var tokenizer = CreateTokenizer();
+        if (tokenizer is null) return;
+
+        // Encode N spaces followed by a sentinel and confirm the count of leading whitespace
+        // tokens scales with N and every id is in range.
+        var four = tokenizer.Encode(new string(' ', 4) + "X");
+        var eight = tokenizer.Encode(new string(' ', 8) + "X");
+        Assert.All(four, id => Assert.InRange(id, 0, tokenizer.VocabSize - 1));
+        Assert.All(eight, id => Assert.InRange(id, 0, tokenizer.VocabSize - 1));
+        // More spaces → at least as many tokens (decomposition is per-space).
+        Assert.True(eight.Count > four.Count,
+            $"expected more tokens for 8 spaces ({eight.Count}) than 4 ({four.Count})");
+    }
+
+    [Fact]
     public void Decode_RoundTrips_SimpleText()
     {
         var tokenizer = CreateTokenizer();


### PR DESCRIPTION
## Summary

Fixes #267 — the CUDA backend crashed with `error 700` (illegal address) during prefill on **SmolLM2-1.7B** whenever the prompt contained indented code (any multi-space run). CPU was unaffected.

## Root cause (confirmed empirically)

`Microsoft.ML.Tokenizers.CodeGenTokenizer` injects model-independent **consecutive-whitespace tokens at ids beyond the supplied vocab** — e.g. an 8-space run → id **50280**, but SmolLM2's `token_embd` has only **49152** rows (`[2048 × 49152]`, tied output). The out-of-range id reaches the GPU embedding-gather kernel, which has **no bounds check**, so it reads past the uploaded table and aborts the entire CUDA context (700). The CPU path silently reads an adjacent mmap'd tensor (garbage, but no fault) — which is exactly why CPU "worked" and produced plausible output.

Probe (pre-fix): `"  X"` → `[50286, 72]`, `"        X"` → `[50280, 72]` — ids 50280–50286 for 2–8 space runs, all ≥ 49152.

## Fix

1. **`GgufTokenizer` (primary):** `Encode` now guarantees every emitted id is `< VocabSize`. An out-of-vocab token is decomposed into its constituent **single-byte GPT-2 tokens** (the base alphabet of a byte-level BPE — always in-vocab), so the whitespace is preserved as embeddable tokens rather than dropped or crashing. The fast path returns the input unchanged when all ids are already in range, so unaffected models (Qwen/Gemma/Llama/etc.) pay only one O(n) scan **per Encode** (never per token), and SPM models bypass it entirely.
2. **`CudaForwardPass` (defensive):** `EnsureTokenInVocab` guards `Forward` (per-token), `Prefill`, and `PrefillPackedMulti` (multi-user packed prefill) so any future tokenizer/model mismatch surfaces as a clear `ArgumentOutOfRangeException` instead of an unrecoverable CUDA-context abort.

## Verification (RTX 4070 Ti, 12 GB)

- Original repro (indented C# line) now runs on **both `-g -1` and `-g 0`** with coherent output, no crash. Prefill ~279 t/s / decode ~267 t/s.
- A normal prompt is unaffected at full decode speed (~274 t/s) — the per-token guard is a single `uint` compare; **no perf regression**.
- CPU now produces the same coherent output (the silent OOB garbage-read is gone too).

## Tests
- `GgufTokenizerTests` (run against the real SmolLM2 model, skipped when absent): indented code + multi-space runs stay within vocab; multi-space runs decompose to repeated single-space tokens; **indented code round-trips through Encode/Decode** (semantic guard against a wrong-but-in-vocab remap).
- Full `SharpInference.Tests.Core` (147) passes; build clean under `TreatWarningsAsErrors`.
- An internal `code-reviewer` pass flagged a double-encode on the `BpeTokenizer` decode path, an unguarded multi-user packed-prefill path, and an unclamped UNK fallback — all addressed in the second commit.

Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
