### PR TITLE
fix(engine): run forward pass on a dedicated context-bound thread (#302)

### DIFF
--- a/src/SharpInference.Core/IForwardPass.cs
+++ b/src/SharpInference.Core/IForwardPass.cs
@@ -4,7 +4,7 @@ namespace SharpInference.Core;
 /// Abstraction over a transformer forward pass. Supports both autoregressive decode (Forward)
 /// and position truncation needed by speculative decoding.
 /// </summary>
-public interface IForwardPass : IDisposable
+public interface IForwardPass : IDisposable, IThreadAffineBackend
 {
     /// <summary>Run one token through the model and return logits[vocabSize].</summary>
     ReadOnlySpan<float> Forward(int token, int position);

--- a/src/SharpInference.Core/IThreadAffineBackend.cs
+++ b/src/SharpInference.Core/IThreadAffineBackend.cs
@@ -1,0 +1,21 @@
+namespace SharpInference.Core;
+
+/// <summary>
+/// A backend whose work must run on a single, consistent OS thread (issue #302). Both the
+/// per-token forward-pass interface (<see cref="IForwardPass"/>) and the engine's batched-forward
+/// surface extend this, so an inference engine can pin all of a backend's work to one owned thread
+/// without knowing which concrete backend it drives.
+/// </summary>
+public interface IThreadAffineBackend
+{
+    /// <summary>
+    /// Make the backend's thread-affine context current on the calling thread. A CUDA context is
+    /// thread-affine: the engine that drives the forward pass must call this on the worker thread
+    /// that issues the backend's calls, before the first one. Otherwise — in non-interactive
+    /// sessions, where the driver does not keep the device's primary context current on freshly-
+    /// scheduled threads — the first CUDA call on an unbound thread can hang forever. Backends with
+    /// no thread-affine context (CPU, Vulkan) leave this a no-op. Idempotent and cheap after the
+    /// first call per thread.
+    /// </summary>
+    void BindToCurrentThread() { }
+}

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -6195,6 +6195,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private static          bool     t_primaryCtxBoundOnThisThread;
 
     /// <summary>
+    /// Make the process-wide device-0 primary CUDA context current on the calling thread (issue
+    /// #302). CUDA contexts are thread-affine; a consumer that drives the forward pass from a
+    /// thread other than the one that loaded the model (e.g. an engine worker thread, or a
+    /// thread-pool continuation) must bind the context first, or in a non-interactive session the
+    /// first CUDA call on that thread can hang forever. Idempotent and cheap after the first call
+    /// per thread (the underlying <see cref="EnsurePrimaryContextCurrent"/> short-circuits on a
+    /// ThreadStatic flag). The forward passes expose this through
+    /// <c>IThreadAffineBackend.BindToCurrentThread</c>.
+    /// </summary>
+    public void BindContextToCurrentThread() => EnsurePrimaryContextCurrent();
+
+    /// <summary>
     /// Ensure the device's primary context is current on the calling thread. Cheap after
     /// the first call per thread (single ThreadStatic check). The retained primary context
     /// is the same one cuBLAS attaches to, so once it's current on a thread the entire

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -255,6 +255,13 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         {
         while (!_disposed)
         {
+            // Issue #302: rebind the backend's thread-affine context (CUDA) before any forward
+            // work this iteration. The loop's `await WaitToReadAsync().ConfigureAwait(false)` on
+            // the idle path can resume the continuation on a different thread-pool thread than the
+            // one that ran the previous step, so a single bind before the loop wouldn't hold. The
+            // call is a no-op on CPU/Vulkan and free after the first call per thread.
+            _fwd.BindToCurrentThread();
+
             // Pull everything queued so far into the local pending queue. Channels have
             // no peek, and admission backpressure needs to inspect the head request's
             // size without consuming it — hence the local FIFO.

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -614,6 +614,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     public int MaxSeqLen => _maxSeqLen;
 
     /// <summary>
+    /// Bind this pass's CUDA context to the calling thread (issue #302). One public method
+    /// satisfies <see cref="IThreadAffineBackend.BindToCurrentThread"/> for both
+    /// <see cref="IForwardPass"/> and <see cref="IBatchedForwardPass"/> — the engines call it on
+    /// the worker thread that drives the forward pass before issuing any CUDA work, so a
+    /// non-interactive session doesn't hang on the first unbound-thread CUDA call.
+    /// </summary>
+    public void BindToCurrentThread() => _gpu.BindContextToCurrentThread();
+
+    /// <summary>
     /// Test-only accessor for the post-prefill KV slot count. After a SnapKV-active
     /// prefill this is the keep-set size (≤ budget); otherwise it's the prompt length.
     /// </summary>

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -257,6 +257,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     public int VocabSize => _hp.VocabSize;
 
     /// <summary>
+    /// Bind this pass's CUDA context to the calling thread (issue #302). The engine calls it on
+    /// the worker thread that drives the forward pass before any CUDA work, so a non-interactive
+    /// session doesn't hang on the first unbound-thread CUDA call.
+    /// </summary>
+    public void BindToCurrentThread() => _gpu.BindContextToCurrentThread();
+
+    /// <summary>
     /// Truncate the KV cache to the given length, discarding positions >= length.
     /// Used by speculative decoding to rewind rejected draft tokens.
     /// </summary>

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -706,6 +706,13 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     public LayerPlacement Placement => _placement;
 
     /// <summary>
+    /// Bind this pass's CUDA context to the calling thread (issue #302). The engine calls it on
+    /// the worker thread that drives the forward pass before any CUDA work, so a non-interactive
+    /// session doesn't hang on the first unbound-thread CUDA call.
+    /// </summary>
+    public void BindToCurrentThread() => _gpu.BindContextToCurrentThread();
+
+    /// <summary>
     /// Host-side bookkeeping cache. Holds slot/length state only — the actual K/V
     /// payload for attention layers lives on the GPU in <c>_gpuKCache</c> /
     /// <c>_gpuVCache</c>. Exposed so tests can assert SnapKV (issue #58)

--- a/src/SharpInference.Engine/IBatchedForwardPass.cs
+++ b/src/SharpInference.Engine/IBatchedForwardPass.cs
@@ -1,3 +1,5 @@
+using SharpInference.Core;
+
 namespace SharpInference.Engine;
 
 /// <summary>
@@ -19,7 +21,7 @@ public interface ISequenceKvCache : IDisposable
 /// today; a CUDA implementation (per-sequence GPU KV caches + batched decode) can slot in behind
 /// the same interface without the engine knowing which backend it drives.
 /// </summary>
-public interface IBatchedForwardPass
+public interface IBatchedForwardPass : IThreadAffineBackend
 {
     /// <summary>Allocate a fresh, empty per-sequence KV cache for one admitted sequence.</summary>
     ISequenceKvCache CreateCache();

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
@@ -34,6 +35,19 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     // shutdown stops the in-flight background worker promptly rather than letting it
     // run to MaxNewTokens (issue #132).
     private readonly CancellationTokenSource _shutdownCts = new();
+
+    // Issue #302: a single dedicated, long-lived thread that drives every forward pass for this
+    // engine. CUDA contexts are thread-affine — running the forward pass on arbitrary Task.Run
+    // pool threads (the old model) deadlocks the first CUDA call in a non-interactive session,
+    // where the driver does not keep the device's primary context current on freshly-scheduled
+    // worker threads. A stable thread binds the backend context once (the first request's
+    // _fwd.BindToCurrentThread, idempotent thereafter) and keeps CUDA streams/graphs on one
+    // consistent thread for the engine's lifetime. _gate already serializes requests to one at a
+    // time, so a single engine thread per device is sufficient. The per-request streaming
+    // Channel<GenerateChunk> is unchanged; only the producer's execution context moved off the
+    // thread pool. Background so a leaked/undisposed engine never blocks process exit.
+    private readonly BlockingCollection<Action> _engineWork = new();
+    private readonly Thread _engineThread;
 
     // Prefix caching state (guarded by _gate — only accessed during generation).
     private int[]? _prevTokens;
@@ -200,6 +214,56 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     "falling back to single-slot prefix cache.");
             }
         }
+
+        // Issue #302: start the dedicated forward-pass thread. It binds the backend's thread-
+        // affine context on the first work item and then serves generation work in arrival order
+        // until Dispose completes the queue.
+        _engineThread = new Thread(EngineThreadLoop)
+        {
+            IsBackground = true,
+            Name = "sharpi-engine",
+        };
+        _engineThread.Start();
+    }
+
+    /// <summary>
+    /// Body of the dedicated forward-pass thread (issue #302). Runs queued generation work items
+    /// in arrival order until <see cref="Dispose"/> / <see cref="DisposeAsync"/> completes the
+    /// queue. Each work item binds the CUDA context (idempotent; a no-op on CPU/Vulkan) and routes
+    /// its own exceptions to its per-request channel, so this loop only needs a last-resort guard
+    /// to keep a surprise escape from tearing down the shared thread and stranding later requests.
+    /// </summary>
+    private void EngineThreadLoop()
+    {
+        foreach (var work in _engineWork.GetConsumingEnumerable())
+        {
+            try
+            {
+                work();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[InferenceEngine] forward-pass work item threw unexpectedly: {ex}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #302: queue <paramref name="work"/> onto the dedicated forward-pass thread and return
+    /// a task that completes when it finishes. Replaces the old <c>Task.Run</c>, which dispatched
+    /// the forward pass to an arbitrary pool thread the CUDA context wasn't bound to. The work item
+    /// reports its own errors through the request's channel and never throws, so this only needs to
+    /// signal completion (so the generation's drain in the <c>finally</c> can release the gate).
+    /// </summary>
+    private Task RunOnEngineThread(Action work)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _engineWork.Add(() =>
+        {
+            try { work(); }
+            finally { tcs.TrySetResult(); }
+        });
+        return tcs.Task;
     }
 
     /// <summary>
@@ -514,8 +578,9 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
             int endThinkId = _endThinkTokenId;
             bool thinkingEnabled = thinkId >= 0 && endThinkId >= 0;
 
-            // Run the blocking CPU generation on a thread-pool thread.
-            var genTask = Task.Run(() =>
+            // Run the blocking generation on the engine's dedicated forward-pass thread (issue
+            // #302), not an arbitrary thread-pool thread — CUDA contexts are thread-affine.
+            var genTask = RunOnEngineThread(() =>
             {
                 // Per-request perf trace (issue: server feels slow on big agentic prompts).
                 // Splits encode / prefill / decode so a huge-prompt request shows where the
@@ -534,6 +599,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 int activeSlotIdx = -1;
                 try
                 {
+                    // Issue #302: bind the backend's thread-affine context (CUDA) to this thread
+                    // before the first CUDA call. No-op on CPU/Vulkan and free after the first
+                    // call on the (stable) engine thread; kept inside the try so a bind failure
+                    // surfaces through this request's channel instead of hanging the consumer.
+                    _fwd.BindToCurrentThread();
                     var tokens = _tokenizer.Encode(prompt).ToArray();
                     promptTokenCount = tokens.Length;
                     encodeMs = swReq.ElapsedMilliseconds;
@@ -1032,7 +1102,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             ttftMs >= 0 ? ttftMs : totalMs, decodeTokens, decTps, totalMs);
                     }
                 }
-            }, ct);
+            });
 
             try
             {
@@ -1126,6 +1196,30 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                 "live worker. Ensure consumers dispose their generation enumerators and that the backend is responsive.");
             return;
         }
+        // Issue #302: stop the dedicated forward-pass thread before freeing the pass it drives.
+        // Safe here because `drained` means the gate was re-acquired — no work item is running,
+        // and request admission is gated by that same gate, so none can be enqueued after this.
+        // CompleteAdding ends the thread's consuming loop; Join awaits its exit (it is idle, so
+        // this returns at once) before the forward pass is disposed below.
+        _engineWork.CompleteAdding();
+        _engineThread.Join();
+        _engineWork.Dispose();
+
+        // Issue #302: the teardown below frees thread-affine backend resources (CUDA device
+        // buffers / streams / modules) on this disposing thread, not the now-exited engine
+        // thread. Bind the context here too, so a host that disposes from an unbound pool thread
+        // (e.g. StopAsync) frees cleanly instead of failing on an invalid current context. The
+        // engine thread has already been joined, so the context is no longer current there.
+        // No-op on CPU/Vulkan; idempotent. Best-effort: a bind failure here must not abort
+        // teardown (the frees below may then fail, but we still free everything we can).
+        try { _fwd.BindToCurrentThread(); }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"[InferenceEngine] could not bind backend context for teardown ({ex.GetType().Name}: {ex.Message}); " +
+                "freeing anyway.");
+        }
+
         // Issue #212: dispose the scratch slot(s) the engine allocated (slot 0 is the pass's
         // OwnedSlot — owned/freed by _fwd.Dispose, never disposed here). Done before _fwd.Dispose
         // so the scratch tensors free while the backend is still live.

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEngineThreadAffinityTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEngineThreadAffinityTests.cs
@@ -1,0 +1,172 @@
+using System.Text;
+using SharpInference.Core;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Regression tests for issue #302: <see cref="InferenceEngine"/> must drive the forward pass
+/// from a single, dedicated, long-lived thread (not arbitrary <c>Task.Run</c> thread-pool
+/// threads), and must call <see cref="IForwardPass.BindToCurrentThread"/> on that thread before
+/// any <c>Forward</c>/<c>Prefill</c> call. CUDA contexts are thread-affine; the old pool-thread
+/// model deadlocked the first CUDA call in non-interactive sessions. These tests use a recording
+/// mock so they assert the threading contract without a real model or GPU.
+/// </summary>
+public sealed class InferenceEngineThreadAffinityTests
+{
+    [Fact]
+    public async Task GenerateChunksAsync_RunsForwardOnDedicatedNonPoolThread_AfterBind()
+    {
+        var tokenizer = new MiniTokenizer();
+        var fwd = new RecordingForwardPass([1, 2, MiniTokenizer.Eos], tokenizer.VocabSize);
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        int callerThreadId = Environment.CurrentManagedThreadId;
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 10 };
+        await foreach (var _ in engine.GenerateChunksAsync("seed", sp)) { }
+
+        // BindToCurrentThread must have run, before the first forward, on the SAME thread that
+        // then issued every Forward/Prefill call.
+        Assert.True(fwd.BindCalled, "BindToCurrentThread was never called");
+        Assert.True(fwd.BindCalledBeforeFirstForward, "a forward ran before the context was bound");
+        Assert.NotEmpty(fwd.ForwardThreadIds);
+        Assert.All(fwd.ForwardThreadIds, id => Assert.Equal(fwd.BindThreadId, id));
+
+        // The forward pass must NOT run on the caller's thread nor on a thread-pool thread — the
+        // whole point of #302 is a stable, owned thread the CUDA context is bound to.
+        Assert.NotEqual(callerThreadId, fwd.BindThreadId);
+        Assert.False(fwd.AnyForwardOnThreadPoolThread,
+            "forward ran on a thread-pool thread — CUDA context affinity is not guaranteed there");
+    }
+
+    [Fact]
+    public async Task GenerateChunksAsync_SuccessiveRequests_ShareOneStableEngineThread()
+    {
+        var tokenizer = new MiniTokenizer();
+        var fwd = new RecordingForwardPass([1, MiniTokenizer.Eos], tokenizer.VocabSize);
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 10 };
+
+        await foreach (var _ in engine.GenerateChunksAsync("seed", sp)) { }
+        int firstThread = fwd.BindThreadId;
+
+        await foreach (var _ in engine.GenerateChunksAsync("seed", sp)) { }
+
+        // Every forward across both requests ran on the one engine thread — confirming a single
+        // owned thread rather than a fresh pool thread per request.
+        Assert.NotEqual(0, firstThread);
+        Assert.All(fwd.ForwardThreadIds, id => Assert.Equal(firstThread, id));
+    }
+
+    [Fact]
+    public async Task GenerateChunksAsync_BindFailure_SurfacesThroughChannel_DoesNotHang()
+    {
+        // A backend whose context bind throws must fault the request's stream, not hang the
+        // consumer forever (the failure mode #302 is about). The dedicated thread survives so
+        // later requests still work.
+        var tokenizer = new MiniTokenizer();
+        var fwd = new RecordingForwardPass([1, MiniTokenizer.Eos], tokenizer.VocabSize) { ThrowOnBind = true };
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 10 };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in engine.GenerateChunksAsync("seed", sp)) { }
+        });
+    }
+
+    // ── Mocks ─────────────────────────────────────────────────────────────
+
+    /// <summary>2-token-plus-EOS tokenizer; the prompt encodes to a single dummy token.</summary>
+    private sealed class MiniTokenizer : ITokenizer
+    {
+        public const int Eos = 2;
+        private static readonly string[] Vocab = ["a", "b", "<eos>"];
+
+        public int VocabSize => Vocab.Length;
+        public int BosTokenId => 0;
+        public int EosTokenId => Eos;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => Eos;
+        public bool AddBosToken => false;
+        public System.Collections.Immutable.ImmutableArray<int> EogTokenIds => [Eos];
+
+        public IReadOnlyList<int> Encode(string text) => [0];
+        public string Decode(IEnumerable<int> tokens)
+        {
+            var sb = new StringBuilder();
+            foreach (var id in tokens)
+                if ((uint)id < (uint)Vocab.Length) sb.Append(Vocab[id]);
+            return sb.ToString();
+        }
+        public byte[] DecodeBytes(int token) =>
+            (uint)token < (uint)Vocab.Length ? Encoding.UTF8.GetBytes(Vocab[token]) : [];
+    }
+
+    /// <summary>
+    /// Scripted forward pass that records which thread <see cref="BindToCurrentThread"/> and each
+    /// <c>Forward</c>/<c>Prefill</c> ran on, plus whether the bind preceded the first forward.
+    /// </summary>
+    private sealed class RecordingForwardPass : IForwardPass
+    {
+        private readonly int[] _sequence;
+        private readonly int _vocabSize;
+        private readonly float[] _logits;
+        private readonly object _gate = new();
+        private int _step;
+
+        public RecordingForwardPass(int[] sequence, int vocabSize)
+        {
+            _sequence = sequence;
+            _vocabSize = vocabSize;
+            _logits = new float[vocabSize];
+        }
+
+        public bool ThrowOnBind { get; init; }
+
+        public bool BindCalled { get; private set; }
+        public int BindThreadId { get; private set; }
+        public bool BindCalledBeforeFirstForward { get; private set; } = true;
+        public bool AnyForwardOnThreadPoolThread { get; private set; }
+        public List<int> ForwardThreadIds { get; } = [];
+
+        public int VocabSize => _vocabSize;
+        public int MaxSeqLen => 4096;
+        public bool SupportsPartialRewind => true;
+
+        public void BindToCurrentThread()
+        {
+            if (ThrowOnBind)
+                throw new InvalidOperationException("simulated cuCtxSetCurrent failure");
+            lock (_gate)
+            {
+                BindCalled = true;
+                BindThreadId = Environment.CurrentManagedThreadId;
+            }
+        }
+
+        private ReadOnlySpan<float> EmitNext()
+        {
+            lock (_gate)
+            {
+                if (!BindCalled) BindCalledBeforeFirstForward = false;
+                if (Thread.CurrentThread.IsThreadPoolThread) AnyForwardOnThreadPoolThread = true;
+                ForwardThreadIds.Add(Environment.CurrentManagedThreadId);
+            }
+
+            Array.Clear(_logits);
+            int id = _step < _sequence.Length ? _sequence[_step++] : MiniTokenizer.Eos;
+            _logits[id] = 1.0f;
+            return _logits;
+        }
+
+        public ReadOnlySpan<float> Forward(int token, int position) => EmitNext();
+        public ReadOnlySpan<float> Prefill(IReadOnlyList<int> tokens, int startPos = 0) => EmitNext();
+        public void TruncateTo(int length) { }
+        public void ResetCache() { _step = 0; }
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #302 — `InferenceEngine.GenerateChunksAsync` ran the forward pass inside `Task.Run(...)` on an arbitrary thread-pool worker. **CUDA contexts are thread-affine**, and in a *non-interactive* session (spawned process / service / agent with redirected stdio) the driver does not keep the device's primary context current on freshly-scheduled threads — so the first CUDA call on the pool thread **hangs forever** (CPU frozen, GPU ~0%, model fully resident). The CLI is unaffected because it decodes synchronously on the context-owning main thread.

Non-obvious root detail: `CudaBackend.EnsurePrimaryContextCurrent()` already existed but was only called on the upload-stream and image-kernel paths — **never on the main forward-compute path**, which silently relied on the implicit per-thread primary context.

## Fix (issue's preferred Option B — dedicated thread)
- **`IThreadAffineBackend.BindToCurrentThread()`** — new shared interface in Core with a default no-op, extended by both `IForwardPass` and `IBatchedForwardPass` (one slot, no duplicate default-interface-method). CPU/Vulkan inherit the no-op; the three CUDA passes override it → `CudaBackend.BindContextToCurrentThread()` → existing `EnsurePrimaryContextCurrent()` (idempotent via `[ThreadStatic]`).
- **`InferenceEngine`** owns a dedicated long-lived **background** thread consuming a `BlockingCollection<Action>`. `GenerateChunksAsync` dispatches the (unchanged) generation lambda via `RunOnEngineThread` instead of `Task.Run`. The lambda binds the context as its first statement inside the existing `try`, so a bind failure surfaces through the per-request channel instead of hanging. The thread is stopped in `DisposeCore` on the drained path (`CompleteAdding` + `Join`) and intentionally leaked on the drain-timeout path (background; matches the existing #132 leak-don't-free-under-live-worker philosophy). `DisposeCore` also binds (best-effort) before freeing CUDA resources, since teardown is context-affine too. The per-request `Channel<GenerateChunk>` streaming and the gate/drain semantics are otherwise unchanged.
- **`ContinuousBatchingEngine.BatcherLoop`** binds at the top of every iteration — its idle `await WaitToReadAsync().ConfigureAwait(false)` can resume the continuation on a different pool thread.

## Tests
New `InferenceEngineThreadAffinityTests` (mock `IForwardPass`, **no GPU/model**) asserts: forward runs on a single stable thread that is neither the caller nor a thread-pool thread, the bind precedes the first forward, the same thread is reused across successive requests, and a bind failure surfaces through the channel without hanging.

- Full solution builds clean (0 warnings, `TreatWarningsAsErrors`).
- 33 engine mock tests pass (3 new + 30 existing chunk/concurrency/prefix-cache, incl. the dispose-drain and drain-timeout cases).

## Review
Three review passes (general correctness, silent-failure, type-design) applied before opening: routed all forward work through the engine thread, added the dispose-teardown bind, and replaced two independent `BindToCurrentThread` DIMs with the shared `IThreadAffineBackend` to remove a latent CS0121 ambiguity and de-duplicate docs.

A good real-GPU confirmation is the original Ayu non-interactive repro (`gemma-4-12b-it-qat-q4_0`, `-g -1 --backend cuda --kv-type q8_0`) against a `GenerateChunksAsync` consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDR5BLSrhvCk7URYqrp6zA