### PR TITLE
feat(cli,server): llama.cpp --cpu-moe flag + server CpuMoe option (#80, #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ MoE expert-cache knobs (`--moe-warmpin`, `--moe-warmpin-after`, `--no-moe-predic
 `--expert-stats`) are CLI-only; the server reads the equivalent `SHARPI_MOE_WARMPIN*`,
 `SHARPI_MOE_PREDICT_PREFETCH=0`, `SHARPI_EXPERT_STATS=<path>` env vars.
 
+MoE expert *placement* matches llama.cpp: `--cpu-moe` (alias `--cmoe`) keeps **all** routed
+experts on the CPU, equivalent to `SHARPI_CPU_MOE=1` (omit for VRAM-fit auto-select;
+`SHARPI_CPU_MOE=0` forces the on-GPU SLRU cache). On the server set `SharpInference:CpuMoe`
+(`true`/`false`) in `appsettings.json`, or export `SHARPI_CPU_MOE` directly. llama.cpp's
+`--n-cpu-moe` (per-layer split) is **not yet supported** — SharpInference's override is
+all-or-nothing, so the flag is recognized but errors with that rationale rather than silently
+behaving like `--cpu-moe`. The llama.cpp single-dash short forms `-cmoe`/`-ncmoe` aren't
+available because Spectre.Console requires single-dash options to be one character; the
+double-dash `--cmoe`/`--ncmoe` aliases stand in.
+
 ### SnapKV (prefill-time KV eviction, issue #51)
 
 On CPU, CUDA (dense + hybrid GDN), and Vulkan. After prefill it scores each prompt position by softmaxed

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -202,6 +202,48 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [CommandOption("--expert-stats")]
         [Description("MoE: write GPU expert-cache (SLRU) hit-rate stats to this file on exit. Env: SHARPI_EXPERT_STATS.")]
         public string? ExpertStatsPath { get; init; }
+
+        // ── MoE expert placement (CPU vs GPU), issue #80. Wraps the existing all-or-nothing
+        // SHARPI_CPU_MOE override the engine reads at forward-pass construction.
+        [CommandOption("--cpu-moe|--cmoe")]
+        [Description("MoE: keep ALL routed expert weights on the CPU (llama.cpp --cpu-moe). Sets SHARPI_CPU_MOE=1, overriding the VRAM-fit auto-select; SHARPI_CPU_MOE=0 in the env still forces on-GPU experts. Alias --cmoe (llama.cpp's single-dash -cmoe isn't representable: Spectre short options must be one character).")]
+        [DefaultValue(false)]
+        public bool CpuMoe { get; init; }
+
+        [CommandOption("--n-cpu-moe|--ncmoe <N>")]
+        [Description("MoE: keep the routed experts of N layers on the CPU (llama.cpp --n-cpu-moe). DEFERRED / not yet supported — SharpInference's expert placement is all-or-nothing (no per-layer split in the engine), so passing any value errors with that rationale. Use --cpu-moe (all on CPU) or omit (auto).")]
+        public int? NCpuMoe { get; init; }
+    }
+
+    /// <summary>
+    /// Translates the llama.cpp-style MoE placement flags (<c>--cpu-moe</c> / <c>--n-cpu-moe</c>,
+    /// issue #80) into the <c>SHARPI_CPU_MOE</c> override the engine reads when it builds the
+    /// hybrid forward pass. <paramref name="cpuMoe"/> forces every routed expert onto the CPU
+    /// (equivalent to <c>SHARPI_CPU_MOE=1</c> and the server's <c>CpuMoe=true</c>, issue #93); an
+    /// explicit flag wins over an inherited env var, and its absence leaves the env (hence the
+    /// engine's VRAM-fit auto-select) untouched. <paramref name="nCpuMoe"/> (partial per-layer
+    /// placement) is <b>deferred</b>: the engine override is all-or-nothing, so any value is
+    /// rejected via <paramref name="error"/>. Returns <c>false</c> (with <paramref name="error"/>
+    /// set) when the caller should abort; the env side effect mirrors <see cref="GpuDevice.Resolve"/>.
+    /// </summary>
+    internal static bool TryApplyCpuMoeFlags(bool cpuMoe, int? nCpuMoe, out string? error)
+    {
+        if (nCpuMoe is int n)
+        {
+            error =
+                $"--n-cpu-moe/--ncmoe ({n}) is not supported yet: SharpInference places routed MoE " +
+                "experts all-or-nothing (the SHARPI_CPU_MOE override the engine reads has no per-layer " +
+                "granularity), so a partial per-layer split can't be honored. Use --cpu-moe to keep all " +
+                "routed experts on the CPU, or omit it to let VRAM fit auto-select (SHARPI_CPU_MOE=0 " +
+                "forces on-GPU experts). Tracked in issue #80.";
+            return false;
+        }
+
+        if (cpuMoe)
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+
+        error = null;
+        return true;
     }
 
     protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
@@ -260,6 +302,15 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             Environment.SetEnvironmentVariable("SHARPI_MOE_WARMPIN_AFTER", settings.MoeWarmPinAfter.ToString());
         if (settings.NoMoePredictPrefetch)
             Environment.SetEnvironmentVariable("SHARPI_MOE_PREDICT_PREFETCH", "0");
+
+        // MoE expert placement (#80): --cpu-moe sets SHARPI_CPU_MOE=1; --n-cpu-moe is deferred
+        // (the engine override is all-or-nothing) and fails fast with the rationale. Done here,
+        // before any forward pass is built, so the engine constructor sees the override.
+        if (!TryApplyCpuMoeFlags(settings.CpuMoe, settings.NCpuMoe, out string? cpuMoeError))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(cpuMoeError!)}");
+            return 1;
+        }
 
         // KV-cache dtype (issue #179): surface SHARPI_KV_DTYPE as a flag. Set before
         // any forward pass is built so an explicit flag overrides; env-only use still

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -343,9 +343,10 @@ public static class InferenceEngineLoader
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Sets the SHARPI_MOE_* environment variables from the options object so the engine's
-    /// MoE-cache code picks them up at construction time. The engine code reads these
-    /// once per backend instance, so we have to do this BEFORE the backend is built.
+    /// Sets the MoE-related environment variables (SHARPI_MOE_* cache knobs plus the
+    /// SHARPI_CPU_MOE placement override, issue #93) from the options object so the engine's
+    /// MoE code picks them up at construction time. The engine reads these once per backend
+    /// instance, so we have to do this BEFORE the backend is built.
     /// </summary>
     private static void ApplyMoeEnvironment(SharpInferenceServerOptions opts)
     {
@@ -357,6 +358,13 @@ public static class InferenceEngineLoader
             Environment.SetEnvironmentVariable("SHARPI_MOE_PREDICT_PREFETCH", "0");
         if (!string.IsNullOrEmpty(opts.ExpertStatsPath))
             Environment.SetEnvironmentVariable("SHARPI_EXPERT_STATS", opts.ExpertStatsPath);
+
+        // CPU-MoE placement (issue #93, mirrors the CLI's --cpu-moe issue #80). The hybrid
+        // forward passes read SHARPI_CPU_MOE once at construction, so write it before load.
+        // Nullable: only an explicit option writes — null leaves any externally-set value (and
+        // the engine's VRAM-fit auto-select) untouched.
+        if (opts.CpuMoe is bool cpuMoe)
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", cpuMoe ? "1" : "0");
     }
 
     /// <summary>

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -195,6 +195,19 @@ public sealed class SharpInferenceServerOptions
     /// </summary>
     public string? ExpertStatsPath { get; set; }
 
+    /// <summary>
+    /// Force all routed MoE experts onto the CPU side — the engine's all-or-nothing
+    /// <c>SHARPI_CPU_MOE</c> override, read by <see cref="CudaHybridGdnForwardPass"/> and
+    /// <see cref="CudaHybridForwardPass"/> at construction. Server analogue of the CLI's
+    /// <c>--cpu-moe</c> (issue #80 / #93). <c>true</c> → <c>SHARPI_CPU_MOE=1</c> (all routed
+    /// experts on CPU; e.g. the <c>Qwen3.6-35B-A3B-MTP</c> hybrid only reaches its headline
+    /// decode rate this way). <c>false</c> → <c>SHARPI_CPU_MOE=0</c> (force the on-GPU SLRU
+    /// expert cache). <c>null</c> (default) writes nothing, preserving the engine's VRAM-fit
+    /// auto-select and any <c>SHARPI_CPU_MOE</c> already set in the process environment. Has
+    /// effect only on the CUDA hybrid MoE paths; ignored by CPU/Vulkan and non-MoE models.
+    /// </summary>
+    public bool? CpuMoe { get; set; }
+
     // ── Speculative decoding defaults ────────────────────────────────────────
 
     /// <summary>

--- a/tests/SharpInference.Tests.Cli/CpuMoeFlagsTests.cs
+++ b/tests/SharpInference.Tests.Cli/CpuMoeFlagsTests.cs
@@ -1,0 +1,82 @@
+using SharpInference.Cli;
+
+namespace SharpInference.Tests.Cli;
+
+/// <summary>
+/// Unit tests for <see cref="RunCommand.TryApplyCpuMoeFlags"/> — the llama.cpp-style MoE
+/// placement flags (<c>--cpu-moe</c> / <c>--n-cpu-moe</c>, issue #80). Each test starts from a
+/// cleared <c>SHARPI_CPU_MOE</c> (restored on dispose) so the env-var side effect is
+/// deterministic. xunit.runner.json disables collection parallelism, so these env-mutating
+/// tests never run concurrently with each other.
+/// </summary>
+public sealed class CpuMoeFlagsTests : IDisposable
+{
+    private const string Var = "SHARPI_CPU_MOE";
+    private readonly string? _saved;
+
+    public CpuMoeFlagsTests()
+    {
+        _saved = Environment.GetEnvironmentVariable(Var);
+        Environment.SetEnvironmentVariable(Var, null);
+    }
+
+    public void Dispose() => Environment.SetEnvironmentVariable(Var, _saved);
+
+    [Fact]
+    public void CpuMoe_True_SetsEnvToOne()
+    {
+        bool ok = RunCommand.TryApplyCpuMoeFlags(cpuMoe: true, nCpuMoe: null, out string? error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal("1", Environment.GetEnvironmentVariable(Var));
+    }
+
+    [Fact]
+    public void CpuMoe_True_OverridesInheritedEnv()
+    {
+        Environment.SetEnvironmentVariable(Var, "0"); // operator had forced GPU experts
+        bool ok = RunCommand.TryApplyCpuMoeFlags(cpuMoe: true, nCpuMoe: null, out _);
+
+        Assert.True(ok);
+        Assert.Equal("1", Environment.GetEnvironmentVariable(Var)); // explicit flag wins
+    }
+
+    [Fact]
+    public void Defaults_LeaveEnvUntouched()
+    {
+        Environment.SetEnvironmentVariable(Var, "preexisting"); // e.g. SHARPI_CPU_MOE in the shell
+        bool ok = RunCommand.TryApplyCpuMoeFlags(cpuMoe: false, nCpuMoe: null, out string? error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal("preexisting", Environment.GetEnvironmentVariable(Var)); // no write → auto-select preserved
+    }
+
+    [Theory]
+    [InlineData(20)]   // partial split
+    [InlineData(0)]    // even the no-op count is rejected — the feature isn't implemented
+    [InlineData(-1)]
+    public void NCpuMoe_Provided_IsDeferredWithError(int n)
+    {
+        Environment.SetEnvironmentVariable(Var, "preexisting");
+        bool ok = RunCommand.TryApplyCpuMoeFlags(cpuMoe: false, nCpuMoe: n, out string? error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+        Assert.Contains("--cpu-moe", error);   // points at the supported all-or-nothing flag
+        Assert.Contains("#80", error);          // rationale references the tracking issue
+        Assert.Equal("preexisting", Environment.GetEnvironmentVariable(Var)); // rejected → no env write
+    }
+
+    [Fact]
+    public void NCpuMoe_TakesPrecedenceOverCpuMoe()
+    {
+        // Both flags passed: the unsupported one must be reported rather than silently honoring --cpu-moe.
+        bool ok = RunCommand.TryApplyCpuMoeFlags(cpuMoe: true, nCpuMoe: 4, out string? error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+        Assert.Null(Environment.GetEnvironmentVariable(Var)); // nothing written
+    }
+}

--- a/tests/SharpInference.Tests.Server/ServerLibraryTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerLibraryTests.cs
@@ -39,11 +39,12 @@ public sealed class SharpInferenceServerOptionsTests
         Assert.Null(opts.KvType);            // fp32 KV unless explicitly narrowed (#179)
         Assert.Equal(0, opts.MinBatchBlas);
 
-        // MoE knob defaults: predictive prefetch on, nothing pinned.
+        // MoE knob defaults: predictive prefetch on, nothing pinned, placement auto-selected.
         Assert.Null(opts.MoeWarmPin);
         Assert.Equal(0L, opts.MoeWarmPinAfter);
         Assert.True(opts.MoePredictPrefetch);
         Assert.Null(opts.ExpertStatsPath);
+        Assert.Null(opts.CpuMoe);            // null = engine VRAM-fit auto-select (#93)
 
         // Spec-decode defaults: auto-engage MTP when supported, strict argmax-match.
         Assert.Equal(ServerSpecType.Auto, opts.SpecType);
@@ -105,6 +106,7 @@ public sealed class OptionsConfigurationBindingTests
             ["SharpInference:MoeWarmPinAfter"]     = "1024",
             ["SharpInference:MoePredictPrefetch"]  = "false",
             ["SharpInference:ExpertStatsPath"]     = "/tmp/stats.json",
+            ["SharpInference:CpuMoe"]              = "true",
 
             // Spec decode
             ["SharpInference:SpecType"]            = "Mtp",
@@ -127,6 +129,7 @@ public sealed class OptionsConfigurationBindingTests
         Assert.Equal(1024L,            opts.MoeWarmPinAfter);
         Assert.False(opts.MoePredictPrefetch);
         Assert.Equal("/tmp/stats.json", opts.ExpertStatsPath);
+        Assert.True(opts.CpuMoe);
 
         Assert.Equal(ServerSpecType.Mtp, opts.SpecType);
         Assert.Equal(2,    opts.SpecDraftNMax);
@@ -479,6 +482,49 @@ public sealed class InferenceEngineLoaderTests
         var ex = Assert.Throws<InvalidOperationException>(() => InferenceEngineLoader.Load(opts));
         Assert.Contains("Model file not found", ex.Message);
         Assert.Contains("SHARPI_MODEL", ex.Message);
+    }
+}
+
+/// <summary>
+/// Issue #93: the server <see cref="SharpInferenceServerOptions.CpuMoe"/> option must reach the
+/// engine as the <c>SHARPI_CPU_MOE</c> override <em>before</em> the forward pass is built (the
+/// hybrid passes read it once at construction). We drive the real translation path:
+/// <see cref="InferenceEngineLoader.Load"/> runs <c>ApplyMoeEnvironment</c> first, then throws on
+/// the absent model — so the env var the engine would read is observable afterwards. The var is
+/// saved/restored, all cases live in one class so they never race each other, and no other
+/// Tests.Server collection touches it (engines under test come from a FakeEngine factory, which
+/// bypasses the loader entirely). Mirrors the existing MoE-knob coverage.
+/// </summary>
+public sealed class CpuMoeEnvironmentTests : IDisposable
+{
+    private const string Var = "SHARPI_CPU_MOE";
+    private readonly string? _saved;
+
+    public CpuMoeEnvironmentTests() => _saved = Environment.GetEnvironmentVariable(Var);
+
+    public void Dispose() => Environment.SetEnvironmentVariable(Var, _saved);
+
+    // ModelPath null → Load throws at model resolution, but only after ApplyMoeEnvironment has run.
+    private static SharpInferenceServerOptions OptsNoModel(bool? cpuMoe) =>
+        new() { ModelPath = null, CpuMoe = cpuMoe };
+
+    [Theory]
+    [InlineData(true, "1")]
+    [InlineData(false, "0")]
+    public void CpuMoe_Set_WritesEnvAheadOfLoad(bool cpuMoe, string expected)
+    {
+        Environment.SetEnvironmentVariable(Var, null);
+        Assert.Throws<InvalidOperationException>(() => InferenceEngineLoader.Load(OptsNoModel(cpuMoe)));
+        Assert.Equal(expected, Environment.GetEnvironmentVariable(Var));
+    }
+
+    [Fact]
+    public void CpuMoe_Null_LeavesEnvUntouched()
+    {
+        const string sentinel = "preexisting"; // e.g. an operator's directly-exported SHARPI_CPU_MOE
+        Environment.SetEnvironmentVariable(Var, sentinel);
+        Assert.Throws<InvalidOperationException>(() => InferenceEngineLoader.Load(OptsNoModel(null)));
+        Assert.Equal(sentinel, Environment.GetEnvironmentVariable(Var)); // null option = no write
     }
 }
 


### PR DESCRIPTION
## Summary

Wraps the engine's existing all-or-nothing `SHARPI_CPU_MOE` MoE-placement override behind first-class, **llama.cpp-named** surfaces on both frontends. These two issues are a tightly-coupled pair (both wrap the same override), so they ship together.

The override itself is unchanged — `CudaHybridForwardPass` / `CudaHybridGdnForwardPass` already read `SHARPI_CPU_MOE` (`"1"` → all routed experts on CPU, `"0"` → on-GPU SLRU cache, unset → VRAM-fit auto-select). This PR just gives it a CLI flag and a server option.

## #80 — CLI (`RunCommand`)

- **`--cpu-moe` / `--cmoe`** — force **all** routed MoE experts onto the CPU; sets `SHARPI_CPU_MOE=1` before any forward pass is built. An explicit flag overrides an inherited env var; absence leaves the env (and the auto-select) untouched.
- **`--n-cpu-moe` / `--ncmoe <N>`** — **deferred, not half-implemented.** SharpInference's override is all-or-nothing (no per-layer expert split in the engine), so any value is rejected fast with that rationale and a pointer to `--cpu-moe`, rather than silently behaving like `--cpu-moe`.
- Translation lives in a small testable `internal static TryApplyCpuMoeFlags` helper (mirrors `GpuDevice.Resolve`), wired into `Execute` next to the other MoE knobs.
- **Deviation (documented):** llama.cpp's single-dash `-cmoe`/`-ncmoe` aren't representable — Spectre.Console requires single-dash options to be exactly one character — so the double-dash `--cmoe`/`--ncmoe` aliases stand in. The long forms `--cpu-moe` / `--n-cpu-moe` match llama.cpp exactly. Noted in `--help` and README.

## #93 — Server

- `SharpInferenceServerOptions.CpuMoe` (`bool?`; **`null` = preserve the engine auto-select**, no env write). XML-doc cross-references the CLI `--cpu-moe`.
- `InferenceEngineLoader.ApplyMoeEnvironment` writes `SHARPI_CPU_MOE=0|1` before model load when set; `null` writes nothing, so a directly-exported `SHARPI_CPU_MOE` and the auto-select both survive.

## Acceptance

- ✅ CLI `--cpu-moe` ≡ `SHARPI_CPU_MOE=1` ≡ server `CpuMoe=true` → same forward-pass routing (all read the same override `"1"`).
- ✅ Unset / `null` preserves auto-select (no env write).
- ✅ `--n-cpu-moe` explicitly deferred with rationale (errors; not half-implemented).
- ✅ Build clean under `TreatWarningsAsErrors`; AOT-safe (no reflection/dynamic codegen); no culture-specific string ops.

## Tests

- **Tests.Cli** (`CpuMoeFlagsTests`, 6 cases): `--cpu-moe` sets env to `1`; overrides an inherited `0`; default leaves env untouched; `--n-cpu-moe` (20 / 0 / -1) is rejected with no env write; `--n-cpu-moe` takes precedence over `--cpu-moe`.
- **Tests.Server**: `CpuMoe` config binding + default `null`; `CpuMoeEnvironmentTests` drives the real `Load` → `ApplyMoeEnvironment` path and asserts the env var written ahead of (the failing) model load — `true`→`1`, `false`→`0`, `null`→untouched.
- Verified against the built binary: `--cpu-moe`/`--cmoe` parse; `--n-cpu-moe`/`--ncmoe` error before any model load; both appear in `--help`.

`Tests.Cli` 32/32 and `Tests.Server` 124/124 green. An internal code-reviewer pass found no issues at/above threshold.

Closes #80
Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)