### PR TITLE
feat(vulkan): Q8_0 and Q4_0 weight matvec shaders (#310)

### DIFF
--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -945,10 +945,11 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             result = _gpu.Upload(floats, TensorShape.D1(floats.Length));
             _weightDTypes[result.Handle] = DType.Float32;
         }
-        else if (info.DType == DType.Q4_K || info.DType == DType.Q6_K)
+        else if (IsRawGpuQuant(info.DType))
         {
-            // Upload raw quantized bytes (reinterpret as floats for storage buffer)
-            int floatCount = data.Length / 4;
+            // Upload raw quantized bytes (reinterpret as floats for storage buffer).
+            // Round up: Q8_0 (34B) / Q4_0 (18B) blocks can make a non-4-multiple total.
+            int floatCount = (data.Length + 3) / 4;
             var rawFloats = new float[floatCount];
             data.CopyTo(MemoryMarshal.AsBytes(rawFloats.AsSpan()));
             result = _gpu.Upload(rawFloats, TensorShape.D1(floatCount));
@@ -1007,9 +1008,9 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         int byteOffset = expertIdx * expertBytes;
         var expertData = data.Slice(byteOffset, expertBytes);
 
-        if (info.DType == DType.Q4_K || info.DType == DType.Q6_K)
+        if (IsRawGpuQuant(info.DType))
         {
-            int floatCount = expertData.Length / 4;
+            int floatCount = (expertData.Length + 3) / 4;
             var rawFloats = new float[floatCount];
             expertData.CopyTo(MemoryMarshal.AsBytes(rawFloats.AsSpan()));
             var result = _gpu.Upload(rawFloats, TensorShape.D1(floatCount));
@@ -1227,9 +1228,17 @@ public sealed unsafe class GpuForwardPass : IForwardPass
 
     private static long EstimateGpuTensorBytes(GgufTensorInfo tensor)
     {
-        if (tensor.DType == DType.Float32 || tensor.DType == DType.Q4_K || tensor.DType == DType.Q6_K)
+        if (tensor.DType == DType.Float32 || IsRawGpuQuant(tensor.DType))
             return (tensor.ByteSize + 3) & ~3L;
 
         return tensor.ElementCount * sizeof(float);
     }
+
+    /// <summary>
+    /// Weight quantizations uploaded to the GPU as raw blocks (dequantized in-shader by the
+    /// matching <c>VulkanBackend.MatMul</c> matvec dispatch) rather than expanded to F32 on
+    /// the CPU. Keeping these quantized is the whole point of the GPU matvec shaders.
+    /// </summary>
+    private static bool IsRawGpuQuant(DType dtype) =>
+        dtype is DType.Q4_K or DType.Q6_K or DType.Q8_0 or DType.Q4_0;
 }

--- a/src/SharpInference.Vulkan/Shaders.cs
+++ b/src/SharpInference.Vulkan/Shaders.cs
@@ -1168,6 +1168,124 @@ internal static class Shaders
         }
         """;
 
+    /// <summary>
+    /// Matrix-vector multiply with Q8_0 dequantization.
+    /// Each workgroup computes 8 output rows (8 rows × 32 lanes = 256 threads).
+    /// Push constants: { uint rows, uint cols }.
+    /// Bindings: 0=quantized weights (uint8), 1=input vector (float), 2=output (float).
+    ///
+    /// Q8_0 block layout (34 bytes per 32 elements):
+    ///   [0:2]  FP16 d (block scale)
+    ///   [2:34] 32 int8 quantized values
+    /// Dequant: value = d * int8. One lane handles one element per block.
+    /// Mirrors the CUDA llm_matvec_q8_0 kernel and the CPU DequantQ8_0 path.
+    /// </summary>
+    internal const string MatVecQ8_0 = """
+        #version 450
+        #extension GL_EXT_control_flow_attributes : enable
+        #extension GL_KHR_shader_subgroup_arithmetic : enable
+
+        #define N_ROWS 8
+        #define THREADS_PER_ROW 32
+
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) readonly buffer Weights { uint weights_data[]; };
+        layout(binding = 1) readonly buffer Input   { float input_data[]; };
+        layout(binding = 2) writeonly buffer Output  { float output_data[]; };
+
+        layout(push_constant) uniform Params {
+            uint rows;
+            uint cols;
+        };
+
+        uint gByte(uint b) { return (weights_data[b >> 2] >> ((b & 3) * 8)) & 0xFF; }
+        int  gInt8(uint b) { int v = int(gByte(b)); return v >= 128 ? v - 256 : v; }
+
+        void main() {
+            uint tid = gl_LocalInvocationID.x;
+            uint row_in_wg = tid / THREADS_PER_ROW;
+            uint lane = tid % THREADS_PER_ROW;
+            uint row = gl_WorkGroupID.x * N_ROWS + row_in_wg;
+            if (row >= rows) return;
+
+            uint num_blocks = cols >> 5;            // cols / 32
+            uint boff_base = row * num_blocks * 34;
+
+            float acc = 0.0;
+            for (uint block = 0; block < num_blocks; block++) {
+                uint b0 = boff_base + block * 34;
+                float d = unpackHalf2x16(gByte(b0) | (gByte(b0 + 1) << 8)).x;
+                int q = gInt8(b0 + 2 + lane);
+                acc += d * float(q) * input_data[block * 32 + lane];
+            }
+
+            float result = subgroupAdd(acc);
+            if (subgroupElect())
+                output_data[row] = result;
+        }
+        """;
+
+    /// <summary>
+    /// Matrix-vector multiply with Q4_0 dequantization.
+    /// Each workgroup computes 8 output rows (8 rows × 32 lanes = 256 threads).
+    /// Push constants: { uint rows, uint cols }.
+    /// Bindings: 0=quantized weights (uint8), 1=input vector (float), 2=output (float).
+    ///
+    /// Q4_0 block layout (18 bytes per 32 elements):
+    ///   [0:2]  FP16 d (block scale)
+    ///   [2:18] 16 bytes of packed 4-bit nibbles (two signed nibbles per byte)
+    /// Element j (0..15) = low nibble of qs[j]; element j+16 = high nibble of qs[j].
+    /// Dequant: value = (nibble - 8) * d. One lane handles one element per block.
+    /// Mirrors the CUDA llm_matvec_q4_0 kernel and the CPU DequantQ4_0 path.
+    /// </summary>
+    internal const string MatVecQ4_0 = """
+        #version 450
+        #extension GL_EXT_control_flow_attributes : enable
+        #extension GL_KHR_shader_subgroup_arithmetic : enable
+
+        #define N_ROWS 8
+        #define THREADS_PER_ROW 32
+
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) readonly buffer Weights { uint weights_data[]; };
+        layout(binding = 1) readonly buffer Input   { float input_data[]; };
+        layout(binding = 2) writeonly buffer Output  { float output_data[]; };
+
+        layout(push_constant) uniform Params {
+            uint rows;
+            uint cols;
+        };
+
+        uint gByte(uint b) { return (weights_data[b >> 2] >> ((b & 3) * 8)) & 0xFF; }
+
+        void main() {
+            uint tid = gl_LocalInvocationID.x;
+            uint row_in_wg = tid / THREADS_PER_ROW;
+            uint lane = tid % THREADS_PER_ROW;
+            uint row = gl_WorkGroupID.x * N_ROWS + row_in_wg;
+            if (row >= rows) return;
+
+            uint num_blocks = cols >> 5;            // cols / 32
+            uint boff_base = row * num_blocks * 18;
+
+            float acc = 0.0;
+            for (uint block = 0; block < num_blocks; block++) {
+                uint b0 = boff_base + block * 18;
+                float d = unpackHalf2x16(gByte(b0) | (gByte(b0 + 1) << 8)).x;
+                // lane 0..15: low nibble of qs[lane]; lane 16..31: high nibble of qs[lane-16].
+                uint qbyte = gByte(b0 + 2 + (lane & 15));
+                int nib = (lane < 16) ? int(qbyte & 0xF) : int(qbyte >> 4);
+                acc += d * float(nib - 8) * input_data[block * 32 + lane];
+            }
+
+            float result = subgroupAdd(acc);
+            if (subgroupElect())
+                output_data[row] = result;
+        }
+        """;
+
     // ================================================================
     //  TurboQuant KV Cache Compression Shaders
     // ================================================================

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -978,6 +978,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     private ComputePipeline? _sigmoidPipeline;
     private ComputePipeline? _matVecQ4KPipeline;
     private ComputePipeline? _matVecQ6KPipeline;
+    private ComputePipeline? _matVecQ8_0Pipeline;
+    private ComputePipeline? _matVecQ4_0Pipeline;
     private ComputePipeline? _matVecF32Pipeline;
     private ComputePipeline? _kvAppendPipeline;
     private ComputePipeline? _attentionPipeline;
@@ -1201,6 +1203,14 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
             case DType.Q6_K:
                 _matVecQ6KPipeline ??= new ComputePipeline(this, Shaders.MatVecQ6K, 3, pushConstantSize: sizeof(MatVecParams));
                 DispatchOrRecord(_matVecQ6KPipeline, bufs, (totalRows + 7) / 8, &p);
+                break;
+            case DType.Q8_0:
+                _matVecQ8_0Pipeline ??= new ComputePipeline(this, Shaders.MatVecQ8_0, 3, pushConstantSize: sizeof(MatVecParams));
+                DispatchOrRecord(_matVecQ8_0Pipeline, bufs, (totalRows + 7) / 8, &p);
+                break;
+            case DType.Q4_0:
+                _matVecQ4_0Pipeline ??= new ComputePipeline(this, Shaders.MatVecQ4_0, 3, pushConstantSize: sizeof(MatVecParams));
+                DispatchOrRecord(_matVecQ4_0Pipeline, bufs, (totalRows + 7) / 8, &p);
                 break;
             default: // Q4_K — 256 threads, 8 rows per workgroup, subgroupAdd reduction
                 _matVecQ4KPipeline ??= new ComputePipeline(this, Shaders.MatVecQ4K, 3, pushConstantSize: sizeof(MatVecParams));
@@ -1702,6 +1712,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _sigmoidPipeline?.Dispose();
         _matVecQ4KPipeline?.Dispose();
         _matVecQ6KPipeline?.Dispose();
+        _matVecQ8_0Pipeline?.Dispose();
+        _matVecQ4_0Pipeline?.Dispose();
         _matVecF32Pipeline?.Dispose();
         _kvAppendPipeline?.Dispose();
         _attentionPipeline?.Dispose();

--- a/tests/SharpInference.Tests.ForwardPass/VulkanShaderTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanShaderTests.cs
@@ -379,6 +379,131 @@ public sealed unsafe class VulkanShaderTests
         backend.Free(gpuOutput);
     }
 
+    // Q8_0 / Q4_0 matvec parity (issue #310). These use synthetic quantized blocks
+    // (no GGUF fixture needed): the bytes are dequantized by the codebase's own
+    // Dequantize.ToFloat32 for the CPU reference and by the new GLSL shader on the GPU,
+    // so identical bytes must yield matching dot products (only float-accumulation order
+    // differs). matRows is deliberately not a multiple of 8 to exercise the row guard.
+
+    [Fact]
+    public void MatVecQ8_0MatchesCpu()
+    {
+        const int matRows = 131;      // not a multiple of 8 → partial workgroup
+        const int matCols = 160;      // 5 blocks of 32
+        var weights = BuildQ8_0(matRows, matCols, seed: 1234);
+        AssertVulkanMatVecMatchesCpu(weights, matRows, matCols, DType.Q8_0, inputSeed: 7);
+    }
+
+    [Fact]
+    public void MatVecQ4_0MatchesCpu()
+    {
+        const int matRows = 131;
+        const int matCols = 160;
+        var weights = BuildQ4_0(matRows, matCols, seed: 4321);
+        AssertVulkanMatVecMatchesCpu(weights, matRows, matCols, DType.Q4_0, inputSeed: 7);
+    }
+
+    private static void AssertVulkanMatVecMatchesCpu(
+        byte[] weightBytes, int matRows, int matCols, DType dtype, int inputSeed)
+    {
+        using var backend = new Vulkan.VulkanBackend();
+
+        // CPU reference: dequantize the same bytes, then naive matvec.
+        int totalElements = matRows * matCols;
+        var f32Weights = new float[totalElements];
+        SharpInference.Cpu.Dequantize.ToFloat32(weightBytes, f32Weights, dtype, totalElements);
+
+        var input = new float[matCols];
+        var rng = new Random(inputSeed);
+        for (int i = 0; i < matCols; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var cpuOutput = new float[matRows];
+        for (int r = 0; r < matRows; r++)
+        {
+            float sum = 0;
+            for (int c = 0; c < matCols; c++)
+                sum += f32Weights[r * matCols + c] * input[c];
+            cpuOutput[r] = sum;
+        }
+
+        // GPU: upload raw quantized bytes reinterpreted as floats (round up to 4 bytes).
+        int floatCount = (weightBytes.Length + 3) / 4;
+        var rawAsFloats = new float[floatCount];
+        weightBytes.CopyTo(System.Runtime.InteropServices.MemoryMarshal.AsBytes(rawAsFloats.AsSpan()));
+
+        var gpuWeights = backend.Upload(rawAsFloats, TensorShape.D1(floatCount));
+        var gpuInput = backend.Upload(input, TensorShape.D1(matCols));
+        var gpuOutput = backend.Allocate(TensorShape.D1(matRows));
+
+        backend.MatMul(gpuOutput, gpuWeights, gpuInput, dtype);
+
+        var gpuResult = new float[matRows];
+        backend.Download(gpuOutput, gpuResult);
+
+        int mismatches = 0;
+        for (int i = 0; i < matRows; i++)
+        {
+            float diff = MathF.Abs(gpuResult[i] - cpuOutput[i]);
+            float relDiff = diff / (MathF.Abs(cpuOutput[i]) + 1e-6f);
+            // Exact dequant on both sides → only accumulation-order error remains.
+            if (diff > 0.1f && relDiff > 0.02f)
+            {
+                if (mismatches < 3)
+                    Console.WriteLine($"  [{i}]: gpu={gpuResult[i]:F4} cpu={cpuOutput[i]:F4} abs={diff:E2} rel={relDiff:P2}");
+                mismatches++;
+            }
+        }
+        Console.WriteLine($"MatVec{dtype}: {mismatches}/{matRows} mismatches");
+        Assert.Equal(0, mismatches);
+
+        backend.Free(gpuWeights);
+        backend.Free(gpuInput);
+        backend.Free(gpuOutput);
+    }
+
+    private static void PutHalf(byte[] dst, int off, float value)
+    {
+        ushort h = BitConverter.HalfToUInt16Bits((Half)value);
+        dst[off] = (byte)(h & 0xFF);
+        dst[off + 1] = (byte)(h >> 8);
+    }
+
+    // Q8_0: 34 bytes/block = FP16 scale + 32 int8. Layout matches DequantQ8_0.
+    private static byte[] BuildQ8_0(int rows, int cols, int seed)
+    {
+        const int qk = 32, blockBytes = 34;
+        int blocksPerRow = cols / qk;
+        var bytes = new byte[rows * blocksPerRow * blockBytes];
+        var rng = new Random(seed);
+        int off = 0;
+        for (int b = 0; b < rows * blocksPerRow; b++)
+        {
+            PutHalf(bytes, off, (float)(rng.NextDouble() * 0.045 + 0.005));
+            for (int j = 0; j < qk; j++)
+                bytes[off + 2 + j] = (byte)(sbyte)(rng.Next(-127, 128));
+            off += blockBytes;
+        }
+        return bytes;
+    }
+
+    // Q4_0: 18 bytes/block = FP16 scale + 16 nibble bytes. Layout matches DequantQ4_0.
+    private static byte[] BuildQ4_0(int rows, int cols, int seed)
+    {
+        const int qk = 32, blockBytes = 18;
+        int blocksPerRow = cols / qk;
+        var bytes = new byte[rows * blocksPerRow * blockBytes];
+        var rng = new Random(seed);
+        int off = 0;
+        for (int b = 0; b < rows * blocksPerRow; b++)
+        {
+            PutHalf(bytes, off, (float)(rng.NextDouble() * 0.045 + 0.005));
+            for (int j = 0; j < qk / 2; j++)
+                bytes[off + 2 + j] = (byte)(rng.Next(0, 256)); // two packed nibbles
+            off += blockBytes;
+        }
+        return bytes;
+    }
+
     [Fact]
     public void GpuEmbedThenRmsNormMatchesCpu()
     {


### PR DESCRIPTION
Closes #310.

## Problem
`VulkanBackend.MatMul` only dispatched weight matvecs for `Float32`, `Q6_K`, and `Q4_K`. Q8_0 and Q4_0 GGUFs had no shader, so `GpuForwardPass.UploadWeight` silently **dequantized them to F32** on upload. They ran on the Vulkan GPU, but at ~4× the weight VRAM — defeating the point of the quantization. This is a concrete user-facing gap: VibeThinker-1.5B ships **Q8_0** as its recommended near-lossless default (per CLAUDE.md), and Q8_0/Q4_0 GGUFs are common.

## Change
- **New GLSL shaders** `MatVecQ8_0` / `MatVecQ4_0` (`Shaders.cs`), modelled on the existing `MatVecQ6K`: byte-addressed `uint[]` storage buffer, 8 rows × 32 lanes per workgroup, one element per lane per 32-wide block, `subgroupAdd` reduction. The dequant math mirrors the CPU `DequantQ8_0`/`DequantQ4_0` and the CUDA `llm_matvec_q8_0`/`llm_matvec_q4_0` kernels:
  - Q8_0 (34 B/block): `value = d * int8`
  - Q4_0 (18 B/block): `value = (nibble - 8) * d`; low nibble = element `j`, high nibble = element `j+16`
- **Dispatch wiring**: `DType.Q8_0` / `DType.Q4_0` cases in `MatMul`, lazy pipelines, disposed in `DisposeCore`.
- **Keep weights raw on GPU**: new `IsRawGpuQuant()` extends the raw-upload gate to Q8_0/Q4_0 in `UploadWeight`, `UploadExpertWeight`, and `EstimateGpuTensorBytes` (was Q4_K/Q6_K only). The raw byte→float reinterpret now rounds up (`(len+3)/4`) so the non-4-multiple block strides of Q8_0/Q4_0 don't truncate/throw — this also hardens the latent Q6_K (210 B) edge case.

## Verification
- **End-to-end** (`Qwen3-0.6B-Q8_0` on Vulkan, `-g -1 --temp 0`): **byte-identical greedy output** vs the prior F32-dequant path, KV auto-context grew **26155 → 33788** (freed weight VRAM), decode **113 → 151 t/s**.
- **Unit parity tests** (new, synthetic quantized bytes — no GGUF fixture): `MatVecQ8_0MatchesCpu` / `MatVecQ4_0MatchesCpu` dequantize identical bytes via the codebase's own `Dequantize.ToFloat32` (CPU ref) vs the shader (GPU); `matRows=131` (not ÷8) exercises the partial-workgroup guard. **All 18 MatVec tests pass.**
- Reviewed by an internal code-review pass: no findings ≥ Low; the one cosmetic doc nit was fixed.

## Scope / notes
- Embeddings stay on the existing path: a Q8_0/Q4_0 `token_embd` is dequantized to F32 for the embed lookup (a separate quantized-gather path that only supports Q4_K-raw). Orthogonal pre-existing limitation; not regressed.
- CUDA already supported these dtypes; this brings the **Vulkan dense path** to parity. Q5_K remains a gap (tracked separately by #73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)