### PR TITLE
fix(vulkan,cuda): implement IComputeBackend.SiLU contract (#314)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -3687,8 +3687,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         return result;
     }
 
-    public void SiLU(Tensor x) =>
-        throw new NotSupportedException("Use SiLuMul(gate, up) for fused SwiGLU on CUDA.");
+    // IComputeBackend contract (#314): standalone in-place SiLU. The fused SwiGLU
+    // path still prefers SiLuMul(gate, up); this delegates to the existing NVRTC
+    // in-place kernel so the interface is honored uniformly across backends.
+    public void SiLU(Tensor x) => SiLUInPlace(x);
 
     public void RoPE(Tensor x, int position, int headDim, float ropeTheta = 10000f, bool neox = false)
     {

--- a/src/SharpInference.Vulkan/Shaders.cs
+++ b/src/SharpInference.Vulkan/Shaders.cs
@@ -84,6 +84,29 @@ internal static class Shaders
         """;
 
     /// <summary>
+    /// SiLU (Swish) activation in-place: x[i] = x[i] * sigmoid(x[i]) = x[i] / (1 + exp(-x[i])).
+    /// Push constants: { uint n }.
+    /// Bindings: 0=x (in/out).
+    /// Standalone (unfused) counterpart to <see cref="SiLuMul"/>; matches the CPU
+    /// GdnKernels.SiLu / CUDA SiLUInPlace formula.
+    /// </summary>
+    internal const string SiLU = """
+        #version 450
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) buffer X { float x_data[]; };
+
+        layout(push_constant) uniform Params { uint n; };
+
+        void main() {
+            uint i = gl_GlobalInvocationID.x;
+            if (i >= n) return;
+            float x = x_data[i];
+            x_data[i] = x / (1.0 + exp(-x));
+        }
+        """;
+
+    /// <summary>
     /// Vector add in-place: dst[i] += src[i]
     /// Push constants: { uint n }.
     /// Bindings: 0=dst (in/out), 1=src (in).

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -1088,7 +1088,9 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     {
         _siluPipeline ??= new ComputePipeline(this, Shaders.SiLU, 1, pushConstantSize: sizeof(CountParams));
         var p = new CountParams { n = (uint)x.ElementCount };
-        DispatchOrRecord(_siluPipeline, [GetBuffer(x)], ((uint)x.ElementCount + 255) / 256, &p);
+        // 64-bit arithmetic before the cast (activation buffers are small, but avoids
+        // any theoretical uint wrap that would dispatch 0 workgroups).
+        DispatchOrRecord(_siluPipeline, [GetBuffer(x)], (uint)((x.ElementCount + 255) / 256), &p);
     }
 
     public void SiLuMul(Tensor gate, Tensor up)

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -967,6 +967,7 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     private ComputePipeline? _headNormPipeline;
     private ComputePipeline? _headNormPurePipeline;
     private ComputePipeline? _siluMulPipeline;
+    private ComputePipeline? _siluPipeline;
     private ComputePipeline? _addInPlacePipeline;
     private ComputePipeline? _addScaledInPlacePipeline;
     private ComputePipeline? _scaleInPlacePipeline;
@@ -1083,7 +1084,12 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         DispatchOrRecord(_headNormPurePipeline, [GetBuffer(data)], numHeads, &p);
     }
 
-    public void SiLU(Tensor x) => throw new NotImplementedException("Use SiLuMul for fused SiLU*gate");
+    public void SiLU(Tensor x)
+    {
+        _siluPipeline ??= new ComputePipeline(this, Shaders.SiLU, 1, pushConstantSize: sizeof(CountParams));
+        var p = new CountParams { n = (uint)x.ElementCount };
+        DispatchOrRecord(_siluPipeline, [GetBuffer(x)], ((uint)x.ElementCount + 255) / 256, &p);
+    }
 
     public void SiLuMul(Tensor gate, Tensor up)
     {
@@ -1701,6 +1707,7 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _headNormPipeline?.Dispose();
         _headNormPurePipeline?.Dispose();
         _siluMulPipeline?.Dispose();
+        _siluPipeline?.Dispose();
         _addInPlacePipeline?.Dispose();
         _addScaledInPlacePipeline?.Dispose();
         _scaleInPlacePipeline?.Dispose();

--- a/tests/SharpInference.Tests.ForwardPass/CudaGdnKernelsTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaGdnKernelsTests.cs
@@ -58,6 +58,34 @@ public sealed unsafe class CudaGdnKernelsTests
     }
 
     [Fact]
+    public void SiLU_HonorsInterfaceContract()
+    {
+        // Issue #314: IComputeBackend.SiLU(Tensor) must not throw (it previously
+        // did on CUDA); it delegates to the in-place NVRTC kernel.
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int N = 257;
+        var rng = new Random(321);
+        var x = RandomArray(rng, N, -4f, 4f);
+
+        var expected = new float[N];
+        for (int i = 0; i < N; i++)
+            expected[i] = x[i] / (1f + MathF.Exp(-x[i]));
+
+        var gpuX = gpu.Upload(x, TensorShape.D1(N));
+        ((IComputeBackend)gpu).SiLU(gpuX);
+        gpu.Synchronize();
+        var result = new float[N];
+        gpu.Download(gpuX, result);
+        gpu.Free(gpuX);
+
+        for (int i = 0; i < N; i++)
+            Assert.True(MathF.Abs(result[i] - expected[i]) < 1e-5f,
+                $"SiLU mismatch at [{i}]: gpu={result[i]} cpu={expected[i]}");
+    }
+
+    [Fact]
     public void GdnConv1dDecode_MatchesCpuReference()
     {
         using var gpu = TryCreate();

--- a/tests/SharpInference.Tests.ForwardPass/VulkanShaderTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanShaderTests.cs
@@ -71,6 +71,35 @@ public sealed unsafe class VulkanShaderTests
     }
 
     [Fact]
+    public void SiLUMatchesCpu()
+    {
+        // Issue #314: standalone SiLU must honor the IComputeBackend contract
+        // (CPU and CUDA implement it; Vulkan previously threw NotImplementedException).
+        using var backend = new Vulkan.VulkanBackend();
+
+        const int N = 1031; // not a multiple of 256 → exercises the bounds guard
+        var input = new float[N];
+        var rng = new Random(123);
+        for (int i = 0; i < N; i++) input[i] = (float)(rng.NextDouble() * 20 - 10);
+
+        var gpuX = backend.Upload(input, TensorShape.D1(N));
+        backend.SiLU(gpuX);
+
+        var result = new float[N];
+        backend.Download(gpuX, result);
+
+        // CPU reference: x * sigmoid(x) = x / (1 + exp(-x)) (matches GdnKernels.SiLu).
+        for (int i = 0; i < N; i++)
+        {
+            float expected = input[i] / (1f + MathF.Exp(-input[i]));
+            Assert.True(MathF.Abs(result[i] - expected) < 1e-5f,
+                $"SiLU mismatch at [{i}]: gpu={result[i]}, cpu={expected}");
+        }
+
+        backend.Free(gpuX);
+    }
+
+    [Fact]
     public void SoftmaxSumsToOne()
     {
         using var backend = new Vulkan.VulkanBackend();


### PR DESCRIPTION
Closes #314.

## Problem
`IComputeBackend` declares `void SiLU(Tensor x)` (in-place SiLU/Swish), and the CPU backend implements it (`GdnKernels.SiLu`). But:
- `VulkanBackend.SiLU` threw `NotImplementedException("Use SiLuMul for fused SiLU*gate")`
- `CudaBackend.SiLU` threw `NotSupportedException("Use SiLuMul(gate, up) for fused SwiGLU on CUDA.")`

So any current or future caller of standalone `backend.SiLU(...)` (e.g. a GDN-on-GPU path that needs the SiLU output independent of a multiplicand) would crash on Vulkan/CUDA instead of working — an unmet interface contract and a latent crash.

## Change
- **Vulkan**: new standalone `SiLU` GLSL shader — in-place `x[i] = x[i] / (1 + exp(-x[i]))`, the unfused counterpart to the existing `SiLuMul`. Wired into `VulkanBackend.SiLU` with a lazy pipeline (single binding, `CountParams`) and disposal, exactly mirroring `SiLuMul`.
- **CUDA**: `SiLU(Tensor)` now delegates to the existing, already-tested `SiLUInPlace(Tensor)` NVRTC kernel (identical formula) instead of throwing.
- **Tests**:
  - `VulkanShaderTests.SiLUMatchesCpu` — N=1031 (not a multiple of 256, exercises the `if (i >= n) return;` bounds guard), compared to the CPU formula within 1e-5.
  - `CudaGdnKernelsTests.SiLU_HonorsInterfaceContract` — calls the `IComputeBackend.SiLU` method directly to guard against re-introducing the throw.

## Verification
All 10 SiLU-related tests pass (Vulkan + CUDA) on a 4070 Ti. Build clean (TreatWarningsAsErrors). Reviewed by an internal code-review pass: no findings ≥ Low on the Vulkan diff; the CUDA delegation (the one suggestion) was incorporated so the contract is now honored uniformly across CPU, Vulkan, and CUDA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)