### PR TITLE
feat(gemma4): agentic 12B download preset + chat-template BOS fix + --thinking

### DIFF
--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -5,7 +5,7 @@
     Downloads from HuggingFace to the models/ directory. Skips if already present.
     Supports: smollm2, vibethinker, qwen3-8b, olmoe-1b-7b, llama31-70b, qwen3-coder-30b-a3b, qwen36-35b-a3b,
               qwen36-27b-mtp, qwen36-27b-mtp-q5, qwen36-35b-a3b-mtp, carnice-35b-a3b-mtp,
-              gemma4-12b-qat, gemma4-12b-q4km, gemma4-e4b-qat,
+              gemma4-12b-qat, gemma4-12b-q4km, gemma4-e4b-qat, gemma4-12b-agentic,
               llama4-scout, z-image-turbo, z-image-turbo-q8, realesrgan-x4
 .PARAMETER Model
     Which model to download. Default: downloads all text models (skips large image models).
@@ -26,6 +26,7 @@
     .\download-model.ps1 -Model gemma4-12b-qat -DestDir E:\models  # Gemma 4 12B-it QAT q4_0 + vision/audio mmproj (~7.2 GB) — issue #124 PRIMARY (official quantization-aware-trained)
     .\download-model.ps1 -Model gemma4-12b-q4km -DestDir E:\models # Gemma 4 12B-it Q4_K_M (~7.3 GB) — issue #124 fallback / K-quant cross-check
     .\download-model.ps1 -Model gemma4-e4b-qat -DestDir E:\models  # Gemma 4 E4B-it QAT q4_0 (~5.15 GB) — fast small Gemma (~1.6× decode vs Q8_0)
+    .\download-model.ps1 -Model gemma4-12b-agentic -DestDir E:\models  # Gemma 4 12B agentic/tool-use finetune (yuxinlu1) Q4_K_M (~7.3 GB) — dense gemma4 arch
     .\download-model.ps1 -Model llama4-scout            # Llama 4 Scout Q4_K_M (60.9 GB, 2 shards)
     .\download-model.ps1 -Model z-image-turbo           # Z-Image-Turbo Q5_K_M + abliterated encoder (~8.5 GB)
     .\download-model.ps1 -Model z-image-turbo-q8        # Z-Image-Turbo Q8_0 + abliterated encoder Q8_0 (~12 GB)
@@ -34,7 +35,7 @@
 param(
     [ValidateSet("smollm2", "vibethinker", "vibethinker-q4", "qwen3-8b", "qwen3-0.6b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
                  "qwen36-27b-mtp", "qwen36-27b-mtp-q5", "qwen36-35b-a3b-mtp", "carnice-35b-a3b-mtp",
-                 "gemma4-12b-qat", "gemma4-12b-q4km", "gemma4-e4b-qat",
+                 "gemma4-12b-qat", "gemma4-12b-q4km", "gemma4-e4b-qat", "gemma4-12b-agentic",
                  "llama4-scout", "z-image-turbo", "z-image-turbo-q8", "realesrgan-x4")]
     [string]$Model,
     [string]$DestDir
@@ -216,6 +217,23 @@ $Models = @{
         Size  = "~7.3 GB"
         SizeGB = 7.3
         Phase = "issue #124 (fallback — Q4_K_M K-quant cross-check)"
+    }
+    # ── Gemma 4 12B agentic finetune (community) ───────────────────────────────
+    # yuxinlu1's agentic/tool-use + coding finetune of google/gemma-4-12B-it,
+    # distributed as a standard dense `gemma4` (gemma4_unified) GGUF — same arch
+    # as gemma4-12b-q4km, so it loads on the existing dense Gemma 4 text path with
+    # no engine changes. Tuned on multi-step tool-use trajectories (tau2) and
+    # verified coding CoT; emits a <think> chain then the answer. Text-only repo
+    # (no companion mmproj). The upstream Q4_K_M filename follows the same
+    # `gemma4-<variant>-Q4_K_M.gguf` convention as the author's coder v1 repo
+    # (gemma4-coding-Q4_K_M.gguf) — VERIFY against the repo file list before use:
+    #   https://huggingface.co/yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF/tree/main
+    "gemma4-12b-agentic" = @{
+        Files = @("gemma4-agentic-Q4_K_M.gguf")
+        Urls  = @("https://huggingface.co/yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF/resolve/main/gemma4-agentic-Q4_K_M.gguf")
+        Size  = "~7.3 GB"
+        SizeGB = 7.3
+        Phase = "Gemma 4 12B agentic/tool-use finetune (yuxinlu1) — dense gemma4 text path"
     }
     "llama4-scout" = @{
         Files = @(

--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -26,7 +26,7 @@
     .\download-model.ps1 -Model gemma4-12b-qat -DestDir E:\models  # Gemma 4 12B-it QAT q4_0 + vision/audio mmproj (~7.2 GB) — issue #124 PRIMARY (official quantization-aware-trained)
     .\download-model.ps1 -Model gemma4-12b-q4km -DestDir E:\models # Gemma 4 12B-it Q4_K_M (~7.3 GB) — issue #124 fallback / K-quant cross-check
     .\download-model.ps1 -Model gemma4-e4b-qat -DestDir E:\models  # Gemma 4 E4B-it QAT q4_0 (~5.15 GB) — fast small Gemma (~1.6× decode vs Q8_0)
-    .\download-model.ps1 -Model gemma4-12b-agentic -DestDir E:\models  # Gemma 4 12B agentic/tool-use finetune (yuxinlu1) Q4_K_M (~7.3 GB) — dense gemma4 arch
+    .\download-model.ps1 -Model gemma4-12b-agentic -DestDir E:\models  # Gemma 4 12B agentic/tool-use finetune (yuxinlu1) Q4_K_M (~7.4 GB) — dense gemma4 arch (reasoning; pass --thinking for the thought chain)
     .\download-model.ps1 -Model llama4-scout            # Llama 4 Scout Q4_K_M (60.9 GB, 2 shards)
     .\download-model.ps1 -Model z-image-turbo           # Z-Image-Turbo Q5_K_M + abliterated encoder (~8.5 GB)
     .\download-model.ps1 -Model z-image-turbo-q8        # Z-Image-Turbo Q8_0 + abliterated encoder Q8_0 (~12 GB)
@@ -221,18 +221,24 @@ $Models = @{
     # ── Gemma 4 12B agentic finetune (community) ───────────────────────────────
     # yuxinlu1's agentic/tool-use + coding finetune of google/gemma-4-12B-it,
     # distributed as a standard dense `gemma4` (gemma4_unified) GGUF — same arch
-    # as gemma4-12b-q4km, so it loads on the existing dense Gemma 4 text path with
-    # no engine changes. Tuned on multi-step tool-use trajectories (tau2) and
-    # verified coding CoT; emits a <think> chain then the answer. Text-only repo
-    # (no companion mmproj). The upstream Q4_K_M filename follows the same
-    # `gemma4-<variant>-Q4_K_M.gguf` convention as the author's coder v1 repo
-    # (gemma4-coding-Q4_K_M.gguf) — VERIFY against the repo file list before use:
+    # as gemma4-12b-q4km, so it runs on the existing dense Gemma 4 text path.
+    # Tuned on multi-step tool-use trajectories (tau2) and verified coding CoT.
+    # Text-only repo (no companion mmproj). Filenames verified against the repo:
+    # the GGUFs are `gemma4-v2-<quant>.gguf` (NOT the author's coder-v1
+    # `gemma4-<variant>-Q4_K_M.gguf` convention). Q4_K_M (~7.4 GB) is the 12 GB
+    # full-offload pick; the repo also has Q3_K_M (~6.1 GB), Q6_K (~9.8 GB) and
+    # Q8_0 (~12.7 GB).
     #   https://huggingface.co/yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF/tree/main
+    #
+    # Unlike stock Gemma 4 instruct (not reasoning-trained), THIS reasoning finetune
+    # thinks in Gemma's native thought channel. It answers fine in the default mode;
+    # to get the reasoning chain pass `--thinking` (Gemma 4 defaults thinking off for
+    # the stock models). Recommended sampling: --temp 1.0 --top-k 64 --top-p 0.95.
     "gemma4-12b-agentic" = @{
-        Files = @("gemma4-agentic-Q4_K_M.gguf")
-        Urls  = @("https://huggingface.co/yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF/resolve/main/gemma4-agentic-Q4_K_M.gguf")
-        Size  = "~7.3 GB"
-        SizeGB = 7.3
+        Files = @("gemma4-v2-Q4_K_M.gguf")
+        Urls  = @("https://huggingface.co/yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF/resolve/main/gemma4-v2-Q4_K_M.gguf")
+        Size  = "~7.4 GB"
+        SizeGB = 7.4
         Phase = "Gemma 4 12B agentic/tool-use finetune (yuxinlu1) — dense gemma4 text path"
     }
     "llama4-scout" = @{

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -366,17 +366,16 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             s_endThinkTokenId = endChannelId;
         }
 
+        // Resolve reasoning on/off (see ResolveThinkingOff for the full precedence). --no-thinking
+        // and --thinking are opposites; if both are passed --no-thinking wins, so warn rather than
+        // silently dropping --thinking.
+        if (settings.Thinking && settings.NoThinking)
+            AnsiConsole.MarkupLine("[yellow]Warning:[/] both --thinking and --no-thinking given; --no-thinking wins.");
+        s_noThinking = ResolveThinkingOff(s_arch, settings.Thinking, settings.NoThinking);
         // Gemma 4's stock instruct models (E4B-it, 12B-it) bracket a <|channel>thought block in
-        // their chat template but are NOT trained to reason — rendering enable_thinking=true makes
-        // them try to fill a think section they weren't trained for and the output degenerates. So
-        // Gemma 4 defaults thinking OFF (its recommended config). Reasoning FINETUNES that share the
-        // same arch/template (e.g. the agentic v2) DO need it on — and nothing in the GGUF metadata
-        // distinguishes a reasoning-trained Gemma 4 from a stock one (identical chat template, tokens,
-        // sampling hints), so --thinking is the explicit opt-in. (--no-thinking forces it off for any
-        // model and wins if both are passed.)
-        bool gemma4DefaultsThinkingOff = s_arch == "gemma4" && !settings.Thinking;
-        s_noThinking = settings.NoThinking || gemma4DefaultsThinkingOff;
-        if (gemma4DefaultsThinkingOff && !settings.NoThinking)
+        // their chat template but are NOT trained to reason, so Gemma 4 defaults thinking off.
+        // Surface that default (and how to override it) only when we actually defaulted off.
+        if (s_arch == "gemma4" && !settings.Thinking && !settings.NoThinking)
             AnsiConsole.MarkupLine("[dim]Gemma 4 defaults to --no-thinking (stock instruct models aren't " +
                 "reasoning-trained). For a reasoning finetune pass --thinking " +
                 "(recommended: --temp 1.0 --top-k 64 --top-p 0.95).[/]");
@@ -1601,6 +1600,21 @@ public sealed class RunCommand : Command<RunCommand.Settings>
     /// it as literal text.
     /// </summary>
     private static IReadOnlyList<int> BuildStopTokenIds(GgufTokenizer tokenizer) => tokenizer.EogTokenIds;
+
+    /// <summary>
+    /// Resolves whether reasoning ("thinking") should be OFF for this run.
+    /// Precedence: <c>--no-thinking</c> forces it off and wins if both flags are passed;
+    /// <c>--thinking</c> forces it on; with neither, Gemma 4 defaults off (its stock instruct
+    /// models aren't reasoning-trained — nothing in the GGUF metadata distinguishes a reasoning
+    /// finetune from a stock model, so reasoning is opt-in there) while every other architecture
+    /// defaults on. Pure and side-effect-free so the precedence is unit-testable.
+    /// </summary>
+    internal static bool ResolveThinkingOff(string arch, bool thinking, bool noThinking)
+    {
+        if (noThinking) return true;   // explicit off wins over a conflicting --thinking
+        if (thinking)   return false;  // explicit on
+        return arch == "gemma4";       // default: off only for Gemma 4
+    }
 
     // Accept llama.cpp's "draft-mtp" alongside the shorter "mtp" so existing command
     // lines copy-paste over. Unknown values fall back to auto with a console warning.

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -171,6 +171,12 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [DefaultValue(false)]
         public bool NoThinking { get; init; }
 
+        [CommandOption("--thinking")]
+        [Description("Enable reasoning mode (sets enable_thinking=true). Needed for Gemma 4 reasoning " +
+            "finetunes, which default off because stock Gemma 4 instruct models aren't reasoning-trained.")]
+        [DefaultValue(false)]
+        public bool Thinking { get; init; }
+
         [CommandOption("--hide-thinking")]
         [Description("Hide reasoning output (the model still reasons; only the answer is shown)")]
         [DefaultValue(false)]
@@ -360,15 +366,19 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             s_endThinkTokenId = endChannelId;
         }
 
-        // Gemma 4 E4B-it brackets a <|channel>thought block in its chat template but is
-        // NOT a reasoning model — rendering enable_thinking=true makes it try to fill a
-        // think section it wasn't trained for and the output degenerates. Default thinking
-        // OFF for Gemma 4 (its recommended config); --no-thinking still forces it off for
-        // every other model. Pass --temp 1.0 --top-k 64 --top-p 0.95 for Gemma 4.
-        bool modelDefaultsThinkingOff = s_arch == "gemma4";
-        s_noThinking = settings.NoThinking || modelDefaultsThinkingOff;
-        if (modelDefaultsThinkingOff && !settings.NoThinking)
-            AnsiConsole.MarkupLine("[dim]Gemma 4 is not a reasoning model — defaulting to --no-thinking " +
+        // Gemma 4's stock instruct models (E4B-it, 12B-it) bracket a <|channel>thought block in
+        // their chat template but are NOT trained to reason — rendering enable_thinking=true makes
+        // them try to fill a think section they weren't trained for and the output degenerates. So
+        // Gemma 4 defaults thinking OFF (its recommended config). Reasoning FINETUNES that share the
+        // same arch/template (e.g. the agentic v2) DO need it on — and nothing in the GGUF metadata
+        // distinguishes a reasoning-trained Gemma 4 from a stock one (identical chat template, tokens,
+        // sampling hints), so --thinking is the explicit opt-in. (--no-thinking forces it off for any
+        // model and wins if both are passed.)
+        bool gemma4DefaultsThinkingOff = s_arch == "gemma4" && !settings.Thinking;
+        s_noThinking = settings.NoThinking || gemma4DefaultsThinkingOff;
+        if (gemma4DefaultsThinkingOff && !settings.NoThinking)
+            AnsiConsole.MarkupLine("[dim]Gemma 4 defaults to --no-thinking (stock instruct models aren't " +
+                "reasoning-trained). For a reasoning finetune pass --thinking " +
                 "(recommended: --temp 1.0 --top-k 64 --top-p 0.95).[/]");
 
         // Greedy on a reasoning model tends to "wait, but actually" itself into infinite

--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -289,7 +289,11 @@ public sealed class GgufTokenizer : ITokenizer
 
         if (model.Metadata.TryGetValue("tokenizer.chat_template", out var tmpl) && tmpl is string tmplStr)
         {
-            try { tokenizer.ChatTemplate = new JinjaChatTemplate(tmplStr); }
+            // Seed the BOS string so the template's `{{- bos_token -}}` (Gemma, Llama, …) renders
+            // it instead of an empty string — otherwise the prompt ships with no BOS token, which
+            // Gemma is sensitive to (the model degenerates). Only when the model actually prepends
+            // BOS (add_bos_token); add_bos_token=false models (e.g. Qwen) keep bos_token empty.
+            try { tokenizer.ChatTemplate = new JinjaChatTemplate(tmplStr) { BosToken = addBosToken ? bosToken : null }; }
             catch { /* malformed template — ChatTemplate stays null */ }
         }
 

--- a/src/SharpInference.Core/JinjaChatTemplate.cs
+++ b/src/SharpInference.Core/JinjaChatTemplate.cs
@@ -35,6 +35,15 @@ public sealed class JinjaChatTemplate
 {
     private readonly List<INode> _nodes;
 
+    /// <summary>
+    /// BOS token string for this model (e.g. <c>&lt;bos&gt;</c>), or null if the model doesn't
+    /// prepend BOS. Seeded by <see cref="GgufTokenizer"/> at construction. Chat templates routinely
+    /// open with <c>{{- bos_token -}}</c>; without a value the variable renders empty and the prompt
+    /// ships with no BOS token — Gemma in particular degenerates without it. <see cref="Render"/>
+    /// injects this into the context unless the caller already supplied its own <c>bos_token</c>.
+    /// </summary>
+    public string? BosToken { get; init; }
+
     public JinjaChatTemplate(string source) => _nodes = ParseTemplate(source);
 
     /// <summary>
@@ -45,6 +54,10 @@ public sealed class JinjaChatTemplate
     public string Render(IReadOnlyDictionary<string, object?> context)
     {
         var ctx = new Dictionary<string, object?>(context, StringComparer.Ordinal);
+        // Templates that open with `{{- bos_token -}}` need the BOS string at render time. Seed it
+        // from the model metadata unless the caller passed its own — otherwise the prompt gets no BOS.
+        if (BosToken != null && !ctx.ContainsKey("bos_token"))
+            ctx["bos_token"] = BosToken;
         var sb  = new StringBuilder();
         EvalNodes(_nodes, ctx, sb);
         return sb.ToString();

--- a/tests/SharpInference.Tests.Cli/ThinkingResolutionTests.cs
+++ b/tests/SharpInference.Tests.Cli/ThinkingResolutionTests.cs
@@ -1,0 +1,26 @@
+using SharpInference.Cli;
+
+namespace SharpInference.Tests.Cli;
+
+/// <summary>
+/// Unit tests for <see cref="RunCommand.ResolveThinkingOff"/> — the --thinking / --no-thinking
+/// precedence. Gemma 4 defaults reasoning off (its stock instruct models aren't reasoning-trained);
+/// every other arch defaults on. --no-thinking always wins; --thinking forces it on.
+/// </summary>
+public sealed class ThinkingResolutionTests
+{
+    [Theory]
+    // Gemma 4: defaults OFF, --thinking opts in, --no-thinking wins over a conflicting --thinking.
+    [InlineData("gemma4", false, false, true)]
+    [InlineData("gemma4", true,  false, false)]
+    [InlineData("gemma4", false, true,  true)]
+    [InlineData("gemma4", true,  true,  true)]
+    // Non-gemma4 (reasoning on by default): --thinking is redundant-but-consistent, --no-thinking off.
+    [InlineData("qwen3",  false, false, false)]
+    [InlineData("qwen3",  true,  false, false)]
+    [InlineData("qwen3",  false, true,  true)]
+    [InlineData("qwen3",  true,  true,  true)]
+    [InlineData("llama",  false, false, false)]
+    public void ResolveThinkingOff_FollowsPrecedence(string arch, bool thinking, bool noThinking, bool expectedOff) =>
+        Assert.Equal(expectedOff, RunCommand.ResolveThinkingOff(arch, thinking, noThinking));
+}

--- a/tests/SharpInference.Tests.Core/JinjaChatTemplateTests.cs
+++ b/tests/SharpInference.Tests.Core/JinjaChatTemplateTests.cs
@@ -83,6 +83,42 @@ public sealed class JinjaChatTemplateTests
         Assert.Equal("42", Render(src, ctx));
     }
 
+    // ── bos_token seeding ─────────────────────────────────────────────────────────
+    // Chat templates (Gemma, Llama, …) open with `{{- bos_token -}}`. The model's BOS string is
+    // injected by GgufTokenizer via JinjaChatTemplate.BosToken; without it the prompt ships with
+    // no BOS token and Gemma degenerates. These lock the seeding semantics.
+
+    [Fact]
+    public void BosToken_WhenSet_RendersIntoTemplate()
+    {
+        var tmpl = new JinjaChatTemplate("{{- bos_token -}}<|turn>user\n") { BosToken = "<bos>" };
+        Assert.Equal("<bos><|turn>user\n", tmpl.Render(new Dictionary<string, object?>()));
+    }
+
+    [Fact]
+    public void BosToken_WhenNull_RendersEmpty()
+    {
+        // Default (no BosToken, e.g. add_bos_token=false models like Qwen) — byte-identical to before.
+        var tmpl = new JinjaChatTemplate("{{- bos_token -}}<|turn>user\n");
+        Assert.Equal("<|turn>user\n", tmpl.Render(new Dictionary<string, object?>()));
+    }
+
+    [Fact]
+    public void BosToken_ExplicitContextValue_Wins()
+    {
+        var tmpl = new JinjaChatTemplate("{{- bos_token -}}x") { BosToken = "<bos>" };
+        var ctx = new Dictionary<string, object?> { ["bos_token"] = "<s>" };
+        Assert.Equal("<s>x", tmpl.Render(ctx));
+    }
+
+    [Fact]
+    public void BosToken_WhenTemplateIgnoresIt_OutputUnchanged()
+    {
+        // Seeding a BOS string must not alter templates that never reference bos_token.
+        var tmpl = new JinjaChatTemplate("<|turn>user\nhi") { BosToken = "<bos>" };
+        Assert.Equal("<|turn>user\nhi", tmpl.Render(new Dictionary<string, object?>()));
+    }
+
     // ── loop.previtem / loop.nextitem tests ──────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds a download preset for yuxinlu1's **Gemma 4 12B agentic finetune** and fixes two real chat-template bugs that smoke-testing it surfaced — both affecting models well beyond this one.

## Changes

**1. `gemma4-12b-agentic` download preset** (`scripts/download-model.ps1`)
Verified the repo's `/tree/main`: the placeholder `gemma4-agentic-Q4_K_M.gguf` does not exist — the real files are `gemma4-v2-<quant>.gguf`. Points `Files`/`Urls` at `gemma4-v2-Q4_K_M.gguf` (~7.4 GB), text-only (no mmproj), with a note that it's a reasoning finetune (use `--thinking`, recommended `--temp 1.0 --top-k 64 --top-p 0.95`).

**2. Missing BOS in the chat-template path** (`Core/JinjaChatTemplate.cs`, `Core/GgufTokenizer.cs`)
Chat templates that open with `{{- bos_token -}}` (Gemma, Llama, Mistral) rendered it as an empty string because the BOS string was never passed to the Jinja renderer — so every such prompt shipped with **no BOS token**. Gemma is BOS-sensitive and degenerates without it (off-topic output / leaked `<channel|>` / empty generations). `GgufTokenizer.Encode` never compensated.

Fixed centrally: seed the BOS string into `JinjaChatTemplate.BosToken` when the tokenizer builds the template, so **both the CLI and the server's `ChatTemplateRenderer`** (which share the same instance) get it. Gated on `add_bos_token`, so `add_bos_token=false` models (e.g. Qwen) are byte-identical.

**3. `--thinking` flag** (`Cli/RunCommand.cs`)
The CLI hard-forced `enable_thinking=false` for all `gemma4` (correct for Google's stock instruct models, which aren't reasoning-trained). Reasoning finetunes share the identical arch/template/tokens/sampling-hints — nothing in the GGUF metadata distinguishes them — so add an explicit `--thinking` opt-in. Default stays off; `--no-thinking` still wins.

## Result

With both fixes the agentic finetune generates correctly — clean answers in the default mode and a coherent `<|channel>` thought chain under `--thinking`. Stock `gemma-4-12b-it` regression-checked (clean, unchanged).

## Testing

- Full Release build clean (0 warnings; `TreatWarningsAsErrors`).
- `Tests.Core` 152 (incl. 4 new `bos_token` seeding tests), `Tests.Server` 124, `Tests.Cli` 32 — all green.
- Manual on RTX 4070Ti (GPU full-offload): agentic finetune + stock 12B-it, both APIs of the rendering path.

## Notes / scope

- Server's per-request thinking default is unchanged (it already has request-level control); the BOS fix covers the server via the shared template instance.
- The finetune's reasoning mode is strong in-domain (coding) but can ramble out-of-domain at temp 1.0 — default mode is the reliable path for simple Q&A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AseYLmrS8RaYpAT7dhMXL7