### PR TITLE
fix(gemma4): stop <|channel> thought markers leaking into text output (#304)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -1545,18 +1545,28 @@ public sealed class RunCommand : Command<RunCommand.Settings>
     /// </summary>
     private static bool EmitToken(int next, GgufTokenizer tok, Utf8StreamDecoder streamDec, ref bool inThinking, bool hideThinking = false)
     {
+        // Reasoning boundary tokens are always consumed (never printed), with the state flip
+        // gated on the current mode so a malformed double-open or a bare close — e.g. Gemma 4's
+        // post-tool prompt primes <|channel>, so the answer pass emits a lone <channel|> with no
+        // open — is swallowed rather than rendered as a literal marker (issue #304).
         if (next == s_thinkTokenId)
         {
-            inThinking = true;
-            // No trailing \n: the model often emits its own leading newline inside the block,
-            // and a double break before the reasoning starts looks noisy.
-            Console.Write("\x1b[2m[Thinking...] ");
+            if (!inThinking)
+            {
+                inThinking = true;
+                // No trailing \n: the model often emits its own leading newline inside the block,
+                // and a double break before the reasoning starts looks noisy.
+                Console.Write("\x1b[2m[Thinking...] ");
+            }
             return false;
         }
-        if (next == s_endThinkTokenId && inThinking)
+        if (next == s_endThinkTokenId)
         {
-            inThinking = false;
-            Console.Write("\x1b[0m\n");
+            if (inThinking)
+            {
+                inThinking = false;
+                Console.Write("\x1b[0m\n");
+            }
             return false;
         }
         // Stream through the same UTF-8 decoder regardless of mode so multibyte

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -347,24 +347,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         var tokenizer = GgufTokenizer.FromGgufModel(model);
         s_jinja = tokenizer.ChatTemplate;
 
-        // Reasoning models (Qwen3, DeepSeek-R1, SmolLM3, ...) register <think>/</think>
-        // as control tokens in their GGUF. The decode loops no-op when these IDs are -1.
-        if (tokenizer.SpecialTokens.TryGetValue("<think>", out int thinkId)
-            && tokenizer.SpecialTokens.TryGetValue("</think>", out int endThinkId)
-            && thinkId > 0 && endThinkId > 0)
-        {
-            s_thinkTokenId = thinkId;
-            s_endThinkTokenId = endThinkId;
-        }
-        // Gemma 4 brackets its reasoning in <|channel>thought … <channel|> instead. Route it
-        // through the same think/end-think machinery so the markers don't leak into output.
-        else if (tokenizer.SpecialTokens.TryGetValue("<|channel>", out int channelId)
-            && tokenizer.SpecialTokens.TryGetValue("<channel|>", out int endChannelId)
-            && channelId > 0 && endChannelId > 0)
-        {
-            s_thinkTokenId = channelId;
-            s_endThinkTokenId = endChannelId;
-        }
+        // Reasoning boundary tokens: ChatML <think>/</think> (Qwen3, DeepSeek-R1, SmolLM3, ...)
+        // or Gemma 4's <|channel>thought … <channel|>. Resolved once on the tokenizer so the CLI,
+        // server, and engine share one definition. The decode loops no-op when these IDs are -1.
+        (s_thinkTokenId, s_endThinkTokenId) = tokenizer.ReasoningTokens;
 
         // Resolve reasoning on/off (see ResolveThinkingOff for the full precedence). --no-thinking
         // and --thinking are opposites; if both are passed --no-thinking wins, so warn rather than

--- a/src/SharpInference.Core/GgufTokenizer.cs
+++ b/src/SharpInference.Core/GgufTokenizer.cs
@@ -49,6 +49,9 @@ public sealed class GgufTokenizer : ITokenizer
     /// <summary>All special (control) tokens keyed by their string representation.</summary>
     public IReadOnlyDictionary<string, int> SpecialTokens => _specialTokens;
 
+    /// <inheritdoc/>
+    public (int Open, int Close) ReasoningTokens { get; }
+
     /// <summary>The type name of the inner tokenizer (for diagnostics).</summary>
     public string InnerTokenizerType => _inner.GetType().Name;
 
@@ -90,6 +93,30 @@ public sealed class GgufTokenizer : ITokenizer
         PadTokenId = padTokenId;
         AddBosToken = addBosToken;
         EogTokenIds = eogTokenIds;
+        ReasoningTokens = ResolveReasoningTokens(specialTokens);
+    }
+
+    /// <summary>
+    /// Resolves the open/close special-token IDs that bracket a model's reasoning stream so an
+    /// engine can split it into a separate thinking channel. Tries the ChatML
+    /// <c>&lt;think&gt;</c>/<c>&lt;/think&gt;</c> convention first, then Gemma 4's
+    /// <c>&lt;|channel&gt;</c>/<c>&lt;channel|&gt;</c> "thought" channel (single special tokens —
+    /// the template strips every channel block from history, so treating the whole block as
+    /// reasoning matches the model's own content/thought split). Both IDs must be positive — id 0
+    /// is usually <c>&lt;pad&gt;</c>/<c>&lt;unk&gt;</c> and would mis-trigger — and both must be
+    /// present. No match returns <c>(-1, -1)</c>, leaving reasoning-stream splitting disabled.
+    /// </summary>
+    internal static (int Open, int Close) ResolveReasoningTokens(IReadOnlyDictionary<string, int> specialTokens)
+    {
+        if (specialTokens.TryGetValue("<think>", out int tid)
+            && specialTokens.TryGetValue("</think>", out int eid)
+            && tid > 0 && eid > 0)
+            return (tid, eid);
+        if (specialTokens.TryGetValue("<|channel>", out int cid)
+            && specialTokens.TryGetValue("<channel|>", out int ceid)
+            && cid > 0 && ceid > 0)
+            return (cid, ceid);
+        return (-1, -1);
     }
 
     /// <summary>

--- a/src/SharpInference.Core/ITokenizer.cs
+++ b/src/SharpInference.Core/ITokenizer.cs
@@ -38,4 +38,16 @@ public interface ITokenizer
 
     /// <summary>Whether BOS token should be automatically prepended.</summary>
     bool AddBosToken { get; }
+
+    /// <summary>
+    /// The <c>(Open, Close)</c> special-token IDs that bracket this model's reasoning stream, or
+    /// <c>(-1, -1)</c> when the vocabulary defines none. An engine uses these to split the
+    /// reasoning channel out of the user-facing text stream (boundary tokens themselves are
+    /// consumed, never emitted). Covers both the ChatML <c>&lt;think&gt;</c>/<c>&lt;/think&gt;</c>
+    /// convention and Gemma 4's <c>&lt;|channel&gt;</c>/<c>&lt;channel|&gt;</c> "thought" channel.
+    /// Default: none — only a vocab-backed tokenizer (e.g. <see cref="GgufTokenizer"/>) resolves a
+    /// real pair, so every consumer that constructs an engine gets the same split without
+    /// re-deriving the convention itself.
+    /// </summary>
+    (int Open, int Close) ReasoningTokens => (-1, -1);
 }

--- a/src/SharpInference.Core/ToolCallAdapter.cs
+++ b/src/SharpInference.Core/ToolCallAdapter.cs
@@ -96,6 +96,18 @@ public interface IToolCallAdapter
     /// <c>{role:"tool", content:string}</c>; some families wrap differently.
     /// </summary>
     Dictionary<string, object?> RenderToolResult(string toolUseId, string resultContent);
+
+    /// <summary>
+    /// Special-token strings that mark the END of this model's tool-call section — i.e. the model
+    /// has finished emitting tool calls and is opening the next (tool-result) turn. A host driving
+    /// an agentic loop can resolve these against the tokenizer's special tokens and add them to its
+    /// stop set so generation halts the instant the tool calls are complete, instead of running on
+    /// and hallucinating a trailing turn. Returns the model-family token so the host doesn't have to
+    /// hardcode it. Empty for families whose end-of-turn / EOG token already covers this boundary;
+    /// Gemma 4 returns <c>&lt;|tool_response&gt;</c> (this QAT line opens a response turn rather than
+    /// emitting <c>&lt;end_of_turn&gt;</c>). See issue #304.
+    /// </summary>
+    IReadOnlyList<string> ToolBoundaryStopMarkers => [];
 }
 
 /// <summary>
@@ -657,8 +669,23 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
     /// </summary>
     private static readonly string[] ResponseMarkers = ["<|tool_response>", "<tool_response|>"];
 
+    /// <summary>Open/close of Gemma 4's reasoning ("thought") channel — same asymmetric-pipe
+    /// convention as the tool markers: open <c>&lt;|channel&gt;</c>, close <c>&lt;channel|&gt;</c>,
+    /// with a channel label (e.g. <c>thought</c>) and any reasoning content between them.</summary>
+    public const string ChannelOpen  = "<|channel>";
+    public const string ChannelClose = "<channel|>";
+
     public string Architecture => "gemma4";
     public int MaxOpenTagLength => OpenMarker.Length;
+
+    private static readonly string[] s_toolBoundaryStopMarkers = ["<|tool_response>"];
+
+    /// <inheritdoc/>
+    /// <remarks>Gemma 4's QAT instruct line opens a <c>&lt;|tool_response&gt;</c> turn after its
+    /// tool calls instead of emitting <c>&lt;end_of_turn&gt;</c>, so without this stop the engine
+    /// runs on past the (complete, parseable) tool-call block and hallucinates a trailing turn —
+    /// issue #304. The block is left intact because the stop token is consumed, not emitted.</remarks>
+    public IReadOnlyList<string> ToolBoundaryStopMarkers => s_toolBoundaryStopMarkers;
 
     public ToolCallParseResult Parse(string rawOutput)
     {
@@ -683,7 +710,7 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
                 // Model stopped mid-call (no <tool_call|>): surface the partial as text and flag
                 // truncation rather than emitting a half-parsed call. Matches the streaming path.
                 plain.Append(rawOutput, contentStart, rawOutput.Length - contentStart);
-                return new ToolCallParseResult(ScrubResponseMarkers(plain), calls, Truncated: true);
+                return new ToolCallParseResult(ScrubControlMarkup(plain), calls, Truncated: true);
             }
 
             string block = rawOutput[contentStart..end];
@@ -691,20 +718,60 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
             foreach (var c in ParseBlock(block)) calls.Add(c);
         }
 
-        return new ToolCallParseResult(ScrubResponseMarkers(plain), calls, Truncated: false);
+        return new ToolCallParseResult(ScrubControlMarkup(plain), calls, Truncated: false);
     }
 
     /// <summary>
-    /// Removes any orphan tool-response turn markers from the accumulated plain text so a
-    /// leftover <c>&lt;|tool_response&gt;</c> (emitted after a tool call) doesn't surface as
-    /// assistant content. Operates on the non-block text only — tool-call blocks were already
-    /// extracted — so a marker that legitimately appears inside a tool argument is untouched.
+    /// Scrubs Gemma 4 turn/channel control markup from the accumulated plain text so it doesn't
+    /// surface as assistant content. Operates on the non-block text only — tool-call blocks were
+    /// already extracted — so a marker that legitimately appears inside a tool argument is untouched.
+    /// Two kinds of markup are removed:
+    /// <list type="bullet">
+    /// <item>orphan tool-response turn markers (<c>&lt;|tool_response&gt;</c>/<c>&lt;tool_response|&gt;</c>),
+    /// emitted when the model opens the next turn after a tool call (issue #150); and</item>
+    /// <item>reasoning-channel blocks (<c>&lt;|channel&gt;label … &lt;channel|&gt;</c>): the header,
+    /// label, and any reasoning content up to the close are dropped, keeping the text before
+    /// <c>&lt;|channel&gt;</c> and after <c>&lt;channel|&gt;</c> — mirroring the GGUF chat template's
+    /// own history scrubber (issue #304). An unterminated <c>&lt;|channel&gt;</c> (no close) drops to
+    /// the end; a bare <c>&lt;channel|&gt;</c> close with no open is removed in place (the
+    /// post-tool generation prompt can prime <c>&lt;|channel&gt;</c>, so the answer pass emits a
+    /// lone close).</item>
+    /// </list>
     /// </summary>
-    private static string ScrubResponseMarkers(StringBuilder plain)
+    private static string ScrubControlMarkup(StringBuilder plain)
     {
         foreach (var marker in ResponseMarkers)
             plain.Replace(marker, "");
-        return plain.ToString();
+
+        string s = plain.ToString();
+        if (s.IndexOf(ChannelOpen, StringComparison.Ordinal) < 0
+            && s.IndexOf(ChannelClose, StringComparison.Ordinal) < 0)
+            return s;
+
+        var sb = new StringBuilder(s.Length);
+        int pos = 0;
+        while (pos < s.Length)
+        {
+            int open = s.IndexOf(ChannelOpen, pos, StringComparison.Ordinal);
+            int closeOnly = s.IndexOf(ChannelClose, pos, StringComparison.Ordinal);
+
+            // A close that precedes the next open (or stands alone) is a bare/orphan close —
+            // drop the marker, keep the surrounding text.
+            if (closeOnly >= 0 && (open < 0 || closeOnly < open))
+            {
+                sb.Append(s, pos, closeOnly - pos);
+                pos = closeOnly + ChannelClose.Length;
+                continue;
+            }
+
+            if (open < 0) { sb.Append(s, pos, s.Length - pos); break; }
+
+            sb.Append(s, pos, open - pos);                                  // text before the block
+            int close = s.IndexOf(ChannelClose, open + ChannelOpen.Length, StringComparison.Ordinal);
+            if (close < 0) break;                                           // unterminated: drop to end
+            pos = close + ChannelClose.Length;                             // resume after the close
+        }
+        return sb.ToString();
     }
 
     public int FindOpenMarker(string buffer, int startSearch, out int contentStart)

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -726,17 +726,17 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             InThinking = promptInThinking,
         };
 
-        // Route the first sampled token through the same state machine as the decode loop.
-        // A `<think>` here without an open block opens one; a `</think>` while in a prompt-
-        // seeded block closes it. A stray `</think>` outside a block falls through to
-        // content (same fall-through as decode).
-        if (_thinkingEnabled && firstToken == _thinkTokenId && !seq.InThinking)
+        // Route the first sampled token through the same always-consume state machine as the
+        // decode loop: a reasoning boundary token is consumed and never emitted, with the state
+        // flip gated on the current InThinking. A bare `<channel|>` close (or a double-open) is
+        // swallowed rather than leaking its literal marker as text — issue #304.
+        if (_thinkingEnabled && firstToken == _thinkTokenId)
         {
-            seq.InThinking = true;
+            if (!seq.InThinking) seq.InThinking = true;
         }
-        else if (_thinkingEnabled && firstToken == _endThinkTokenId && seq.InThinking)
+        else if (_thinkingEnabled && firstToken == _endThinkTokenId)
         {
-            seq.InThinking = false;
+            if (seq.InThinking) seq.InThinking = false;
         }
         else
         {

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -371,22 +371,29 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                     if (_thinkingEnabled && next == _thinkTokenId) seq.ThinkingCount = 0;
                     else if (seq.InThinking) seq.ThinkingCount++;
 
-                    // Reasoning boundary tokens: flip state, consume the token, do NOT emit content.
-                    // Each direction requires the opposite state, so malformed double <think>
-                    // or orphan </think> falls through to the content path below.
-                    if (_thinkingEnabled && next == _thinkTokenId && !seq.InThinking)
+                    // Reasoning boundary tokens are ALWAYS consumed and never emitted. State flips
+                    // only on a valid transition, so a malformed double-open or an orphan close is
+                    // swallowed rather than leaking its literal marker as text — e.g. a bare Gemma 4
+                    // <channel|> close with no preceding open (issue #304).
+                    if (_thinkingEnabled && next == _thinkTokenId)
                     {
-                        var textTail = seq.TextDec.Flush();
-                        if (textTail.Length > 0)
-                            seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
-                        seq.InThinking = true;
+                        if (!seq.InThinking)
+                        {
+                            var textTail = seq.TextDec.Flush();
+                            if (textTail.Length > 0)
+                                seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
+                            seq.InThinking = true;
+                        }
                     }
-                    else if (_thinkingEnabled && next == _endThinkTokenId && seq.InThinking)
+                    else if (_thinkingEnabled && next == _endThinkTokenId)
                     {
-                        var thinkTail = seq.ThinkDec.Flush();
-                        if (thinkTail.Length > 0)
-                            seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
-                        seq.InThinking = false;
+                        if (seq.InThinking)
+                        {
+                            var thinkTail = seq.ThinkDec.Flush();
+                            if (thinkTail.Length > 0)
+                                seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
+                            seq.InThinking = false;
+                        }
                     }
                     else
                     {
@@ -672,8 +679,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         // Stop on ANY end-of-generation token, not just the configured EOS — matches the
         // single-user InferenceEngine path. A model with an alternate end token (e.g. Gemma's
         // <eos>, distinct from its <turn|> EOS) would otherwise decode it as text and run on.
+        // StopTokenIds replaces this set; AdditionalStopTokenIds is unioned on top (issue #304).
         System.Collections.Immutable.ImmutableArray<int> stopIds =
-            req.Sp.StopTokenIds is { } userStops ? [.. userStops] : _tokenizer.EogTokenIds;
+            req.Sp.ResolveStopSet(_tokenizer.EogTokenIds);
         var rng = new Random();
 
         int firstToken = req.Sp.Temperature <= 0f

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -275,15 +275,22 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
     public bool MultiSlotPrefixActive => _slots is not null;
 
     /// <summary>
-    /// Back-compat constructor preserving the original positional signature
-    /// (no reasoning-token IDs). Equivalent to passing <c>thinkTokenId = -1</c>.
+    /// Convenience constructor that auto-resolves the reasoning-stream boundary tokens from the
+    /// tokenizer (<see cref="ITokenizer.ReasoningTokens"/>) so an in-process consumer gets the
+    /// same Thinking/Text split the server and CLI configure — without having to re-derive the
+    /// model-family convention. A tokenizer that defines none (the default) yields
+    /// <c>(-1, -1)</c>, leaving the engine in plain text-only mode exactly as before. Pass the
+    /// explicit five-argument constructor with <c>thinkTokenId = -1</c> to force the split off.
+    /// (Fixes issue #304: a Gemma 4 host using this constructor leaked <c>&lt;|channel&gt;</c>
+    /// markers because the split was hardcoded off here.)
     /// </summary>
     public InferenceEngine(
         IForwardPass fwd,
         ITokenizer tokenizer,
         string modelId,
         params IDisposable[] owned)
-        : this(fwd, tokenizer, modelId, thinkTokenId: -1, endThinkTokenId: -1, owned)
+        : this(fwd, tokenizer, modelId,
+               tokenizer.ReasoningTokens.Open, tokenizer.ReasoningTokens.Close, owned)
     {
     }
 
@@ -613,8 +620,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     // ignore the Usage kind.
                     channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Usage, "", promptTokenCount));
                     var rng = new Random();
+                    // Explicit StopTokenIds REPLACE the EOG set; AdditionalStopTokenIds are unioned
+                    // on top so a caller can add a stop (e.g. a tool-boundary token) without dropping
+                    // EOG — issue #304.
                     System.Collections.Immutable.ImmutableArray<int> stopIds =
-                        sp.StopTokenIds is { } userStops ? [.. userStops] : _tokenizer.EogTokenIds;
+                        sp.ResolveStopSet(_tokenizer.EogTokenIds);
 
                     // Issue #102: canonical-history prefix resolution. The endpoint passes a
                     // chat-template render of just the message history (add_generation_prompt=false);
@@ -1001,28 +1011,36 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         if (thinkingEnabled && next == thinkId) thinkingCount = 0;
                         else if (inThinking) thinkingCount++;
 
-                        // Reasoning boundary tokens: flip state, consume the token, do NOT emit.
-                        // Both directions require the *opposite* state — a malformed second
-                        // <think> mid-reasoning, or a stray </think> with no open block, falls
-                        // through to the content path below rather than silently corrupting state.
-                        if (thinkingEnabled && next == thinkId && !inThinking)
+                        // Reasoning boundary tokens are ALWAYS consumed and never emitted (the
+                        // documented contract). State flips only on a valid transition, so a
+                        // malformed double-open or an orphan close is swallowed instead of leaking
+                        // its literal marker as text — e.g. Gemma 4's post-tool generation prompt
+                        // primes <|channel>, so the answer pass can emit a bare <channel|> close
+                        // with no preceding open (issue #304).
+                        if (thinkingEnabled && next == thinkId)
                         {
-                            // Flush any pending text bytes before entering thinking mode.
-                            var textTail = textDec.Flush();
-                            if (textTail.Length > 0)
-                                channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
-                            inThinking = true;
+                            if (!inThinking)
+                            {
+                                // Flush any pending text bytes before entering thinking mode.
+                                var textTail = textDec.Flush();
+                                if (textTail.Length > 0)
+                                    channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Text, textTail));
+                                inThinking = true;
+                            }
                             if (useGpuArgmax) gpuNext = _fwd.ForwardArgmax(next, startPos + i).Token;
                             else logits = _fwd.Forward(next, startPos + i);
                             continue;
                         }
-                        if (thinkingEnabled && next == endThinkId && inThinking)
+                        if (thinkingEnabled && next == endThinkId)
                         {
-                            // Flush thinking-decoder tail as a final Thinking chunk.
-                            var thinkTail = thinkDec.Flush();
-                            if (thinkTail.Length > 0)
-                                channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
-                            inThinking = false;
+                            if (inThinking)
+                            {
+                                // Flush thinking-decoder tail as a final Thinking chunk.
+                                var thinkTail = thinkDec.Flush();
+                                if (thinkTail.Length > 0)
+                                    channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
+                                inThinking = false;
+                            }
                             if (useGpuArgmax) gpuNext = _fwd.ForwardArgmax(next, startPos + i).Token;
                             else logits = _fwd.Forward(next, startPos + i);
                             continue;

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -289,7 +289,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
         ITokenizer tokenizer,
         string modelId,
         params IDisposable[] owned)
-        : this(fwd, tokenizer, modelId,
+        // Guard tokenizer before the base initializer dereferences ReasoningTokens, so a null
+        // surfaces as a clear ArgumentNullException rather than an opaque NullReferenceException.
+        : this(fwd ?? throw new ArgumentNullException(nameof(fwd)),
+               tokenizer ?? throw new ArgumentNullException(nameof(tokenizer)),
+               modelId,
                tokenizer.ReasoningTokens.Open, tokenizer.ReasoningTokens.Close, owned)
     {
     }

--- a/src/SharpInference.Engine/Sampler.cs
+++ b/src/SharpInference.Engine/Sampler.cs
@@ -639,7 +639,7 @@ public sealed record SamplingParams
         if (AdditionalStopTokenIds is not { Length: > 0 } extra)
             return StopTokenIds is { } userStops ? [.. userStops] : eog;
 
-        var set = new HashSet<int>(StopTokenIds ?? (IEnumerable<int>)eog);
+        var set = StopTokenIds is { } baseStops ? new HashSet<int>(baseStops) : new HashSet<int>(eog);
         foreach (int id in extra) set.Add(id);
         return [.. set];
     }

--- a/src/SharpInference.Engine/Sampler.cs
+++ b/src/SharpInference.Engine/Sampler.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace SharpInference.Engine;
 
 /// <summary>
@@ -542,7 +544,24 @@ public sealed record SamplingParams
     public float MinP { get; init; } = 0.0f;
     public float RepetitionPenalty { get; init; } = 1.0f;
     public int MaxNewTokens { get; init; } = 512;
+
+    /// <summary>
+    /// Token IDs that halt generation. <b>Replace semantics</b>: when non-null this <em>replaces</em>
+    /// the tokenizer's end-of-generation set (<see cref="ITokenizer.EogTokenIds"/>) rather than
+    /// adding to it — a caller that sets this to add one stop silently loses the EOG tokens unless it
+    /// re-includes them. To ADD stops while keeping EOG, leave this null and use
+    /// <see cref="AdditionalStopTokenIds"/> instead (issue #304).
+    /// </summary>
     public int[]? StopTokenIds { get; init; }
+
+    /// <summary>
+    /// Extra stop token IDs that are <b>always unioned</b> with the effective stop set
+    /// (<see cref="StopTokenIds"/> when set, otherwise <see cref="ITokenizer.EogTokenIds"/>) —
+    /// never replacing it. This is the footgun-free way to add a stop, e.g. a tool-boundary token
+    /// from <see cref="IToolCallAdapter.ToolBoundaryStopMarkers"/> for an agentic loop, without
+    /// dropping the model's end-of-turn / EOS tokens. Null or empty = no additions. See issue #304.
+    /// </summary>
+    public int[]? AdditionalStopTokenIds { get; init; }
 
     /// <summary>
     /// Additive logit bias applied before temperature scaling.
@@ -607,6 +626,23 @@ public sealed record SamplingParams
     /// Issue #38.
     /// </summary>
     public float SpecDraftPMin { get; init; } = 1f;
+
+    /// <summary>
+    /// Resolves the effective stop-token set for a request. <see cref="StopTokenIds"/> REPLACES
+    /// <paramref name="eog"/> when non-null (replace semantics); otherwise <paramref name="eog"/>
+    /// is the base. <see cref="AdditionalStopTokenIds"/> is then unioned on top (de-duplicated),
+    /// never replacing — so adding a stop can't drop the EOG set. With no additions this returns
+    /// the base unchanged, byte-identical to the pre-#304 behavior.
+    /// </summary>
+    internal ImmutableArray<int> ResolveStopSet(ImmutableArray<int> eog)
+    {
+        if (AdditionalStopTokenIds is not { Length: > 0 } extra)
+            return StopTokenIds is { } userStops ? [.. userStops] : eog;
+
+        var set = new HashSet<int>(StopTokenIds ?? (IEnumerable<int>)eog);
+        foreach (int id in extra) set.Add(id);
+        return [.. set];
+    }
 }
 
 /// <summary>Speculative-decoding type. Mirrors llama.cpp's <c>--spec-type</c>.</summary>

--- a/src/SharpInference.Server/ChatTemplate.cs
+++ b/src/SharpInference.Server/ChatTemplate.cs
@@ -83,6 +83,15 @@ public sealed class ChatTemplateRenderer
     /// </summary>
     public IToolCallAdapter ToolCallAdapter => _toolCallAdapter;
 
+    /// <summary>
+    /// Token IDs that mark the end of the loaded model's tool-call section (Gemma 4:
+    /// <c>&lt;|tool_response&gt;</c>), resolved at <see cref="Configure"/> time from the adapter's
+    /// <see cref="IToolCallAdapter.ToolBoundaryStopMarkers"/> against the model vocab. The chat
+    /// endpoints union these into the stop set on tool-active requests so generation halts when the
+    /// tool calls finish instead of running on (issue #304). Empty for families that need none.
+    /// </summary>
+    public IReadOnlyList<int> ToolBoundaryStopTokenIds { get; private set; } = [];
+
     /// <param name="architecture">Default architecture (used both for fallback and exposed via <see cref="Architecture"/>).</param>
     /// <param name="template">Optional compiled Jinja template; null means "use the hardcoded fallback".</param>
     public ChatTemplateRenderer(string architecture = "qwen2", JinjaChatTemplate? template = null)
@@ -96,12 +105,16 @@ public sealed class ChatTemplateRenderer
     /// Reconfigures the renderer with model-specific metadata. Called by the built-in
     /// engine loader once the GGUF file has been opened. Safe to call once; subsequent
     /// calls overwrite previous values (used by hot-reload scenarios).
+    /// <paramref name="toolBoundaryStopTokenIds"/> are the vocab-resolved tool-boundary stops
+    /// (see <see cref="ToolBoundaryStopTokenIds"/>); null leaves the set empty.
     /// </summary>
-    public void Configure(string architecture, JinjaChatTemplate? template)
+    public void Configure(string architecture, JinjaChatTemplate? template,
+        IReadOnlyList<int>? toolBoundaryStopTokenIds = null)
     {
         _architecture = architecture;
         _template = template;
         _toolCallAdapter = ToolCallAdapterRegistry.Get(architecture);
+        ToolBoundaryStopTokenIds = toolBoundaryStopTokenIds ?? [];
     }
 
     /// <param name="messages">Messages in order (system, user, assistant, ...).</param>

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -142,6 +142,12 @@ public static class AnthropicEndpoints
             maxTokens:   req.MaxTokens,
             maxThinking: req.Thinking?.BudgetTokens);
 
+        // Tool-active turn: add the model family's tool-boundary stop (Gemma 4: <|tool_response>)
+        // so generation halts when the tool calls finish instead of running on. Additive — keeps
+        // the EOG set (issue #304).
+        if (req.Tools is { Length: > 0 } && chatTemplate.ToolBoundaryStopTokenIds is { Count: > 0 } toolStops)
+            sp = sp with { AdditionalStopTokenIds = [.. toolStops] };
+
         var msgId = $"msg_{Guid.NewGuid():N}";
         var modelId = engine.ModelId;
 

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -144,7 +144,9 @@ public static class AnthropicEndpoints
 
         // Tool-active turn: add the model family's tool-boundary stop (Gemma 4: <|tool_response>)
         // so generation halts when the tool calls finish instead of running on. Additive — keeps
-        // the EOG set (issue #304).
+        // the EOG set (issue #304). Gated on req.Tools to match THIS endpoint's tool-aware
+        // rendering condition above (Anthropic only routes through the rich/tool path when tools
+        // are declared); OpenAI also folds in tool messages in history, mirroring its wider gate.
         if (req.Tools is { Length: > 0 } && chatTemplate.ToolBoundaryStopTokenIds is { Count: > 0 } toolStops)
             sp = sp with { AdditionalStopTokenIds = [.. toolStops] };
 

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -152,6 +152,12 @@ public static class OpenAiEndpoints
             maxThinking: req.MaxThinkingTokens,
             logitBias:   logitBias);
 
+        // Tool-active agentic turn: add the model family's tool-boundary stop (Gemma 4:
+        // <|tool_response>) so generation halts the instant the tool calls finish rather than
+        // running on into a hallucinated trailing turn. Additive — keeps the EOG set (issue #304).
+        if (toolsActive && chatTemplate.ToolBoundaryStopTokenIds is { Count: > 0 } toolStops)
+            sp = sp with { AdditionalStopTokenIds = [.. toolStops] };
+
         var requestId = $"chatcmpl-{Guid.NewGuid():N}";
         long created = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -61,11 +61,20 @@ public static class InferenceEngineLoader
         // adapter markers (Gemma 4: <|tool_response>) against the vocab. The chat endpoints add
         // these to the stop set on tool-active requests so the model halts the instant it finishes
         // its tool calls instead of opening a hallucinated trailing turn.
-        var toolBoundaryStopTokenIds = ToolCallAdapterRegistry.Get(arch).ToolBoundaryStopMarkers
+        var toolBoundaryMarkers = ToolCallAdapterRegistry.Get(arch).ToolBoundaryStopMarkers;
+        var toolBoundaryStopTokenIds = toolBoundaryMarkers
             .Select(m => tokenizer.SpecialTokens.TryGetValue(m, out int id) ? id : -1)
             .Where(id => id > 0)
             .Distinct()
             .ToArray();
+        // The adapter declared it needs a tool-boundary stop but none resolved to a vocab id —
+        // agentic generation will run past the tool calls (the #304 symptom) with no other clue.
+        // Warn rather than fail silently (mirrors the image-input diagnostic below).
+        if (toolBoundaryMarkers.Count > 0 && toolBoundaryStopTokenIds.Length == 0)
+            Console.Error.WriteLine(
+                $"[SharpInference] {arch} declares tool-boundary stop markers [{string.Join(", ", toolBoundaryMarkers)}] " +
+                "that were not found in this model's vocab; agentic tool-call generation may run past " +
+                "the tool calls (issue #304).");
 
         // ── 3. Validate TurboQuant up-front so a mis-shaped request fails fast (and not
         // after the model has already been mmap'd into VRAM).

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -55,7 +55,17 @@ public static class InferenceEngineLoader
             ? (string)a
             : opts.Architecture;
         var modelId = Path.GetFileNameWithoutExtension(modelPath);
-        var (thinkTokenId, endThinkTokenId) = ResolveReasoningTokens(tokenizer);
+        var (thinkTokenId, endThinkTokenId) = tokenizer.ReasoningTokens;
+
+        // Tool-boundary stop tokens for agentic loops (issue #304): resolve the architecture's
+        // adapter markers (Gemma 4: <|tool_response>) against the vocab. The chat endpoints add
+        // these to the stop set on tool-active requests so the model halts the instant it finishes
+        // its tool calls instead of opening a hallucinated trailing turn.
+        var toolBoundaryStopTokenIds = ToolCallAdapterRegistry.Get(arch).ToolBoundaryStopMarkers
+            .Select(m => tokenizer.SpecialTokens.TryGetValue(m, out int id) ? id : -1)
+            .Where(id => id > 0)
+            .Distinct()
+            .ToArray();
 
         // ── 3. Validate TurboQuant up-front so a mis-shaped request fails fast (and not
         // after the model has already been mmap'd into VRAM).
@@ -159,7 +169,7 @@ public static class InferenceEngineLoader
             throw;
         }
 
-        return new LoadedEngine(engine, arch, tokenizer.ChatTemplate);
+        return new LoadedEngine(engine, arch, tokenizer.ChatTemplate, toolBoundaryStopTokenIds);
     }
 
     // ── Backend dispatch ─────────────────────────────────────────────────────
@@ -365,32 +375,6 @@ public static class InferenceEngineLoader
         // the engine's VRAM-fit auto-select) untouched.
         if (opts.CpuMoe is bool cpuMoe)
             Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", cpuMoe ? "1" : "0");
-    }
-
-    /// <summary>
-    /// Resolves the open/close special-token IDs that bracket a model's reasoning stream so
-    /// the engine can split it into a separate <c>Thinking</c> channel. Tries the ChatML
-    /// <c>&lt;think&gt;</c>/<c>&lt;/think&gt;</c> convention first, then Gemma 4's
-    /// <c>&lt;|channel&gt;</c>/<c>&lt;channel|&gt;</c> "thought" channel. Both IDs must be
-    /// positive — id 0 is usually <c>&lt;pad&gt;</c>/<c>&lt;unk&gt;</c> and would mis-trigger —
-    /// and both must be present. No match leaves reasoning-stream splitting disabled (the
-    /// engine emits Text chunks only), which is why a Gemma model would otherwise leak raw
-    /// <c>&lt;|channel&gt;thought…&lt;channel|&gt;</c> markers into the assistant content.
-    /// </summary>
-    private static (int thinkTokenId, int endThinkTokenId) ResolveReasoningTokens(GgufTokenizer tokenizer)
-    {
-        if (tokenizer.SpecialTokens.TryGetValue("<think>", out int tid)
-            && tokenizer.SpecialTokens.TryGetValue("</think>", out int eid)
-            && tid > 0 && eid > 0)
-            return (tid, eid);
-        // Gemma 4 wraps reasoning in <|channel>thought … <channel|> (single special tokens).
-        // The template strips every channel block from history, so treating the whole block
-        // as reasoning matches the model's own content/thought split.
-        if (tokenizer.SpecialTokens.TryGetValue("<|channel>", out int cid)
-            && tokenizer.SpecialTokens.TryGetValue("<channel|>", out int ceid)
-            && cid > 0 && ceid > 0)
-            return (cid, ceid);
-        return (-1, -1);
     }
 
     /// <summary>

--- a/src/SharpInference.Server/ServiceCollectionExtensions.cs
+++ b/src/SharpInference.Server/ServiceCollectionExtensions.cs
@@ -66,7 +66,8 @@ public static class ServiceCollectionExtensions
             // resolving ChatTemplateRenderer doesn't transitively trigger model loading
             // — important for tests that override IInferenceEngine but expect the
             // renderer to use the safe fallback path.
-            sp.GetRequiredService<ChatTemplateRenderer>().Configure(loaded.Architecture, loaded.ChatTemplate);
+            sp.GetRequiredService<ChatTemplateRenderer>().Configure(
+                loaded.Architecture, loaded.ChatTemplate, loaded.ToolBoundaryStopTokenIds);
 
             return loaded.Engine;
         });

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -327,7 +327,15 @@ public sealed class SamplingDefaults
 /// Compiled Jinja chat template from the model's GGUF metadata, or null when the model
 /// has no <c>tokenizer.chat_template</c> key.
 /// </param>
+/// <param name="ToolBoundaryStopTokenIds">
+/// Token IDs that mark the end of the tool-call section for this model family (Gemma 4:
+/// <c>&lt;|tool_response&gt;</c>), resolved from the adapter's
+/// <see cref="SharpInference.Core.IToolCallAdapter.ToolBoundaryStopMarkers"/> against the vocab.
+/// The chat endpoints add these to the stop set on tool-active requests so the model halts the
+/// instant it finishes its tool calls (issue #304). Null/empty when the family needs none.
+/// </param>
 public sealed record LoadedEngine(
     IInferenceEngine Engine,
     string Architecture,
-    SharpInference.Core.JinjaChatTemplate? ChatTemplate);
+    SharpInference.Core.JinjaChatTemplate? ChatTemplate,
+    IReadOnlyList<int>? ToolBoundaryStopTokenIds = null);

--- a/tests/SharpInference.Tests.Core/ReasoningTokensTests.cs
+++ b/tests/SharpInference.Tests.Core/ReasoningTokensTests.cs
@@ -1,0 +1,64 @@
+using SharpInference.Core;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Model-free unit tests for <see cref="GgufTokenizer.ResolveReasoningTokens"/> — the open/close
+/// boundary-token resolution an engine uses to split the reasoning channel out of the text stream.
+/// Centralizing it on the tokenizer (exposed as <see cref="ITokenizer.ReasoningTokens"/>) is the
+/// fix for issue #304: an in-process consumer using the convenience engine constructor now gets the
+/// same Gemma 4 <c>&lt;|channel&gt;</c>/<c>&lt;channel|&gt;</c> split the server and CLI configure.
+/// </summary>
+public sealed class ReasoningTokensTests
+{
+    private static Dictionary<string, int> Vocab(params (string tok, int id)[] entries)
+    {
+        var d = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var (tok, id) in entries) d[tok] = id;
+        return d;
+    }
+
+    [Fact]
+    public void NoMarkers_ReturnsDisabled()
+    {
+        Assert.Equal((-1, -1), GgufTokenizer.ResolveReasoningTokens(Vocab()));
+    }
+
+    [Fact]
+    public void ChatMlThinkTokens_Resolved()
+    {
+        var vocab = Vocab(("<think>", 50), ("</think>", 51));
+        Assert.Equal((50, 51), GgufTokenizer.ResolveReasoningTokens(vocab));
+    }
+
+    [Fact]
+    public void Gemma4ChannelTokens_Resolved()
+    {
+        // Real Gemma 4 12B QAT ids: <|channel> = 100, <channel|> = 101 (both USER_DEFINED).
+        var vocab = Vocab(("<|channel>", 100), ("<channel|>", 101));
+        Assert.Equal((100, 101), GgufTokenizer.ResolveReasoningTokens(vocab));
+    }
+
+    [Fact]
+    public void ThinkTokens_TakePrecedenceOverChannel()
+    {
+        var vocab = Vocab(("<think>", 50), ("</think>", 51), ("<|channel>", 100), ("<channel|>", 101));
+        Assert.Equal((50, 51), GgufTokenizer.ResolveReasoningTokens(vocab));
+    }
+
+    [Fact]
+    public void ZeroIds_Rejected()
+    {
+        // id 0 is usually <pad>/<unk> and would mis-trigger the split — both ids must be positive.
+        Assert.Equal((-1, -1), GgufTokenizer.ResolveReasoningTokens(Vocab(("<think>", 0), ("</think>", 51))));
+        Assert.Equal((-1, -1), GgufTokenizer.ResolveReasoningTokens(Vocab(("<|channel>", 100), ("<channel|>", 0))));
+    }
+
+    [Fact]
+    public void PartialPair_Rejected()
+    {
+        // Only one half present → no split (an unmatched boundary would corrupt the stream).
+        Assert.Equal((-1, -1), GgufTokenizer.ResolveReasoningTokens(Vocab(("<think>", 50))));
+        Assert.Equal((-1, -1), GgufTokenizer.ResolveReasoningTokens(Vocab(("<|channel>", 100))));
+    }
+}

--- a/tests/SharpInference.Tests.Core/ToolCallAdapterTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolCallAdapterTests.cs
@@ -356,6 +356,88 @@ public sealed class ToolCallAdapterTests
         Assert.Single(calls);
     }
 
+    // ── Gemma 4 reasoning-channel scrub (issue #304) ────────────────────────────
+
+    [Fact]
+    public void Gemma4_Parse_ScrubsChannelHeader_KeepsAnswer()
+    {
+        // enable_thinking=false primes an empty thought channel; the answer follows the close.
+        // The <|channel>thought<channel|> header must not survive in PlainText; the answer must.
+        var a = new Gemma4ToolCallAdapter();
+        var (plain, calls) = a.Parse("<|channel>thought<channel|>The answer is 42.");
+        Assert.Equal("The answer is 42.", plain);
+        Assert.Empty(calls);
+    }
+
+    [Fact]
+    public void Gemma4_Parse_ScrubsChannelBlockWithReasoningContent()
+    {
+        // A full thought block (header + reasoning content) is dropped entirely; only the text
+        // before <|channel> and after <channel|> survives — mirrors the chat template's scrubber.
+        var a = new Gemma4ToolCallAdapter();
+        var (plain, _) = a.Parse("Sure. <|channel>thought\nlet me think hard<channel|>Done.");
+        Assert.Equal("Sure. Done.", plain);
+    }
+
+    [Fact]
+    public void Gemma4_Parse_ScrubsBareChannelClose()
+    {
+        // The post-tool generation prompt can prime <|channel>, so the answer pass emits a lone
+        // <channel|> close with no preceding open. The bare marker is removed, surrounding text kept.
+        var a = new Gemma4ToolCallAdapter();
+        var (plain, _) = a.Parse("<channel|>The file reads three variables.");
+        Assert.Equal("The file reads three variables.", plain);
+    }
+
+    [Fact]
+    public void Gemma4_Parse_ScrubsUnterminatedChannelOpen()
+    {
+        // An unterminated <|channel> (model stopped mid-thought) drops the marker and everything
+        // after it — matching the template's split-on-close history scrubber.
+        var a = new Gemma4ToolCallAdapter();
+        var (plain, _) = a.Parse("Prefix.<|channel>thought\nreasoning with no close");
+        Assert.Equal("Prefix.", plain);
+    }
+
+    [Fact]
+    public void Gemma4_Parse_ScrubsChannelAfterToolCall()
+    {
+        // The exact #304 agentic-loop shape: a tool call, then a channel-wrapped answer.
+        var a = new Gemma4ToolCallAdapter();
+        var raw = "<|tool_call>call:read_file{path:<|\"|>a.cs<|\"|>}<tool_call|><|channel>thought<channel|>It imports two modules.";
+        var (plain, calls) = a.Parse(raw);
+        Assert.Equal("It imports two modules.", plain);
+        Assert.Single(calls);
+        Assert.Equal("read_file", calls[0].Name);
+    }
+
+    [Fact]
+    public void Gemma4_Parse_DoesNotScrubChannelMarkupInsideToolArgument()
+    {
+        // A channel-looking substring inside a quoted tool argument is part of the extracted
+        // block, not PlainText, so it must round-trip into the argument untouched.
+        var a = new Gemma4ToolCallAdapter();
+        var raw = "<|tool_call>call:echo{text:<|\"|>say <|channel>hi<channel|> now<|\"|>}<tool_call|>";
+        var (plain, calls) = a.Parse(raw);
+        Assert.Equal("", plain);
+        Assert.Single(calls);
+        Assert.Equal("say <|channel>hi<channel|> now", calls[0].Arguments["text"]);
+    }
+
+    [Fact]
+    public void Gemma4_ToolBoundaryStopMarkers_IsToolResponseOpen()
+    {
+        Assert.Equal(["<|tool_response>"], new Gemma4ToolCallAdapter().ToolBoundaryStopMarkers);
+    }
+
+    [Theory]
+    [InlineData("qwen2")]
+    [InlineData("qwen3coder")]
+    [InlineData("llama")]
+    [InlineData("deepseek2")]
+    public void NonGemma4_ToolBoundaryStopMarkers_AreEmpty(string arch) =>
+        Assert.Empty(ToolCallAdapterRegistry.Get(arch).ToolBoundaryStopMarkers);
+
     [Fact]
     public void Gemma4_FindMarkers_RoundTripsBlock()
     {

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
@@ -263,6 +263,103 @@ public sealed class InferenceEngineChunkTests
         Assert.Equal("Y", answerText);
     }
 
+    // ── Bare / orphan boundary tokens (issue #304) ──────────────────────────
+
+    [Fact]
+    public async Task GenerateChunksAsync_BareCloseWithNoOpen_IsSwallowedNotLeaked()
+    {
+        // Gemma 4's post-tool generation prompt can prime <|channel>, so the answer pass emits a
+        // bare close (here </think>) with no matching open while NOT in thinking mode. The boundary
+        // token must be consumed, never decoded as literal text into the Text stream.
+        var scripted = new int[] { TokX, TokEndThink, TokY, TokEos };
+        var tokenizer = new ScriptedTokenizer();   // prompt = [TokHi], decode starts outside thinking
+        var fwd = new ScriptedForwardPass(scripted, tokenizer.VocabSize);
+        using var engine = new InferenceEngine(
+            fwd, tokenizer, "mock",
+            thinkTokenId: TokThink, endThinkTokenId: TokEndThink);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 10 };
+        var chunks = new List<GenerateChunk>();
+        await foreach (var c in engine.GenerateChunksAsync("seed", sp))
+            chunks.Add(c);
+
+        var thinkingText = string.Concat(chunks.Where(c => c.Kind == GenerateChunkKind.Thinking).Select(c => c.Text));
+        var answerText = string.Concat(chunks.Where(c => c.Kind == GenerateChunkKind.Text).Select(c => c.Text));
+
+        Assert.Equal("", thinkingText);
+        Assert.Equal("XY", answerText);   // the bare </think> never reached the stream
+        foreach (var c in chunks)
+            Assert.DoesNotContain("</think>", c.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GenerateChunksAsync_ConvenienceCtor_AutoResolvesReasoningSplit()
+    {
+        // Issue #304: an in-process consumer using the convenience constructor (no explicit think
+        // IDs) must still get the reasoning split, resolved from ITokenizer.ReasoningTokens — else
+        // a Gemma 4 host leaks <|channel> markers into Text.
+        var scripted = new int[] { TokThink, TokX, TokEndThink, TokY, TokEos };
+        var tokenizer = new ScriptedTokenizer { ReasoningOverride = (TokThink, TokEndThink) };
+        var fwd = new ScriptedForwardPass(scripted, tokenizer.VocabSize);
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock");   // convenience ctor
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 10 };
+        var chunks = new List<GenerateChunk>();
+        await foreach (var c in engine.GenerateChunksAsync("seed", sp))
+            chunks.Add(c);
+
+        var thinkingText = string.Concat(chunks.Where(c => c.Kind == GenerateChunkKind.Thinking).Select(c => c.Text));
+        var answerText = string.Concat(chunks.Where(c => c.Kind == GenerateChunkKind.Text).Select(c => c.Text));
+        Assert.Equal("X", thinkingText);
+        Assert.Equal("Y", answerText);
+    }
+
+    [Fact]
+    public async Task GenerateChunksAsync_AdditionalStopTokenIds_AddsStopWithoutDroppingEog()
+    {
+        // AdditionalStopTokenIds is unioned with EOG, not a replacement (issue #304). Stop fires on
+        // the added token (TokThere) even though EOG (TokEos) is unchanged.
+        var scripted = new int[] { TokHi, TokThere, TokX, TokEos };
+        var tokenizer = new ScriptedTokenizer();
+        var fwd = new ScriptedForwardPass(scripted, tokenizer.VocabSize);
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams
+        {
+            Temperature = 0f,
+            MaxNewTokens = 10,
+            AdditionalStopTokenIds = [TokThere],   // no StopTokenIds → base set stays EOG
+        };
+        var sb = new StringBuilder();
+        await foreach (var s in engine.GenerateAsync("seed", sp))
+            sb.Append(s);
+
+        Assert.Equal("Hi", sb.ToString());   // stopped at the added token, TokX never reached
+    }
+
+    [Fact]
+    public async Task GenerateChunksAsync_AdditionalStopTokenIds_KeepsEogStop()
+    {
+        // The companion case: with an additional stop set that the model never emits, the EOG token
+        // (TokEos) must still halt generation — proving the union didn't drop EOG.
+        var scripted = new int[] { TokHi, TokEos, TokX };
+        var tokenizer = new ScriptedTokenizer();
+        var fwd = new ScriptedForwardPass(scripted, tokenizer.VocabSize);
+        using var engine = new InferenceEngine(fwd, tokenizer, "mock", thinkTokenId: -1, endThinkTokenId: -1);
+
+        var sp = new SamplingParams
+        {
+            Temperature = 0f,
+            MaxNewTokens = 10,
+            AdditionalStopTokenIds = [TokThere],   // never emitted by the script
+        };
+        var sb = new StringBuilder();
+        await foreach (var s in engine.GenerateAsync("seed", sp))
+            sb.Append(s);
+
+        Assert.Equal("Hi", sb.ToString());   // halted on EOS; "<eos>" never leaked as text
+    }
+
     // ── Mocks ─────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -287,6 +384,11 @@ public sealed class InferenceEngineChunkTests
         /// <summary>When set, overrides the end-of-generation set (default is just EOS).</summary>
         public System.Collections.Immutable.ImmutableArray<int>? EogOverride { get; set; }
         public System.Collections.Immutable.ImmutableArray<int> EogTokenIds => EogOverride ?? [EosTokenId];
+
+        /// <summary>Reasoning boundary tokens reported to the engine's convenience constructor
+        /// (default disabled). Set to exercise <see cref="ITokenizer.ReasoningTokens"/> auto-resolution.</summary>
+        public (int Open, int Close) ReasoningOverride { get; set; } = (-1, -1);
+        public (int Open, int Close) ReasoningTokens => ReasoningOverride;
 
         public int[] PromptTokens { get; set; } = [TokHi];
 

--- a/tests/SharpInference.Tests.Server/ServerLibraryTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerLibraryTests.cs
@@ -330,6 +330,23 @@ public sealed class ChatTemplateRendererTests
     }
 
     [Fact]
+    public void ToolBoundaryStopTokenIds_DefaultEmpty_AndSetByConfigure()
+    {
+        // Issue #304: the loader resolves the adapter's tool-boundary markers (Gemma 4:
+        // <|tool_response>) against the vocab and stashes the IDs here; the chat endpoints add them
+        // to the stop set on tool-active turns. Default is empty until Configure supplies them.
+        var r = new ChatTemplateRenderer("gemma4");
+        Assert.Empty(r.ToolBoundaryStopTokenIds);
+
+        r.Configure("gemma4", null, [50]);
+        Assert.Equal([50], r.ToolBoundaryStopTokenIds);
+
+        // A subsequent Configure without IDs clears them back to empty.
+        r.Configure("gemma4", null);
+        Assert.Empty(r.ToolBoundaryStopTokenIds);
+    }
+
+    [Fact]
     public void JinjaTemplate_TakesPrecedenceOverArchFallback()
     {
         // Once configured with a Jinja template, the architecture fallback is bypassed.


### PR DESCRIPTION
Fixes #304.

## Problem

Driving **Gemma 4 12B (QAT q4_0)** through an in-process agentic tool-call loop leaked the model's `<|channel>thought<channel|>` reasoning-channel header into the user-facing `GenerateChunkKind.Text` stream. The issue + its comment surface three coupled problems in the same scenario:

1. **Channel markers leak into `Text`** (the titled bug) — and a *bare* `<channel|>` close can appear with no preceding open.
2. **Generation doesn't stop** at the tool-call boundary — this QAT line opens a `<|tool_response>` turn (not in the EOG set) instead of `<end_of_turn>`, so it runs on and hallucinates the channel tail.
3. **`StopTokenIds` is a replace-not-augment footgun** — `sp.StopTokenIds ?? EogTokenIds` silently drops EOG when a consumer adds a stop.

## Root cause of (1)

The reasoning split is keyed on token IDs the engine is *told* about. `<|channel>` / `<channel|>` **are** single special tokens in the Gemma 4 vocab (verified: ids **100 / 101**, type 4 USER_DEFINED), and the server + CLI each resolved them — but `InferenceEngine`'s convenience constructor hardcoded the split **off** (`thinkTokenId: -1`), so an in-process host (e.g. Ayu) never got it. The boundary handling also *emitted* an orphan/bare close as literal text.

## Fix

**Core**
- `ITokenizer.ReasoningTokens` (default `(-1,-1)`); `GgufTokenizer` resolves `<think>`/`</think>` then `<|channel>`/`<channel|>` — one source of truth for engine, loader, and CLI.
- `IToolCallAdapter.ToolBoundaryStopMarkers` (default `[]`); Gemma 4 returns `<|tool_response>`.
- `Gemma4ToolCallAdapter.Parse` scrubs `<|channel>label … <channel|>` blocks (incl. bare close / unterminated open) from `PlainText`, mirroring the GGUF chat template's own history scrubber.

**Engine**
- Convenience constructor auto-resolves the split from `tokenizer.ReasoningTokens` (fixes the in-process leak; explicit `-1` still forces it off).
- Reasoning boundary tokens are **always consumed, never emitted** — a bare `<channel|>` close (which the post-tool generation prompt can prime) is swallowed, not leaked. Mirrored in `ContinuousBatchingEngine`.
- `SamplingParams.AdditionalStopTokenIds` — always unioned with the effective stop set (footgun-free way to add a stop); `StopTokenIds` replace semantics documented.

**Server**
- Loader resolves the adapter's tool-boundary markers → ids, stashed on `ChatTemplateRenderer`; the OpenAI + Anthropic chat endpoints add them to the stop set on tool-active turns so generation halts the instant the tool calls finish.

## Compatibility

All default paths are byte-identical: no reasoning tokens → `(-1,-1)`; null `AdditionalStopTokenIds` → base stop set unchanged; non-Gemma adapters → no tool-boundary markers.

## Tests

- **Core** — channel scrub shapes (header-only, with reasoning content, bare close, unterminated open, after a tool call, untouched inside a tool arg) + tool-boundary markers; model-free `ResolveReasoningTokens` (think/channel/precedence/zero-id/partial-pair).
- **Engine** — bare-close suppression, convenience-ctor auto-resolve, additive-stop union + EOG retention.
- **Server** — renderer tool-boundary stash/clear.

Build clean (warnings-as-errors). Model-free suites green (Core 169, Server 125, Cli 41) + mock-based engine tests (50). The heavy GPU/CPU model matrix was not run locally; channel behavior is unit-tested against the real Gemma 4 vocab ids (100/101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDR5BLSrhvCk7URYqrp6zA