### PR TITLE
fix(vulkan): harden + centralize MoE FFN scratch sizing (#315)

### DIFF
--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -225,7 +225,10 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         // max(_intermDim, _expertDim) would make an expert MatMul write _intermDim rows
         // when only _expertDim are valid — the MoE-on-Vulkan garble that's been chased
         // since #2. Pure-MoE and pure-dense models both fall out correctly from this.
-        int ffnScratchDim = _isMoE ? _expertDim : _intermDim;
+        // Sizing is centralized in ComputeFfnScratchDim and enforced by
+        // ValidateFfnScratchDim so the MoE-vs-dense distinction can't drift (issue #315).
+        int ffnScratchDim = ComputeFfnScratchDim(_isMoE, _intermDim, _expertDim);
+        ValidateFfnScratchDim(_isMoE, ffnScratchDim, _intermDim, _expertDim);
         _ffnGate = gpu.Allocate(TensorShape.D1(ffnScratchDim));
         _ffnUp = gpu.Allocate(TensorShape.D1(ffnScratchDim));
         _logits = gpu.Allocate(TensorShape.D1(hp.VocabSize));
@@ -1224,6 +1227,39 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         if (_snapKvScoreScratch is { } scrBuf && _snapKvScoreScratchOwned) _gpu.Free(scrBuf);
 
         _kvCache.Dispose();
+    }
+
+    /// <summary>
+    /// FFN scratch dimension: MoE expert FFNs write _expertDim rows; dense FFNs write _intermDim.
+    /// Centralized so the MoE-vs-dense distinction can't drift (issue #315).
+    /// </summary>
+    internal static int ComputeFfnScratchDim(bool isMoE, int intermDim, int expertDim)
+        => isMoE ? expertDim : intermDim;
+
+    /// <summary>
+    /// Invariant guard for the FFN scratch buffers (issue #315 / "the MoE-on-Vulkan garble
+    /// chased since #2"). VulkanBackend.MatMul derives output row count from
+    /// output.ElementCount, so an expert MatMul writing into a buffer sized
+    /// max(_intermDim,_expertDim) would silently corrupt expert output. Fail loudly instead.
+    /// </summary>
+    internal static void ValidateFfnScratchDim(bool isMoE, int scratchDim, int intermDim, int expertDim)
+    {
+        if (isMoE)
+        {
+            if (expertDim <= 0)
+                throw new InvalidOperationException(
+                    "MoE model (IsMoE=true) but ExpertIntermediateDim is 0 — check GGUF metadata.");
+            if (scratchDim != expertDim)
+                throw new InvalidOperationException(
+                    $"MoE FFN scratch dim {scratchDim} must equal _expertDim {expertDim}, " +
+                    $"not max(_intermDim={intermDim}, _expertDim={expertDim}). Expert MatMuls write " +
+                    "_expertDim rows; an oversized buffer corrupts expert output (issue #315).");
+        }
+        else if (scratchDim != intermDim)
+        {
+            throw new InvalidOperationException(
+                $"Dense FFN scratch dim {scratchDim} must equal _intermDim {intermDim} (issue #315).");
+        }
     }
 
     private static long EstimateGpuTensorBytes(GgufTensorInfo tensor)

--- a/tests/SharpInference.Tests.ForwardPass/GpuFfnScratchGuardTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/GpuFfnScratchGuardTests.cs
@@ -1,0 +1,203 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #315: hardening the Vulkan MoE FFN scratch-buffer sizing
+/// ("the MoE-on-Vulkan garble chased since #2").
+///
+/// Part 1 (GPU-free): the centralized sizing helper <see cref="GpuForwardPass.ComputeFfnScratchDim"/>
+/// and its invariant guard <see cref="GpuForwardPass.ValidateFfnScratchDim"/> are exercised directly
+/// (no model, no GPU) so the MoE-vs-dense distinction can't silently drift. The regression direction
+/// — scratch sized to max(intermDim, expertDim) instead of expertDim — is covered deterministically
+/// here by <see cref="ValidateFfnScratchDim_MoE_OversizedToIntermDim_Throws"/>.
+///
+/// Part 2 (GPU): a real MoE model (OLMoE) is run end-to-end on the Vulkan
+/// <see cref="GpuForwardPass"/>. This is a no-false-positive + well-formedness smoke test: it confirms
+/// (a) the scratch guard does NOT false-positive on a genuine MoE layout and (b) MoE inference produces
+/// well-formed logits on Vulkan. It is NOT itself a regression detector: OLMoE's GGUF carries only
+/// feed_forward_length (1024) and no expert_feed_forward_length, so ExpertIntermediateDim falls back to
+/// feed_forward_length and expertDim == intermDim == 1024. With those dims equal, max(intermDim, expertDim)
+/// equals the correct expertDim, so reverting to the bug would neither garble OLMoE nor trip the guard —
+/// the unit test above is what pins the regression direction.
+/// </summary>
+public sealed class GpuFfnScratchGuardTests
+{
+    // ---- Part 1: GPU-free guard logic ---------------------------------------
+
+    [Fact]
+    public void ComputeFfnScratchDim_MoE_UsesExpertDim()
+    {
+        // illustrative MoE dims (Qwen3-Coder-style: expertDim 2816 < intermDim 8192).
+        // NOT OLMoE, whose real dims are expertDim == intermDim == 1024.
+        Assert.Equal(2816, GpuForwardPass.ComputeFfnScratchDim(isMoE: true, intermDim: 8192, expertDim: 2816));
+    }
+
+    [Fact]
+    public void ComputeFfnScratchDim_Dense_UsesIntermDim()
+    {
+        Assert.Equal(8192, GpuForwardPass.ComputeFfnScratchDim(isMoE: false, intermDim: 8192, expertDim: 0));
+    }
+
+    [Fact]
+    public void ValidateFfnScratchDim_MoE_CorrectSizing_DoesNotThrow()
+    {
+        // scratch == expertDim → the only correct MoE sizing.
+        GpuForwardPass.ValidateFfnScratchDim(isMoE: true, scratchDim: 2816, intermDim: 8192, expertDim: 2816);
+    }
+
+    [Fact]
+    public void ValidateFfnScratchDim_MoE_OversizedToIntermDim_Throws()
+    {
+        // The exact regression: scratch sized to max(intermDim, expertDim).
+        Assert.Throws<InvalidOperationException>(() =>
+            GpuForwardPass.ValidateFfnScratchDim(isMoE: true, scratchDim: 8192, intermDim: 8192, expertDim: 2816));
+    }
+
+    [Fact]
+    public void ValidateFfnScratchDim_MoE_ZeroExpertDim_Throws()
+    {
+        // MoE flagged but ExpertIntermediateDim is 0 (bad GGUF metadata).
+        Assert.Throws<InvalidOperationException>(() =>
+            GpuForwardPass.ValidateFfnScratchDim(isMoE: true, scratchDim: 0, intermDim: 8192, expertDim: 0));
+    }
+
+    [Fact]
+    public void ValidateFfnScratchDim_Dense_CorrectSizing_DoesNotThrow()
+    {
+        GpuForwardPass.ValidateFfnScratchDim(isMoE: false, scratchDim: 8192, intermDim: 8192, expertDim: 0);
+    }
+
+    [Fact]
+    public void ValidateFfnScratchDim_Dense_WrongSizing_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            GpuForwardPass.ValidateFfnScratchDim(isMoE: false, scratchDim: 2816, intermDim: 8192, expertDim: 0));
+    }
+
+    // ---- Part 2: GPU MoE forward-pass well-formedness ------------------------
+
+    /// <summary>
+    /// Runs a real MoE model (OLMoE: no shared expert) through the Vulkan
+    /// <see cref="GpuForwardPass"/> and asserts the output logits are well-formed.
+    /// This is a no-false-positive + well-formedness smoke test: it confirms the FFN scratch
+    /// guard (issue #315) does NOT false-positive on a genuine MoE layout and that MoE inference
+    /// produces well-formed logits on Vulkan.
+    ///
+    /// It is NOT a regression detector: OLMoE has expertDim == intermDim == 1024 (its GGUF has
+    /// feed_forward_length but no expert_feed_forward_length), so max(intermDim, expertDim) equals
+    /// the correct expertDim — reverting the sizing bug would neither garble OLMoE nor trip the
+    /// guard. The regression direction is pinned by the GPU-free unit test
+    /// <see cref="ValidateFfnScratchDim_MoE_OversizedToIntermDim_Throws"/>.
+    ///
+    /// Silently no-ops if the Vulkan backend can't be created or no MoE GGUF is present —
+    /// matches the model-dependent skip idiom used throughout this test project.
+    /// </summary>
+    [Fact]
+    public void GpuForwardPassMoE_ProducesWellFormedLogits()
+    {
+        var path = FindMoEModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        // Pass `model` so HasQkNorm / IsPerChannelQkNorm probe the tensor index (OLMoE needs it).
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        if (!hp.IsMoE) return; // dense model found instead — nothing MoE-specific to assert.
+
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+        Vulkan.VulkanBackend gpu;
+        try
+        {
+            gpu = new Vulkan.VulkanBackend();
+        }
+        catch
+        {
+            return; // No usable Vulkan device — skip.
+        }
+
+        using (gpu)
+        using (var gpuFwd = new GpuForwardPass(model, gpu, hp))
+        {
+            var tokens = tokenizer.Encode("The capital of France is");
+
+            // Prefill the prompt one token at a time (mirrors GpuForwardPassMatchesCpuOutput).
+            ReadOnlySpan<float> logits = default;
+            for (int i = 0; i < tokens.Count; i++)
+                logits = gpuFwd.Forward(tokens[i], i);
+
+            // Greedy-decode ~4 steps, collecting the argmax token at each step.
+            const int steps = 4;
+            var decoded = new int[steps];
+            int pos = tokens.Count;
+            for (int s = 0; s < steps; s++)
+            {
+                Assert.Equal(hp.VocabSize, logits.Length);
+
+                // (1) Every logit must be finite — a corrupted expert MatMul cascades to NaN/Inf.
+                float min = float.MaxValue, max = float.MinValue;
+                for (int i = 0; i < logits.Length; i++)
+                {
+                    float v = logits[i];
+                    Assert.True(float.IsFinite(v), $"Non-finite logit at step {s} index {i}: {v}");
+                    if (v < min) min = v;
+                    if (v > max) max = v;
+                }
+
+                // (2) Logits must have spread — all-zero / all-equal output is degenerate.
+                Assert.True(max - min > 0.1f,
+                    $"Degenerate logit range at step {s}: [{min:F4}, {max:F4}] (expected spread > 0.1).");
+
+                int next = Argmax(logits);
+                decoded[s] = next;
+                logits = gpuFwd.Forward(next, pos++);
+            }
+
+            // (3) Coherent decode produces variety — corruption tends to lock onto one token.
+            int distinct = decoded.Distinct().Count();
+            Assert.True(distinct >= 2,
+                $"Greedy decode produced only {distinct} distinct token(s): " +
+                $"[{string.Join(", ", decoded)}] — expert output looks garbled (issue #315).");
+        }
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    /// <summary>
+    /// Finds a MoE GGUF. OLMoE is a small MoE model (1B active / 7B total) that fully fits the
+    /// pure Vulkan <see cref="GpuForwardPass"/> path — which uploads all layers — on a typical
+    /// 12 GB GPU. Larger MoE models (Qwen3-Coder-30B, Llama-4-Scout) are deliberately excluded:
+    /// they would OOM/crash rather than skip on that path.
+    /// </summary>
+    private static string? FindMoEModelPath()
+    {
+        return FindModelPath(
+            "models\\OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf");
+    }
+
+    private static string? FindModelPath(params string[] candidates)
+    {
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            foreach (var candidate in candidates)
+            {
+                var fullPath = Path.Combine(dir, candidate);
+                if (File.Exists(fullPath))
+                    return fullPath;
+            }
+            var parent = Directory.GetParent(dir);
+            if (parent == null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #315.

## Problem
`GpuForwardPass` sized its FFN scratch buffers (`_ffnGate`/`_ffnUp`) with a fragile manual invariant documented only by a comment — the *"MoE-on-Vulkan garble that's been chased since #2"*:
```csharp
int ffnScratchDim = _isMoE ? _expertDim : _intermDim;
```
`VulkanBackend.MatMul` derives the output row count from `output.ElementCount`, so a future refactor that reintroduces `max(_intermDim, _expertDim)` — or a new expert MatMul writing `_intermDim` rows — would silently corrupt expert output again, with no test to catch it.

## Change
- **Centralize** the sizing in `internal static ComputeFfnScratchDim(isMoE, intermDim, expertDim)` and **enforce** it with `internal static ValidateFfnScratchDim(...)`, called right at the scratch-allocation site. The guard throws `InvalidOperationException` when:
  - a MoE model is mis-sized (`scratch != expertDim`), i.e. the exact `max(intermDim,expertDim)` regression,
  - a MoE model has `expertDim <= 0` (bad GGUF metadata), or
  - a dense model is mis-sized (`scratch != intermDim`).
  Fail loudly instead of garbling. `internal static` keeps it unit-testable via the existing `InternalsVisibleTo`.
- **Tests** (`GpuFfnScratchGuardTests.cs`):
  - 7 GPU-free unit tests pin the invariant in both directions — including the exact regression (`ValidateFfnScratchDim(isMoE:true, scratchDim:8192, intermDim:8192, expertDim:2816)` → throws). This is the deterministic regression detector.
  - A GPU OLMoE forward-pass test confirms the guard does **not** false-positive on a real MoE layout and that MoE inference produces well-formed logits on Vulkan (finite, non-degenerate spread, ≥2 distinct greedy tokens).

## Notes / scope
- Behavior is unchanged for all valid models — `ComputeFfnScratchDim` is byte-identical to the old inline logic; the guard only adds a throw on the corrupting cases.
- OLMoE has `expertDim == intermDim == 1024` (its GGUF lacks `expert_feed_forward_length`), so it can't itself distinguish the regression — the **unit test** covers that direction; the GPU test is the no-false-positive + well-formedness check. (The only local model with `expertDim < intermDim` is Qwen3-Coder-30B, which is too large to fully offload to a 12 GB GPU on the pure Vulkan path, so it isn't used as a GPU fixture.) These facts are documented honestly in the test.
- **Follow-up**: `CudaForwardPass` carries the same `_isMoE ? _expertDim : _intermDim` pattern with no guard; it can adopt these backend-agnostic statics. Also, the shared-expert FFN reuses the `_expertDim`-sized scratch (fine for current models, where `expert_shared_feed_forward_length` is 0) — worth a guard if a model with a divergent shared-expert dim is ever added.

Verified on a 4070 Ti: build clean (TreatWarningsAsErrors), 8/8 new tests pass (the GPU OLMoE test runs real inference). Reviewed by an internal code-review pass; the one substantive finding (misleading OLMoE docstrings) was corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)