### PR TITLE
feat(vulkan): Q8_0 KV cache (~4× vs fp32) (#325)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -739,10 +739,9 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
                 if (nGpuLayers >= hp.NumLayers)
                 {
-                    // All layers on GPU. Pass the configured KV dtype (issue #311): fp32 default,
-                    // bf16 = half-width KV. The Vulkan ctor rejects q8_0 with a clear message
-                    // (q8_0 KV is CUDA-only for now). Reuses the same --kv-type/SHARPI_KV_DTYPE
-                    // parser the CUDA path uses.
+                    // All layers on GPU. Pass the configured KV dtype (issues #311 / #325): fp32
+                    // default, bf16 = half-width KV, q8_0 = block-quantized (~quarter) KV. Reuses
+                    // the same --kv-type/SHARPI_KV_DTYPE parser the CUDA path uses.
                     var gfwd = new GpuForwardPass(model, gpu, hp, ctxSize,
                         enableTurboQuant: settings.TurboQuant,
                         kvDtype: CudaForwardPass.ResolveConfiguredKvDType());

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -128,11 +128,12 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     private bool _snapKvScoreScratchOwned; // false if aliased to _attnScoresScratch
     private int _snapKvCaptureSlot = -1; // 0..W-1 for tokens in the capture window; -1 otherwise
 
-    // KV-cache store dtype (issue #311). Float32 (default) keeps the original fp32 cache;
-    // BFloat16 selects the half-width KV path. On Vulkan "bf16" means "half-width KV" but the
-    // value is stored as IEEE fp16 packed two-per-uint (more precise than bf16 for the small KV
-    // magnitudes, and packHalf2x16 is core GLSL so no device extension is needed). Arithmetic
-    // stays fp32 — only the stored value is narrowed. q8_0 is CUDA-only for now (rejected below).
+    // KV-cache store dtype (issues #311 / #325). Float32 (default) keeps the original fp32 cache;
+    // BFloat16 selects the half-width KV path (stored as IEEE fp16 packed two-per-uint — more
+    // precise than bf16 for the small KV magnitudes, and packHalf2x16 is core GLSL so no device
+    // extension is needed); Q8_0 selects the block-quantized store (34 bytes per 32 elements,
+    // ~4× smaller than fp32) added in #325. Arithmetic everywhere stays fp32 — only the stored
+    // value is narrowed.
     private readonly DType _kvDType;
 
     public GpuForwardPass(GgufModel model, VulkanBackend gpu, ModelHyperparams hp,
@@ -154,20 +155,25 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         _tqEnabled = enableTurboQuant;
         _kvDType = kvDtype;
 
-        // Issue #311: the Vulkan KV cache supports fp32 and a half-width (bf16) store only.
-        // q8_0 KV is CUDA-only for now (block-quantized append/attention kernels not ported),
-        // so reject anything that isn't fp32 or bf16 up front rather than silently mis-store.
+        // Issues #311 / #325: the Vulkan KV cache supports fp32, a half-width (bf16) store, and a
+        // block-quantized q8_0 store. Reject anything else up front rather than silently mis-store.
         bool kvNarrowed = _kvDType != DType.Float32;
-        if (kvNarrowed && _kvDType != DType.BFloat16)
+        if (kvNarrowed && _kvDType is not (DType.BFloat16 or DType.Q8_0))
             throw new NotSupportedException(
-                "Vulkan KV cache supports fp32 and bf16 only (q8_0 is CUDA-only for now; issue #311).");
+                "Vulkan KV cache supports fp32, bf16, and q8_0 only (issue #325).");
         // The bf16 path packs two fp16 per uint, so a KV row (numKvHeads*headDim) must be
         // even for rows to stay word-aligned. True for all supported head dims (64/128/256),
         // but enforce it so a future odd-head_dim model fails loudly instead of corrupting KV.
-        if (kvNarrowed && ((hp.NumKvHeads * hp.HeadDim) & 1) != 0)
+        if (_kvDType == DType.BFloat16 && ((hp.NumKvHeads * hp.HeadDim) & 1) != 0)
             throw new NotSupportedException(
                 $"bf16 KV requires an even KV-row width (numKvHeads*headDim); got " +
                 $"{hp.NumKvHeads}*{hp.HeadDim}. Use fp32 KV for this model (issue #311).");
+        // The q8_0 path quantizes per 32-element block (one thread per block), so a KV row must
+        // be a multiple of 32 for blocks to align to row boundaries (no straddling).
+        if (_kvDType == DType.Q8_0 && ((hp.NumKvHeads * hp.HeadDim) & 31) != 0)
+            throw new NotSupportedException(
+                $"q8_0 KV requires kvDim % 32 == 0; got {hp.NumKvHeads}*{hp.HeadDim}. " +
+                "Use fp32 or bf16 (issue #325).");
         // bf16 KV narrows the store the same way TurboQuant does; the two are mutually
         // exclusive (TQ owns the KV quantization).
         if (kvNarrowed && _tqEnabled)
@@ -194,8 +200,14 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         // Bookkeeping-only: KV lives in GPU buffers, this tracks only the position counter.
         // Allocating the full host K/V buffers is pure waste (tens of GB at long ctx, #179).
         _kvCache = Engine.KvCache.CreateBookkeepingOnly(hp.NumLayers, _maxSeqLen, hp.NumKvHeads, hp.HeadDim);
+        string kvTag = _kvDType switch
+        {
+            DType.BFloat16 => " [KV bf16]",
+            DType.Q8_0 => " [KV q8_0]",
+            _ => "",
+        };
         Console.Error.WriteLine($"[GpuForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength})" +
-            $"{(enableTurboQuant ? " [TQ3]" : "")}{(_kvDType == DType.BFloat16 ? " [KV bf16]" : "")}");
+            $"{(enableTurboQuant ? " [TQ3]" : "")}{kvTag}");
 
         _embDim = hp.EmbeddingDim;
         _headDim = hp.HeadDim;
@@ -220,15 +232,15 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             throw new NotSupportedException(
                 "SnapKV + TurboQuant composition is not yet implemented (issue #60). " +
                 "Set SHARPI_SNAPKV_BUDGET=0 to disable or disable --tq.");
-        // Issue #311: SnapKV's score/compact shaders read the cache as fp32 floats, so they
-        // would read garbage from a packed-fp16 buffer. bf16 + SnapKV is not yet wired; reject
-        // an explicit budget and force the auto path off (bf16 already shrinks the KV footprint
-        // SnapKV chases).
+        // Issues #311 / #325: SnapKV's score/compact shaders read the cache as fp32 floats, so
+        // they would read garbage from a narrowed buffer (fp16-packed for bf16, block-quantized
+        // for q8_0). Narrowed KV + SnapKV is not yet wired; reject an explicit budget and force
+        // the auto path off (the narrowed store already shrinks the KV footprint SnapKV chases).
         if (kvNarrowed && _snapKvCfg.IsBudgetExplicit && _snapKvCfg.Budget > 0)
             throw new NotSupportedException(
                 $"SHARPI_KV_DTYPE={_kvDType} + SnapKV is not yet implemented on Vulkan " +
-                "(SnapKvScore/KvCompact read the cache as fp32, but bf16 stores it fp16-packed; " +
-                "issue #311). Set SHARPI_SNAPKV_BUDGET=0 to disable SnapKV.");
+                "(SnapKvScore/KvCompact read the cache as fp32, but the narrowed store packs it; " +
+                "issue #325). Set SHARPI_SNAPKV_BUDGET=0 to disable SnapKV.");
         if (_snapKvCfg.IsBudgetExplicit)
         {
             _snapKvEffectiveBudget = _snapKvCfg.Budget;
@@ -239,8 +251,9 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         }
         else if (kvNarrowed)
         {
-            // bf16 already shrinks the KV footprint (the memory win SnapKV auto-enable chases),
-            // and its compaction shaders read fp32; don't auto-enable eviction on the packed cache.
+            // A narrowed store (bf16/q8_0) already shrinks the KV footprint (the memory win SnapKV
+            // auto-enable chases), and the compaction shaders read fp32; don't auto-enable
+            // eviction on the packed cache (issues #311 / #325).
             _snapKvEffectiveBudget = 0;
         }
         else
@@ -334,6 +347,21 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             {
                 _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), DType.BFloat16);
                 _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), DType.BFloat16);
+            }
+        }
+        else if (_kvDType == DType.Q8_0)
+        {
+            // Block-quantized KV (issue #325): the cache holds ggml block_q8_0 (34 bytes per 32
+            // elements). Vulkan's Allocate(shape, DType) computes bytes via BytesPerElement, which
+            // THROWS for quantized dtypes, so allocate a raw uint-word buffer sized to the exact
+            // q8_0 byte count (rounded up to whole words). The append/attention shaders bind it as
+            // uint[] and index it by block regardless of the declared dtype — same pattern as bf16.
+            long q8Bytes = DTypeInfo.ByteSize((long)_maxSeqLen * kvDim, DType.Q8_0); // (count/32)*34
+            long words = (q8Bytes + 3) / 4;
+            for (int i = 0; i < hp.NumLayers; i++)
+            {
+                _gpuKCache[i] = gpu.Allocate(TensorShape.D1(words));
+                _gpuVCache[i] = gpu.Allocate(TensorShape.D1(words));
             }
         }
         else
@@ -787,6 +815,19 @@ public sealed unsafe class GpuForwardPass : IForwardPass
                     (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim,
                     (uint)(position + 1), (uint)_maxSeqLen);
             }
+            else if (_kvDType == DType.Q8_0)
+            {
+                // Block-quantized KV (issue #325): same args as the fp32/bf16 paths; the q8_0
+                // shaders quantize/dequantize the cache (block_q8_0) but index it identically.
+                _gpu.KvAppendQ8_0(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
+                    (uint)(_numKvHeads * _headDim), (uint)position, (uint)_maxSeqLen);
+                _gpu.RecordBarrier();
+
+                _gpu.AttentionQ8_0(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim,
+                    (uint)(position + 1), (uint)_maxSeqLen);
+            }
             else
             {
                 _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
@@ -1214,11 +1255,12 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         long available = vramBytes - weightBytes - scratchBytes - reserved;
         if (available <= 0) available = 64L * 1024 * 1024; // minimum fallback
 
-        // KV cache: 2 (K+V) * numLayers * numKvHeads * headDim * (bytes/elem) per token.
-        // bf16 (issue #311) halves the per-element store (2 bytes vs fp32's 4), so the
-        // auto-context actually buys ~2× the tokens under --kv-type bf16.
-        int kvElemBytes = DTypeInfo.BytesPerElement(kvDType);
-        long bytesPerToken = 2L * hp.NumLayers * hp.NumKvHeads * headDim * kvElemBytes;
+        // KV cache: 2 (K+V) * numLayers * ByteSize(kvDim) per token. DTypeInfo.ByteSize handles
+        // every store dtype (fp32 = kvDim*4, bf16 = kvDim*2, q8_0 = (kvDim/32)*34), so use it
+        // instead of BytesPerElement (which THROWS for the quantized q8_0 store, issue #325).
+        // bf16 (#311) ~halves the per-token store and q8_0 (#325) ~quarters it, so the
+        // auto-context buys ~2×/~4× the tokens under --kv-type bf16/q8_0 respectively.
+        long bytesPerToken = 2L * hp.NumLayers * DTypeInfo.ByteSize(hp.NumKvHeads * headDim, kvDType);
 
         int maxCtx = (int)(available / bytesPerToken);
         maxCtx = Math.Clamp(maxCtx, 512, hp.ContextLength);

--- a/src/SharpInference.Vulkan/Shaders.cs
+++ b/src/SharpInference.Vulkan/Shaders.cs
@@ -945,6 +945,239 @@ internal static class Shaders
         """;
 
     /// <summary>
+    /// q8_0 (issue #325) variant of <see cref="KvAppend"/>: block-quantizes the K/V vectors
+    /// into the cache as ggml <c>block_q8_0</c> (34 bytes = fp16 scale + 32 int8, per 32
+    /// elements; ~4× smaller than fp32). Mirrors the CUDA <c>llm_kv_append_q8_0</c> /
+    /// <c>sharpi_q8_append_one</c> ground truth: per 32-element block, <c>amax = max(|x|)</c>,
+    /// <c>d = amax / 127</c>, <c>invd = (d &lt; 1e-30) ? 0 : 1/d</c> (the 1e-30 guard avoids
+    /// 0*inf=NaN — replicated verbatim), <c>q = clamp(round(x*invd), -127, 127)</c>.
+    ///
+    /// Dispatched ONE THREAD PER 32-ELEMENT BLOCK (not a subgroup — subgroup width is
+    /// hardware-dependent; one-thread-per-block sidesteps that). Each thread owns all 34
+    /// bytes of its destination block. Because the cache is bound as <c>uint[]</c> and a
+    /// 34-byte block is not 4-aligned, adjacent blocks share the seam <c>uint</c> word but
+    /// write DISJOINT bytes; the masked <c>atomicAnd</c>+<c>atomicOr</c> byte writer makes the
+    /// disjoint-bitfield RMW correct under any thread interleaving (the atomicAnd clears the
+    /// byte first, so ring-reuse overwrites cleanly — no zero-init needed).
+    ///
+    /// CRITICAL: indexes the cache IDENTICALLY to the fp32 <see cref="KvAppend"/>
+    /// (<c>position * kv_dim + i</c> element addressing, expressed in blocks). No
+    /// <c>% max_seq_len</c> ring modulo, matching the fp32/bf16 shaders. kv_dim is always a
+    /// multiple of 32 (enforced in GpuForwardPass), so a KV row's blocks never straddle a row.
+    ///
+    /// Push constants: { uint kv_dim, position, max_seq_len } — unchanged.
+    /// Bindings: 0=k_input[kv_dim] (float), 1=v_input[kv_dim] (float),
+    ///           2=k_cache (uint, packed block_q8_0), 3=v_cache (uint, packed block_q8_0).
+    /// </summary>
+    internal const string KvAppendQ8_0 = """
+        #version 450
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) readonly buffer KIn  { float k_input[]; };
+        layout(binding = 1) readonly buffer VIn  { float v_input[]; };
+        layout(binding = 2) buffer KCache { uint k_cache[]; };
+        layout(binding = 3) buffer VCache { uint v_cache[]; };
+
+        layout(push_constant) uniform Params {
+            uint kv_dim;
+            uint position;
+            uint max_seq_len;
+        };
+
+        // Masked-atomic byte writers: clear the target byte, then OR in the value.
+        // Disjoint bytes within a shared uint stay correct under any interleaving.
+        void sByteK(uint b, uint val) {
+            uint w = b >> 2; uint sh = (b & 3u) * 8u;
+            atomicAnd(k_cache[w], ~(0xFFu << sh));
+            atomicOr (k_cache[w], (val & 0xFFu) << sh);
+        }
+        void sByteV(uint b, uint val) {
+            uint w = b >> 2; uint sh = (b & 3u) * 8u;
+            atomicAnd(v_cache[w], ~(0xFFu << sh));
+            atomicOr (v_cache[w], (val & 0xFFu) << sh);
+        }
+
+        void main() {
+            uint blk = gl_GlobalInvocationID.x;
+            uint blocks_per_row = kv_dim >> 5;   // kv_dim % 32 == 0
+            if (blk >= blocks_per_row) return;
+
+            // Same element address as fp32 (position * kv_dim + i), expressed in blocks.
+            uint dst_block = position * blocks_per_row + blk;
+            uint b0 = dst_block * 34u;
+            uint src = blk << 5;                 // first source element of this block
+
+            // ── K block ──
+            {
+                float amax = 0.0;
+                for (uint j = 0u; j < 32u; j++)
+                    amax = max(amax, abs(k_input[src + j]));
+                float d = amax / 127.0;
+                float invd = (d < 1e-30) ? 0.0 : (1.0 / d);
+                uint dh = packHalf2x16(vec2(d, 0.0)) & 0xFFFFu;
+                sByteK(b0, dh & 0xFFu);
+                sByteK(b0 + 1u, dh >> 8);
+                for (uint j = 0u; j < 32u; j++) {
+                    int q = clamp(int(round(k_input[src + j] * invd)), -127, 127);
+                    sByteK(b0 + 2u + j, uint(q & 0xFF));
+                }
+            }
+            // ── V block ──
+            {
+                float amax = 0.0;
+                for (uint j = 0u; j < 32u; j++)
+                    amax = max(amax, abs(v_input[src + j]));
+                float d = amax / 127.0;
+                float invd = (d < 1e-30) ? 0.0 : (1.0 / d);
+                uint dh = packHalf2x16(vec2(d, 0.0)) & 0xFFFFu;
+                sByteV(b0, dh & 0xFFu);
+                sByteV(b0 + 1u, dh >> 8);
+                for (uint j = 0u; j < 32u; j++) {
+                    int q = clamp(int(round(v_input[src + j] * invd)), -127, 127);
+                    sByteV(b0 + 2u + j, uint(q & 0xFF));
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// q8_0 (issue #325) variant of <see cref="Attention"/>: control flow is IDENTICAL to the
+    /// fp32 shader; the only difference is that the K/V cache buffers (bindings 1, 2) are
+    /// <c>uint[]</c> holding ggml <c>block_q8_0</c> (34 bytes/block: fp16 scale + 32 int8), so
+    /// every element read becomes a byte-gather + dequant <c>value = fp16(d) * int8</c>. All
+    /// scores / softmax / value accumulation stay fp32 — only the stored K/V is narrowed.
+    /// scores_scratch (binding 4) stays fp32. The <c>inversesqrt(head_dim)</c> scale is kept
+    /// exactly as the fp32 shader has it. Element addressing (<c>off = t*kv_dim + kv_head*head_dim</c>,
+    /// <c>e = off + d</c>) is identical to fp32/bf16; per element <c>blk=e&gt;&gt;5</c>,
+    /// <c>lane=e&amp;31</c>, <c>b0=blk*34</c>. kv_dim%32==0, so blocks never straddle a KV row.
+    ///
+    /// Push constants: { uint num_heads, num_kv_heads, head_dim, seq_len, max_seq_len } — unchanged.
+    /// Bindings: 0=Q (float), 1=K_cache (uint, block_q8_0), 2=V_cache (uint, block_q8_0),
+    ///           3=output (float), 4=scores_scratch (float).
+    /// </summary>
+    internal const string AttentionQ8_0 = """
+        #version 450
+        #extension GL_EXT_control_flow_attributes : enable
+
+        layout(local_size_x = 256) in;
+
+        layout(binding = 0) readonly buffer Q     { float q_data[]; };
+        layout(binding = 1) readonly buffer KCache { uint k_cache[]; };
+        layout(binding = 2) readonly buffer VCache { uint v_cache[]; };
+        layout(binding = 3) buffer Out             { float out_data[]; };
+        layout(binding = 4) buffer ScoresScratch   { float scores_scratch[]; };
+
+        layout(push_constant) uniform Params {
+            uint num_heads;
+            uint num_kv_heads;
+            uint head_dim;
+            uint seq_len;
+            uint max_seq_len;
+        };
+
+        // Score-storage strategy mirrors the fp32 Attention shader.
+        const uint MAX_SHARED_SCORES = 4096u;
+        shared float scores[MAX_SHARED_SCORES];
+        shared float sdata[256];   // reduction scratch
+
+        uint gByteK(uint b) { return (k_cache[b >> 2] >> ((b & 3u) * 8u)) & 0xFFu; }
+        int  gInt8K(uint b) { int v = int(gByteK(b)); return v >= 128 ? v - 256 : v; }
+        uint gByteV(uint b) { return (v_cache[b >> 2] >> ((b & 3u) * 8u)) & 0xFFu; }
+        int  gInt8V(uint b) { int v = int(gByteV(b)); return v >= 128 ? v - 256 : v; }
+
+        float loadK(uint e) {
+            uint blk = e >> 5; uint lane = e & 31u; uint b0 = blk * 34u;
+            float dsc = unpackHalf2x16(gByteK(b0) | (gByteK(b0 + 1u) << 8)).x;
+            return dsc * float(gInt8K(b0 + 2u + lane));
+        }
+        float loadV(uint e) {
+            uint blk = e >> 5; uint lane = e & 31u; uint b0 = blk * 34u;
+            float dsc = unpackHalf2x16(gByteV(b0) | (gByteV(b0 + 1u) << 8)).x;
+            return dsc * float(gInt8V(b0 + 2u + lane));
+        }
+
+        void main() {
+            uint h = gl_WorkGroupID.x;
+            uint tid = gl_LocalInvocationID.x;
+            if (h >= num_heads) return;
+
+            uint kv_head = h / (num_heads / num_kv_heads);
+            uint kv_dim = num_kv_heads * head_dim;
+            float scale = inversesqrt(float(head_dim));
+            uint q_off = h * head_dim;
+            uint out_off = h * head_dim;
+
+            bool use_shared = (seq_len <= MAX_SHARED_SCORES);
+            uint scratch_base = h * max_seq_len;
+
+            // ─── Phase 1: per-position Q·K scores ───
+            for (uint t = tid; t < seq_len; t += 256) {
+                float dot = 0.0;
+                uint k_off = t * kv_dim + kv_head * head_dim;
+                for (uint d = 0; d < head_dim; d++)
+                    dot += q_data[q_off + d] * loadK(k_off + d);
+                float score = dot * scale;
+                if (use_shared) scores[t] = score;
+                else            scores_scratch[scratch_base + t] = score;
+            }
+            if (use_shared) {
+                for (uint t = seq_len + tid; t < MAX_SHARED_SCORES; t += 256)
+                    scores[t] = -1.0/0.0;
+            }
+            barrier();
+
+            // ─── Phase 2: in-place softmax over [0, seq_len) ───
+            float local_max = -1.0/0.0;
+            for (uint t = tid; t < seq_len; t += 256) {
+                float s = use_shared ? scores[t] : scores_scratch[scratch_base + t];
+                local_max = max(local_max, s);
+            }
+            sdata[tid] = local_max;
+            barrier();
+            [[unroll]] for (uint s = 128; s > 0; s >>= 1) {
+                if (tid < s) sdata[tid] = max(sdata[tid], sdata[tid + s]);
+                barrier();
+            }
+            float max_val = sdata[0];
+            barrier();
+
+            float local_sum = 0.0;
+            for (uint t = tid; t < seq_len; t += 256) {
+                float s = use_shared ? scores[t] : scores_scratch[scratch_base + t];
+                float e = exp(s - max_val);
+                if (use_shared) scores[t] = e;
+                else            scores_scratch[scratch_base + t] = e;
+                local_sum += e;
+            }
+            sdata[tid] = local_sum;
+            barrier();
+            [[unroll]] for (uint s = 128; s > 0; s >>= 1) {
+                if (tid < s) sdata[tid] += sdata[tid + s];
+                barrier();
+            }
+            float inv_sum = 1.0 / sdata[0];
+            barrier();
+
+            for (uint t = tid; t < seq_len; t += 256) {
+                if (use_shared) scores[t] *= inv_sum;
+                else            scores_scratch[scratch_base + t] *= inv_sum;
+            }
+            barrier();
+
+            // ─── Phase 3: weighted V sum. K is NOT re-derived here. ───
+            for (uint d = tid; d < head_dim; d += 256) {
+                float sum = 0.0;
+                for (uint t = 0; t < seq_len; t++) {
+                    float weight = use_shared ? scores[t] : scores_scratch[scratch_base + t];
+                    uint v_off = t * kv_dim + kv_head * head_dim;
+                    sum += weight * loadV(v_off + d);
+                }
+                out_data[out_off + d] = sum;
+            }
+        }
+        """;
+
+    /// <summary>
     /// SnapKV (issue #59) — per-head attention scoring across a layer's K cache.
     /// Mirrors the CUDA `llm_snapkv_score` kernel: one workgroup per query head,
     /// 256 threads. Phase 1 computes causal-masked dot(q_head, k_cache[t, kvHead, :]) * scale

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -987,6 +987,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     private ComputePipeline? _attentionPipeline;
     private ComputePipeline? _kvAppendBf16Pipeline;
     private ComputePipeline? _attentionBf16Pipeline;
+    private ComputePipeline? _kvAppendQ8Pipeline;
+    private ComputePipeline? _attentionQ8Pipeline;
     private ComputePipeline? _snapKvScorePipeline;
     private ComputePipeline? _kvCompactPipeline;
     private ComputePipeline? _embedLookupPipeline;
@@ -1322,6 +1324,49 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
             headDim = headDim, seqLen = seqLen, maxSeqLen = maxSeqLen
         };
         DispatchOrRecord(_attentionBf16Pipeline,
+            [GetBuffer(q), GetBuffer(kCache), GetBuffer(vCache), GetBuffer(output),
+             GetBuffer(scoresScratch)],
+            numHeads, &p);
+    }
+
+    /// <summary>
+    /// q8_0 (issue #325) variant of <see cref="KvAppend"/>: block-quantizes the K/V vectors
+    /// into the cache as ggml <c>block_q8_0</c> (34 bytes/block = fp16 scale + 32 int8, per 32
+    /// elements; ~4× smaller than fp32). The cache buffers are bound as <c>uint[]</c> and
+    /// indexed identically to the fp32 path (<c>position * kv_dim + i</c>, expressed in blocks).
+    /// Dispatched ONE THREAD PER 32-ELEMENT BLOCK; kv_dim must be a multiple of 32 (enforced in
+    /// GpuForwardPass). The shader owns a whole 34-byte block per thread and uses masked atomics
+    /// for the (non-4-aligned) seam words shared between adjacent blocks.
+    /// </summary>
+    public void KvAppendQ8_0(Tensor kInput, Tensor vInput, Tensor kCache, Tensor vCache,
+        uint kvDim, uint position, uint maxSeqLen)
+    {
+        _kvAppendQ8Pipeline ??= new ComputePipeline(this, Shaders.KvAppendQ8_0, 4, pushConstantSize: sizeof(KvAppendParams));
+        var p = new KvAppendParams { kvDim = kvDim, position = position, maxSeqLen = maxSeqLen };
+        DispatchOrRecord(_kvAppendQ8Pipeline,
+            [GetBuffer(kInput), GetBuffer(vInput), GetBuffer(kCache), GetBuffer(vCache)],
+            ((kvDim >> 5) + 255) / 256, &p);
+    }
+
+    /// <summary>
+    /// q8_0 (issue #325) variant of <see cref="Attention"/>: identical control flow to the fp32
+    /// path, but the K/V cache buffers hold ggml <c>block_q8_0</c> (34 bytes/block) and are read
+    /// via a per-element byte-gather + dequant (<c>fp16(d) * int8</c>). All arithmetic (scores /
+    /// softmax / value accumulation) stays fp32 — only the stored K/V is narrowed.
+    /// <paramref name="scoresScratch"/> stays fp32 (see <see cref="Attention"/> for the spill
+    /// convention).
+    /// </summary>
+    public void AttentionQ8_0(Tensor q, Tensor kCache, Tensor vCache, Tensor output,
+        Tensor scoresScratch,
+        uint numHeads, uint numKvHeads, uint headDim, uint seqLen, uint maxSeqLen)
+    {
+        _attentionQ8Pipeline ??= new ComputePipeline(this, Shaders.AttentionQ8_0, 5, pushConstantSize: sizeof(AttentionParams));
+        var p = new AttentionParams
+        {
+            numHeads = numHeads, numKvHeads = numKvHeads,
+            headDim = headDim, seqLen = seqLen, maxSeqLen = maxSeqLen
+        };
+        DispatchOrRecord(_attentionQ8Pipeline,
             [GetBuffer(q), GetBuffer(kCache), GetBuffer(vCache), GetBuffer(output),
              GetBuffer(scoresScratch)],
             numHeads, &p);
@@ -1778,6 +1823,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _attentionPipeline?.Dispose();
         _kvAppendBf16Pipeline?.Dispose();
         _attentionBf16Pipeline?.Dispose();
+        _kvAppendQ8Pipeline?.Dispose();
+        _attentionQ8Pipeline?.Dispose();
         _snapKvScorePipeline?.Dispose();
         _kvCompactPipeline?.Dispose();
         _embedLookupPipeline?.Dispose();

--- a/tests/SharpInference.Tests.ForwardPass/GpuForwardPassKvDtypeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/GpuForwardPassKvDtypeTests.cs
@@ -5,23 +5,27 @@ using SharpInference.Vulkan;
 namespace SharpInference.Tests.ForwardPass;
 
 /// <summary>
-/// bf16 KV-cache parity for the Vulkan <see cref="GpuForwardPass"/> (issue #311). With
-/// <c>kvDtype: DType.BFloat16</c> the K/V cache is stored half-width (IEEE fp16 packed
-/// two-per-uint via core-GLSL <c>packHalf2x16</c>); kernel arithmetic stays fp32, so decode
-/// must be argmax-stable vs the fp32 cache at short context — only the stored value's mantissa
-/// is narrowed. The bf16 decode is teacher-forced onto the fp32 trajectory so the KV dtype is
-/// the only variable at each position. Asserts, per teacher-forced position:
+/// Narrowed KV-cache parity for the Vulkan <see cref="GpuForwardPass"/> (issues #311 / #325).
+/// With <c>kvDtype: DType.BFloat16</c> the K/V cache is stored half-width (IEEE fp16 packed
+/// two-per-uint via core-GLSL <c>packHalf2x16</c>); with <c>DType.Q8_0</c> it is block-quantized
+/// (ggml <c>block_q8_0</c>: fp16 scale + 32 int8 per 32 elements, ~4× smaller than fp32). Kernel
+/// arithmetic stays fp32 in both, so decode must be argmax-stable vs the fp32 cache at short
+/// context — only the stored value is narrowed. The narrowed decode is teacher-forced onto the
+/// fp32 trajectory so the KV dtype is the only variable at each position. Asserts, per
+/// teacher-forced position:
 /// <list type="bullet">
-///   <item>all bf16 logits are finite,</item>
-///   <item>fp32's top-1 stays within bf16's top-5 — the reorder-tolerant "argmax-stable"
-///         criterion (a genuine near-tie can flip top-1 with no kernel bug),</item>
-///   <item>the logit max-abs gap is within a small rounding budget.</item>
+///   <item>all narrowed logits are finite,</item>
+///   <item>fp32's top-1 stays within the narrowed run's top-K — the reorder-tolerant
+///         "argmax-stable" criterion (a genuine near-tie can flip top-1 with no kernel bug),</item>
+///   <item>the logit max-abs gap is within a per-dtype rounding budget.</item>
 /// </list>
 ///
-/// The parity test is the correctness gate for the <c>AttentionBf16</c> read shader: a failure
-/// most likely means the <c>unpackHalf2x16(buf[idx&gt;&gt;1])[idx&amp;1]</c> lane-select or an
-/// indexing divergence from the fp32 shader. SnapKV is forced off so the KV dtype is the only
-/// variable. Each case is skipped silently when Vulkan is unavailable or the GGUF isn't on disk.
+/// The parity test is the correctness gate for the narrowed read shader: a bf16 failure most
+/// likely means the <c>unpackHalf2x16(buf[idx&gt;&gt;1])[idx&amp;1]</c> lane-select; a q8_0 failure
+/// most likely means the append-quant (amax/invd/round/clamp), the masked-atomic byte store
+/// (seam corruption), or the block/lane indexing in <c>AttentionQ8_0</c>. SnapKV is forced off so
+/// the KV dtype is the only variable. Each case is skipped silently when Vulkan is unavailable or
+/// the GGUF isn't on disk.
 /// </summary>
 public sealed class GpuForwardPassKvDtypeTests
 {
@@ -191,5 +195,84 @@ public sealed class GpuForwardPassKvDtypeTests
         Assert.True(seen.Count >= 2,
             $"bf16 greedy decode produced only {seen.Count} distinct token(s) " +
             $"([{string.Join(",", argmax)}]) — bf16-KV greedy decode is degenerate.");
+    }
+
+    /// <summary>
+    /// q8_0 KV must stay argmax-stable vs fp32 KV on the SAME teacher-forced trajectory (issue
+    /// #325). q8_0 is lossier than bf16, so the bound is looser (max-abs &lt; 2.5, top-5 overlap).
+    /// This is the correctness gate for the full q8_0 round-trip: the KvAppendQ8_0 append-quant +
+    /// masked-atomic byte store and the AttentionQ8_0 byte-gather + dequant read.
+    /// Qwen3-8B has kvDim = 8*128 = 1024 (% 32 == 0), so the q8_0 path is engaged.
+    /// </summary>
+    [Fact]
+    public void Q8Kv_ArgmaxStable_VsFp32()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int steps = 6;
+        const int ctx = 2048;
+        const float maxAbsTol = 2.5f; // q8_0 is lossier than bf16 — looser than Bf16Kv's 2.0
+
+        var (f32, f32Argmax) = RunPrefillDecode(gpu, path, DType.Float32, LowEntropyPrompt, steps, ctx, forced: null);
+        var (kv, _) = RunPrefillDecode(gpu, path, DType.Q8_0, LowEntropyPrompt, steps, ctx, forced: f32Argmax);
+
+        for (int p = 0; p <= steps; p++)
+        {
+            Assert.Equal(f32[p].Length, kv[p].Length);
+            float maxAbs = 0f;
+            for (int i = 0; i < f32[p].Length; i++)
+            {
+                Assert.True(float.IsFinite(kv[p][i]), $"non-finite q8_0 logit at pos {p}, idx {i}.");
+                maxAbs = Math.Max(maxAbs, Math.Abs(f32[p][i] - kv[p][i]));
+            }
+            Assert.True(maxAbs < maxAbsTol,
+                $"pos {p} q8_0 vs fp32 logit max-abs {maxAbs:F3} exceeds the rounding budget " +
+                $"({maxAbsTol:F1}) — likely a KvAppendQ8_0 quant/byte-store bug or an AttentionQ8_0 " +
+                "block/lane indexing bug, not q8_0-store rounding.");
+            Assert.True(TopK(kv[p], 5).Contains(f32Argmax[p]),
+                $"pos {p} fp32 top-1 ({f32Argmax[p]}) fell out of q8_0's top-5 (max-abs {maxAbs:F3}) — " +
+                "the q8_0 attention read reordered the head of the distribution.");
+        }
+    }
+
+    /// <summary>
+    /// q8_0 KV greedy decode (the path picks its OWN tokens — not teacher-forced) on a
+    /// template-correct prompt must stay coherent: all logits finite, the first generated token
+    /// is not EOS, and ≥2 distinct argmaxes over the run (catches NaN / single-token collapse
+    /// from a wrong append-quant or attention read). Issue #325.
+    /// </summary>
+    [Fact]
+    public void Q8Kv_GreedyDecode_Coherent()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        int eosId;
+        using (var model = GgufModel.Open(path))
+            eosId = GgufTokenizer.FromGgufModel(model).EosTokenId;
+
+        const int steps = 5;
+        const int ctx = 2048;
+
+        var (logits, argmax) = RunPrefillDecode(gpu, path, DType.Q8_0, Qwen3TemplatePrompt, steps, ctx, forced: null);
+
+        for (int p = 0; p <= steps; p++)
+            for (int i = 0; i < logits[p].Length; i++)
+                Assert.True(float.IsFinite(logits[p][i]),
+                    $"q8_0 greedy: non-finite logit at pos {p}, idx {i} — a q8_0-KV attention read bug.");
+
+        Assert.True(argmax[0] != eosId,
+            "q8_0 greedy: first token was EOS — the template-correct prompt should have a real " +
+            "continuation, so this means the q8_0 greedy path collapsed.");
+
+        var seen = new HashSet<int>(argmax);
+        Assert.True(seen.Count >= 2,
+            $"q8_0 greedy decode produced only {seen.Count} distinct token(s) " +
+            $"([{string.Join(",", argmax)}]) — q8_0-KV greedy decode is degenerate.");
     }
 }


### PR DESCRIPTION
Closes #325. Completes the #311 KV-narrowing scope (bf16 shipped in #323; q8_0 was the remaining half).

## Problem
The Vulkan KV cache supported fp32 and (since #311) bf16, but not Q8_0. Q8_0 stores K/V as 8-bit (~4× smaller than fp32, ~2× smaller than bf16), letting the **full** model context fit on the GPU. CUDA already has q8_0 KV.

## Change
Mirrors CUDA's q8_0 KV (`block_q8_0` = fp16 scale + 32 int8 per 32-element block, 34 bytes; dequant `value = d * int8`) and extends the #311 bf16 scaffolding at every site. Default behavior (no `--kv-type`) is unchanged fp32.

- **`KvAppendQ8_0` GLSL** — one thread per 32-element block (no subgroup → portable across subgroup widths): computes `amax`, `d = amax/127`, `invd = (d<1e-30)?0:1/d` (guards `0*inf=NaN`), `q = clamp(round(x*invd), ±127)`, and byte-stores `fp16(d) + 32 int8` into a `uint[]` cache via **masked `atomicAnd`+`atomicOr`** (34-byte blocks aren't 4-aligned; adjacent blocks share a seam word but write *disjoint* bytes → atomic RMW is correct under any interleaving, no zero-init needed).
- **`AttentionQ8_0` GLSL** — verbatim copy of `AttentionBf16` (fp32 scores/softmax/accumulate, shared + scratch-spill paths, `1/sqrt(headDim)` scale) with only the K/V read swapped to a q8_0 dequant (`blk=e>>5, lane=e&31, b0=blk*34, value=fp16(d)*int8`), reusing the proven `MatVecQ8_0` `gByte` byte-gather.
- **`VulkanBackend.KvAppendQ8_0`/`AttentionQ8_0`** (+ pipelines/disposal, reusing the push-constant structs).
- **`GpuForwardPass`**: accept `Q8_0` (drop the "CUDA-only" rejection); require `kvDim % 32 == 0`; allocate a raw uint-word buffer sized via `DTypeInfo.ByteSize` (Vulkan `Allocate` throws on Q8_0); dispatch branch; `[KV q8_0]` banner; `EstimateMaxContext` via `DTypeInfo.ByteSize` (q8_0 ≈ 3.76× fp32 context; fp32/bf16 unchanged). TQ/SnapKV exclusivity already covered by the `kvNarrowed` guards.
- `--kv-type q8_0` already flows from CLI + server (`ResolveConfiguredKvDType`).

## Verification (4070 Ti)
- **Full context fits**: Qwen3-8B `--backend vulkan -g -1 --kv-type q8_0` reaches `Context size: 40960` (the model max) `[KV q8_0]` — vs fp32 **11399** and bf16 **22798** — with **coherent greedy output**.
- **Tests**: new `Q8Kv_ArgmaxStable_VsFp32` (teacher-forced q8_0-vs-fp32, looser 2.5 bound for 8-bit + top-5/8 overlap) and `Q8Kv_GreedyDecode_Coherent`. All **16** KV-dtype tests pass (CUDA + Vulkan, fp32/bf16/q8_0). fp32 path byte-identical (default ctor arg); bf16 path unchanged.
- Internal code-review pass: **no findings above the reporting bar** — the append-quant, masked-atomic byte store, allocation byte math, and attention dequant were each verified against the CUDA reference.

## Scope / notes
- The `AttentionQ8_0` scratch-spill (>4096) branch is the verbatim bf16 scratch logic (validated e2e at 5149 tokens in #311) with the proven q8_0 read; the read is identical in the shared and scratch branches (the parity test exercises it). A dedicated `ctx>4096` parity test is a worthwhile follow-up (bf16 has the identical gap).
- q8_0 + SnapKV / TurboQuant remain guarded off on Vulkan (same as bf16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)