### PR TITLE
feat(vulkan): batched-trunk BatchVerify for speculative decoding (#308 PR1c)

### DIFF
--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -1833,26 +1833,43 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     private void EnsureBatchVerifyScratch(int k)
     {
         if (_bvK >= k) return;
-        if (_bvK > 0) FreeBatchVerifyScratch();
+        if (_bvK > 0) FreeBatchVerifyScratch(); // free the prior (fully-allocated) generation
 
         int qDim = _numHeads * _headDim;
         int kvDim = _numKvHeads * _headDim;
         int ffnDim = ComputeFfnScratchDim(_isMoE, _intermDim, _expertDim);
 
-        _hiddenK = _gpu.Allocate(TensorShape.D1((long)k * _embDim));
-        _residualK = _gpu.Allocate(TensorShape.D1((long)k * _embDim));
-        _normK = _gpu.Allocate(TensorShape.D1((long)k * _embDim));
-        _qK = _gpu.Allocate(TensorShape.D1((long)k * qDim));
-        _kK = _gpu.Allocate(TensorShape.D1((long)k * kvDim));
-        _vK = _gpu.Allocate(TensorShape.D1((long)k * kvDim));
-        _attnOutK = _gpu.Allocate(TensorShape.D1((long)k * qDim));
-        _ffnGateK = _gpu.Allocate(TensorShape.D1((long)k * ffnDim));
-        _ffnUpK = _gpu.Allocate(TensorShape.D1((long)k * ffnDim));
-        _logitsK = _gpu.Allocate(TensorShape.D1((long)k * _hp.VocabSize));
-        _logitsKBuf = new float[(long)k * _hp.VocabSize];
-        _bvK = k;
+        // Track each allocation so a mid-way throw (e.g. OOM on a later buffer) frees the
+        // partial set instead of leaking it (the fields would otherwise hold live-but-orphaned
+        // tensors with _bvK==0).
+        var allocated = new List<Tensor>(10);
+        Tensor Alloc(long n) { var t = _gpu.Allocate(TensorShape.D1(n)); allocated.Add(t); return t; }
+        try
+        {
+            _hiddenK = Alloc((long)k * _embDim);
+            _residualK = Alloc((long)k * _embDim);
+            _normK = Alloc((long)k * _embDim);
+            _qK = Alloc((long)k * qDim);
+            _kK = Alloc((long)k * kvDim);
+            _vK = Alloc((long)k * kvDim);
+            _attnOutK = Alloc((long)k * qDim);
+            _ffnGateK = Alloc((long)k * ffnDim);
+            _ffnUpK = Alloc((long)k * ffnDim);
+            _logitsK = Alloc((long)k * _hp.VocabSize);
+            _logitsKBuf = new float[k * _hp.VocabSize]; // k ≤ 8, vocab small → fits int
+            _bvK = k;
+        }
+        catch
+        {
+            foreach (var t in allocated) _gpu.Free(t);
+            _bvK = 0; // fields hold freed tensors; next call (re)allocates, Dispose skips (_bvK==0)
+            throw;
+        }
     }
 
+    // Called only when fully allocated (_bvK > 0); the tensors are non-null here. A partial
+    // allocation that threw is freed in EnsureBatchVerifyScratch's catch, not here (the fields
+    // would be null/freed). Free dereferences tensor.Handle, so it is NOT null-safe.
     private void FreeBatchVerifyScratch()
     {
         _gpu.Free(_hiddenK); _gpu.Free(_residualK); _gpu.Free(_normK);
@@ -2336,7 +2353,8 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         if (_snapKvScoreAccum is { } accBuf) _gpu.Free(accBuf);
         if (_snapKvScoreScratch is { } scrBuf && _snapKvScoreScratchOwned) _gpu.Free(scrBuf);
 
-        // Batched-verify scratch (#308 PR1c), null/zero unless BatchVerifyBatched ran.
+        // Batched-verify scratch (#308 PR1c). Guarded: only fully-allocated when _bvK > 0 (a
+        // partial alloc that threw is freed in EnsureBatchVerifyScratch's catch, leaving _bvK==0).
         if (_bvK > 0) FreeBatchVerifyScratch();
 
         _kvCache.Dispose();

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -92,6 +92,40 @@ public sealed unsafe class GpuForwardPass : IForwardPass
 
     // ── Speculative-decode batched verify (issue #308) ───────────────────────────────────
 
+    /// <summary>Maximum k for the batched-trunk verify path (matches MatMulBatched's nTok cap of 8
+    /// and the lazily-sized <see cref="EnsureBatchVerifyScratch"/> buffers).</summary>
+    private const int MaxBatchVerifyK = 8;
+
+    /// <summary>
+    /// Whether the weight-amortizing batched trunk (<see cref="BatchVerifyBatched"/>) is usable: a
+    /// dense (non-MoE) model whose EVERY trunk matmul weight is Q4_K or Q6_K — the only dtypes
+    /// <c>MatMulBatched</c> amortizes (every other dtype hits its per-token single-row fallback,
+    /// which allocates/frees temp tensors mid-recording — a recording hazard, and no speedup). When
+    /// false, <see cref="BatchVerify"/> uses the bit-exact <see cref="BatchVerifyKLoop"/>. Computed
+    /// once in the ctor: Qwen3-8B-Q4_K_M ⇒ true; Qwen3-0.6B-Q8_0 ⇒ false (Q8_0 weights).
+    /// </summary>
+    private readonly bool _canBatchedTrunk;
+
+    /// <summary>Test hook: whether <see cref="BatchVerify"/> takes the weight-amortizing batched
+    /// trunk (true) or the K-loop fallback (false). True for an all-Q4_K/Q6_K dense model.</summary>
+    internal bool CanBatchedTrunk => _canBatchedTrunk;
+
+    // Batched-verify scratch buffers [K][dim] (token-major contiguous), lazily allocated by
+    // EnsureBatchVerifyScratch on first use (K ≤ MaxBatchVerifyK) and freed in Dispose. Sized at
+    // the single-query dims × the allocated K; reused across calls when K is non-decreasing.
+    private int _bvK;                          // K the buffers below are currently sized for (0 = unallocated)
+    private Tensor _hiddenK = default!;        // [K * embDim]
+    private Tensor _residualK = default!;      // [K * embDim]
+    private Tensor _normK = default!;          // [K * embDim]
+    private Tensor _qK = default!;             // [K * numHeads * headDim]
+    private Tensor _kK = default!;             // [K * numKvHeads * headDim]
+    private Tensor _vK = default!;             // [K * numKvHeads * headDim]
+    private Tensor _attnOutK = default!;       // [K * numHeads * headDim]
+    private Tensor _ffnGateK = default!;       // [K * ffnScratchDim]
+    private Tensor _ffnUpK = default!;         // [K * ffnScratchDim]
+    private Tensor _logitsK = default!;        // [K * vocabSize]
+    private float[]? _logitsKBuf;              // host download buffer [K * vocabSize]
+
     /// <summary>
     /// Whether <see cref="BatchVerify"/> can run on this Vulkan dense full-offload pass. Gated to
     /// the dense path (non-Gemma-4 — its per-layer head_dim / SWA rings / shared-KV / softcap need
@@ -112,12 +146,16 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     /// after <c>tokens[i]</c>. All k K/V entries are appended at contiguous positions
     /// [<paramref name="startPos"/>, <paramref name="startPos"/> + k); the caller rewinds rejected
     /// tokens via <see cref="TruncateTo"/>.
-    /// <para>This is the FOUNDATION K-loop reference: it loops the existing single-query
-    /// <see cref="Forward"/> k times, which establishes the interface, the contiguous-append
-    /// semantics, and the rollback contract that the parity-test harness asserts. It does NOT yet
-    /// amortize the weight HBM reads — each Forward re-streams the weights — that is the batched
-    /// matvec of the next PR (which will reuse this gate and these tests). Bit-identical to k
-    /// sequential <see cref="Forward"/> calls by construction (it IS those calls).</para>
+    /// <para>The payoff path (issue #308 PR1c): when <see cref="_canBatchedTrunk"/> (a dense model
+    /// whose every trunk matmul weight is Q4_K or Q6_K), this dispatches to
+    /// <see cref="BatchVerifyBatched"/>, which streams the K draft tokens through ONE command buffer
+    /// and reads each weight matrix from VRAM exactly once via <c>MatMulBatched</c> (the
+    /// weight-amortization). Otherwise (mixed/other weight dtype) it falls back to
+    /// <see cref="BatchVerifyKLoop"/>, the bit-exact K-sequential-<see cref="Forward"/> reference.
+    /// k == 1 short-circuits to a single <see cref="Forward"/> (mirrors CUDA). The batched path is
+    /// bit-exact to the K-loop by construction (<c>MatMulBatched</c> is bit-identical to single-row
+    /// matvec, the gather/scatter copies are exact, and the per-token RmsNorm/QK-norm/RoPE/append/
+    /// attention reuse the single-query shaders with the same positions/seqLens).</para>
     /// </summary>
     public float[][] BatchVerify(int[] tokens, int startPos)
     {
@@ -132,6 +170,29 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             throw new ArgumentOutOfRangeException(nameof(startPos),
                 $"BatchVerify range [{startPos}, {startPos + k}) exceeds the context window (maxSeqLen={_maxSeqLen}).");
 
+        // k == 1 has nothing to amortize — one Forward is strictly cheaper than the batched
+        // gather/scatter machinery (and bit-identical). Mirrors CudaForwardPass.BatchVerify.
+        if (k == 1)
+        {
+            TruncateTo(startPos);
+            return [Forward(tokens[0], startPos).ToArray()];
+        }
+
+        if (_canBatchedTrunk && k <= MaxBatchVerifyK)
+            return BatchVerifyBatched(tokens, startPos);
+
+        return BatchVerifyKLoop(tokens, startPos);
+    }
+
+    /// <summary>
+    /// FOUNDATION K-loop reference: loops the single-query <see cref="Forward"/> k times. Establishes
+    /// the contiguous-append semantics and the rollback contract; bit-identical to k sequential
+    /// <see cref="Forward"/> calls by construction (it IS those calls). Used as the fallback when the
+    /// model's trunk weights are not all Q4_K/Q6_K, and as the parity oracle for the batched path.
+    /// </summary>
+    private float[][] BatchVerifyKLoop(int[] tokens, int startPos)
+    {
+        int k = tokens.Length;
         // The cache must hold exactly startPos positions; soft-truncate to make it so (the K-loop
         // then appends the k K/V rows over any stale rewound slots, position by position).
         TruncateTo(startPos);
@@ -695,7 +756,40 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             _gpuRopeFreqs = UploadWeight("rope_freqs.weight");
         }
 
+        // Batched-trunk verify gate (issue #308 PR1c): only when this is a dense model and every
+        // trunk matmul weight (Q/K/V/O + gate/up/down per layer, plus the lm-head) is Q4_K or
+        // Q6_K — the dtypes MatMulBatched amortizes. Gemma 4 uses ForwardGemma4 (a separate batched
+        // path is a later PR) so it never qualifies. Computed here, after all weights are uploaded
+        // and _weightDTypes is populated.
+        _canBatchedTrunk = ComputeCanBatchedTrunk();
+
         Console.Error.WriteLine(" done.");
+    }
+
+    /// <summary>
+    /// Determine <see cref="_canBatchedTrunk"/>: dense (non-MoE, non-Gemma-4) with every trunk
+    /// matmul weight in {Q4_K, Q6_K}. Reads the per-weight dtype recorded at upload in
+    /// <see cref="_weightDTypes"/> (defaulting to Q4_K matches <see cref="GpuMatMul"/>).
+    /// </summary>
+    private bool ComputeCanBatchedTrunk()
+    {
+        // MoE (mid-trunk router submit), gemma4 (per-layer dims), and TQ are excluded.
+        // QKV/output bias is excluded too: the batched trunk wires a bias gather/add/scatter
+        // path but no local Q4_K bias model (e.g. a Q4 Qwen2) exercises it yet, so keep bias
+        // models on the verified K-loop fallback until a parity test covers that path.
+        if (_isMoE || _isGemma4 || _hasAttnBias || _hasAttnOutputBias) return false;
+
+        bool IsBatchable(Tensor w) =>
+            _weightDTypes.GetValueOrDefault(w.Handle, DType.Q4_K) is DType.Q4_K or DType.Q6_K;
+
+        for (int i = 0; i < _hp.NumLayers; i++)
+        {
+            if (!IsBatchable(_wq[i]) || !IsBatchable(_wk[i]) || !IsBatchable(_wv[i]) ||
+                !IsBatchable(_wo[i]) || !IsBatchable(_wGate[i]) || !IsBatchable(_wUp[i]) ||
+                !IsBatchable(_wDown[i]))
+                return false;
+        }
+        return IsBatchable(_wOutput);
     }
 
     public Engine.KvCache Cache => _kvCache;
@@ -1444,8 +1538,328 @@ public sealed unsafe class GpuForwardPass : IForwardPass
 
     private void GpuMatMul(Tensor output, Tensor weights, Tensor input)
     {
-        var dtype = _weightDTypes.GetValueOrDefault(weights.Handle, DType.Q4_K);
-        _gpu.MatMul(output, weights, input, dtype);
+        _gpu.MatMul(output, weights, input, WeightDType(weights));
+    }
+
+    /// <summary>Recorded weight dtype (defaults to Q4_K to match <see cref="GpuMatMul"/>).</summary>
+    private DType WeightDType(Tensor weights) =>
+        _weightDTypes.GetValueOrDefault(weights.Handle, DType.Q4_K);
+
+    /// <summary>
+    /// Batched trunk for k-token speculative verify (issue #308 PR1c). Processes all k draft tokens
+    /// through ONE command buffer, reading each weight matrix from VRAM exactly once via
+    /// <c>MatMulBatched</c> (the weight-amortization). The per-token reductions (RmsNorm, QK-norm,
+    /// RoPE) and the position-dependent KV-append + causal attention run as a K-loop with
+    /// gather/scatter to single-token temp buffers (the existing single-query scratch), while the
+    /// position-independent elementwise ops (residual copy/add, SiLuMul) run once over the whole
+    /// [K][dim] buffer. Bit-exact to <see cref="BatchVerifyKLoop"/> by construction.
+    /// <para>Op ordering MIRRORS the single-query <see cref="Forward"/> exactly (the #157 QK-norm /
+    /// RoPE ordering branches included). RoPE position for token i is startPos+i; the attention
+    /// seqLen for token i is startPos+i+1 (causal among the k tokens). Only the non-TQ fp32 KV path
+    /// is reachable here — <see cref="SupportsBatchVerify"/> excludes TurboQuant, and
+    /// <see cref="_canBatchedTrunk"/> excludes Gemma-4/MoE; bf16/q8_0 KV stores still work (the
+    /// per-token append/attention dispatch the matching narrowed shaders).</para>
+    /// </summary>
+    private float[][] BatchVerifyBatched(int[] tokens, int startPos)
+    {
+        int k = tokens.Length;
+        EnsureBatchVerifyScratch(k);
+
+        // Cache must hold exactly startPos positions; soft-truncate (the per-token KvAppend below
+        // overwrites any stale rewound slots at [startPos, startPos+k)).
+        TruncateTo(startPos);
+
+        int qDim = _numHeads * _headDim;
+        int kvDim = _numKvHeads * _headDim;
+        int embDim = _embDim;
+        const int f32 = sizeof(float);
+
+        // Per-token single-token temps (reuse the single-query scratch buffers as gather targets).
+        // _hidden/_normBuf are [embDim], _q is [numHeads*headDim], _k/_v [numKvHeads*headDim],
+        // _attnOut [numHeads*headDim], _ffnGate/_ffnUp [ffnScratchDim].
+
+        _gpu.BeginRecord();
+
+        // ── Embed: K-loop lookup into the [K][embDim] hidden buffer. ──
+        // DispatchEmbedLookup writes _hidden (offset 0); copy each token's row into _hiddenK[i].
+        for (int i = 0; i < k; i++)
+        {
+            DispatchEmbedLookup(tokens[i]);
+            _gpu.RecordBarrier();
+            _gpu.RecordComputeCopyRegion(_hiddenK, (long)i * embDim * f32, _hidden, 0, (long)embDim * f32);
+            _gpu.RecordBarrier();
+        }
+
+        for (int layer = 0; layer < _hp.NumLayers; layer++)
+        {
+            // residualK = hiddenK (whole buffer, elementwise).
+            _gpu.RecordComputeCopy(_residualK, _hiddenK);
+            _gpu.RecordBarrier();
+
+            // attn RmsNorm per token: hiddenK[i] → _hidden temp → RmsNorm → normK[i].
+            for (int i = 0; i < k; i++)
+            {
+                _gpu.RecordComputeCopyRegion(_hidden, 0, _hiddenK, (long)i * embDim * f32, (long)embDim * f32);
+                _gpu.RecordBarrier();
+                _gpu.RmsNorm(_normBuf, _hidden, _wAttnNorm[layer], _hp.RmsNormEps);
+                _gpu.RecordBarrier();
+                _gpu.RecordComputeCopyRegion(_normK, (long)i * embDim * f32, _normBuf, 0, (long)embDim * f32);
+                _gpu.RecordBarrier();
+            }
+
+            // Q/K/V projections: batched (weight read once for all k tokens).
+            _gpu.MatMulBatched(_qK, _wq[layer], _normK, k, WeightDType(_wq[layer]));
+            _gpu.MatMulBatched(_kK, _wk[layer], _normK, k, WeightDType(_wk[layer]));
+            _gpu.MatMulBatched(_vK, _wv[layer], _normK, k, WeightDType(_wv[layer]));
+            _gpu.RecordBarrier();
+
+            if (_hasAttnBias)
+            {
+                // Bias is per-channel and identical across tokens; replicate per token via views.
+                for (int i = 0; i < k; i++)
+                {
+                    _gpu.RecordComputeCopyRegion(_q, 0, _qK, (long)i * qDim * f32, (long)qDim * f32);
+                    _gpu.RecordComputeCopyRegion(_k, 0, _kK, (long)i * kvDim * f32, (long)kvDim * f32);
+                    _gpu.RecordComputeCopyRegion(_v, 0, _vK, (long)i * kvDim * f32, (long)kvDim * f32);
+                    _gpu.RecordBarrier();
+                    _gpu.AddInPlace(_q, _bq![layer]);
+                    _gpu.AddInPlace(_k, _bk![layer]);
+                    _gpu.AddInPlace(_v, _bv![layer]);
+                    _gpu.RecordBarrier();
+                    _gpu.RecordComputeCopyRegion(_qK, (long)i * qDim * f32, _q, 0, (long)qDim * f32);
+                    _gpu.RecordComputeCopyRegion(_kK, (long)i * kvDim * f32, _k, 0, (long)kvDim * f32);
+                    _gpu.RecordComputeCopyRegion(_vK, (long)i * kvDim * f32, _v, 0, (long)kvDim * f32);
+                    _gpu.RecordBarrier();
+                }
+            }
+
+            bool useRoPE = _hp.NoRopeLayerStep == 0
+                || (layer + 1) % _hp.NoRopeLayerStep != 0;
+
+            // Per-token QK-norm / RoPE / L2-norm (issue #157 ordering, mirrors Forward). Each op
+            // reduces or is position-dependent per token, so gather → temp → op → scatter.
+            for (int i = 0; i < k; i++)
+            {
+                int position = startPos + i;
+                _gpu.RecordComputeCopyRegion(_q, 0, _qK, (long)i * qDim * f32, (long)qDim * f32);
+                _gpu.RecordComputeCopyRegion(_k, 0, _kK, (long)i * kvDim * f32, (long)kvDim * f32);
+                _gpu.RecordBarrier();
+
+                if (_hasQkNorm && !_hp.UseL2QkNorm)
+                {
+                    _gpu.HeadNorm(_q, _wqNorm![layer], (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                    _gpu.HeadNorm(_k, _wkNorm![layer], (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps, _hp.IsPerChannelQkNorm);
+                    _gpu.RecordBarrier();
+                }
+
+                if (useRoPE)
+                {
+                    _gpu.RoPE(_q, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                    _gpu.RoPE(_k, position, _headDim, _hp.RopeTheta, _hp.IsNeoxRope);
+                    _gpu.RecordBarrier();
+                }
+
+                if (_hasQkNorm && _hp.UseL2QkNorm && useRoPE)
+                {
+                    _gpu.HeadNormPure(_q, (uint)_numHeads, (uint)_headDim, _hp.RmsNormEps);
+                    _gpu.HeadNormPure(_k, (uint)_numKvHeads, (uint)_headDim, _hp.RmsNormEps);
+                    _gpu.RecordBarrier();
+                }
+
+                _gpu.RecordComputeCopyRegion(_qK, (long)i * qDim * f32, _q, 0, (long)qDim * f32);
+                _gpu.RecordComputeCopyRegion(_kK, (long)i * kvDim * f32, _k, 0, (long)kvDim * f32);
+                _gpu.RecordBarrier();
+            }
+
+            // KvAppend + Attention per token, INTERLEAVED so token i attends to [0, startPos+i]
+            // (causal among the k tokens). seqLen = startPos+i+1 — bit-identical to k sequential
+            // Forwards. Appends the post-RoPE k/v at slot startPos+i, then attends.
+            for (int i = 0; i < k; i++)
+            {
+                int position = startPos + i;
+                _gpu.RecordComputeCopyRegion(_q, 0, _qK, (long)i * qDim * f32, (long)qDim * f32);
+                _gpu.RecordComputeCopyRegion(_k, 0, _kK, (long)i * kvDim * f32, (long)kvDim * f32);
+                _gpu.RecordComputeCopyRegion(_v, 0, _vK, (long)i * kvDim * f32, (long)kvDim * f32);
+                _gpu.RecordBarrier();
+
+                BatchVerifyAppendAttend(layer, position);
+
+                _gpu.RecordComputeCopyRegion(_attnOutK, (long)i * qDim * f32, _attnOut, 0, (long)qDim * f32);
+                _gpu.RecordBarrier();
+            }
+
+            // O projection: batched (weight read once). hiddenK = Wo · attnOutK.
+            _gpu.MatMulBatched(_hiddenK, _wo[layer], _attnOutK, k, WeightDType(_wo[layer]));
+            _gpu.RecordBarrier();
+
+            if (_hasAttnOutputBias)
+            {
+                for (int i = 0; i < k; i++)
+                {
+                    _gpu.RecordComputeCopyRegion(_hidden, 0, _hiddenK, (long)i * embDim * f32, (long)embDim * f32);
+                    _gpu.RecordBarrier();
+                    _gpu.AddInPlace(_hidden, _bo![layer]);
+                    _gpu.RecordBarrier();
+                    _gpu.RecordComputeCopyRegion(_hiddenK, (long)i * embDim * f32, _hidden, 0, (long)embDim * f32);
+                    _gpu.RecordBarrier();
+                }
+            }
+
+            // + residual (whole buffer), then residualK = hiddenK for the FFN.
+            _gpu.AddInPlace(_hiddenK, _residualK);
+            _gpu.RecordBarrier();
+            _gpu.RecordComputeCopy(_residualK, _hiddenK);
+            _gpu.RecordBarrier();
+
+            // ffn RmsNorm per token.
+            for (int i = 0; i < k; i++)
+            {
+                _gpu.RecordComputeCopyRegion(_hidden, 0, _hiddenK, (long)i * embDim * f32, (long)embDim * f32);
+                _gpu.RecordBarrier();
+                _gpu.RmsNorm(_normBuf, _hidden, _wFfnNorm[layer], _hp.RmsNormEps);
+                _gpu.RecordBarrier();
+                _gpu.RecordComputeCopyRegion(_normK, (long)i * embDim * f32, _normBuf, 0, (long)embDim * f32);
+                _gpu.RecordBarrier();
+            }
+
+            // gate/up: batched. SiLuMul over the whole [K][ffnDim] buffer. down: batched.
+            _gpu.MatMulBatched(_ffnGateK, _wGate[layer], _normK, k, WeightDType(_wGate[layer]));
+            _gpu.MatMulBatched(_ffnUpK, _wUp[layer], _normK, k, WeightDType(_wUp[layer]));
+            _gpu.RecordBarrier();
+            _gpu.SiLuMul(_ffnGateK, _ffnUpK); // [K*ffnDim] elementwise, K-agnostic
+            _gpu.RecordBarrier();
+            _gpu.MatMulBatched(_hiddenK, _wDown[layer], _ffnGateK, k, WeightDType(_wDown[layer]));
+            _gpu.RecordBarrier();
+
+            _gpu.AddInPlace(_hiddenK, _residualK);
+            _gpu.RecordBarrier();
+        }
+
+        // Final norm per token + batched output projection → logitsK.
+        for (int i = 0; i < k; i++)
+        {
+            _gpu.RecordComputeCopyRegion(_hidden, 0, _hiddenK, (long)i * embDim * f32, (long)embDim * f32);
+            _gpu.RecordBarrier();
+            _gpu.RmsNorm(_hidden, _hidden, _wOutputNorm, _hp.RmsNormEps);
+            _gpu.RecordBarrier();
+            _gpu.RecordComputeCopyRegion(_hiddenK, (long)i * embDim * f32, _hidden, 0, (long)embDim * f32);
+            _gpu.RecordBarrier();
+        }
+        _gpu.MatMulBatched(_logitsK, _wOutput, _hiddenK, k, WeightDType(_wOutput));
+
+        _gpu.RecordComputeToTransferBarrier();
+        _gpu.RecordDownloadToStaging(_logitsK, _logitsKBuf!.Length);
+        _gpu.EndRecordAndSubmit();
+        _gpu.ReadFromStaging(_logitsKBuf);
+
+        // The per-token KvAppend wrote slots [startPos, startPos+k); advance the length counter.
+        _kvLength = Math.Max(_kvLength, startPos + k);
+
+        // Split into k logit rows.
+        int vocab = _hp.VocabSize;
+        var result = new float[k][];
+        for (int i = 0; i < k; i++)
+        {
+            var row = new float[vocab];
+            Array.Copy(_logitsKBuf, (long)i * vocab, row, 0, vocab);
+            result[i] = row;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// KvAppend the single-token K/V in <see cref="_k"/>/<see cref="_v"/> at <paramref name="position"/>
+    /// then run causal attention into <see cref="_attnOut"/> for that token (seqLen = position+1).
+    /// Dispatches the matching KV-store shaders for the active <see cref="_kvDType"/> (fp32 / bf16 /
+    /// q8_0) — identical to the single-query <see cref="Forward"/> non-TQ branches. TurboQuant is
+    /// excluded by <see cref="SupportsBatchVerify"/>, so the TQ path is unreachable here.
+    /// </summary>
+    private void BatchVerifyAppendAttend(int layer, int position)
+    {
+        int kvDim = _numKvHeads * _headDim;
+        uint seqLen = (uint)(position + 1);
+
+        if (_kvDType == DType.BFloat16)
+        {
+            _gpu.KvAppendBf16(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
+                (uint)kvDim, (uint)position, (uint)_maxSeqLen);
+            _gpu.RecordBarrier();
+            if (_splitKvEnabled && position + 1 > 4096 && _headDim % 32 == 0 && _splitKvPartialO is not null)
+                _gpu.AttentionSplitKvBf16(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _splitKvPartialO, _splitKvPartialMeta!,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim, seqLen, (uint)_maxSeqLen, window: 0u);
+            else
+                _gpu.AttentionBf16(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim, seqLen, (uint)_maxSeqLen, window: 0u);
+        }
+        else if (_kvDType == DType.Q8_0)
+        {
+            _gpu.KvAppendQ8_0(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
+                (uint)kvDim, (uint)position, (uint)_maxSeqLen);
+            _gpu.RecordBarrier();
+            if (_splitKvEnabled && position + 1 > 4096 && _headDim % 32 == 0 && _splitKvPartialO is not null)
+                _gpu.AttentionSplitKvQ8(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _splitKvPartialO, _splitKvPartialMeta!,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim, seqLen, (uint)_maxSeqLen, window: 0u);
+            else
+                _gpu.AttentionQ8_0(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim, seqLen, (uint)_maxSeqLen, window: 0u);
+        }
+        else
+        {
+            _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
+                (uint)kvDim, (uint)position, (uint)_maxSeqLen);
+            _gpu.RecordBarrier();
+            if (_splitKvEnabled && position + 1 > 4096 && _headDim % 32 == 0 && _splitKvPartialO is not null)
+                _gpu.AttentionSplitKv(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _splitKvPartialO, _splitKvPartialMeta!,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim, seqLen, (uint)_maxSeqLen, window: 0u);
+            else
+                _gpu.Attention(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)_numKvHeads, (uint)_headDim, seqLen, (uint)_maxSeqLen, window: 0u);
+        }
+        _gpu.RecordBarrier();
+    }
+
+    /// <summary>
+    /// Lazily allocate the batched-verify [K][dim] scratch (and the host logits buffer) for
+    /// <paramref name="k"/> tokens. Sizes each buffer at the single-query dim × K; reused when the
+    /// requested K is ≤ the currently-allocated K. Reallocates (freeing the old set) on a larger K.
+    /// Freed in <see cref="Dispose"/>. K is bounded by <see cref="MaxBatchVerifyK"/>.
+    /// </summary>
+    private void EnsureBatchVerifyScratch(int k)
+    {
+        if (_bvK >= k) return;
+        if (_bvK > 0) FreeBatchVerifyScratch();
+
+        int qDim = _numHeads * _headDim;
+        int kvDim = _numKvHeads * _headDim;
+        int ffnDim = ComputeFfnScratchDim(_isMoE, _intermDim, _expertDim);
+
+        _hiddenK = _gpu.Allocate(TensorShape.D1((long)k * _embDim));
+        _residualK = _gpu.Allocate(TensorShape.D1((long)k * _embDim));
+        _normK = _gpu.Allocate(TensorShape.D1((long)k * _embDim));
+        _qK = _gpu.Allocate(TensorShape.D1((long)k * qDim));
+        _kK = _gpu.Allocate(TensorShape.D1((long)k * kvDim));
+        _vK = _gpu.Allocate(TensorShape.D1((long)k * kvDim));
+        _attnOutK = _gpu.Allocate(TensorShape.D1((long)k * qDim));
+        _ffnGateK = _gpu.Allocate(TensorShape.D1((long)k * ffnDim));
+        _ffnUpK = _gpu.Allocate(TensorShape.D1((long)k * ffnDim));
+        _logitsK = _gpu.Allocate(TensorShape.D1((long)k * _hp.VocabSize));
+        _logitsKBuf = new float[(long)k * _hp.VocabSize];
+        _bvK = k;
+    }
+
+    private void FreeBatchVerifyScratch()
+    {
+        _gpu.Free(_hiddenK); _gpu.Free(_residualK); _gpu.Free(_normK);
+        _gpu.Free(_qK); _gpu.Free(_kK); _gpu.Free(_vK); _gpu.Free(_attnOutK);
+        _gpu.Free(_ffnGateK); _gpu.Free(_ffnUpK); _gpu.Free(_logitsK);
+        _logitsKBuf = null;
+        _bvK = 0;
     }
 
     private void GpuDenseFfn(int layer)
@@ -1921,6 +2335,9 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         if (_snapKvQCapture is { } capBuf) _gpu.Free(capBuf);
         if (_snapKvScoreAccum is { } accBuf) _gpu.Free(accBuf);
         if (_snapKvScoreScratch is { } scrBuf && _snapKvScoreScratchOwned) _gpu.Free(scrBuf);
+
+        // Batched-verify scratch (#308 PR1c), null/zero unless BatchVerifyBatched ran.
+        if (_bvK > 0) FreeBatchVerifyScratch();
 
         _kvCache.Dispose();
     }

--- a/tests/SharpInference.Tests.ForwardPass/VulkanSpecBatchVerifyTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanSpecBatchVerifyTests.cs
@@ -1,30 +1,36 @@
+using System.Diagnostics;
 using SharpInference.Core;
 using SharpInference.Engine;
 using SharpInference.Vulkan;
+using Xunit.Abstractions;
 
 namespace SharpInference.Tests.ForwardPass;
 
 /// <summary>
-/// Issue #308: foundation for single-user speculative decoding on the dense Vulkan
-/// (full-offload) path. This first PR ships <see cref="GpuForwardPass.BatchVerify"/> as a
-/// correct K-loop reference — it loops the existing single-query <see cref="GpuForwardPass.Forward"/>
-/// k times — so it establishes the interface, the contiguous-append semantics, and the
-/// <see cref="GpuForwardPass.TruncateTo"/> rollback contract that the later weight-amortizing
-/// batched-matvec PR will reuse. It does NOT yet amortize the weight reads, and no CLI spec gate
-/// is flipped.
+/// Issue #308: single-user speculative decoding on the dense Vulkan (full-offload) path.
 ///
-/// Because the K-loop IS k sequential Forward calls, BatchVerify is bit-identical to the
-/// sequential reference by construction; the parity oracle below asserts this with a tight
-/// tolerance (exact for greedy argmax, &lt;1e-4 on the raw logits) to lock in the KV/position
-/// plumbing. The rollback oracle mirrors <see cref="CudaSpecBatchVerifyTests"/>'s
-/// TruncateAndCommit shape.
+/// PR1 shipped <see cref="GpuForwardPass.BatchVerify"/> as a correct K-loop reference (k sequential
+/// <see cref="GpuForwardPass.Forward"/> calls). PR1c (this) re-implements BatchVerify on a BATCHED
+/// trunk that streams all k draft tokens through ONE command buffer, reading each Q4_K/Q6_K weight
+/// matrix from VRAM once via <c>MatMulBatched</c> (the weight-amortization). The batched path is
+/// gated to dense models whose every trunk matmul weight is Q4_K/Q6_K (<c>CanBatchedTrunk</c>);
+/// other dtypes (e.g. Qwen3-0.6B-Q8_0) keep the K-loop fallback.
 ///
-/// Small dense model (Qwen3-0.6B-Q8_0) — on GPU, fast. Silent-skips when Vulkan is unavailable
-/// or the GGUF isn't on disk.
+/// The batched path is bit-exact to the K-loop by construction (MatMulBatched is bit-identical to
+/// single-row matvec, the gather/scatter copies are exact, the per-token RmsNorm/QK-norm/RoPE/
+/// append/attention reuse the single-query shaders with the same positions/seqLens). Parity oracles
+/// below assert this on BOTH models — Qwen3-8B-Q4_K_M exercises the batched trunk; Qwen3-0.6B-Q8_0
+/// exercises the K-loop fallback — with exact greedy-argmax equality and a &lt;1e-4 logit tolerance.
+///
+/// All cases run on GPU and silent-skip when Vulkan is unavailable or the GGUF isn't on disk.
 /// </summary>
 public sealed class VulkanSpecBatchVerifyTests
 {
-    private const string ModelFile = "Qwen3-0.6B-Q8_0.gguf";
+    private const string SmallModel = "Qwen3-0.6B-Q8_0.gguf";   // Q8_0 weights → K-loop fallback
+    private const string BatchedModel = "Qwen3-8B-Q4_K_M.gguf"; // Q4_K weights → batched trunk
+
+    private readonly ITestOutputHelper _out;
+    public VulkanSpecBatchVerifyTests(ITestOutputHelper output) => _out = output;
 
     private static readonly int[] Prompt = { 9707, 11, 1879, 0, 358, 1079, 264, 4108, 1614, 13 };
 
@@ -34,12 +40,12 @@ public sealed class VulkanSpecBatchVerifyTests
         catch { return null; }
     }
 
-    private static string? FindModelPath()
+    private static string? FindModelPath(string modelFile)
     {
         string[] absoluteCandidates =
         {
-            $@"C:\p\sharpi\models\{ModelFile}",
-            $@"E:\models\{ModelFile}",
+            $@"C:\p\sharpi\models\{modelFile}",
+            $@"E:\models\{modelFile}",
         };
         foreach (var p in absoluteCandidates)
             if (File.Exists(p)) return p;
@@ -47,7 +53,7 @@ public sealed class VulkanSpecBatchVerifyTests
         var dir = Directory.GetCurrentDirectory();
         for (int i = 0; i < 8; i++)
         {
-            var p = Path.Combine(dir, "models", ModelFile);
+            var p = Path.Combine(dir, "models", modelFile);
             if (File.Exists(p)) return p;
             var parent = Directory.GetParent(dir);
             if (parent is null) break;
@@ -87,14 +93,15 @@ public sealed class VulkanSpecBatchVerifyTests
 
     /// <summary>
     /// Gate: a small dense (non-Gemma-4, non-TurboQuant) model with an uncompacted cache must
-    /// report SupportsBatchVerify on the Vulkan path.
+    /// report SupportsBatchVerify on the Vulkan path; the Q8_0 weights make it take the K-loop
+    /// fallback (CanBatchedTrunk == false).
     /// </summary>
     [Fact]
     public void Qwen3_0_6B_DenseModel_ReportsSupportsBatchVerify()
     {
         using var gpu = TryCreate();
         if (gpu is null) return;
-        var path = FindModelPath();
+        var path = FindModelPath(SmallModel);
         if (path is null) return;
 
         using var model = GgufModel.Open(path);
@@ -105,23 +112,19 @@ public sealed class VulkanSpecBatchVerifyTests
         using var fwd = NewFwd(model, gpu, hp);
         Assert.True(fwd.SupportsBatchVerify,
             "Dense Qwen3-0.6B Q8_0 must report SupportsBatchVerify on the Vulkan path.");
+        Assert.False(fwd.CanBatchedTrunk,
+            "Qwen3-0.6B Q8_0 weights must NOT qualify for the batched trunk (Q8_0 ∉ {Q4_K, Q6_K}).");
     }
 
     /// <summary>
-    /// Parity oracle: BatchVerify's per-position logits for k packed tokens must reproduce k
-    /// sequential Forward calls at every position. Since the K-loop reference IS those calls, the
-    /// match is bit-exact by construction — asserted with exact argmax equality and a &lt;1e-4
-    /// tolerance on the raw logits. This verifies the BatchVerify KV/position plumbing. Run at
-    /// k=4 and k=6.
+    /// Gate: the Q4_K model must qualify for the weight-amortizing batched trunk.
     /// </summary>
-    [Theory]
-    [InlineData(4)]
-    [InlineData(6)]
-    public void Qwen3_0_6B_BatchVerify_MatchesSequentialForward(int k)
+    [Fact]
+    public void Qwen3_8B_Q4K_QualifiesForBatchedTrunk()
     {
         using var gpu = TryCreate();
         if (gpu is null) return;
-        var path = FindModelPath();
+        var path = FindModelPath(BatchedModel);
         if (path is null) return;
 
         using var model = GgufModel.Open(path);
@@ -131,6 +134,48 @@ public sealed class VulkanSpecBatchVerifyTests
 
         using var fwd = NewFwd(model, gpu, hp);
         Assert.True(fwd.SupportsBatchVerify);
+        Assert.True(fwd.CanBatchedTrunk,
+            "Qwen3-8B Q4_K_M weights must qualify for the batched trunk.");
+    }
+
+    /// <summary>
+    /// Parity oracle (K-loop fallback path): BatchVerify's per-position logits for k packed tokens
+    /// reproduce k sequential Forward calls. Bit-exact by construction (it IS those calls).
+    /// </summary>
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    public void Qwen3_0_6B_BatchVerify_MatchesSequentialForward(int k)
+        => RunParity(SmallModel, k, expectBatchedTrunk: false);
+
+    /// <summary>
+    /// Parity oracle (BATCHED trunk path, the payoff): BatchVerify on Qwen3-8B-Q4_K_M must match k
+    /// sequential Forward calls bit-exactly (exact argmax, &lt;1e-4 logit tolerance) — the
+    /// weight-amortized trunk is numerically identical to the K-loop because MatMulBatched is
+    /// bit-identical to single-row matvec and every per-token op reuses the single-query shaders.
+    /// </summary>
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    public void Qwen3_8B_Q4K_BatchVerify_MatchesSequentialForward(int k)
+        => RunParity(BatchedModel, k, expectBatchedTrunk: true);
+
+    private void RunParity(string modelFile, int k, bool expectBatchedTrunk)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(modelFile);
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim);
+        Assert.False(hp.IsMoE);
+
+        // 8B Q4_K KV at ctx 64 fits comfortably; small ctx keeps the test fast.
+        using var fwd = NewFwd(model, gpu, hp, ctx: 64);
+        Assert.True(fwd.SupportsBatchVerify);
+        Assert.Equal(expectBatchedTrunk, fwd.CanBatchedTrunk);
 
         fwd.ResetCache();
         var prefillLogits = fwd.Prefill(Prompt);
@@ -140,8 +185,7 @@ public sealed class VulkanSpecBatchVerifyTests
         var tokens = new int[k];
         tokens[0] = Argmax(prefillLogits);
 
-        // Sequential reference: k Forward calls from the prefilled cache, capturing logits at
-        // every position.
+        // Sequential reference: k Forward calls from the prefilled cache (the K-loop oracle).
         var reference = new float[k][];
         for (int i = 0; i < k; i++)
         {
@@ -155,14 +199,17 @@ public sealed class VulkanSpecBatchVerifyTests
         float[][] batch = fwd.BatchVerify(tokens, P);
 
         Assert.Equal(k, batch.Length);
+        float worst = 0f;
         for (int i = 0; i < k; i++)
         {
             Assert.Equal(Argmax(reference[i]), Argmax(batch[i]));
             float maxAbs = MaxAbsDiff(reference[i], batch[i]);
+            worst = MathF.Max(worst, maxAbs);
             Assert.True(maxAbs < 1e-4f,
                 $"Position {i}: batched vs sequential logits diverged beyond the bit-exact " +
                 $"K-loop tolerance: maxAbs={maxAbs}.");
         }
+        _out.WriteLine($"{modelFile} k={k} batchedTrunk={fwd.CanBatchedTrunk} worstMaxAbs={worst:E3}");
 
         // After BatchVerify the cache must hold exactly P + k positions (all k K/V appended).
         Assert.Equal(P + k, fwd.KvLength);
@@ -170,24 +217,24 @@ public sealed class VulkanSpecBatchVerifyTests
 
     /// <summary>
     /// Rollback oracle — the full speculative-step shape: BatchVerify k tokens (some deliberately
-    /// wrong), TruncateTo(P+accepted), then Forward the correction at P+accepted. The post-rollback
-    /// logits must match the sequential trajectory that never saw the rejected tokens — catching
-    /// stale-KV leaks past the truncation point (the rejected rows' K/V stays in VRAM and must be
-    /// masked by the seqLen/_kvLength rewind and overwritten by the commit). Mirrors
-    /// <see cref="CudaSpecBatchVerifyTests"/>'s TruncateAndCommit oracle.
+    /// wrong), TruncateTo(P+accepted), then Forward the correction. Post-rollback logits must match
+    /// the sequential trajectory that never saw the rejected tokens (catches stale-KV leaks past the
+    /// truncation point). Runs on the BATCHED trunk model (Qwen3-8B-Q4_K_M) so the rollback contract
+    /// is asserted on the new path; falls back to the K-loop model if the 8B GGUF is absent.
     /// </summary>
     [Fact]
-    public void Qwen3_0_6B_BatchVerify_TruncateAndCommit_MatchesSequential()
+    public void BatchVerify_TruncateAndCommit_MatchesSequential()
     {
         using var gpu = TryCreate();
         if (gpu is null) return;
-        var path = FindModelPath();
+        // Prefer the batched-trunk model; degrade to the small model so CI without the 8B still runs.
+        var path = FindModelPath(BatchedModel) ?? FindModelPath(SmallModel);
         if (path is null) return;
 
         using var model = GgufModel.Open(path);
         var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
 
-        using var fwd = NewFwd(model, gpu, hp);
+        using var fwd = NewFwd(model, gpu, hp, ctx: 64);
         Assert.True(fwd.SupportsBatchVerify);
 
         fwd.ResetCache();
@@ -195,20 +242,18 @@ public sealed class VulkanSpecBatchVerifyTests
         int P = Prompt.Length;
         int t0 = Argmax(prefillLogits);
 
-        // Sequential reference trajectory: accept t0, then the correction t1. This path only ever
-        // appends the accepted tokens.
+        // Sequential reference trajectory: accept t0, then the correction t1.
         int t1 = Argmax(fwd.Forward(t0, P));
         float[] reference = fwd.Forward(t1, P + 1).ToArray();
 
-        // Spec-step shape: rewind to P, verify [t0, junk, junk, junk] (junk = off-chain tokens
-        // that will be rejected), accept only t0, commit t1.
+        // Spec-step shape: rewind to P, verify [t0, junk, junk, junk] (junk rejected), accept t0.
         fwd.TruncateTo(P);
         int junk = (t0 + 7919) % hp.VocabSize;
         float[][] batch = fwd.BatchVerify([t0, junk, junk, junk], P);
         Assert.Equal(t1, Argmax(batch[0])); // verify logits after t0 must still pick t1
 
-        // Roll back the rejected tail; the rejected K/V rows at [P+1, P+4) stay in VRAM but must be
-        // ignored (masked by the rewound _kvLength) and overwritten by the commit.
+        // Roll back the rejected tail; rejected K/V at [P+1, P+4) stays but must be ignored and
+        // overwritten by the commit.
         fwd.TruncateTo(P + 1);
         float[] committed = fwd.Forward(t1, P + 1).ToArray();
 
@@ -216,5 +261,83 @@ public sealed class VulkanSpecBatchVerifyTests
         float maxAbs = MaxAbsDiff(reference, committed);
         Assert.True(maxAbs < 1e-4f,
             $"Post-rollback commit diverged from the sequential trajectory: maxAbs={maxAbs}.");
+    }
+
+    /// <summary>
+    /// Micro-bench (GPU-only, silent-skip): on Qwen3-8B-Q4_K_M, prefill ~512 tokens then time
+    /// BatchVerify(k=4) — the weight-amortizing batched trunk — against 4× single Forward (the
+    /// K-loop equivalent). Reports the median wall-clock ratio so the speedup is honest. This is the
+    /// PR2 arbiter: it asserts only that the batched path is not catastrophically slower (≤ 1.5×
+    /// the K-loop) and logs the real ratio. Skips unless SHARPI_RUN_VULKAN_SPEC_BENCH=1 (it's a
+    /// timing probe, not a correctness gate).
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_Q4K_BatchVerify_MicroBench()
+    {
+        if (Environment.GetEnvironmentVariable("SHARPI_RUN_VULKAN_SPEC_BENCH") != "1")
+            return;
+
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(BatchedModel);
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        int prefillLen = int.TryParse(Environment.GetEnvironmentVariable("SHARPI_SPEC_BENCH_PREFILL"), out var pl) ? pl : 512;
+        int k = int.TryParse(Environment.GetEnvironmentVariable("SHARPI_SPEC_BENCH_K"), out var kk) ? kk : 4;
+        using var fwd = NewFwd(model, gpu, hp, ctx: prefillLen + 64);
+        Assert.True(fwd.SupportsBatchVerify);
+        Assert.True(fwd.CanBatchedTrunk);
+
+        // Build a ~512-token prompt (repeat the seed prompt) and prefill it.
+        var longPrompt = new int[prefillLen];
+        for (int i = 0; i < prefillLen; i++) longPrompt[i] = Prompt[i % Prompt.Length];
+        fwd.ResetCache();
+        var prefillLogits = fwd.Prefill(longPrompt);
+        int P = prefillLen;
+
+        var tokens = new int[k];
+        tokens[0] = Argmax(prefillLogits);
+        for (int i = 1; i < k; i++) tokens[i] = (tokens[i - 1] + 1) % hp.VocabSize;
+
+        // Warm up both paths (compiles pipelines, warms caches).
+        fwd.TruncateTo(P);
+        _ = fwd.BatchVerify(tokens, P);
+        fwd.TruncateTo(P);
+        for (int i = 0; i < k; i++) _ = fwd.Forward(tokens[i], P + i).ToArray();
+
+        const int iters = 9;
+        var batchedMs = new double[iters];
+        var kloopMs = new double[iters];
+        var sw = new Stopwatch();
+        for (int it = 0; it < iters; it++)
+        {
+            fwd.TruncateTo(P);
+            sw.Restart();
+            _ = fwd.BatchVerify(tokens, P);
+            sw.Stop();
+            batchedMs[it] = sw.Elapsed.TotalMilliseconds;
+
+            fwd.TruncateTo(P);
+            sw.Restart();
+            for (int i = 0; i < k; i++) _ = fwd.Forward(tokens[i], P + i).ToArray();
+            sw.Stop();
+            kloopMs[it] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        Array.Sort(batchedMs);
+        Array.Sort(kloopMs);
+        double medBatched = batchedMs[iters / 2];
+        double medKloop = kloopMs[iters / 2];
+        double ratio = medKloop / medBatched; // >1 ⇒ batched is faster
+
+        _out.WriteLine($"BatchVerify(k={k}, prefill={prefillLen}) median: batched={medBatched:F2}ms, " +
+            $"{k}xForward={medKloop:F2}ms, speedup={ratio:F2}x");
+
+        Assert.True(medBatched <= medKloop * 1.5,
+            $"Batched trunk should not be much slower than the K-loop: " +
+            $"batched={medBatched:F2}ms vs kloop={medKloop:F2}ms.");
     }
 }


### PR DESCRIPTION
#308 PR1c — the payoff integration. Wires the merged batched matvecs (#339/#340) into a batched-trunk `BatchVerify`.

## Change
Re-implements `GpuForwardPass.BatchVerify` on a batched trunk that processes all K draft tokens in **one command buffer**, using `MatMulBatched` (Q4_K/Q6_K weight-stationary) for the weight-bound matmuls — each weight matrix read from VRAM once for all K tokens. The previous K-loop body is preserved as `BatchVerifyKLoop` (fallback + parity oracle).

- **`_canBatchedTrunk` gate**: dense (`!_isMoE`), `!_isGemma4`, **no QKV/output bias**, every trunk matmul weight ∈ {Q4_K, Q6_K} (so the `MatMulBatched` non-Q4K/Q6K fallback's recording-hazard is never hit). Qwen3-8B-Q4_K_M qualifies; Q8_0/bias/MoE/gemma4 use the unchanged K-loop. K==1 → single `Forward`.
- **Batched trunk**: matmuls (Q/K/V/O, gate/up/down, lm-head) via `MatMulBatched` over `[K][dim]` buffers; elementwise (residual add/copy, SiLuMul) whole-buffer; per-token reductions/position ops (RmsNorm, HeadNorm, RoPE@startPos+i, KvAppend@startPos+i, Attention seqLen=startPos+i+1 for causal-among-K) via gather/scatter to single-token scratch. One `BeginRecord`/`EndRecordAndSubmit`, one K×vocab download then host-split.

## Verification
- **BIT-EXACT**: Qwen3-8B-Q4_K_M `BatchVerify(k=4,6)` == k sequential `Forward`, **maxAbs = 0.0** (truly bit-identical); Q8_0 still passes via the K-loop fallback; truncate-commit rollback holds. Full `~Vulkan` suite **82/82**, no regression; review clean (no-regression + bit-exactness + gate verified).
- **PERF (honest micro-bench, the PR2 arbiter)**, batched vs K-loop: **~0.90–1.08×** across k=4..8 / 512..2048 ctx — essentially **break-even** in the spec regime. The matmul amortization (≈4× less weight traffic at k=4) is real but masked by per-token gather/scatter + dispatch overhead.

## Why land it (gate-off, no user change)
The **CLI spec gate is NOT flipped** — default behavior is unchanged. This lands the bit-exact batched-trunk **foundation** (like the #338 K-loop foundation). Unlike a bandwidth-bound dead-end (cf. #313 coop-matrix), the break-even here is from **optimizable overhead**: the next step is **batched cheap-ops** (RmsNorm/RoPE/HeadNorm over [K][dim] in one dispatch, eliminating the gather/scatter) and/or batched attention. PR2 flips the gate only once the micro-bench shows a clear win.

## Follow-ups
- Batched cheap-ops to remove the gather/scatter overhead (the main break-even cause) → re-measure.
- Bias-model coverage (a Q4_K Qwen2 like VibeThinker-Q4 would exercise the currently-gated-out bias path).
- Then PR2: flip the CLI gate for prompt-lookup spec + E2E greedy parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)