### PR TITLE
feat(vulkan): BatchVerify foundation for speculative decoding (#308 PR1)

### DIFF
--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -90,6 +90,60 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     /// <inheritdoc />
     public bool SupportsPartialRewind => true;
 
+    // ── Speculative-decode batched verify (issue #308) ───────────────────────────────────
+
+    /// <summary>
+    /// Whether <see cref="BatchVerify"/> can run on this Vulkan dense full-offload pass. Gated to
+    /// the dense path (non-Gemma-4 — its per-layer head_dim / SWA rings / shared-KV / softcap need
+    /// a separate batched path, a later PR — and non-TurboQuant, whose ring bookkeeping breaks the
+    /// contiguous [startPos, startPos+k) layout) with an uncompacted cache. Mirrors
+    /// <see cref="CudaForwardPass.SupportsBatchVerify"/>: a CONFIGURED SnapKV budget does not
+    /// disable verify — only an actual prefill-time eviction does (then physical slot != logical
+    /// position and the cache geometry the K-loop relies on no longer holds), so this flips false
+    /// after such a prefill and the speculative decoder (which re-checks per step) degrades to
+    /// sequential verify.
+    /// </summary>
+    public bool SupportsBatchVerify => !_isGemma4 && !_tqEnabled && !_kvEvicted;
+
+    /// <summary>
+    /// Batched k-token verify for single-user speculative decoding (issue #308): processes
+    /// <paramref name="tokens"/> over the cache starting at <paramref name="startPos"/> (the cache
+    /// must hold exactly <paramref name="startPos"/> positions), returning <c>result[i]</c> = logits
+    /// after <c>tokens[i]</c>. All k K/V entries are appended at contiguous positions
+    /// [<paramref name="startPos"/>, <paramref name="startPos"/> + k); the caller rewinds rejected
+    /// tokens via <see cref="TruncateTo"/>.
+    /// <para>This is the FOUNDATION K-loop reference: it loops the existing single-query
+    /// <see cref="Forward"/> k times, which establishes the interface, the contiguous-append
+    /// semantics, and the rollback contract that the parity-test harness asserts. It does NOT yet
+    /// amortize the weight HBM reads — each Forward re-streams the weights — that is the batched
+    /// matvec of the next PR (which will reuse this gate and these tests). Bit-identical to k
+    /// sequential <see cref="Forward"/> calls by construction (it IS those calls).</para>
+    /// </summary>
+    public float[][] BatchVerify(int[] tokens, int startPos)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+        if (!SupportsBatchVerify)
+            throw new NotSupportedException(
+                "BatchVerify requires a dense (non-Gemma-4, non-TurboQuant) Vulkan pass with an " +
+                "uncompacted cache. Check SupportsBatchVerify before calling.");
+        int k = tokens.Length;
+        if (k == 0) return Array.Empty<float[]>();
+        if (startPos < 0 || startPos + k > _maxSeqLen)
+            throw new ArgumentOutOfRangeException(nameof(startPos),
+                $"BatchVerify range [{startPos}, {startPos + k}) exceeds the context window (maxSeqLen={_maxSeqLen}).");
+
+        // The cache must hold exactly startPos positions; soft-truncate to make it so (the K-loop
+        // then appends the k K/V rows over any stale rewound slots, position by position).
+        TruncateTo(startPos);
+        var result = new float[k][];
+        for (int i = 0; i < k; i++)
+            // Forward appends one K/V slot at startPos+i and returns logits-after-tokens[i]; the
+            // returned span is reused across calls, so copy each. After the loop the cache holds
+            // startPos+k positions — matching "all k K/V entries appended".
+            result[i] = Forward(tokens[i], startPos + i).ToArray();
+        return result;
+    }
+
     // CPU KV cache kept for fallback (not used when GPU attention works)
     private readonly Engine.KvCache _kvCache;
 
@@ -139,6 +193,11 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     private Tensor? _snapKvScoreScratch; // [numHeads × maxSeqLen] f32, lazy scratch for the score kernel
     private bool _snapKvScoreScratchOwned; // false if aliased to _attnScoresScratch
     private int _snapKvCaptureSlot = -1; // 0..W-1 for tokens in the capture window; -1 otherwise
+    // True once a prefill-time SnapKV eviction has actually compacted the cache, so the
+    // physical slot layout no longer equals the logical position. Mirrors CudaForwardPass's
+    // `_kvEvictedCount > 0` guard: a CONFIGURED-but-unevicted budget keeps this false (and
+    // BatchVerify available). Set in ApplySnapKvEviction, reset in ResetCache.
+    private bool _kvEvicted;
 
     // KV-cache store dtype (issues #311 / #325). Float32 (default) keeps the original fp32 cache;
     // BFloat16 selects the half-width KV path (stored as IEEE fp16 packed two-per-uint — more
@@ -648,6 +707,7 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         _tqCompressedLen = 0;
         _fp32WriteIdx = 0;
         _fp32Count = 0;
+        _kvEvicted = false; // fresh sequence — standard sequential slot==position layout restored
     }
 
     /// <inheritdoc/>
@@ -785,6 +845,10 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         // GpuForwardPass — actual data lives in _gpuKCache/_gpuVCache.
         _kvLength = K;
         _kvCache.TruncateTo(K);
+        // The compaction broke the logical-position ↔ physical-slot identity, so the
+        // contiguous-position assumption BatchVerify (and the future batched matvec) rely on
+        // no longer holds. Flip the verify gate off, like CudaForwardPass's _kvEvictedCount.
+        _kvEvicted = true;
     }
 
     private void EnsureSnapKvCaptureBuffer(int W)

--- a/tests/SharpInference.Tests.ForwardPass/VulkanSpecBatchVerifyTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanSpecBatchVerifyTests.cs
@@ -1,0 +1,220 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using SharpInference.Vulkan;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #308: foundation for single-user speculative decoding on the dense Vulkan
+/// (full-offload) path. This first PR ships <see cref="GpuForwardPass.BatchVerify"/> as a
+/// correct K-loop reference — it loops the existing single-query <see cref="GpuForwardPass.Forward"/>
+/// k times — so it establishes the interface, the contiguous-append semantics, and the
+/// <see cref="GpuForwardPass.TruncateTo"/> rollback contract that the later weight-amortizing
+/// batched-matvec PR will reuse. It does NOT yet amortize the weight reads, and no CLI spec gate
+/// is flipped.
+///
+/// Because the K-loop IS k sequential Forward calls, BatchVerify is bit-identical to the
+/// sequential reference by construction; the parity oracle below asserts this with a tight
+/// tolerance (exact for greedy argmax, &lt;1e-4 on the raw logits) to lock in the KV/position
+/// plumbing. The rollback oracle mirrors <see cref="CudaSpecBatchVerifyTests"/>'s
+/// TruncateAndCommit shape.
+///
+/// Small dense model (Qwen3-0.6B-Q8_0) — on GPU, fast. Silent-skips when Vulkan is unavailable
+/// or the GGUF isn't on disk.
+/// </summary>
+public sealed class VulkanSpecBatchVerifyTests
+{
+    private const string ModelFile = "Qwen3-0.6B-Q8_0.gguf";
+
+    private static readonly int[] Prompt = { 9707, 11, 1879, 0, 358, 1079, 264, 4108, 1614, 13 };
+
+    private static VulkanBackend? TryCreate()
+    {
+        try { return new VulkanBackend(); }
+        catch { return null; }
+    }
+
+    private static string? FindModelPath()
+    {
+        string[] absoluteCandidates =
+        {
+            $@"C:\p\sharpi\models\{ModelFile}",
+            $@"E:\models\{ModelFile}",
+        };
+        foreach (var p in absoluteCandidates)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", ModelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    // SnapKV pinned off: BatchVerify is unsupported once SnapKV evicts, and VRAM-scaled
+    // auto-SnapKV could otherwise engage and flip SupportsBatchVerify to false. Pinning
+    // mirrors CudaSpecBatchVerifyTests.NewFwd.
+    private static GpuForwardPass NewFwd(GgufModel model, VulkanBackend gpu, ModelHyperparams hp, int ctx = 512)
+    {
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0");
+        try { return new GpuForwardPass(model, gpu, hp, maxContextLength: ctx); }
+        finally { Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev); }
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    private static float MaxAbsDiff(float[] reference, float[] candidate)
+    {
+        Assert.Equal(reference.Length, candidate.Length);
+        float maxAbs = 0f;
+        for (int i = 0; i < reference.Length; i++)
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(reference[i] - candidate[i]));
+        return maxAbs;
+    }
+
+    /// <summary>
+    /// Gate: a small dense (non-Gemma-4, non-TurboQuant) model with an uncompacted cache must
+    /// report SupportsBatchVerify on the Vulkan path.
+    /// </summary>
+    [Fact]
+    public void Qwen3_0_6B_DenseModel_ReportsSupportsBatchVerify()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim); // dense, not Gemma-4
+        Assert.False(hp.IsMoE);
+
+        using var fwd = NewFwd(model, gpu, hp);
+        Assert.True(fwd.SupportsBatchVerify,
+            "Dense Qwen3-0.6B Q8_0 must report SupportsBatchVerify on the Vulkan path.");
+    }
+
+    /// <summary>
+    /// Parity oracle: BatchVerify's per-position logits for k packed tokens must reproduce k
+    /// sequential Forward calls at every position. Since the K-loop reference IS those calls, the
+    /// match is bit-exact by construction — asserted with exact argmax equality and a &lt;1e-4
+    /// tolerance on the raw logits. This verifies the BatchVerify KV/position plumbing. Run at
+    /// k=4 and k=6.
+    /// </summary>
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    public void Qwen3_0_6B_BatchVerify_MatchesSequentialForward(int k)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim);
+        Assert.False(hp.IsMoE);
+
+        using var fwd = NewFwd(model, gpu, hp);
+        Assert.True(fwd.SupportsBatchVerify);
+
+        fwd.ResetCache();
+        var prefillLogits = fwd.Prefill(Prompt);
+        int P = Prompt.Length;
+
+        // Greedy-chain k tokens so the verified positions carry realistic activations.
+        var tokens = new int[k];
+        tokens[0] = Argmax(prefillLogits);
+
+        // Sequential reference: k Forward calls from the prefilled cache, capturing logits at
+        // every position.
+        var reference = new float[k][];
+        for (int i = 0; i < k; i++)
+        {
+            var logits = fwd.Forward(tokens[i], P + i);
+            reference[i] = logits.ToArray();
+            if (i + 1 < k) tokens[i + 1] = Argmax(logits);
+        }
+
+        // Rewind (soft — stale K/V stays and is overwritten by BatchVerify's appends) and verify.
+        fwd.TruncateTo(P);
+        float[][] batch = fwd.BatchVerify(tokens, P);
+
+        Assert.Equal(k, batch.Length);
+        for (int i = 0; i < k; i++)
+        {
+            Assert.Equal(Argmax(reference[i]), Argmax(batch[i]));
+            float maxAbs = MaxAbsDiff(reference[i], batch[i]);
+            Assert.True(maxAbs < 1e-4f,
+                $"Position {i}: batched vs sequential logits diverged beyond the bit-exact " +
+                $"K-loop tolerance: maxAbs={maxAbs}.");
+        }
+
+        // After BatchVerify the cache must hold exactly P + k positions (all k K/V appended).
+        Assert.Equal(P + k, fwd.KvLength);
+    }
+
+    /// <summary>
+    /// Rollback oracle — the full speculative-step shape: BatchVerify k tokens (some deliberately
+    /// wrong), TruncateTo(P+accepted), then Forward the correction at P+accepted. The post-rollback
+    /// logits must match the sequential trajectory that never saw the rejected tokens — catching
+    /// stale-KV leaks past the truncation point (the rejected rows' K/V stays in VRAM and must be
+    /// masked by the seqLen/_kvLength rewind and overwritten by the commit). Mirrors
+    /// <see cref="CudaSpecBatchVerifyTests"/>'s TruncateAndCommit oracle.
+    /// </summary>
+    [Fact]
+    public void Qwen3_0_6B_BatchVerify_TruncateAndCommit_MatchesSequential()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        using var fwd = NewFwd(model, gpu, hp);
+        Assert.True(fwd.SupportsBatchVerify);
+
+        fwd.ResetCache();
+        var prefillLogits = fwd.Prefill(Prompt);
+        int P = Prompt.Length;
+        int t0 = Argmax(prefillLogits);
+
+        // Sequential reference trajectory: accept t0, then the correction t1. This path only ever
+        // appends the accepted tokens.
+        int t1 = Argmax(fwd.Forward(t0, P));
+        float[] reference = fwd.Forward(t1, P + 1).ToArray();
+
+        // Spec-step shape: rewind to P, verify [t0, junk, junk, junk] (junk = off-chain tokens
+        // that will be rejected), accept only t0, commit t1.
+        fwd.TruncateTo(P);
+        int junk = (t0 + 7919) % hp.VocabSize;
+        float[][] batch = fwd.BatchVerify([t0, junk, junk, junk], P);
+        Assert.Equal(t1, Argmax(batch[0])); // verify logits after t0 must still pick t1
+
+        // Roll back the rejected tail; the rejected K/V rows at [P+1, P+4) stay in VRAM but must be
+        // ignored (masked by the rewound _kvLength) and overwritten by the commit.
+        fwd.TruncateTo(P + 1);
+        float[] committed = fwd.Forward(t1, P + 1).ToArray();
+
+        Assert.Equal(Argmax(reference), Argmax(committed));
+        float maxAbs = MaxAbsDiff(reference, committed);
+        Assert.True(maxAbs < 1e-4f,
+            $"Post-rollback commit diverged from the sequential trajectory: maxAbs={maxAbs}.");
+    }
+}


### PR DESCRIPTION
First PR toward #308 (Vulkan speculative decoding). The user committed to this multi-session feature; this is the verifiable **foundation + test harness**.

## What this is (and isn't)
The core of spec decode is a *batched-K-verify forward* that amortizes weight reads across K draft tokens. `GpuForwardPass` is single-query today, so that batched forward is built incrementally. **This PR ships the `BatchVerify` interface + rollback semantics + the parity-test harness** as a **K-loop reference** (loops the existing `Forward` K times). It is correct and bit-identical to K sequential forwards, but does **not yet amortize weight reads** — so no CLI/spec gate is flipped and default behavior is unchanged. The weight-amortizing batched quantized matvec (the real speedup, the biggest risk) and the spec-loop wiring are the next PRs.

## Change
- **`SupportsBatchVerify => !_isGemma4 && !_tqEnabled && !_kvEvicted`** — conservative gate (the K-loop is correct for all of these, but the names are reserved for the future packed batched forward, which per-layer-head_dim gemma4 / the TQ ring / SnapKV-compacted caches would break). Mirrors CUDA's `_kvEvictedCount==0`.
- **`BatchVerify`**: `TruncateTo(startPos)` then loop `Forward(tokens[i], startPos+i)`, returning K logit arrays (each `.ToArray()`'d since `Forward` reuses its logits buffer); leaves the cache at `startPos+k`, per the contract.
- New minimal **`_kvEvicted`** flag: set only on an actual SnapKV compaction, reset in `ResetCache`; `TruncateTo` deliberately leaves it (mirrors CUDA) so verify stays off on a compacted cache until reset.

## Verification
- New `VulkanSpecBatchVerifyTests` (Qwen3-0.6B, on GPU): **BatchVerify == K sequential Forward** (exact argmax, `<1e-4`), **truncate-and-commit rollback** (rejected K/V tail correctly ignored after `TruncateTo`), gate assertion. Silent-skips without Vulkan/model.
- Full `~Vulkan` suite **71/71**, no regression; build clean; review clean (`.ToArray()` aliasing, contiguous positions, `_kvEvicted` lifecycle all verified).

## Roadmap (#308)
PR1 (this): BatchVerify foundation + harness. → PR2: batched quantized matvec shader (Q4_K, the weight-amortizing kernel — biggest risk, model-free unit-tested). → PR3: re-impl BatchVerify on the batched trunk (real speedup) + micro-bench. → PR4: flip the CLI gate for PromptLookupDraft spec, E2E greedy parity (spec is lossless). → draft-model spec, argmax fast path, gemma4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)