### PR TITLE
feat(vulkan): bf16 (fp16-packed) KV cache (#311)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -739,9 +739,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
                 if (nGpuLayers >= hp.NumLayers)
                 {
-                    // All layers on GPU
+                    // All layers on GPU. Pass the configured KV dtype (issue #311): fp32 default,
+                    // bf16 = half-width KV. The Vulkan ctor rejects q8_0 with a clear message
+                    // (q8_0 KV is CUDA-only for now). Reuses the same --kv-type/SHARPI_KV_DTYPE
+                    // parser the CUDA path uses.
                     var gfwd = new GpuForwardPass(model, gpu, hp, ctxSize,
-                        enableTurboQuant: settings.TurboQuant);
+                        enableTurboQuant: settings.TurboQuant,
+                        kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
                     if (settings.TurboQuant)
                         AnsiConsole.MarkupLine($"[dim]TurboQuant: [green]enabled[/] (3-bit, context: {gfwd.MaxSeqLen})[/]");
                     gpuFwd = gfwd;

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -128,8 +128,16 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     private bool _snapKvScoreScratchOwned; // false if aliased to _attnScoresScratch
     private int _snapKvCaptureSlot = -1; // 0..W-1 for tokens in the capture window; -1 otherwise
 
+    // KV-cache store dtype (issue #311). Float32 (default) keeps the original fp32 cache;
+    // BFloat16 selects the half-width KV path. On Vulkan "bf16" means "half-width KV" but the
+    // value is stored as IEEE fp16 packed two-per-uint (more precise than bf16 for the small KV
+    // magnitudes, and packHalf2x16 is core GLSL so no device extension is needed). Arithmetic
+    // stays fp32 — only the stored value is narrowed. q8_0 is CUDA-only for now (rejected below).
+    private readonly DType _kvDType;
+
     public GpuForwardPass(GgufModel model, VulkanBackend gpu, ModelHyperparams hp,
-        int maxContextLength = 0, bool enableTurboQuant = false, int tqFp32Window = 256, int tqBits = 3)
+        int maxContextLength = 0, bool enableTurboQuant = false, int tqFp32Window = 256, int tqBits = 3,
+        DType kvDtype = DType.Float32)
     {
         // Gemma 4's per-layer head_dim, sliding-window attention, PLE injection, KV-share tail,
         // and final-logit softcap have no Vulkan implementation — only CUDA and CPU. Running it
@@ -144,6 +152,28 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         _gpu = gpu;
         _hp = hp;
         _tqEnabled = enableTurboQuant;
+        _kvDType = kvDtype;
+
+        // Issue #311: the Vulkan KV cache supports fp32 and a half-width (bf16) store only.
+        // q8_0 KV is CUDA-only for now (block-quantized append/attention kernels not ported),
+        // so reject anything that isn't fp32 or bf16 up front rather than silently mis-store.
+        bool kvNarrowed = _kvDType != DType.Float32;
+        if (kvNarrowed && _kvDType != DType.BFloat16)
+            throw new NotSupportedException(
+                "Vulkan KV cache supports fp32 and bf16 only (q8_0 is CUDA-only for now; issue #311).");
+        // The bf16 path packs two fp16 per uint, so a KV row (numKvHeads*headDim) must be
+        // even for rows to stay word-aligned. True for all supported head dims (64/128/256),
+        // but enforce it so a future odd-head_dim model fails loudly instead of corrupting KV.
+        if (kvNarrowed && ((hp.NumKvHeads * hp.HeadDim) & 1) != 0)
+            throw new NotSupportedException(
+                $"bf16 KV requires an even KV-row width (numKvHeads*headDim); got " +
+                $"{hp.NumKvHeads}*{hp.HeadDim}. Use fp32 KV for this model (issue #311).");
+        // bf16 KV narrows the store the same way TurboQuant does; the two are mutually
+        // exclusive (TQ owns the KV quantization).
+        if (kvNarrowed && _tqEnabled)
+            throw new NotSupportedException(
+                $"SHARPI_KV_DTYPE={_kvDType} + TurboQuant is not supported on Vulkan " +
+                "(TQ owns the KV quantization). Use one or the other (issue #311).");
 
         if (maxContextLength > 0)
         {
@@ -155,7 +185,7 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         }
         else
         {
-            _maxSeqLen = EstimateMaxContext(model, gpu, hp);
+            _maxSeqLen = EstimateMaxContext(model, gpu, hp, _kvDType);
         }
 
         _tqFp32Window = enableTurboQuant ? Math.Min(tqFp32Window, _maxSeqLen) : 0;
@@ -164,7 +194,8 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         // Bookkeeping-only: KV lives in GPU buffers, this tracks only the position counter.
         // Allocating the full host K/V buffers is pure waste (tens of GB at long ctx, #179).
         _kvCache = Engine.KvCache.CreateBookkeepingOnly(hp.NumLayers, _maxSeqLen, hp.NumKvHeads, hp.HeadDim);
-        Console.Error.WriteLine($"[GpuForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength}){(enableTurboQuant ? " [TQ3]" : "")}");
+        Console.Error.WriteLine($"[GpuForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength})" +
+            $"{(enableTurboQuant ? " [TQ3]" : "")}{(_kvDType == DType.BFloat16 ? " [KV bf16]" : "")}");
 
         _embDim = hp.EmbeddingDim;
         _headDim = hp.HeadDim;
@@ -189,12 +220,27 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             throw new NotSupportedException(
                 "SnapKV + TurboQuant composition is not yet implemented (issue #60). " +
                 "Set SHARPI_SNAPKV_BUDGET=0 to disable or disable --tq.");
+        // Issue #311: SnapKV's score/compact shaders read the cache as fp32 floats, so they
+        // would read garbage from a packed-fp16 buffer. bf16 + SnapKV is not yet wired; reject
+        // an explicit budget and force the auto path off (bf16 already shrinks the KV footprint
+        // SnapKV chases).
+        if (kvNarrowed && _snapKvCfg.IsBudgetExplicit && _snapKvCfg.Budget > 0)
+            throw new NotSupportedException(
+                $"SHARPI_KV_DTYPE={_kvDType} + SnapKV is not yet implemented on Vulkan " +
+                "(SnapKvScore/KvCompact read the cache as fp32, but bf16 stores it fp16-packed; " +
+                "issue #311). Set SHARPI_SNAPKV_BUDGET=0 to disable SnapKV.");
         if (_snapKvCfg.IsBudgetExplicit)
         {
             _snapKvEffectiveBudget = _snapKvCfg.Budget;
         }
         else if (_tqEnabled)
         {
+            _snapKvEffectiveBudget = 0;
+        }
+        else if (kvNarrowed)
+        {
+            // bf16 already shrinks the KV footprint (the memory win SnapKV auto-enable chases),
+            // and its compaction shaders read fp32; don't auto-enable eviction on the packed cache.
             _snapKvEffectiveBudget = 0;
         }
         else
@@ -277,6 +323,18 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             _evictK = gpu.Allocate(TensorShape.D1(_numKvHeads * _headDim));
             _evictV = gpu.Allocate(TensorShape.D1(_numKvHeads * _headDim));
 
+        }
+        else if (_kvDType == DType.BFloat16)
+        {
+            // Half-width KV (issue #311): allocate the cache as BFloat16 so byte accounting is
+            // honest (2 bytes/elem = the packed-fp16-word byte count). The append/attention
+            // shaders bind the buffer as uint[] (2 fp16 per word) regardless of the declared
+            // dtype, and index it identically to the fp32 path (no ring modulo).
+            for (int i = 0; i < hp.NumLayers; i++)
+            {
+                _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), DType.BFloat16);
+                _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), DType.BFloat16);
+            }
         }
         else
         {
@@ -716,6 +774,19 @@ public sealed unsafe class GpuForwardPass : IForwardPass
                     (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim,
                     (uint)_tqCompressedLen, fp32SeqLen, (uint)_maxSeqLen, (uint)_tqBlockBytes);
             }
+            else if (_kvDType == DType.BFloat16)
+            {
+                // Half-width KV (issue #311): same args as the fp32 path; the bf16 shaders
+                // store/read the cache as fp16-packed uint[] but index it identically.
+                _gpu.KvAppendBf16(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
+                    (uint)(_numKvHeads * _headDim), (uint)position, (uint)_maxSeqLen);
+                _gpu.RecordBarrier();
+
+                _gpu.AttentionBf16(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim,
+                    (uint)(position + 1), (uint)_maxSeqLen);
+            }
             else
             {
                 _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
@@ -1113,7 +1184,8 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         return maxCtx;
     }
 
-    private static int EstimateMaxContext(GgufModel model, VulkanBackend gpu, ModelHyperparams hp)
+    private static int EstimateMaxContext(GgufModel model, VulkanBackend gpu, ModelHyperparams hp,
+        DType kvDType = DType.Float32)
     {
         long vramBytes = (long)gpu.VramBytes;
 
@@ -1142,8 +1214,11 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         long available = vramBytes - weightBytes - scratchBytes - reserved;
         if (available <= 0) available = 64L * 1024 * 1024; // minimum fallback
 
-        // KV cache: 2 (K+V) * numLayers * numKvHeads * headDim * sizeof(float) per token
-        long bytesPerToken = 2L * hp.NumLayers * hp.NumKvHeads * headDim * sizeof(float);
+        // KV cache: 2 (K+V) * numLayers * numKvHeads * headDim * (bytes/elem) per token.
+        // bf16 (issue #311) halves the per-element store (2 bytes vs fp32's 4), so the
+        // auto-context actually buys ~2× the tokens under --kv-type bf16.
+        int kvElemBytes = DTypeInfo.BytesPerElement(kvDType);
+        long bytesPerToken = 2L * hp.NumLayers * hp.NumKvHeads * headDim * kvElemBytes;
 
         int maxCtx = (int)(available / bytesPerToken);
         maxCtx = Math.Clamp(maxCtx, 512, hp.ContextLength);

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -344,7 +344,8 @@ public static class InferenceEngineLoader
 
             if (gpuLayers >= hp.NumLayers)
             {
-                var gfwd = new GpuForwardPass(model, vulkan, hp, ctxSize, enableTurboQuant: turboQuant);
+                var gfwd = new GpuForwardPass(model, vulkan, hp, ctxSize, enableTurboQuant: turboQuant,
+                    kvDtype: CudaForwardPass.ResolveConfiguredKvDType());
                 owned.Add(gfwd);
                 return (gfwd, BatchingSupported: false);
             }

--- a/src/SharpInference.Vulkan/Shaders.cs
+++ b/src/SharpInference.Vulkan/Shaders.cs
@@ -776,6 +776,175 @@ internal static class Shaders
         """;
 
     /// <summary>
+    /// bf16 (issue #311) variant of <see cref="KvAppend"/>: the K/V cache buffers store
+    /// IEEE fp16 packed two-per-uint via core-GLSL <c>packHalf2x16</c> (no device extension).
+    /// The user-facing <c>--kv-type bf16</c> means "half-width KV"; Vulkan stores fp16
+    /// because for the small-magnitude KV values fp16 is more precise than bf16. Arithmetic
+    /// elsewhere stays fp32 — only the stored value is narrowed.
+    ///
+    /// CRITICAL: this indexes the cache IDENTICALLY to the fp32 <see cref="KvAppend"/>
+    /// (<c>position * kv_dim + i</c> element addressing, just expressed in words because
+    /// each word holds 2 elements). There is NO <c>% max_seq_len</c> ring modulo, matching
+    /// the fp32 shader exactly. kv_dim is always even (numKvHeads*headDim), so we dispatch
+    /// one thread per 2 elements (word granular).
+    ///
+    /// Push constants: { uint kv_dim, uint position, uint max_seq_len } — unchanged.
+    /// Bindings: 0=k_input[kv_dim] (float), 1=v_input[kv_dim] (float),
+    ///           2=k_cache (uint, packed fp16×2), 3=v_cache (uint, packed fp16×2).
+    /// </summary>
+    internal const string KvAppendBf16 = """
+        #version 450
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) readonly buffer KIn  { float k_input[]; };
+        layout(binding = 1) readonly buffer VIn  { float v_input[]; };
+        layout(binding = 2) buffer KCache { uint k_cache[]; };
+        layout(binding = 3) buffer VCache { uint v_cache[]; };
+
+        layout(push_constant) uniform Params {
+            uint kv_dim;
+            uint position;
+            uint max_seq_len;
+        };
+
+        void main() {
+            uint w = gl_GlobalInvocationID.x;
+            uint half_dim = kv_dim >> 1;   // kv_dim is even (numKvHeads*headDim)
+            if (w >= half_dim) return;
+            uint i = w << 1;
+            // Same element address as fp32 (position * kv_dim + i), expressed in words.
+            uint row_word = position * half_dim;
+            k_cache[row_word + w] = packHalf2x16(vec2(k_input[i], k_input[i + 1u]));
+            v_cache[row_word + w] = packHalf2x16(vec2(v_input[i], v_input[i + 1u]));
+        }
+        """;
+
+    /// <summary>
+    /// bf16 (issue #311) variant of <see cref="Attention"/>: control flow is IDENTICAL to
+    /// the fp32 shader; the only difference is that the K/V cache buffers (bindings 1, 2)
+    /// are <c>uint[]</c> holding IEEE fp16 packed two-per-uint (<c>packHalf2x16</c> on
+    /// write, <c>unpackHalf2x16</c> on read), so every element read becomes an unpack +
+    /// lane-select. All scores / softmax / value accumulation stay fp32 — the arithmetic is
+    /// bit-identical to the fp32 Attention; only the stored K/V mantissa is narrowed.
+    /// scores_scratch (binding 4) stays fp32. The <c>inversesqrt(head_dim)</c> scale is kept
+    /// exactly as the fp32 shader has it.
+    ///
+    /// Push constants: { uint num_heads, num_kv_heads, head_dim, seq_len, max_seq_len } — unchanged.
+    /// Bindings: 0=Q (float), 1=K_cache (uint, packed fp16×2), 2=V_cache (uint, packed fp16×2),
+    ///           3=output (float), 4=scores_scratch (float).
+    /// </summary>
+    internal const string AttentionBf16 = """
+        #version 450
+        #extension GL_EXT_control_flow_attributes : enable
+
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) readonly buffer Q     { float q_data[]; };
+        layout(binding = 1) readonly buffer KCache { uint k_cache[]; };
+        layout(binding = 2) readonly buffer VCache { uint v_cache[]; };
+        layout(binding = 3) buffer Out             { float out_data[]; };
+        layout(binding = 4) buffer ScoresScratch   { float scores_scratch[]; };
+
+        layout(push_constant) uniform Params {
+            uint num_heads;
+            uint num_kv_heads;
+            uint head_dim;
+            uint seq_len;
+            uint max_seq_len;
+        };
+
+        // Score-storage strategy mirrors the fp32 Attention shader.
+        const uint MAX_SHARED_SCORES = 4096u;
+        shared float scores[MAX_SHARED_SCORES];
+        shared float sdata[256];   // reduction scratch
+
+        void main() {
+            uint h = gl_WorkGroupID.x;
+            uint tid = gl_LocalInvocationID.x;
+            if (h >= num_heads) return;
+
+            uint kv_head = h / (num_heads / num_kv_heads);
+            uint kv_dim = num_kv_heads * head_dim;
+            float scale = inversesqrt(float(head_dim));
+            uint q_off = h * head_dim;
+            uint out_off = h * head_dim;
+
+            bool use_shared = (seq_len <= MAX_SHARED_SCORES);
+            uint scratch_base = h * max_seq_len;
+
+            // ─── Phase 1: per-position Q·K scores ───
+            for (uint t = tid; t < seq_len; t += 256) {
+                float dot = 0.0;
+                uint k_off = t * kv_dim + kv_head * head_dim;
+                for (uint d = 0; d < head_dim; d++) {
+                    uint e = k_off + d;
+                    float kv = unpackHalf2x16(k_cache[e >> 1])[e & 1u];
+                    dot += q_data[q_off + d] * kv;
+                }
+                float score = dot * scale;
+                if (use_shared) scores[t] = score;
+                else            scores_scratch[scratch_base + t] = score;
+            }
+            if (use_shared) {
+                for (uint t = seq_len + tid; t < MAX_SHARED_SCORES; t += 256)
+                    scores[t] = -1.0/0.0;
+            }
+            barrier();
+
+            // ─── Phase 2: in-place softmax over [0, seq_len) ───
+            float local_max = -1.0/0.0;
+            for (uint t = tid; t < seq_len; t += 256) {
+                float s = use_shared ? scores[t] : scores_scratch[scratch_base + t];
+                local_max = max(local_max, s);
+            }
+            sdata[tid] = local_max;
+            barrier();
+            [[unroll]] for (uint s = 128; s > 0; s >>= 1) {
+                if (tid < s) sdata[tid] = max(sdata[tid], sdata[tid + s]);
+                barrier();
+            }
+            float max_val = sdata[0];
+            barrier();
+
+            float local_sum = 0.0;
+            for (uint t = tid; t < seq_len; t += 256) {
+                float s = use_shared ? scores[t] : scores_scratch[scratch_base + t];
+                float e = exp(s - max_val);
+                if (use_shared) scores[t] = e;
+                else            scores_scratch[scratch_base + t] = e;
+                local_sum += e;
+            }
+            sdata[tid] = local_sum;
+            barrier();
+            [[unroll]] for (uint s = 128; s > 0; s >>= 1) {
+                if (tid < s) sdata[tid] += sdata[tid + s];
+                barrier();
+            }
+            float inv_sum = 1.0 / sdata[0];
+            barrier();
+
+            for (uint t = tid; t < seq_len; t += 256) {
+                if (use_shared) scores[t] *= inv_sum;
+                else            scores_scratch[scratch_base + t] *= inv_sum;
+            }
+            barrier();
+
+            // ─── Phase 3: weighted V sum. K is NOT re-derived here. ───
+            for (uint d = tid; d < head_dim; d += 256) {
+                float sum = 0.0;
+                for (uint t = 0; t < seq_len; t++) {
+                    float weight = use_shared ? scores[t] : scores_scratch[scratch_base + t];
+                    uint v_off = t * kv_dim + kv_head * head_dim;
+                    uint e = v_off + d;
+                    float vv = unpackHalf2x16(v_cache[e >> 1])[e & 1u];
+                    sum += weight * vv;
+                }
+                out_data[out_off + d] = sum;
+            }
+        }
+        """;
+
+    /// <summary>
     /// SnapKV (issue #59) — per-head attention scoring across a layer's K cache.
     /// Mirrors the CUDA `llm_snapkv_score` kernel: one workgroup per query head,
     /// 256 threads. Phase 1 computes causal-masked dot(q_head, k_cache[t, kvHead, :]) * scale

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -985,6 +985,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     private ComputePipeline? _matVecF32Pipeline;
     private ComputePipeline? _kvAppendPipeline;
     private ComputePipeline? _attentionPipeline;
+    private ComputePipeline? _kvAppendBf16Pipeline;
+    private ComputePipeline? _attentionBf16Pipeline;
     private ComputePipeline? _snapKvScorePipeline;
     private ComputePipeline? _kvCompactPipeline;
     private ComputePipeline? _embedLookupPipeline;
@@ -1278,6 +1280,48 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
             headDim = headDim, seqLen = seqLen, maxSeqLen = maxSeqLen
         };
         DispatchOrRecord(_attentionPipeline,
+            [GetBuffer(q), GetBuffer(kCache), GetBuffer(vCache), GetBuffer(output),
+             GetBuffer(scoresScratch)],
+            numHeads, &p);
+    }
+
+    /// <summary>
+    /// bf16 (issue #311) variant of <see cref="KvAppend"/>: writes the K/V vectors into the
+    /// cache as IEEE fp16 packed two-per-uint (core-GLSL <c>packHalf2x16</c>, no extension).
+    /// The cache buffers (<paramref name="kCache"/>/<paramref name="vCache"/>) are bound as
+    /// <c>uint[]</c> in the shader regardless of the tensor's declared dtype. Indexes the
+    /// cache identically to the fp32 path (<c>position * kv_dim + i</c>, just word-granular).
+    /// kv_dim is even, so one thread covers 2 elements.
+    /// </summary>
+    public void KvAppendBf16(Tensor kInput, Tensor vInput, Tensor kCache, Tensor vCache,
+        uint kvDim, uint position, uint maxSeqLen)
+    {
+        _kvAppendBf16Pipeline ??= new ComputePipeline(this, Shaders.KvAppendBf16, 4, pushConstantSize: sizeof(KvAppendParams));
+        var p = new KvAppendParams { kvDim = kvDim, position = position, maxSeqLen = maxSeqLen };
+        DispatchOrRecord(_kvAppendBf16Pipeline,
+            [GetBuffer(kInput), GetBuffer(vInput), GetBuffer(kCache), GetBuffer(vCache)],
+            ((kvDim >> 1) + 255) / 256, &p);
+    }
+
+    /// <summary>
+    /// bf16 (issue #311) variant of <see cref="Attention"/>: identical control flow to the
+    /// fp32 path, but the K/V cache buffers (<paramref name="kCache"/>/<paramref name="vCache"/>)
+    /// hold IEEE fp16 packed two-per-uint and are read via <c>unpackHalf2x16</c>. All
+    /// arithmetic (scores / softmax / value accumulation) stays fp32 — only the stored K/V
+    /// mantissa is narrowed. <paramref name="scoresScratch"/> stays fp32 (see
+    /// <see cref="Attention"/> for the spill-buffer convention).
+    /// </summary>
+    public void AttentionBf16(Tensor q, Tensor kCache, Tensor vCache, Tensor output,
+        Tensor scoresScratch,
+        uint numHeads, uint numKvHeads, uint headDim, uint seqLen, uint maxSeqLen)
+    {
+        _attentionBf16Pipeline ??= new ComputePipeline(this, Shaders.AttentionBf16, 5, pushConstantSize: sizeof(AttentionParams));
+        var p = new AttentionParams
+        {
+            numHeads = numHeads, numKvHeads = numKvHeads,
+            headDim = headDim, seqLen = seqLen, maxSeqLen = maxSeqLen
+        };
+        DispatchOrRecord(_attentionBf16Pipeline,
             [GetBuffer(q), GetBuffer(kCache), GetBuffer(vCache), GetBuffer(output),
              GetBuffer(scoresScratch)],
             numHeads, &p);
@@ -1732,6 +1776,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _matVecF32Pipeline?.Dispose();
         _kvAppendPipeline?.Dispose();
         _attentionPipeline?.Dispose();
+        _kvAppendBf16Pipeline?.Dispose();
+        _attentionBf16Pipeline?.Dispose();
         _snapKvScorePipeline?.Dispose();
         _kvCompactPipeline?.Dispose();
         _embedLookupPipeline?.Dispose();

--- a/tests/SharpInference.Tests.ForwardPass/GpuForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/GpuForwardPassKvDtypeTests.cs
@@ -1,0 +1,195 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using SharpInference.Vulkan;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// bf16 KV-cache parity for the Vulkan <see cref="GpuForwardPass"/> (issue #311). With
+/// <c>kvDtype: DType.BFloat16</c> the K/V cache is stored half-width (IEEE fp16 packed
+/// two-per-uint via core-GLSL <c>packHalf2x16</c>); kernel arithmetic stays fp32, so decode
+/// must be argmax-stable vs the fp32 cache at short context — only the stored value's mantissa
+/// is narrowed. The bf16 decode is teacher-forced onto the fp32 trajectory so the KV dtype is
+/// the only variable at each position. Asserts, per teacher-forced position:
+/// <list type="bullet">
+///   <item>all bf16 logits are finite,</item>
+///   <item>fp32's top-1 stays within bf16's top-5 — the reorder-tolerant "argmax-stable"
+///         criterion (a genuine near-tie can flip top-1 with no kernel bug),</item>
+///   <item>the logit max-abs gap is within a small rounding budget.</item>
+/// </list>
+///
+/// The parity test is the correctness gate for the <c>AttentionBf16</c> read shader: a failure
+/// most likely means the <c>unpackHalf2x16(buf[idx&gt;&gt;1])[idx&amp;1]</c> lane-select or an
+/// indexing divergence from the fp32 shader. SnapKV is forced off so the KV dtype is the only
+/// variable. Each case is skipped silently when Vulkan is unavailable or the GGUF isn't on disk.
+/// </summary>
+public sealed class GpuForwardPassKvDtypeTests
+{
+    private const string ModelFile = "Qwen3-8B-Q4_K_M.gguf";
+
+    private static VulkanBackend? TryCreate()
+    {
+        try { return new VulkanBackend(); }
+        catch { return null; }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absoluteCandidates =
+        {
+            $@"C:\p\sharpi\models\{ModelFile}",
+            $@"E:\models\{ModelFile}",
+        };
+        foreach (var p in absoluteCandidates)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    /// <summary>Indices of the <paramref name="k"/> largest entries of <paramref name="v"/>.</summary>
+    private static HashSet<int> TopK(float[] v, int k)
+    {
+        var idx = new int[v.Length];
+        for (int i = 0; i < v.Length; i++) idx[i] = i;
+        Array.Sort(idx, (a, b) => v[b].CompareTo(v[a]));
+        var set = new HashSet<int>(k);
+        for (int i = 0; i < k && i < idx.Length; i++) set.Add(idx[i]);
+        return set;
+    }
+
+    /// <summary>
+    /// Prefill <paramref name="prompt"/>, then decode <paramref name="steps"/> tokens on a fresh
+    /// GpuForwardPass with the given KV dtype. When <paramref name="forced"/> is non-null the
+    /// decode is TEACHER-FORCED on those tokens so two runs follow an identical trajectory — the
+    /// KV dtype is then the only variable at each decode position. Returns the per-position logits
+    /// (index 0 = prefill, 1.. = each decode step) and the greedy argmax at each. SnapKV is forced
+    /// off so the KV dtype is isolated.
+    /// </summary>
+    private static (float[][] logits, int[] argmax) RunPrefillDecode(
+        VulkanBackend gpu, string path, DType kvDtype, string prompt, int steps, int ctx, int[]? forced)
+    {
+        var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0"); // isolate the KV dtype
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int useCtx = Math.Min(hp.ContextLength, ctx);
+            using var fwd = new GpuForwardPass(model, gpu, hp, maxContextLength: useCtx, kvDtype: kvDtype);
+
+            var tokens = tokenizer.Encode(prompt).ToArray();
+            var perPos = new float[steps + 1][];
+            var argmax = new int[steps + 1];
+
+            var logits = fwd.Prefill(tokens).ToArray();
+            perPos[0] = logits;
+            argmax[0] = Sampler.Greedy(logits);
+
+            for (int i = 0; i < steps; i++)
+            {
+                int fed = forced is not null ? forced[i] : argmax[i];
+                logits = fwd.Forward(fed, tokens.Length + i).ToArray();
+                perPos[i + 1] = logits;
+                argmax[i + 1] = Sampler.Greedy(logits);
+            }
+            return (perPos, argmax);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap);
+        }
+    }
+
+    private const string LowEntropyPrompt = "The quick brown fox jumps over the lazy";
+
+    // Qwen3 ChatML. Thinking is left on (the template auto-opens <think>), which only makes the
+    // continuation longer/more varied — fine for a coherence check.
+    private const string Qwen3TemplatePrompt =
+        "<|im_start|>user\nWrite a short sentence about the ocean.<|im_end|>\n<|im_start|>assistant\n";
+
+    /// <summary>
+    /// bf16 KV must stay argmax-stable vs fp32 KV on the SAME teacher-forced trajectory. fp32 is
+    /// the reference; bf16 is forced onto its tokens so the only variable is the KV store dtype.
+    /// This is the correctness gate for the AttentionBf16 fp16-unpack read path.
+    /// </summary>
+    [Fact]
+    public void Bf16Kv_ArgmaxStable_VsFp32()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int steps = 6;
+        const int ctx = 2048;
+        const float maxAbsTol = 2.0f;
+
+        var (f32, f32Argmax) = RunPrefillDecode(gpu, path, DType.Float32, LowEntropyPrompt, steps, ctx, forced: null);
+        var (kv, _) = RunPrefillDecode(gpu, path, DType.BFloat16, LowEntropyPrompt, steps, ctx, forced: f32Argmax);
+
+        for (int p = 0; p <= steps; p++)
+        {
+            Assert.Equal(f32[p].Length, kv[p].Length);
+            float maxAbs = 0f;
+            for (int i = 0; i < f32[p].Length; i++)
+            {
+                Assert.True(float.IsFinite(kv[p][i]), $"non-finite bf16 logit at pos {p}, idx {i}.");
+                maxAbs = Math.Max(maxAbs, Math.Abs(f32[p][i] - kv[p][i]));
+            }
+            Assert.True(maxAbs < maxAbsTol,
+                $"pos {p} bf16 vs fp32 logit max-abs {maxAbs:F3} exceeds the rounding budget " +
+                $"({maxAbsTol:F1}) — likely an AttentionBf16 indexing/lane-select bug, not fp16-store rounding.");
+            Assert.True(TopK(kv[p], 5).Contains(f32Argmax[p]),
+                $"pos {p} fp32 top-1 ({f32Argmax[p]}) fell out of bf16's top-5 (max-abs {maxAbs:F3}) — " +
+                "the bf16 attention read reordered the head of the distribution.");
+        }
+    }
+
+    /// <summary>
+    /// bf16 KV greedy decode (the path picks its OWN tokens — not teacher-forced) on a
+    /// template-correct prompt must stay coherent: all logits finite, the first generated token
+    /// is not EOS, and ≥2 distinct argmaxes over the run (catches NaN / single-token collapse
+    /// from a wrong attention read).
+    /// </summary>
+    [Fact]
+    public void Bf16Kv_GreedyDecode_Coherent()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        int eosId;
+        using (var model = GgufModel.Open(path))
+            eosId = GgufTokenizer.FromGgufModel(model).EosTokenId;
+
+        const int steps = 5;
+        const int ctx = 2048;
+
+        var (logits, argmax) = RunPrefillDecode(gpu, path, DType.BFloat16, Qwen3TemplatePrompt, steps, ctx, forced: null);
+
+        for (int p = 0; p <= steps; p++)
+            for (int i = 0; i < logits[p].Length; i++)
+                Assert.True(float.IsFinite(logits[p][i]),
+                    $"bf16 greedy: non-finite logit at pos {p}, idx {i} — a bf16-KV attention read bug.");
+
+        Assert.True(argmax[0] != eosId,
+            "bf16 greedy: first token was EOS — the template-correct prompt should have a real " +
+            "continuation, so this means the bf16 greedy path collapsed.");
+
+        var seen = new HashSet<int>(argmax);
+        Assert.True(seen.Count >= 2,
+            $"bf16 greedy decode produced only {seen.Count} distinct token(s) " +
+            $"([{string.Join(",", argmax)}]) — bf16-KV greedy decode is degenerate.");
+    }
+}


### PR DESCRIPTION
Closes #311.

## Problem
The Vulkan KV cache was **FP32-only** (the CUDA path already has bf16/q8_0 KV). At fp32, KV dominates VRAM at long context — e.g. Qwen3-8B on a 12 GB GPU auto-caps context at ~11.4K and auto-enables SnapKV to fit.

## Change
Add a half-width KV option selected by `--kv-type bf16`. **Storage is IEEE fp16 packed two-per-`uint`** via core-GLSL `packHalf2x16`/`unpackHalf2x16` (no device extension); attention arithmetic stays fp32 — only the stored K/V mantissa is narrowed. The user-facing flag stays `bf16` (= "half-width KV"); fp16 is in fact *more* precise than bf16 for the small-magnitude KV values, and needs no extension gating.

- **New `KvAppendBf16` / `AttentionBf16` GLSL shaders** — structurally identical to the fp32 `KvAppend`/`Attention`, indexing the cache the same way (**no ring modulo**); only the K/V store/load is fp16-packed. `KvAppendBf16` runs one thread per 2 elements (`kv_dim` is always even); `AttentionBf16` reads `unpackHalf2x16(cache[(off+d)>>1])[(off+d)&1]` and keeps scores/softmax/accumulation + the `1/sqrt(headDim)` scale in fp32.
- **`VulkanBackend.KvAppendBf16`/`AttentionBf16`** (+ lazy pipelines, disposal), reusing the existing push-constant structs.
- **`GpuForwardPass`**: new `kvDtype` ctor arg (default `Float32` → byte-identical fp32 path); bf16 cache allocated as `DType.BFloat16`; per-layer dispatch branch; `EstimateMaxContext` halves the KV byte estimate under bf16 (buys ~2× auto-context); `[KV bf16]` banner. **Guards**: bf16 rejects q8_0, TurboQuant, and explicit SnapKV, and forces auto-SnapKV off (the `SnapKvScore`/`KvCompact` shaders read fp32 KV); plus an even-KV-row-width guard so a future odd-`head_dim` model fails loudly instead of corrupting the packed cache.
- **Plumbing**: `--kv-type` now reaches the Vulkan ctor on **both** the CLI and the server (`InferenceEngineLoader`).

## Verification (4070 Ti)
- **2× context, identical output**: Qwen3-8B `--backend vulkan -g -1` — fp32 caps at `Context size: 11399` (SnapKV auto-on, ~3206 MiB cache); bf16 reaches **22798** `[KV bf16]` (SnapKV correctly auto-off) with **byte-identical greedy output** and unchanged decode t/s.
- **Long-context (>4096) scratch-spill attention path**: a **5149-token prefill** with bf16 decodes coherently with no NaN — exercising the `AttentionBf16` `seq_len > 4096` branch for thousands of positions.
- **Tests**: new `GpuForwardPassKvDtypeTests` — teacher-forced bf16-vs-fp32 argmax parity + greedy coherence. fp32 path is byte-identical (default ctor arg); existing Vulkan SnapKV/scratch-guard tests still pass.
- Internal code-review pass: the one High finding (server path silently ignored the flag) and a kv_dim-even guard were applied; the long-context path it flagged was then validated by the 5149-token e2e run above.

## Scope / follow-ups
- **bf16 only**; Q8_0 KV on Vulkan is a natural follow-up (needs per-block quant on append + dequant in attention).
- bf16 + SnapKV on Vulkan is guarded off (would need fp16 variants of the SnapKV score/compact shaders) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)