### PR TITLE
fix(vulkan): pin requiredSubgroupSize=32 for reduction shaders (#318)

### DIFF
--- a/src/SharpInference.Vulkan/ComputePipeline.cs
+++ b/src/SharpInference.Vulkan/ComputePipeline.cs
@@ -34,10 +34,11 @@ public sealed unsafe class ComputePipeline : IDisposable
     // Public for tests/diagnostics that need to assert per-recording DS isolation.
     public int CurrentRecordingDispatchCount => _recordingIdx;
 
-    // Matches "local_size_x = <N>" in a GLSL layout qualifier. Every compute shader in this
-    // backend declares it as a literal; used to decide subgroup-size pinning (issue #318).
+    // Matches "local_size_x = <N>" inside a GLSL layout(...) qualifier (scoped to the
+    // qualifier so a stray mention in a comment can't false-match). Every compute shader in
+    // this backend declares it as a literal; used to decide subgroup-size pinning (issue #318).
     private static readonly Regex LocalSizeXRegex =
-        new(@"local_size_x\s*=\s*(\d+)", RegexOptions.Compiled);
+        new(@"layout\s*\([^)]*local_size_x\s*=\s*(\d+)", RegexOptions.Compiled);
 
     /// <summary>
     /// Parse the <c>local_size_x</c> workgroup dimension from GLSL source.

--- a/src/SharpInference.Vulkan/ComputePipeline.cs
+++ b/src/SharpInference.Vulkan/ComputePipeline.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Vortice.Vulkan;
 
 namespace SharpInference.Vulkan;
@@ -32,6 +33,42 @@ public sealed unsafe class ComputePipeline : IDisposable
 
     // Public for tests/diagnostics that need to assert per-recording DS isolation.
     public int CurrentRecordingDispatchCount => _recordingIdx;
+
+    // Matches "local_size_x = <N>" in a GLSL layout qualifier. Every compute shader in this
+    // backend declares it as a literal; used to decide subgroup-size pinning (issue #318).
+    private static readonly Regex LocalSizeXRegex =
+        new(@"local_size_x\s*=\s*(\d+)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parse the <c>local_size_x</c> workgroup dimension from GLSL source.
+    /// Returns 0 if not found (which disables subgroup-size pinning — every real compute
+    /// shader declares one, so a 0 result signals a malformed/non-compute source).
+    /// </summary>
+    internal static int ParseLocalSizeX(string glsl)
+    {
+        var m = LocalSizeXRegex.Match(glsl);
+        return m.Success ? int.Parse(m.Groups[1].Value) : 0;
+    }
+
+    /// <summary>
+    /// Whether requiredSubgroupSize=32 should be pinned for a shader with the given
+    /// <paramref name="localSizeX"/> on the given <paramref name="backend"/> (issue #318).
+    /// True only when:
+    ///   • the extension is present, AND
+    ///   • 32 lies within the supported subgroup-size range, AND
+    ///   • the device is NOT already locked to exactly 32 (min==max==32) — on such devices
+    ///     (e.g. NVIDIA) every subgroup is already 32 wide, so pinning is a pure no-op and we
+    ///     skip it to avoid forcing the driver's required-subgroup-size pipeline path, AND
+    ///   • the workgroup x-dimension is a whole multiple of 32 (so a 32-wide subgroup is valid —
+    ///     pinning 32 on the 16-thread image-op workgroups would make pipeline creation fail).
+    /// The bug only manifests when the device could pick a non-32 subgroup (AMD Wave64 → 64;
+    /// Intel → possibly &lt;32), which is exactly the !(min==max==32) case.
+    /// </summary>
+    internal static bool ShouldPinSubgroupSize32(VulkanBackend backend, int localSizeX) =>
+        backend.HasSubgroupSizeControl
+        && backend.MinSubgroupSize <= 32 && 32 <= backend.MaxSubgroupSize
+        && !(backend.MinSubgroupSize == 32 && backend.MaxSubgroupSize == 32)
+        && localSizeX > 0 && localSizeX % 32 == 0;
 
     /// <summary>
     /// Create a compute pipeline from GLSL source.
@@ -101,14 +138,31 @@ public sealed unsafe class ComputePipeline : IDisposable
         vkd.vkCreatePipelineLayout(&pipelineLayoutCI, null, &pipeLayout).CheckResult();
         _pipelineLayout = pipeLayout;
 
-        // 4. Compute pipeline
+        // 4. Compute pipeline.
+        // Pin requiredSubgroupSize=32 for reduction shaders (issue #318): they pack
+        // "8 rows × 32 lanes" and assume a 32-wide subgroup, which breaks on AMD Wave64
+        // (subgroup 64 → subgroupAdd sums across two rows). Pin only when the workgroup
+        // x-dim is a multiple of 32 (the 256/128 reduction shaders) — pinning 32 on the
+        // 16-thread image-op shaders would make the workgroup smaller than one subgroup and
+        // pipeline creation would fail. On NVIDIA (subgroup already 32) this is a no-op.
+        int localSizeX = ParseLocalSizeX(glslSource);
+        bool pinSubgroup = ShouldPinSubgroupSize32(backend, localSizeX);
+        VkPipelineShaderStageRequiredSubgroupSizeCreateInfo requiredSgSize = new()
+        {
+            requiredSubgroupSize = 32,
+        };
+
         var entryName = "main"u8;
+        // requiredSgSize is a stack local; &requiredSgSize stays valid for the whole synchronous
+        // vkCreateComputePipelines call below. It is chained into the shader-stage pNext only when
+        // pinning is enabled (issue #318).
         fixed (byte* entryPtr = entryName)
         {
             VkComputePipelineCreateInfo pipelineCI = new()
             {
                 stage = new VkPipelineShaderStageCreateInfo
                 {
+                    pNext = pinSubgroup ? &requiredSgSize : null,
                     stage = VkShaderStageFlags.Compute,
                     module = _shaderModule,
                     pName = entryPtr,

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -312,6 +312,25 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         HasSubgroupSizeControl  = extNames.Contains("VK_EXT_subgroup_size_control");
         HasShaderBfloat16       = hasBfloat16;
         HasShaderFloat8         = hasFloat8;
+        bool hasSubgroupSizeControl = HasSubgroupSizeControl;
+
+        // 5b. Query the supported subgroup-size range (issue #318). The reduction shaders pack
+        // "8 rows × 32 lanes" per workgroup and assume the subgroup is exactly 32 wide; on AMD
+        // Wave64 a subgroup would span two row groups and corrupt subgroupAdd/subgroupElect.
+        // We pin requiredSubgroupSize=32 at pipeline creation (ComputePipeline) when the device
+        // could pick a non-32 subgroup (see ComputePipeline.ShouldPinSubgroupSize32). If the
+        // extension is absent these stay 0 → pinning disabled.
+        if (hasSubgroupSizeControl)
+        {
+            VkPhysicalDeviceSubgroupSizeControlProperties sgProps = new();
+            VkPhysicalDeviceProperties2 props2 = new()
+            {
+                pNext = &sgProps,
+            };
+            _vki.vkGetPhysicalDeviceProperties2(_physicalDevice, &props2);
+            MinSubgroupSize = sgProps.minSubgroupSize;
+            MaxSubgroupSize = sgProps.maxSubgroupSize;
+        }
 
         // 6. Create logical device with one compute queue, enabling detected extensions
         float queuePriority = 1.0f;
@@ -329,10 +348,12 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         byte[] intDotNameBytes    = System.Text.Encoding.UTF8.GetBytes("VK_KHR_shader_integer_dot_product\0");
         byte[] bf16NameBytes      = System.Text.Encoding.UTF8.GetBytes("VK_KHR_shader_bfloat16\0");
         byte[] fp8NameBytes       = System.Text.Encoding.UTF8.GetBytes("VK_EXT_shader_float8\0");
+        byte[] sgSizeNameBytes    = System.Text.Encoding.UTF8.GetBytes("VK_EXT_subgroup_size_control\0");
 
         int enabledExtCount = (hasFloat16Int8 ? 1 : 0) + (has16BitStorage ? 1 : 0)
                             + (has8BitStorage ? 1 : 0) + (hasIntDot ? 1 : 0)
-                            + (hasBfloat16 ? 1 : 0) + (hasFloat8 ? 1 : 0);
+                            + (hasBfloat16 ? 1 : 0) + (hasFloat8 ? 1 : 0)
+                            + (hasSubgroupSizeControl ? 1 : 0);
         int extIdx = 0;
 
         fixed (byte* pF16Int8   = f16Int8NameBytes,
@@ -340,7 +361,8 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
                      pStorage8  = storage8NameBytes,
                      pIntDot    = intDotNameBytes,
                      pBf16      = bf16NameBytes,
-                     pFp8       = fp8NameBytes)
+                     pFp8       = fp8NameBytes,
+                     pSgSize    = sgSizeNameBytes)
         {
             byte** extPtrs = stackalloc byte*[enabledExtCount > 0 ? enabledExtCount : 1];
             if (hasFloat16Int8)  extPtrs[extIdx++] = pF16Int8;
@@ -349,6 +371,7 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
             if (hasIntDot)       extPtrs[extIdx++] = pIntDot;
             if (hasBfloat16)     extPtrs[extIdx++] = pBf16;
             if (hasFloat8)       extPtrs[extIdx++] = pFp8;
+            if (hasSubgroupSizeControl) extPtrs[extIdx++] = pSgSize;
 
             // Build pNext feature chain (back to front so earlier structs point to later ones)
             VkPhysicalDevice8BitStorageFeatures storage8Features = new()
@@ -385,10 +408,24 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
                 pNext = hasFloat8 ? (void*)&fp8Features : baseChain,
             };
 
-            void* pNextChain =
+            void* featureChain =
                 hasBfloat16 ? (void*)&bf16Features :
                 hasFloat8   ? (void*)&fp8Features :
                 baseChain;
+
+            // Prepend the subgroup-size-control feature (issue #318). We only enable
+            // subgroupSizeControl; computeFullSubgroups is unnecessary because every pinned
+            // shader has local_size_x a multiple of 32 (so the workgroup already fills whole
+            // subgroups). The actual requiredSubgroupSize=32 is set per pipeline stage.
+            VkPhysicalDeviceSubgroupSizeControlFeatures sgSizeFeatures = new()
+            {
+                subgroupSizeControl = VkBool32.True,
+                pNext = featureChain,
+            };
+
+            void* pNextChain =
+                hasSubgroupSizeControl ? (void*)&sgSizeFeatures :
+                featureChain;
 
             VkDeviceCreateInfo deviceCI = new()
             {
@@ -468,6 +505,11 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     public bool HasShaderIntegerDotProduct { get; private set; }
     public bool HasShaderBfloat16 { get; private set; }
     public bool HasShaderFloat8 { get; private set; }
+
+    // Subgroup-size range reported by VK_EXT_subgroup_size_control (issue #318).
+    // 0 when the extension is absent (subgroup-size pinning then stays disabled).
+    public uint MinSubgroupSize { get; private set; }
+    public uint MaxSubgroupSize { get; private set; }
 
     public SgemmPrecision BestSgemmPrecision =>
         HasShaderFloat16Int8 && Has16BitStorage ? SgemmPrecision.Fp16 :

--- a/tests/SharpInference.Tests.ForwardPass/VulkanSubgroupSizeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanSubgroupSizeTests.cs
@@ -1,0 +1,162 @@
+using SharpInference.Core;
+using SharpInference.Vulkan;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Tests for subgroup-size pinning (issue #318). The reduction shaders assume a 32-wide
+/// subgroup; on AMD Wave64 (subgroup 64) two 32-lane row groups share one subgroup, so
+/// subgroupAdd/subgroupElect corrupt the output. We pin requiredSubgroupSize=32 via
+/// VK_EXT_subgroup_size_control on shaders whose local_size_x is a multiple of 32, but only
+/// on devices that could pick a non-32 subgroup. Devices locked to exactly 32 (NVIDIA report
+/// min==max==32) are already correct, so the pin is skipped there (avoids the driver's
+/// required-subgroup-size pipeline path entirely).
+///
+/// CAVEAT: the Wave64 effect cannot be exercised on NVIDIA hardware (subgroup is already 32,
+/// so no pin is even applied). These tests verify the host-side wiring (properties queried,
+/// device/pipeline still create, output unchanged) and the pin-gate logic.
+/// </summary>
+public sealed unsafe class VulkanSubgroupSizeTests
+{
+    /// <summary>Construct a backend, returning null (test skipped) if no Vulkan device exists.</summary>
+    private static VulkanBackend? TryCreateBackend()
+    {
+        try
+        {
+            return new VulkanBackend();
+        }
+        catch
+        {
+            // No Vulkan-capable device / loader in this environment — skip.
+            return null;
+        }
+    }
+
+    [Fact]
+    public void SubgroupSizeRangeIsQueried()
+    {
+        using var backend = TryCreateBackend();
+        if (backend is null) return; // no device
+
+        if (backend.HasSubgroupSizeControl)
+        {
+            // The properties query (vkGetPhysicalDeviceProperties2 + SubgroupSizeControlProperties)
+            // must have populated a valid, ordered range.
+            Assert.True(backend.MinSubgroupSize >= 1,
+                $"MinSubgroupSize should be >= 1 when the extension is present, got {backend.MinSubgroupSize}");
+            Assert.True(backend.MaxSubgroupSize >= backend.MinSubgroupSize,
+                $"MaxSubgroupSize ({backend.MaxSubgroupSize}) should be >= MinSubgroupSize ({backend.MinSubgroupSize})");
+        }
+        else
+        {
+            // Extension absent → fields left at their disabling default of 0.
+            Assert.Equal(0u, backend.MinSubgroupSize);
+            Assert.Equal(0u, backend.MaxSubgroupSize);
+        }
+    }
+
+    [Fact]
+    public void ParseLocalSizeXReadsTheLiteral()
+    {
+        Assert.Equal(256, ComputePipeline.ParseLocalSizeX(
+            "#version 450\nlayout(local_size_x = 256) in;\nvoid main() {}"));
+        Assert.Equal(128, ComputePipeline.ParseLocalSizeX(
+            "layout(local_size_x = 128, local_size_y = 1) in;"));
+        Assert.Equal(16, ComputePipeline.ParseLocalSizeX(
+            "layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;"));
+        // Tolerates extra whitespace around the '='.
+        Assert.Equal(256, ComputePipeline.ParseLocalSizeX("local_size_x   =   256"));
+        // No declaration → 0 (disables pinning).
+        Assert.Equal(0, ComputePipeline.ParseLocalSizeX("void main() {}"));
+    }
+
+    [Theory]
+    [InlineData(256, true)]   // reduction shaders → pinned
+    [InlineData(128, true)]   // reduction shaders → pinned
+    [InlineData(512, true)]   // any multiple of 32 → pinned
+    [InlineData(16, false)]   // image-op shaders → NOT pinned (smaller than one subgroup)
+    [InlineData(0, false)]    // no local_size_x → NOT pinned
+    public void PinGateIncludesMultiplesOf32(int localSizeX, bool multipleOf32Expected)
+    {
+        // The local_size_x % 32 == 0 sub-condition of the gate (independent of HW capability).
+        bool multipleOf32 = localSizeX > 0 && localSizeX % 32 == 0;
+        Assert.Equal(multipleOf32Expected, multipleOf32);
+    }
+
+    [Fact]
+    public void ShouldPinSubgroupSize32MatchesGate()
+    {
+        using var backend = TryCreateBackend();
+        if (backend is null) return; // no device
+
+        // Pinning is needed only when the device could pick a non-32 subgroup (AMD Wave64 → 64,
+        // Intel → possibly <32). A device locked to exactly 32 (e.g. NVIDIA) is already correct,
+        // so we skip the pin there to avoid the driver's required-subgroup-size pipeline path.
+        bool needsPin = backend.HasSubgroupSizeControl
+            && backend.MinSubgroupSize <= 32 && 32 <= backend.MaxSubgroupSize
+            && !(backend.MinSubgroupSize == 32 && backend.MaxSubgroupSize == 32);
+
+        // 16-thread image-op shaders must never be pinned, regardless of HW capability.
+        Assert.False(ComputePipeline.ShouldPinSubgroupSize32(backend, 16));
+        // 0 (no local_size_x) must never be pinned.
+        Assert.False(ComputePipeline.ShouldPinSubgroupSize32(backend, 0));
+
+        // Multiples of 32 are pinned iff the device needs the pin.
+        Assert.Equal(needsPin, ComputePipeline.ShouldPinSubgroupSize32(backend, 256));
+        Assert.Equal(needsPin, ComputePipeline.ShouldPinSubgroupSize32(backend, 128));
+    }
+
+    [Fact]
+    public void RmsNormUnchangedWithSubgroupPin()
+    {
+        // No-regression smoke: RmsNorm is a 256-thread reduction shader (subgroupAdd over a
+        // 32-lane row group). Output must match the CPU reference whether or not the pin is
+        // applied — i.e. the #318 wiring did not break pipeline creation or compute.
+        using var backend = TryCreateBackend();
+        if (backend is null) return; // no device
+
+        const int N = 2048;
+        var input = new float[N];
+        var weight = new float[N];
+        var rng = new Random(42);
+        for (int i = 0; i < N; i++)
+        {
+            input[i] = (float)(rng.NextDouble() * 2 - 1);
+            weight[i] = (float)(rng.NextDouble() * 0.5 + 0.75);
+        }
+
+        var gpuInput = backend.Upload(input, TensorShape.D1(N));
+        var gpuWeight = backend.Upload(weight, TensorShape.D1(N));
+        var gpuOutput = backend.Allocate(TensorShape.D1(N));
+        backend.RmsNorm(gpuOutput, gpuInput, gpuWeight, 1e-5f);
+
+        var gpuResult = new float[N];
+        backend.Download(gpuOutput, gpuResult);
+
+        float sumSq = 0;
+        for (int i = 0; i < N; i++) sumSq += input[i] * input[i];
+        float scale = 1f / MathF.Sqrt(sumSq / N + 1e-5f);
+        for (int i = 0; i < N; i++)
+        {
+            float expected = input[i] * scale * weight[i];
+            Assert.True(MathF.Abs(gpuResult[i] - expected) < 0.001f,
+                $"RmsNorm mismatch at [{i}]: gpu={gpuResult[i]}, cpu={expected}");
+        }
+
+        backend.Free(gpuInput);
+        backend.Free(gpuWeight);
+        backend.Free(gpuOutput);
+    }
+
+    [Fact]
+    public void PrintsQueriedSubgroupSizeRange()
+    {
+        // Surfaces the queried range in test output for the issue report.
+        using var backend = TryCreateBackend();
+        if (backend is null) return; // no device
+
+        Console.WriteLine(
+            $"[#318] HasSubgroupSizeControl={backend.HasSubgroupSizeControl} " +
+            $"MinSubgroupSize={backend.MinSubgroupSize} MaxSubgroupSize={backend.MaxSubgroupSize}");
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/VulkanSubgroupSizeTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanSubgroupSizeTests.cs
@@ -64,10 +64,12 @@ public sealed unsafe class VulkanSubgroupSizeTests
             "layout(local_size_x = 128, local_size_y = 1) in;"));
         Assert.Equal(16, ComputePipeline.ParseLocalSizeX(
             "layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;"));
-        // Tolerates extra whitespace around the '='.
-        Assert.Equal(256, ComputePipeline.ParseLocalSizeX("local_size_x   =   256"));
+        // Tolerates extra whitespace around the '=' (within a layout qualifier).
+        Assert.Equal(256, ComputePipeline.ParseLocalSizeX("layout(local_size_x   =   256) in;"));
         // No declaration → 0 (disables pinning).
         Assert.Equal(0, ComputePipeline.ParseLocalSizeX("void main() {}"));
+        // A mention outside a layout(...) qualifier (e.g. a comment) must NOT false-match.
+        Assert.Equal(0, ComputePipeline.ParseLocalSizeX("// local_size_x = 64 is the default\nvoid main() {}"));
     }
 
     [Theory]


### PR DESCRIPTION
Closes #318.

## Problem
The Vulkan reduction shaders (matvec / attention / etc.) pack "8 rows × 32 lanes" in a 256/128-thread workgroup and use `subgroupAdd`/`subgroupElect` **assuming a 32-wide subgroup**. On **AMD Wave64** (subgroup size 64), a subgroup spans two 32-lane row groups → `subgroupAdd` sums across two rows and `subgroupElect` writes only half the rows → **garbage output**. The Vulkan backend explicitly targets cross-vendor (AMD / Intel / NVIDIA), so this is a real correctness gap for the stated platforms.

## Change
Pin `requiredSubgroupSize = 32` via `VK_EXT_subgroup_size_control` so every subgroup is exactly one 32-lane row group on all hardware:
- **`VulkanBackend`**: enable the `VK_EXT_subgroup_size_control` extension + the `subgroupSizeControl` device feature, and query min/max subgroup size (`VkPhysicalDeviceSubgroupSizeControlProperties`) at init.
- **`ComputePipeline`**: chain `VkPipelineShaderStageRequiredSubgroupSizeCreateInfo{requiredSubgroupSize=32}` into the shader stage, **gated** to shaders whose `local_size_x` is a multiple of 32 (the 43 reduction shaders; the 5 sixteen-thread image-op shaders are excluded — pinning 32 on a 16-thread workgroup is invalid, and they don't assume 32-lane subgroups), and only when 32 ∈ [min, max] **and** the device isn't already locked to 32 (`min==max==32`, e.g. NVIDIA → pin is a no-op, skipped).

## Verification
- **No-regression on the dev NVIDIA HW**: subgroup is already 32, so the pin never engages — all 43 Vulkan tests pass with byte-identical output; device + pipelines create cleanly with the feature/extension enabled, and the properties query returns 32/32. New `VulkanSubgroupSizeTests` (10) cover the query + the pin-gate logic.
- **Wiring verified by construction**: an internal code-review pass confirmed (incl. decompiling the Vortice.Vulkan metadata + a runtime `sType` check) that the feature struct is correctly prepended to the device pNext chain and genuinely enabled, the extension-array math has no off-by-one, and the pipeline pNext/pointer-lifetime are correct — i.e. the two test-invisible failure modes (silent feature-enable failure, extension off-by-one) are clean. So the fix will engage correctly on a Wave64 device (min=32/max=64).
- Shader **sources are untouched** → the precompiled SPIR-V table needs no regeneration.

## ⚠️ Verification caveat (please read)
The **Wave64 effect cannot be verified on the available NVIDIA-only hardware** — the pin path engages only on devices that can choose a subgroup size ≠ 32 (AMD Wave64, possibly Intel), which aren't present here. On NVIDIA the change is a verified no-op. Correctness on Wave64 rests on the standard `VK_EXT_subgroup_size_control` mechanism + the wiring review, not a live AMD run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)