### PR TITLE
feat(server): opt-in fast-reject for overlapping requests (#109)

### DIFF
--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -24,6 +24,12 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     if (int.TryParse(Environment.GetEnvironmentVariable("SHARPI_MAX_BATCH"), out int maxBatch) && maxBatch > 0)
         opts.MaxBatchSize = maxBatch;
 
+    // Fast-reject overlapping requests with HTTP 429 instead of serializing them on the
+    // single-user engine (issue #109). Set to 1 for a single-user server fronting an agentic
+    // client; unset keeps the legacy serialize-and-queue behaviour.
+    if (int.TryParse(Environment.GetEnvironmentVariable("SHARPI_MAX_CONCURRENT"), out int maxConcurrent) && maxConcurrent > 0)
+        opts.MaxConcurrentRequests = maxConcurrent;
+
     // Continuous-batching scheduling knobs (issue #183): prefill chunk size (Gap 1)
     // and KV admission budget in MiB (Gap 3). Same precedence as SHARPI_MAX_BATCH.
     if (int.TryParse(Environment.GetEnvironmentVariable("SHARPI_PREFILL_CHUNK"), out int prefillChunk) && prefillChunk >= 0)

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -15,7 +15,7 @@ public static class AnthropicEndpoints
 {
     public static IEndpointRouteBuilder MapAnthropicEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/v1/messages", HandleMessages);
+        app.MapPost("/v1/messages", HandleMessages).WithConcurrencyLimit();
         return app;
     }
 

--- a/src/SharpInference.Server/Endpoints/ConcurrencyLimit.cs
+++ b/src/SharpInference.Server/Endpoints/ConcurrencyLimit.cs
@@ -12,7 +12,7 @@ namespace SharpInference.Server.Endpoints;
 /// <see cref="SharpInferenceServerOptions.MaxConcurrentRequests"/> is set, this caps the number
 /// of in-flight generation requests and the endpoints fast-reject the overflow with HTTP 429.
 /// </summary>
-internal sealed class RequestConcurrencyGate
+internal sealed class RequestConcurrencyGate : IDisposable
 {
     private readonly SemaphoreSlim? _sem;
 
@@ -30,10 +30,15 @@ internal sealed class RequestConcurrencyGate
     /// <summary>Whether admission control is active. When false the gate is a pure passthrough.</summary>
     public bool Enabled => _sem is not null;
 
-    /// <summary>Non-blocking acquire — returns false immediately when at capacity (no queuing).</summary>
-    public bool TryEnter() => _sem!.Wait(0);
+    /// <summary>Non-blocking acquire — returns false immediately when at capacity (no queuing).
+    /// A no-op (returns true) when disabled, so callers don't have to special-case it.</summary>
+    public bool TryEnter() => _sem?.Wait(0) ?? true;
 
-    public void Exit() => _sem!.Release();
+    public void Exit() => _sem?.Release();
+
+    /// <summary>Disposes the underlying semaphore on host shutdown (the DI container disposes
+    /// this singleton).</summary>
+    public void Dispose() => _sem?.Dispose();
 }
 
 /// <summary>
@@ -54,13 +59,29 @@ internal static class ConcurrencyLimitExtensions
             if (!gate.TryEnter())
                 return BusyResult(ctx.HttpContext, gate.Limit);
 
+            // Today the generation handlers write to the response and return a bare Task, so
+            // `await next(ctx)` completes only after the (possibly streaming) response is fully
+            // written — the slot is correctly held for the whole request and released below.
+            // But if a handler is ever refactored to RETURN an IResult (e.g. TypedResults.Stream),
+            // `next(ctx)` would complete as soon as the result is constructed, before it executes
+            // — releasing the slot mid-stream and breaking the limit. Hand any returned IResult to
+            // a decorator that releases only after it has finished executing, so the gate stays
+            // correct regardless of handler shape.
+            bool releaseHere = true;
             try
             {
-                return await next(ctx);
+                var result = await next(ctx);
+                if (result is IResult inner)
+                {
+                    releaseHere = false;
+                    return new GateReleasingResult(inner, gate);
+                }
+                return result;
             }
             finally
             {
-                gate.Exit();
+                if (releaseHere)
+                    gate.Exit();
             }
         });
 
@@ -75,5 +96,22 @@ internal static class ConcurrencyLimitExtensions
             "or start the server with SHARPI_MAX_BATCH>1 to enable continuous batching for concurrent requests.");
         return TypedResults.Json(error, SharpInferenceJsonContext.Default.ErrorResponse,
             statusCode: StatusCodes.Status429TooManyRequests);
+    }
+
+    /// <summary>Releases the admission slot only after the wrapped result has finished executing
+    /// (i.e. after a streaming response is fully written), even if execution throws.</summary>
+    private sealed class GateReleasingResult(IResult inner, RequestConcurrencyGate gate) : IResult
+    {
+        public async Task ExecuteAsync(HttpContext httpContext)
+        {
+            try
+            {
+                await inner.ExecuteAsync(httpContext);
+            }
+            finally
+            {
+                gate.Exit();
+            }
+        }
     }
 }

--- a/src/SharpInference.Server/Endpoints/ConcurrencyLimit.cs
+++ b/src/SharpInference.Server/Endpoints/ConcurrencyLimit.cs
@@ -59,29 +59,21 @@ internal static class ConcurrencyLimitExtensions
             if (!gate.TryEnter())
                 return BusyResult(ctx.HttpContext, gate.Limit);
 
-            // Today the generation handlers write to the response and return a bare Task, so
-            // `await next(ctx)` completes only after the (possibly streaming) response is fully
-            // written — the slot is correctly held for the whole request and released below.
-            // But if a handler is ever refactored to RETURN an IResult (e.g. TypedResults.Stream),
-            // `next(ctx)` would complete as soon as the result is constructed, before it executes
-            // — releasing the slot mid-stream and breaking the limit. Hand any returned IResult to
-            // a decorator that releases only after it has finished executing, so the gate stays
-            // correct regardless of handler shape.
-            bool releaseHere = true;
+            // The gated generation handlers write the response and return a bare Task (they do
+            // not return an IResult), so `await next(ctx)` completes only after the response —
+            // including a streaming SSE body — is fully written. The finally then releases the
+            // slot exactly once on every path: normal completion, an exception out of next(), or
+            // a mid-stream client abort (which the streaming handlers catch and return from
+            // normally). A future handler that instead RETURNS an IResult would release the slot
+            // before the result executes — revisit this (e.g. release via Response.OnCompleted)
+            // if that ever changes.
             try
             {
-                var result = await next(ctx);
-                if (result is IResult inner)
-                {
-                    releaseHere = false;
-                    return new GateReleasingResult(inner, gate);
-                }
-                return result;
+                return await next(ctx);
             }
             finally
             {
-                if (releaseHere)
-                    gate.Exit();
+                gate.Exit();
             }
         });
 
@@ -96,22 +88,5 @@ internal static class ConcurrencyLimitExtensions
             "or start the server with SHARPI_MAX_BATCH>1 to enable continuous batching for concurrent requests.");
         return TypedResults.Json(error, SharpInferenceJsonContext.Default.ErrorResponse,
             statusCode: StatusCodes.Status429TooManyRequests);
-    }
-
-    /// <summary>Releases the admission slot only after the wrapped result has finished executing
-    /// (i.e. after a streaming response is fully written), even if execution throws.</summary>
-    private sealed class GateReleasingResult(IResult inner, RequestConcurrencyGate gate) : IResult
-    {
-        public async Task ExecuteAsync(HttpContext httpContext)
-        {
-            try
-            {
-                await inner.ExecuteAsync(httpContext);
-            }
-            finally
-            {
-                gate.Exit();
-            }
-        }
     }
 }

--- a/src/SharpInference.Server/Endpoints/ConcurrencyLimit.cs
+++ b/src/SharpInference.Server/Endpoints/ConcurrencyLimit.cs
@@ -1,0 +1,79 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SharpInference.Server.Endpoints;
+
+/// <summary>
+/// Process-wide admission gate for generation requests (issue #109). The single-user
+/// <see cref="SharpInference.Engine.InferenceEngine"/> serializes overlapping requests on an
+/// internal lock, so without this gate a concurrent request silently blocks for the full
+/// duration of the in-flight one — an agentic client reads that as an indefinite hang. When
+/// <see cref="SharpInferenceServerOptions.MaxConcurrentRequests"/> is set, this caps the number
+/// of in-flight generation requests and the endpoints fast-reject the overflow with HTTP 429.
+/// </summary>
+internal sealed class RequestConcurrencyGate
+{
+    private readonly SemaphoreSlim? _sem;
+
+    /// <summary>Configured ceiling (0 when disabled).</summary>
+    public int Limit { get; }
+
+    public RequestConcurrencyGate(int? maxConcurrent)
+    {
+        // A non-positive limit is treated as "disabled" rather than "reject everything", which
+        // would wedge the server — the only sensible interpretation of 0/negative here.
+        Limit = maxConcurrent.GetValueOrDefault();
+        _sem = Limit > 0 ? new SemaphoreSlim(Limit, Limit) : null;
+    }
+
+    /// <summary>Whether admission control is active. When false the gate is a pure passthrough.</summary>
+    public bool Enabled => _sem is not null;
+
+    /// <summary>Non-blocking acquire — returns false immediately when at capacity (no queuing).</summary>
+    public bool TryEnter() => _sem!.Wait(0);
+
+    public void Exit() => _sem!.Release();
+}
+
+/// <summary>
+/// Wires <see cref="RequestConcurrencyGate"/> onto a generation endpoint as an endpoint filter.
+/// The filter brackets the entire request (including a streaming response, since the handler's
+/// Task completes only when the stream is fully written), so the slot is held for the request's
+/// whole lifetime and released in a finally.
+/// </summary>
+internal static class ConcurrencyLimitExtensions
+{
+    public static RouteHandlerBuilder WithConcurrencyLimit(this RouteHandlerBuilder builder) =>
+        builder.AddEndpointFilter(async (ctx, next) =>
+        {
+            var gate = ctx.HttpContext.RequestServices.GetRequiredService<RequestConcurrencyGate>();
+            if (!gate.Enabled)
+                return await next(ctx);
+
+            if (!gate.TryEnter())
+                return BusyResult(ctx.HttpContext, gate.Limit);
+
+            try
+            {
+                return await next(ctx);
+            }
+            finally
+            {
+                gate.Exit();
+            }
+        });
+
+    private static IResult BusyResult(HttpContext http, int limit)
+    {
+        // Set the advisory header before returning — the result executes (and starts the
+        // response) afterwards, so the header is still mutable here.
+        http.Response.Headers.RetryAfter = "1";
+        var error = new ErrorResponse(
+            "rate_limit_error",
+            $"The inference engine is at capacity (max {limit} concurrent request(s)). Retry shortly, " +
+            "or start the server with SHARPI_MAX_BATCH>1 to enable continuous batching for concurrent requests.");
+        return TypedResults.Json(error, SharpInferenceJsonContext.Default.ErrorResponse,
+            statusCode: StatusCodes.Status429TooManyRequests);
+    }
+}

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -16,7 +16,7 @@ public static class OpenAiEndpoints
 {
     public static IEndpointRouteBuilder MapOpenAiEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/v1/chat/completions", HandleChatCompletion);
+        app.MapPost("/v1/chat/completions", HandleChatCompletion).WithConcurrencyLimit();
         app.MapGet("/v1/models", HandleListModels);
         return app;
     }

--- a/src/SharpInference.Server/Endpoints/ResponsesEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/ResponsesEndpoints.cs
@@ -17,7 +17,7 @@ public static class ResponsesEndpoints
 {
     public static IEndpointRouteBuilder MapResponsesEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/v1/responses", HandleCreateResponse);
+        app.MapPost("/v1/responses", HandleCreateResponse).WithConcurrencyLimit();
         return app;
     }
 

--- a/src/SharpInference.Server/ServiceCollectionExtensions.cs
+++ b/src/SharpInference.Server/ServiceCollectionExtensions.cs
@@ -38,6 +38,13 @@ public static class ServiceCollectionExtensions
         // TryAdd: a test or downstream module may already have registered a fake/replacement
         // for any of these services. We never overwrite an existing registration here.
         services.TryAddSingleton<ServerMetrics>();
+
+        // Request admission gate (issue #109). Resolved lazily so the options object is fully
+        // bound (config + the host's inline Configure, which runs after AddSharpInference) by
+        // the time the first request constructs it. Disabled (passthrough) unless
+        // MaxConcurrentRequests is set.
+        services.TryAddSingleton(sp => new Endpoints.RequestConcurrencyGate(
+            sp.GetRequiredService<IOptions<SharpInferenceServerOptions>>().Value.MaxConcurrentRequests));
         services.TryAddSingleton<ChatTemplateRenderer>(sp =>
         {
             var opts = sp.GetRequiredService<IOptions<SharpInferenceServerOptions>>().Value;

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -118,6 +118,20 @@ public sealed class SharpInferenceServerOptions
     public int MaxBatchSize { get; set; } = 1;
 
     /// <summary>
+    /// Maximum number of generation requests allowed in flight at once before the server
+    /// fast-rejects with HTTP 429 (issue #109). <c>null</c> (default) keeps the legacy
+    /// behaviour: the single-user <see cref="InferenceEngine"/> serializes overlapping
+    /// requests on an internal gate, so a concurrent request silently blocks for the full
+    /// duration of the in-flight one — which an agentic client (e.g. Claude Code firing
+    /// near-simultaneous requests) experiences as an unbounded hang. Set to <c>1</c> to make
+    /// the single-user limit explicit: overlapping requests get an immediate 429 pointing at
+    /// <c>SHARPI_MAX_BATCH</c> instead of queuing. Leave unset (or use a value matching
+    /// <see cref="MaxBatchSize"/>) when running <see cref="ContinuousBatchingEngine"/>, which
+    /// serves concurrency itself. Mirrors <c>SHARPI_MAX_CONCURRENT</c>.
+    /// </summary>
+    public int? MaxConcurrentRequests { get; set; }
+
+    /// <summary>
     /// Prompt tokens prefilled per batcher iteration under continuous batching
     /// (issue #183 Gap 1). Active sequences advance one decode step between chunks, so
     /// a long inbound prompt no longer freezes every in-flight generation. <c>0</c>

--- a/tests/SharpInference.Tests.Server/ConcurrencyLimitTests.cs
+++ b/tests/SharpInference.Tests.Server/ConcurrencyLimitTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SharpInference.Engine;
+using SharpInference.Server;
+
+namespace SharpInference.Tests.Server;
+
+/// <summary>
+/// Issue #109: when <see cref="SharpInferenceServerOptions.MaxConcurrentRequests"/> is set, the
+/// server fast-rejects overlapping generation requests with HTTP 429 instead of silently
+/// serializing them on the single-user engine (which an agentic client reads as a hang). When
+/// unset, the legacy passthrough behaviour is preserved.
+/// </summary>
+public sealed class ConcurrencyLimitTests
+{
+    private static HttpClient CreateClient(FakeInferenceEngine fake, int? maxConcurrent) =>
+        new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(b => b.ConfigureServices(s =>
+            {
+                s.Configure<SharpInferenceServerOptions>(o => o.MaxConcurrentRequests = maxConcurrent);
+                s.AddSingleton<IInferenceEngine>(fake);
+            }))
+            .CreateClient();
+
+    private static object ChatRequest() => new
+    {
+        model = "test-model",
+        messages = new[] { new { role = "user", content = "hi" } },
+        max_tokens = 5,
+        stream = false,
+    };
+
+    [Fact]
+    public async Task MaxConcurrent1_OverlappingRequest_Rejected429()
+    {
+        var fake = new FakeInferenceEngine("test-model") { Hold = new TaskCompletionSource() };
+        var client = CreateClient(fake, maxConcurrent: 1);
+
+        // Request A enters the engine and blocks (holding the single admission slot).
+        var aTask = client.PostAsJsonAsync("/v1/chat/completions", ChatRequest());
+        Assert.True(fake.Entered.Wait(TimeSpan.FromSeconds(5)), "Request A never reached the engine.");
+
+        // Request B overlaps A → must be fast-rejected with 429 (it never reaches the engine).
+        var bResp = await client.PostAsJsonAsync("/v1/chat/completions", ChatRequest());
+        Assert.Equal(HttpStatusCode.TooManyRequests, bResp.StatusCode);
+        Assert.True(bResp.Headers.Contains("Retry-After"));
+        var body = await bResp.Content.ReadAsStringAsync();
+        Assert.Contains("SHARPI_MAX_BATCH", body);
+
+        // Release A; it completes normally, and the slot frees for a subsequent request.
+        fake.Hold!.SetResult();
+        var aResp = await aTask;
+        Assert.Equal(HttpStatusCode.OK, aResp.StatusCode);
+
+        var cResp = await client.PostAsJsonAsync("/v1/chat/completions", ChatRequest());
+        Assert.Equal(HttpStatusCode.OK, cResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unset_OverlappingRequests_BothSucceed_NoRejection()
+    {
+        // Default (no limit): the gate is a passthrough — overlapping requests are not rejected.
+        var fake = new FakeInferenceEngine("test-model") { Hold = new TaskCompletionSource() };
+        var client = CreateClient(fake, maxConcurrent: null);
+
+        var aTask = client.PostAsJsonAsync("/v1/chat/completions", ChatRequest());
+        var bTask = client.PostAsJsonAsync("/v1/chat/completions", ChatRequest());
+        Assert.True(fake.Entered.Wait(TimeSpan.FromSeconds(5)), "No request reached the engine.");
+
+        // Both requests are in flight against the (un-gated) engine; release and confirm neither
+        // was rejected.
+        fake.Hold!.SetResult();
+        var responses = await Task.WhenAll(aTask, bTask);
+        Assert.All(responses, r => Assert.Equal(HttpStatusCode.OK, r.StatusCode));
+    }
+
+    [Fact]
+    public async Task MaxConcurrent1_NonGenerationEndpoints_NotGated()
+    {
+        // /v1/models and /health must stay reachable even while a generation request holds the slot.
+        var fake = new FakeInferenceEngine("test-model") { Hold = new TaskCompletionSource() };
+        var client = CreateClient(fake, maxConcurrent: 1);
+
+        var aTask = client.PostAsJsonAsync("/v1/chat/completions", ChatRequest());
+        Assert.True(fake.Entered.Wait(TimeSpan.FromSeconds(5)), "Request A never reached the engine.");
+
+        var models = await client.GetAsync("/v1/models");
+        Assert.Equal(HttpStatusCode.OK, models.StatusCode);
+        var health = await client.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.OK, health.StatusCode);
+
+        fake.Hold!.SetResult();
+        Assert.Equal(HttpStatusCode.OK, (await aTask).StatusCode);
+    }
+}

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -1149,6 +1149,16 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
     public int PromptTokens { get; init; }
 
     /// <summary>
+    /// When set, generation blocks until this task completes — lets a test hold one request
+    /// in flight to exercise the concurrency-limit gate (issue #109).
+    /// </summary>
+    public TaskCompletionSource? Hold { get; init; }
+
+    /// <summary>Signaled when a generation call has started (and, if <see cref="Hold"/> is set,
+    /// is about to block) — so a test knows the first request is genuinely in flight.</summary>
+    public readonly ManualResetEventSlim Entered = new();
+
+    /// <summary>
     /// Captures the <see cref="SamplingParams"/> handed to the most recent
     /// <see cref="GenerateChunksAsync"/> call. Lets wire-level tests confirm that request
     /// fields (e.g. <c>thinking.budget_tokens</c>, <c>max_thinking_tokens</c>) reach the
@@ -1192,6 +1202,9 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
         LastSamplingParams = sp;
         LastCanonicalHistoryPrefix = canonicalHistoryPrefix;
         LastPrompt = prompt;
+        Entered.Set();
+        if (Hold is not null)
+            await Hold.Task.WaitAsync(ct);
         if (PromptTokens > 0)
             yield return new GenerateChunk(GenerateChunkKind.Usage, "", PromptTokens);
         foreach (var (kind, text) in _script)


### PR DESCRIPTION
## Summary

Resolves #109 by adding the issue's explicitly-requested second guard for the single-user engine: **opt-in fast-rejection of overlapping requests with HTTP 429**, pointing at `SHARPI_MAX_BATCH`.

### Background

The single-user `InferenceEngine` already serializes overlapping requests on an internal gate (the deadlock/corruption fix in `4033f0c`, plus the dispose-drain in #132 — all with passing regression tests). That is *correct*, but for an agentic client firing near-simultaneous requests (the issue's exact scenario — Claude Code), a concurrent request silently blocks for the full duration of the in-flight one, which reads as an indefinite hang with `active_requests` pinned at 1.

The issue listed two guard options — "serialize **or** reject/409." The serialize path exists; this PR adds the reject path as **opt-in**.

### Changes

- **`SharpInferenceServerOptions.MaxConcurrentRequests`** (`int?`, default `null`; env `SHARPI_MAX_CONCURRENT`). Unset = legacy serialize-and-queue (unchanged). Set to `1` to make the single-user limit explicit.
- **`RequestConcurrencyGate`** — a `SemaphoreSlim` wrapper with non-blocking `TryEnter()`, registered as a lazily-resolved DI singleton (disabled/passthrough when the option is unset).
- **`WithConcurrencyLimit()` endpoint filter** applied to the three generation endpoints (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`). Overflow → `429` + `Retry-After` + a message pointing at `SHARPI_MAX_BATCH`, via `TypedResults.Json` (source-gen, AOT-safe). The filter brackets the whole request — including a streaming SSE response, since `await next()` completes only when the handler's Task finishes — and releases the slot in a `finally`. `/v1/models`, `/health`, `/metrics` stay ungated.
- Host maps `SHARPI_MAX_CONCURRENT` → the option.

### Why opt-in

Default-`null` keeps the exact current behavior, so existing deployments (and `ContinuousBatchingEngine`, which serves concurrency itself) are unaffected. An operator running single-user behind an agentic client sets one flag to turn the looks-like-hang into an immediate, actionable signal.

### Tests / verification

- New `ConcurrencyLimitTests`: 429-on-overflow (+ slot frees afterward), passthrough-when-unset (overlapping requests both succeed), and non-generation endpoints staying reachable while a slot is held.
- Full `SharpInference.Tests.Server` (121) passes; Release build clean under `TreatWarningsAsErrors`; **NativeAOT publish succeeds** (the host is AOT-published).
- The pre-existing engine-level concurrency/deadlock regression tests (`InferenceEngineConcurrencyTests`, 6) still pass — this PR is additive and doesn't touch the engine serialization.

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
