### PR TITLE
feat(vulkan): Gemma 4 image input (ForwardEmbedding seam) (#252)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -32,7 +32,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         public string? PromptFile { get; init; }
 
         [CommandOption("--image <PATH>")]
-        [Description("Path to a PNG image for multimodal input (Gemma 4 encoder-free vision). Repeatable for multiple images; reference each with an <image> marker in -p (left-to-right), or omit markers to prepend them. Requires --mmproj and a text prompt (-p). CPU only for now (-g 0).")]
+        [Description("Path to a PNG image for multimodal input (Gemma 4 encoder-free vision). Repeatable for multiple images; reference each with an <image> marker in -p (left-to-right), or omit markers to prepend them. Requires --mmproj and a text prompt (-p). Runs on CPU, CUDA, and Vulkan (full offload).")]
         public string[]? ImagePaths { get; init; }
 
         [CommandOption("--mmproj")]

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -1173,6 +1173,12 @@ public sealed unsafe class GpuForwardPass : IForwardPass
 
         // 2. Transformer layers + final norm/output/softcap (same device region as text decode).
         _gpu.BeginRecord();
+        // The upload above is a transfer write in a prior (fence-waited) submission; insert a
+        // transfer→compute barrier so the first layer's _hidden read is ordered after it and the
+        // write is made visible to the shader (host fence-wait alone doesn't guarantee visibility
+        // to this submission's compute reads). The barrier's first scope includes the earlier
+        // transfer submission in queue order.
+        _gpu.RecordTransferBarrier();
         RunGemma4Layers(position);
 
         _gpu.RmsNorm(_hidden, _hidden, _wOutputNorm, _hp.RmsNormEps);

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -1137,6 +1137,62 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         return _logitsBuf;
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Gemma 4 only: image input (issue #252) splices vision soft tokens into the decode
+    /// stream. Other arches and the partial-offload hybrids don't implement the seam.
+    /// </remarks>
+    public bool SupportsEmbeddingInput => _isGemma4;
+
+    /// <summary>
+    /// Forward one position from a PRECOMPUTED embedding (a vision soft token) instead of a
+    /// token-table lookup. The Vulkan mirror of <see cref="ForwardGemma4"/> (and of
+    /// <c>ForwardPass.ForwardEmbedding</c> / <c>CudaForwardPass.ForwardEmbedding</c>): the
+    /// supplied embedding is uploaded into the device hidden buffer and — per the
+    /// <see cref="IForwardPass.ForwardEmbedding"/> contract and gemma4.cpp:182 — the
+    /// sqrt(EmbeddingDim) embedding scale is SKIPPED (the soft tokens arrive already final).
+    /// The transformer trunk + final norm/output/softcap are identical to
+    /// <see cref="ForwardGemma4"/>. Gemma 4 only (PLE/shared-KV are rejected at construction
+    /// on this backend, so there is no per-layer-projection pre-pass to mirror). The upload
+    /// runs BEFORE <c>BeginRecord</c> because <see cref="UploadToExisting"/> owns its own
+    /// command-buffer begin/submit/wait and cannot be nested inside an in-progress record.
+    /// </summary>
+    public ReadOnlySpan<float> ForwardEmbedding(ReadOnlySpan<float> embedding, int position)
+    {
+        if (!_isGemma4)
+            throw new NotSupportedException(
+                "ForwardEmbedding (image input) is only supported for Gemma 4 on the Vulkan backend.");
+        if (embedding.Length != _embDim)
+            throw new ArgumentException(
+                $"embedding length {embedding.Length} != model embedding dim {_embDim}.");
+
+        // 1. Upload the precomputed embedding into _hidden. No sqrt(d) scale (gemma4.cpp:182).
+        //    Done OUTSIDE the record block: UploadToExisting submits + waits its own command
+        //    buffer, so it cannot be nested between BeginRecord and EndRecordAndSubmit.
+        UploadToExisting(_hidden, embedding);
+
+        // 2. Transformer layers + final norm/output/softcap (same device region as text decode).
+        _gpu.BeginRecord();
+        RunGemma4Layers(position);
+
+        _gpu.RmsNorm(_hidden, _hidden, _wOutputNorm, _hp.RmsNormEps);
+        _gpu.RecordBarrier();
+        GpuMatMul(_logits, _wOutput, _hidden);
+        if (_hp.FinalLogitSoftcap > 0f)
+        {
+            _gpu.RecordBarrier();
+            _gpu.SoftcapInPlace(_logits, _hp.FinalLogitSoftcap);
+        }
+
+        _gpu.RecordComputeToTransferBarrier();
+        _gpu.RecordDownloadToStaging(_logits, _logitsBuf.Length);
+        _gpu.EndRecordAndSubmit();
+        _gpu.ReadFromStaging(_logitsBuf);
+
+        _kvLength = Math.Max(_kvLength, position + 1);
+        return _logitsBuf;
+    }
+
     /// <summary>Gemma 4 embedding gather. Mirrors the CUDA path, but Vulkan ships only
     /// F32 + Q4_K + Q6_K embed-lookup shaders (the Q4_K_M tied embedding is Q4_K, the Q6_K
     /// variant stays raw via EmbedLookupQ6K; any other quant is dequantized to F32 at

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4VisionVulkanE2ETests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4VisionVulkanE2ETests.cs
@@ -1,0 +1,193 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using SharpInference.Vision;
+using SharpInference.Vulkan;
+using Vortice.Vulkan;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// End-to-end image→text for Gemma 4 on the Vulkan <see cref="GpuForwardPass"/> (issue #252):
+/// preprocess → encoder-free projector (CPU) → splice soft tokens into the Vulkan decoder via
+/// <see cref="GpuForwardPass.ForwardEmbedding"/> → greedy decode. The Vulkan analogue of
+/// <see cref="Gemma4VisionE2ETests"/>; it pins the new <c>ForwardEmbedding</c> seam end-to-end.
+///
+/// Validates (a) the capability flag (<see cref="IForwardPass.SupportsEmbeddingInput"/>),
+/// (b) correctness (a solid-RED image decodes the word "red") and (c) image-dependence (a
+/// solid-BLUE image does NOT decode "red", proving the vision embeddings actually steer the LM).
+///
+/// The prompt is rendered through the model's OWN chat template with thinking disabled (mirrors
+/// the CLI's <c>RunImagePrompt</c>): <c>gemma4-v2</c> otherwise opens a <c>&lt;|channel&gt;thought</c>
+/// block and the one-word answer falls outside a short decode budget. The single <c>&lt;|image|&gt;</c>
+/// placeholder token is expanded into <c>&lt;|image&gt;</c> … soft tokens … <c>&lt;image|&gt;</c>.
+///
+/// Uses <c>gemma4-v2-Q4_K_M.gguf</c> (PLE-off, Vulkan-loadable) + the gemma4uv projector
+/// <c>mmproj-gemma-4-12b-it-qat-q4_0.gguf</c> (output dim 3840 — a valid pair). Silent-skips when
+/// Vulkan is unavailable, the device is out of memory for full offload, or the GGUFs aren't on
+/// disk. NOT run by the implementation pass (the orchestrator verifies on a real GPU).
+/// </summary>
+public sealed class Gemma4VisionVulkanE2ETests
+{
+    private readonly ITestOutputHelper _out;
+    public Gemma4VisionVulkanE2ETests(ITestOutputHelper output) => _out = output;
+
+    private const string TextModel = "gemma4-v2-Q4_K_M.gguf";
+    private const string Mmproj = "mmproj-gemma-4-12b-it-qat-q4_0.gguf";
+
+    private static VulkanBackend? TryCreate()
+    {
+        try { return new VulkanBackend(); }
+        catch { return null; }
+    }
+
+    private static string? Find(string file)
+    {
+        foreach (var p in new[] { $@"C:\p\sharpi\models\{file}", $@"E:\models\{file}" })
+            if (File.Exists(p)) return p;
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8 && dir is not null; i++)
+        {
+            var p = Path.Combine(dir, "models", file);
+            if (File.Exists(p)) return p;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        return null;
+    }
+
+    [Fact]
+    public void Gemma4_Vulkan_Image_SplicesAndSteersDecode()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;                                // Vulkan-gated
+        var textPath = Find(TextModel);
+        var mmprojPath = Find(Mmproj);
+        if (textPath is null || mmprojPath is null) return;     // model-gated
+
+        using var model = GgufModel.Open(textPath);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.NotNull(hp.LayerHeadDim);                        // real gemma4 GGUF
+        var tok = GgufTokenizer.FromGgufModel(model);
+        Assert.NotNull(tok.ChatTemplate);                       // need the template to suppress thinking
+
+        GpuForwardPass fwd;
+        try
+        {
+            fwd = new GpuForwardPass(model, gpu, hp);
+        }
+        catch (VkException ex) when (ex.Result == VkResult.ErrorOutOfDeviceMemory)
+        {
+            // Full gemma4 offload doesn't fit this device's VRAM — skip silently (the
+            // orchestrator verifies end-to-end on a GPU with enough memory).
+            return;
+        }
+        using (fwd)
+        {
+            Assert.True(fwd.SupportsEmbeddingInput);
+
+            using var vision = VisionModel.Open(mmprojPath);
+            var embedder = new GemmaUvVisionEmbedder(vision);
+            int embd = hp.EmbeddingDim;
+
+            // Image marker / placeholder ids (gemma4uv runtime wrapping is
+            // <|image> ... soft ... <image|>; the chat template emits the <|image|> placeholder).
+            int imgOpen = tok.SpecialTokens.TryGetValue("<|image>", out var o) ? o : 255999;
+            int imgClose = tok.SpecialTokens.TryGetValue("<image|>", out var c) ? c : 258882;
+            int placeholder = tok.SpecialTokens.TryGetValue("<|image|>", out var ph) ? ph : 258880;
+
+            var redOut = RunImagePrompt(fwd, embedder, vision, embd, tok,
+                                        imgOpen, imgClose, placeholder,
+                                        SolidColor(96, 96, 220, 30, 30), "RED");
+            fwd.ResetCache();
+            var blueOut = RunImagePrompt(fwd, embedder, vision, embd, tok,
+                                         imgOpen, imgClose, placeholder,
+                                         SolidColor(96, 96, 30, 30, 220), "BLUE");
+
+            // Coherence: each decode is non-degenerate.
+            AssertCoherent(redOut, tok.EosTokenId, "red");
+            AssertCoherent(blueOut, tok.EosTokenId, "blue");
+
+            // Image-dependence: different images must produce different token streams.
+            Assert.False(redOut.SequenceEqual(blueOut),
+                "red and blue images produced identical Vulkan decodes — vision embeddings are not steering the model.");
+
+            // Correctness: greedy temp-0 decode names the dominant color.
+            Assert.Contains("red", tok.Decode(redOut), StringComparison.OrdinalIgnoreCase);
+            // Image-dependence (negative): the blue image must NOT name "red".
+            Assert.DoesNotContain("red", tok.Decode(blueOut), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private List<int> RunImagePrompt(
+        GpuForwardPass fwd, GemmaUvVisionEmbedder embedder, VisionModel vision, int embd,
+        GgufTokenizer tok, int imgOpen, int imgClose, int placeholder,
+        byte[] rgb, string label)
+    {
+        var img = ImagePreprocessor.Preprocess(rgb, 96, 96, vision);
+        var soft = embedder.Forward(img.Chw, img.Height, img.Width, out int nTok);
+
+        // Render through the model's own chat template with thinking OFF (mirrors the CLI image
+        // path). The <|image|> placeholder marks where the image's soft tokens are spliced.
+        var messages = JinjaChatTemplate.BuildMessages(
+            "<|image|>What color is this image? Answer in one word.");
+        var prompt = tok.ChatTemplate!.Render(new Dictionary<string, object?>
+        {
+            ["messages"] = messages,
+            ["add_generation_prompt"] = true,
+            ["tools"] = null,
+            ["enable_thinking"] = false,
+        });
+        var allTokens = tok.Encode(prompt).ToList();
+        Assert.Equal(1, allTokens.Count(t => t == placeholder));
+
+        int pos = 0;
+        ReadOnlySpan<float> logits = default;
+        foreach (int id in allTokens)
+        {
+            if (id == placeholder)
+            {
+                logits = fwd.Forward(imgOpen, pos++);
+                for (int t = 0; t < nTok; t++)
+                    logits = fwd.ForwardEmbedding(soft.AsSpan(t * embd, embd), pos++);
+                logits = fwd.Forward(imgClose, pos++);
+            }
+            else
+            {
+                logits = fwd.Forward(id, pos++);
+            }
+        }
+
+        var outIds = new List<int>();
+        int next = Argmax(logits);
+        for (int i = 0; i < 12 && next != tok.EosTokenId; i++)
+        {
+            outIds.Add(next);
+            logits = fwd.Forward(next, pos++);
+            next = Argmax(logits);
+        }
+        _out.WriteLine($"[{label}] {nTok} soft tokens -> {outIds.Count} decoded: \"{tok.Decode(outIds)}\" {string.Join(",", outIds)}");
+        return outIds;
+    }
+
+    private static void AssertCoherent(List<int> outIds, int eos, string which)
+    {
+        Assert.True(outIds.Count > 0, $"[{which}] decoded nothing (immediate EOS).");
+        Assert.DoesNotContain(eos, outIds);                // we stop before EOS, so none present
+        Assert.True(outIds.Distinct().Count() >= 2,
+            $"[{which}] decode is degenerate (only {outIds.Distinct().Count()} distinct of {outIds.Count}): {string.Join(",", outIds)}");
+    }
+
+    private static byte[] SolidColor(int w, int h, byte r, byte g, byte b)
+    {
+        var buf = new byte[w * h * 3];
+        for (int i = 0; i < w * h; i++) { buf[i * 3] = r; buf[i * 3 + 1] = g; buf[i * 3 + 2] = b; }
+        return buf;
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0; float bv = logits[0];
+        for (int i = 1; i < logits.Length; i++) if (logits[i] > bv) { bv = logits[i]; best = i; }
+        return best;
+    }
+}


### PR DESCRIPTION
Toward #252 — Gemma 4 image input on the Vulkan full-offload path. Follow-on to #309 (gemma4 text on Vulkan).

## Change
Gemma 4 encoder-free vision injects image soft-token embeddings into the prefill via `IForwardPass.ForwardEmbedding`. CPU + CUDA implement it; Vulkan didn't. Everything above the forward pass — the CPU `GemmaUvVisionEmbedder`, `InferenceEngine.SplicePrefillImages`, the CLI `--image` path — is backend-agnostic and already routes the active forward pass. So the only missing piece was the Vulkan seam:
- **`GpuForwardPass.SupportsEmbeddingInput => _isGemma4`** (was the `false` default)
- **`GpuForwardPass.ForwardEmbedding`**: mirrors `ForwardGemma4` with the embedding-lookup prologue replaced by uploading the provided soft-token embedding into `_hidden` with **NO √d scale** (soft tokens arrive already-final, per the contract + CPU/CUDA), via `UploadToExisting` *before* `BeginRecord`; then the identical `RunGemma4Layers` + final-norm/output/softcap/download tail. Guards: gemma4-only + `embedding.Length == embDim`. No PLE pre-pass (Vulkan gemma4 rejects PLE at construction).
- CLI `--image` help text: drop the stale "CPU only (-g 0)" note.

**Purely additive** — non-gemma4 models report `SupportsEmbeddingInput=false` (unchanged); the dense/MoE paths are byte-identical.

## Verification
- New model-gated `Gemma4VisionVulkanE2ETests` (gemma4-v2 + the 12B gemma4uv mmproj) **runs on GPU**: solid-RED image → "Red", solid-BLUE → not "red" (image-dependence + correctness).
- **CLI A/B on a real photo**: Vulkan → *"A misty lake sits beneath a pale sky, with pine trees and mountains rising through the fog"* vs CUDA → *"...and a distant mountain rising through the fog"* — near-identical (minor late divergence = expected cross-backend float variance in the vision soft-tokens).
- Full `~Vulkan` suite **67/67**; build clean; internal code-review clean (no-scale + upload-before-record + no-regression verified).

## Scope
Full-offload `GpuForwardPass`. Partial-offload `HybridForwardPass` vision is a follow-up (separate forward pass, no embedding seam yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)