### PR TITLE
fix(vulkan): dispose TurboQuant pipelines — fixes flaky 0xC0000005 (#153)

### DIFF
--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -39,6 +39,12 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     // Serializes vkQueueSubmit from both main and background threads.
     private readonly object _queueLock = new();
 
+    // Opt-in Vulkan validation layers (SHARPI_VULKAN_VALIDATION=1). Used to turn
+    // flaky native access-violations into deterministic validation diagnostics
+    // (issue #153). Null when validation is off (the default).
+    private VkDebugUtilsMessengerEXT _debugMessenger;
+    private readonly bool _validationEnabled;
+
     private bool _disposed;
 
     public string Name { get; }
@@ -260,17 +266,66 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         // 1. Initialize Vulkan loader
         vkInitialize().CheckResult();
 
+        // Opt-in validation layers (issue #153): when SHARPI_VULKAN_VALIDATION=1 we
+        // enable the Khronos validation layer + VK_EXT_debug_utils so invalid buffer/
+        // descriptor/pipeline usage is reported deterministically (even on runs that
+        // don't crash). Default (env unset/0) keeps the instance exactly as before —
+        // no extra layers, no debug-utils, zero validation overhead.
+        _validationEnabled =
+            Environment.GetEnvironmentVariable("SHARPI_VULKAN_VALIDATION") is "1" or "true" or "TRUE";
+
         // 2. Create instance (Vulkan 1.3+)
         VkApplicationInfo appInfo = new()
         {
             apiVersion = VkVersion.Version_1_3, // Vortice may not have 1.4 constant yet
         };
-        VkInstanceCreateInfo instanceCI = new()
+
+        // Validation-layer name + debug-utils extension name (null-terminated UTF-8).
+        byte[] validationLayerBytes = System.Text.Encoding.UTF8.GetBytes("VK_LAYER_KHRONOS_validation\0");
+        byte[] debugUtilsExtBytes   = System.Text.Encoding.UTF8.GetBytes("VK_EXT_debug_utils\0");
+
+        // A messenger create-info chained into pNext also catches validation errors
+        // raised *during* vkCreateInstance/vkDestroyInstance themselves.
+        VkDebugUtilsMessengerCreateInfoEXT dbgCI = MakeDebugMessengerCreateInfo();
+
+        fixed (byte* pValidationLayer = validationLayerBytes)
+        fixed (byte* pDebugUtilsExt   = debugUtilsExtBytes)
         {
-            pApplicationInfo = &appInfo,
-        };
-        vkCreateInstance(in instanceCI, out _instance).CheckResult();
+            byte** layerPtrs = stackalloc byte*[1];
+            byte** instExtPtrs = stackalloc byte*[1];
+            layerPtrs[0] = pValidationLayer;
+            instExtPtrs[0] = pDebugUtilsExt;
+
+            VkInstanceCreateInfo instanceCI = new()
+            {
+                pApplicationInfo = &appInfo,
+                pNext = _validationEnabled ? &dbgCI : null,
+                enabledLayerCount = _validationEnabled ? 1u : 0u,
+                ppEnabledLayerNames = _validationEnabled ? layerPtrs : null,
+                enabledExtensionCount = _validationEnabled ? 1u : 0u,
+                ppEnabledExtensionNames = _validationEnabled ? instExtPtrs : null,
+            };
+            vkCreateInstance(in instanceCI, out _instance).CheckResult();
+        }
         _vki = new VkInstanceApi(in _instance);
+
+        // Register the standalone debug messenger now that we have an instance + loaded
+        // instance-extension entry points. Errors/warnings go to Console.Error.
+        if (_validationEnabled)
+        {
+            VkDebugUtilsMessengerEXT messenger;
+            var res = _vki.vkCreateDebugUtilsMessengerEXT(&dbgCI, &messenger);
+            if (res == VkResult.Success)
+            {
+                _debugMessenger = messenger;
+                Console.Error.WriteLine("[VK-VALIDATION] Vulkan validation layers ENABLED (SHARPI_VULKAN_VALIDATION=1)");
+            }
+            else
+            {
+                Console.Error.WriteLine($"[VK-VALIDATION] WARNING: vkCreateDebugUtilsMessengerEXT failed ({res}); " +
+                    "validation messages from pNext-chained create/destroy still fire, standalone messenger disabled.");
+            }
+        }
 
         // 3. Select physical device (prefer discrete GPU)
         _physicalDevice = SelectPhysicalDevice(deviceIndex);
@@ -1833,6 +1888,57 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
     //  Disposal
     // ================================================================
 
+    // ── Vulkan validation layer support (issue #153, opt-in) ──────────────
+
+    /// <summary>
+    /// Build the debug-messenger create-info used both for the pNext chain on
+    /// instance creation and for the standalone messenger. Severity is limited to
+    /// WARNING + ERROR; all message types are reported.
+    /// </summary>
+    private static VkDebugUtilsMessengerCreateInfoEXT MakeDebugMessengerCreateInfo() => new()
+    {
+        messageSeverity = VkDebugUtilsMessageSeverityFlagsEXT.Warning
+                        | VkDebugUtilsMessageSeverityFlagsEXT.Error,
+        messageType = VkDebugUtilsMessageTypeFlagsEXT.General
+                    | VkDebugUtilsMessageTypeFlagsEXT.Validation
+                    | VkDebugUtilsMessageTypeFlagsEXT.Performance,
+        pfnUserCallback = &DebugCallback,
+    };
+
+    /// <summary>
+    /// Validation-layer callback. AOT-safe: a <c>[UnmanagedCallersOnly]</c> static method
+    /// (no managed delegate to keep alive / GC). Writes WARNING/ERROR lines — including any
+    /// named objects involved — to <see cref="Console.Error"/> with a <c>[VK-VALIDATION]</c> prefix.
+    /// </summary>
+    [System.Runtime.InteropServices.UnmanagedCallersOnly]
+    private static uint DebugCallback(
+        VkDebugUtilsMessageSeverityFlagsEXT severity,
+        VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+        VkDebugUtilsMessengerCallbackDataEXT* data,
+        void* userData)
+    {
+        // Return VK_FALSE (0): the callback does not abort the triggering API call.
+        if (data == null) return 0u;
+
+        string sev = severity.HasFlag(VkDebugUtilsMessageSeverityFlagsEXT.Error) ? "ERROR" : "WARNING";
+        string msg = data->pMessage != null ? new string((sbyte*)data->pMessage) : "(no message)";
+        string idName = data->pMessageIdName != null ? new string((sbyte*)data->pMessageIdName) : "";
+
+        Console.Error.WriteLine($"[VK-VALIDATION] {sev} ({messageTypes}) [{idName}] {msg}");
+
+        // Dump any named objects involved (buffer / descriptor set / pipeline / etc.)
+        for (uint i = 0; i < data->objectCount; i++)
+        {
+            VkDebugUtilsObjectNameInfoEXT obj = data->pObjects[i];
+            string objName = obj.pObjectName != null ? new string((sbyte*)obj.pObjectName) : "(unnamed)";
+            Console.Error.WriteLine(
+                $"[VK-VALIDATION]   object[{i}] type={obj.objectType} handle=0x{obj.objectHandle:X} name={objName}");
+        }
+        Console.Error.Flush();
+
+        return 0u; // VK_FALSE
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -1869,6 +1975,9 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _attentionQ8Pipeline?.Dispose();
         _snapKvScorePipeline?.Dispose();
         _kvCompactPipeline?.Dispose();
+        _tqRotateQueryPipeline?.Dispose();
+        _tqKvAppendPipeline?.Dispose();
+        _tqAttentionPipeline?.Dispose();
         _embedLookupPipeline?.Dispose();
         _embedLookupQ4KPipeline?.Dispose();
         _bufCopyPipeline?.Dispose();
@@ -1900,6 +2009,11 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         _vkd.vkDestroyCommandPool(_commandPool, null);
         _vkd.vkDestroyCommandPool(_asyncPool, null);
         _vkd.vkDestroyDevice(null);
+
+        // Tear down the validation messenger (if registered) before the instance.
+        if (_validationEnabled && _debugMessenger.IsNotNull)
+            _vki.vkDestroyDebugUtilsMessengerEXT(_debugMessenger);
+
         _vki.vkDestroyInstance(null);
     }
 }

--- a/src/SharpInference.Vulkan/VulkanBackend.cs
+++ b/src/SharpInference.Vulkan/VulkanBackend.cs
@@ -271,8 +271,9 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         // descriptor/pipeline usage is reported deterministically (even on runs that
         // don't crash). Default (env unset/0) keeps the instance exactly as before —
         // no extra layers, no debug-utils, zero validation overhead.
+        var validationEnv = Environment.GetEnvironmentVariable("SHARPI_VULKAN_VALIDATION");
         _validationEnabled =
-            Environment.GetEnvironmentVariable("SHARPI_VULKAN_VALIDATION") is "1" or "true" or "TRUE";
+            validationEnv is "1" || string.Equals(validationEnv, "true", StringComparison.OrdinalIgnoreCase);
 
         // 2. Create instance (Vulkan 1.3+)
         VkApplicationInfo appInfo = new()
@@ -280,16 +281,14 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
             apiVersion = VkVersion.Version_1_3, // Vortice may not have 1.4 constant yet
         };
 
-        // Validation-layer name + debug-utils extension name (null-terminated UTF-8).
-        byte[] validationLayerBytes = System.Text.Encoding.UTF8.GetBytes("VK_LAYER_KHRONOS_validation\0");
-        byte[] debugUtilsExtBytes   = System.Text.Encoding.UTF8.GetBytes("VK_EXT_debug_utils\0");
-
         // A messenger create-info chained into pNext also catches validation errors
         // raised *during* vkCreateInstance/vkDestroyInstance themselves.
         VkDebugUtilsMessengerCreateInfoEXT dbgCI = MakeDebugMessengerCreateInfo();
 
-        fixed (byte* pValidationLayer = validationLayerBytes)
-        fixed (byte* pDebugUtilsExt   = debugUtilsExtBytes)
+        // Validation-layer name + debug-utils extension name (null-terminated UTF-8 literals
+        // → no heap allocation; only consumed when validation is enabled).
+        fixed (byte* pValidationLayer = "VK_LAYER_KHRONOS_validation\0"u8)
+        fixed (byte* pDebugUtilsExt   = "VK_EXT_debug_utils\0"u8)
         {
             byte** layerPtrs = stackalloc byte*[1];
             byte** instExtPtrs = stackalloc byte*[1];
@@ -1917,24 +1916,40 @@ public sealed unsafe class VulkanBackend : IComputeBackend, IImageOpsBackend, ID
         VkDebugUtilsMessengerCallbackDataEXT* data,
         void* userData)
     {
-        // Return VK_FALSE (0): the callback does not abort the triggering API call.
-        if (data == null) return 0u;
-
-        string sev = severity.HasFlag(VkDebugUtilsMessageSeverityFlagsEXT.Error) ? "ERROR" : "WARNING";
-        string msg = data->pMessage != null ? new string((sbyte*)data->pMessage) : "(no message)";
-        string idName = data->pMessageIdName != null ? new string((sbyte*)data->pMessageIdName) : "";
-
-        Console.Error.WriteLine($"[VK-VALIDATION] {sev} ({messageTypes}) [{idName}] {msg}");
-
-        // Dump any named objects involved (buffer / descriptor set / pipeline / etc.)
-        for (uint i = 0; i < data->objectCount; i++)
+        // An exception escaping an [UnmanagedCallersOnly] callback fail-fasts the process,
+        // so swallow everything. PtrToStringUTF8 decodes the native strings as UTF-8
+        // (new string((sbyte*)..) would use the ANSI code page on Windows).
+        try
         {
-            VkDebugUtilsObjectNameInfoEXT obj = data->pObjects[i];
-            string objName = obj.pObjectName != null ? new string((sbyte*)obj.pObjectName) : "(unnamed)";
-            Console.Error.WriteLine(
-                $"[VK-VALIDATION]   object[{i}] type={obj.objectType} handle=0x{obj.objectHandle:X} name={objName}");
+            // Return VK_FALSE (0): the callback does not abort the triggering API call.
+            if (data == null) return 0u;
+
+            string sev = severity.HasFlag(VkDebugUtilsMessageSeverityFlagsEXT.Error) ? "ERROR" : "WARNING";
+            string msg = data->pMessage != null
+                ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)data->pMessage) ?? "(no message)"
+                : "(no message)";
+            string idName = data->pMessageIdName != null
+                ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)data->pMessageIdName) ?? ""
+                : "";
+
+            Console.Error.WriteLine($"[VK-VALIDATION] {sev} ({messageTypes}) [{idName}] {msg}");
+
+            // Dump any named objects involved (buffer / descriptor set / pipeline / etc.)
+            for (uint i = 0; i < data->objectCount; i++)
+            {
+                VkDebugUtilsObjectNameInfoEXT obj = data->pObjects[i];
+                string objName = obj.pObjectName != null
+                    ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)obj.pObjectName) ?? "(unnamed)"
+                    : "(unnamed)";
+                Console.Error.WriteLine(
+                    $"[VK-VALIDATION]   object[{i}] type={obj.objectType} handle=0x{obj.objectHandle:X} name={objName}");
+            }
+            Console.Error.Flush();
         }
-        Console.Error.Flush();
+        catch
+        {
+            // Never let a managed exception cross back into the Vulkan driver.
+        }
 
         return 0u; // VK_FALSE
     }


### PR DESCRIPTION
Closes #153.

## Root cause
`VulkanBackend.Dispose()` disposed every lazily-created `ComputePipeline` **except the three TurboQuant ones** — `_tqRotateQueryPipeline`, `_tqKvAppendPipeline`, `_tqAttentionPipeline` were declared but missing from the disposal list. Each leaked pipeline also leaks its descriptor pools.

Across repeated backend lifecycles (the full `~Vulkan` / ForwardPass test churn), destroying a `VkDevice` with live child objects is undefined behavior; on this driver it corrupts internal descriptor/pipeline state, which later surfaces as the flaky native **`0xC0000005`** access violation inside a recorded compute dispatch (`CopyBuffer` → `vkCmdBindDescriptorSets`) in a **subsequent** backend — exactly matching #153's variable abort points (58/141/382...) and the prior triage's `vkCmdBindDescriptorSets` observation. Only the TurboQuant path creates these pipelines, so only `GpuForwardPassTurboQuantRunsPastFp32Window` was the trigger.

## Fix
Add the three missing `?.Dispose()` calls. The disposal list is now **complete** (47 pipeline fields ↔ 47 disposals, verified 1:1 in review).

## Diagnosis tooling (kept; opt-in, default-off)
This was diagnosed by adding **opt-in Vulkan validation layers** (`SHARPI_VULKAN_VALIDATION=1`): enables `VK_LAYER_KHRONOS_validation` + `VK_EXT_debug_utils` with an AOT-safe `[UnmanagedCallersOnly]` debug callback writing `[VK-VALIDATION]` messages to stderr. Validation pinpointed `VUID-vkDestroyDevice-device-05137` ("VkPipeline/... has not been destroyed"). The **default path (env var unset) is byte-identical** — no layers, no extension, no messenger, zero overhead; the messenger is destroyed before the instance. Useful future Vulkan-debugging infra.

## Verification (deterministic)
- **With the leak** (fix reverted): **5/5** churn runs crash with `0xC0000005` + the `VUID-vkDestroyDevice` validation error.
- **After the fix**: validation-clean (the VUID error is gone — deterministic proof the leak is closed) and the `~Vulkan` filter passes **47/47**, repeatedly, with no AV.
- Build clean (TreatWarningsAsErrors + AOT analyzers); internal code-review pass confirmed the disposal list is complete and the default-off path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)