### PR TITLE
feat(vulkan): enable prompt-lookup speculative decoding (#308 PR2)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -806,6 +806,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         if (settings.DraftModelPath is not null || settings.DraftLookup)
         {
             bool cudaSpecTarget = gpuFwd is CudaForwardPass { SupportsBatchVerify: true };
+            // Vulkan full-offload of a dense Q4_K/Q6_K model exposes the same weight-amortized
+            // BatchVerify (issue #308). gemma4/TurboQuant report SupportsBatchVerify=false (no spec);
+            // MoE/bias models report true but stay on the bit-exact K-loop fallback (still lossless,
+            // just not weight-amortized). --draft-LOOKUP only on Vulkan; --draft-model (needs a 2nd
+            // GpuForwardPass + VRAM mgmt) is a CUDA-only follow-up.
+            bool vulkanSpecTarget = gpuFwd is GpuForwardPass { SupportsBatchVerify: true };
+            bool gpuSpecTarget = cudaSpecTarget || vulkanSpecTarget;
             // Sampled speculative decoding (issue #178): temp>0 now drives distribution-preserving
             // spec sampling on the model-draft path (greedy at temp 0 stays byte-stable). Gated to
             // model drafts (lookup proposals expose no q), to non-penalized/-biased sampling (draft
@@ -819,9 +826,15 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 AnsiConsole.MarkupLine("[red]Error:[/] --draft-model and --draft-lookup are mutually exclusive.");
                 return 1;
             }
-            if (nGpuLayers != 0 && !cudaSpecTarget)
+            if (nGpuLayers != 0 && !gpuSpecTarget)
             {
-                AnsiConsole.MarkupLine("[yellow]Warning:[/] Speculative decoding requires pure CPU (-g 0) or full CUDA offload of a dense or Gemma-4 model. Falling back to normal generation.");
+                AnsiConsole.MarkupLine("[yellow]Warning:[/] Speculative decoding requires pure CPU (-g 0), full CUDA offload of a dense or Gemma-4 model, or full Vulkan offload of a dense Q4_K/Q6_K model (--draft-lookup). Falling back to normal generation.");
+            }
+            else if (vulkanSpecTarget && settings.DraftModelPath is not null)
+            {
+                // --draft-model needs a 2nd GpuForwardPass + VRAM management on Vulkan; not yet
+                // wired. Guard before the draft-model branch's (CudaForwardPass)gpuFwd cast.
+                AnsiConsole.MarkupLine("[yellow]Warning:[/] --draft-model speculative decoding is not yet supported on Vulkan (use --draft-lookup, or CUDA); falling back to normal generation.");
             }
             else if (sampledSpec && settings.DraftLookup)
             {
@@ -842,7 +855,9 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 // batched-verify step. Floor is ~baseline (no match → plain decode step).
                 try
                 {
-                    IForwardPass lookupTarget = cudaSpecTarget ? (CudaForwardPass)gpuFwd! : fwd!;
+                    // gpuFwd is the CudaForwardPass or GpuForwardPass (both IForwardPass) on a GPU
+                    // spec target; fall back to the CPU pass otherwise.
+                    IForwardPass lookupTarget = gpuSpecTarget ? (IForwardPass)gpuFwd! : fwd!;
                     AnsiConsole.MarkupLine($"[dim]Speculative decoding: prompt-lookup (n-gram) drafting | Lookahead k={settings.SpecLookahead}[/]");
                     if (settings.Prompt is not null)
                         return RunSpeculativeSinglePrompt(settings, lookupTarget, null, tokenizer, sp, rng);

--- a/tests/SharpInference.Tests.ForwardPass/VulkanSpecDecodeE2ETests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanSpecDecodeE2ETests.cs
@@ -1,0 +1,145 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using SharpInference.Vulkan;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #308 PR2 (the finale): end-to-end speculative-decoding correctness on the dense Vulkan
+/// (full-offload) path. The CLI now admits Vulkan full-offload of a dense Q4_K/Q6_K model as a
+/// spec target for <c>--draft-lookup</c> (prompt-lookup, no draft model); this test exercises the
+/// whole wired path — <see cref="SpeculativeDecoder"/> → <see cref="GpuForwardPass.BatchVerify"/>
+/// → accept/reject → <see cref="GpuForwardPass.TruncateTo"/> rollback — on real generation.
+///
+/// Speculative decoding is LOSSLESS at greedy (temp 0): the draft only proposes, and every emitted
+/// token is the argmax of the TARGET's logits. So the spec-on stream must EXACTLY equal the target's
+/// own non-spec greedy continuation. Asserting exact token equality (not a per-logit tolerance)
+/// makes any verify/accept/rollback bug fail the test — divergence means spec is not lossless on
+/// Vulkan, which is the load-bearing correctness gate for the feature.
+///
+/// Runs on GPU and silent-skips when Vulkan or the Q4_K GGUF is unavailable.
+/// </summary>
+public sealed class VulkanSpecDecodeE2ETests
+{
+    // Q4_K_M dense model = the batched-trunk-eligible target (CanBatchedTrunk == true). This is
+    // the model the CLI --draft-lookup Vulkan path is meant for.
+    private const string BatchedModel = "Qwen3-8B-Q4_K_M.gguf";
+
+    private readonly ITestOutputHelper _out;
+    public VulkanSpecDecodeE2ETests(ITestOutputHelper output) => _out = output;
+
+    // A deliberately repetitive prompt so prompt-lookup's tail n-gram matching (NgramMin=2)
+    // actually proposes tokens during decode — this drives the accept/reject/rollback machinery
+    // rather than degrading to plain single-token steps.
+    private static readonly int[] Prompt =
+    {
+        9707, 11, 1879, 0,        // "Hello, world!"
+        9707, 11, 1879, 0,        // repeated
+        358, 1079, 264, 4108, 1614, 13,
+        358, 1079, 264, 4108, 1614, 13,
+    };
+
+    private static VulkanBackend? TryCreate()
+    {
+        try { return new VulkanBackend(); }
+        catch { return null; }
+    }
+
+    private static string? FindModelPath(string modelFile)
+    {
+        string[] absoluteCandidates =
+        {
+            $@"C:\p\sharpi\models\{modelFile}",
+            $@"E:\models\{modelFile}",
+        };
+        foreach (var p in absoluteCandidates)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", modelFile);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    // SnapKV pinned off: BatchVerify is unsupported once SnapKV evicts, and VRAM-scaled
+    // auto-SnapKV could otherwise engage and flip SupportsBatchVerify to false. Mirrors
+    // VulkanSpecBatchVerifyTests.NewFwd.
+    private static GpuForwardPass NewFwd(GgufModel model, VulkanBackend gpu, ModelHyperparams hp, int ctx)
+    {
+        var prev = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "0");
+        try { return new GpuForwardPass(model, gpu, hp, maxContextLength: ctx); }
+        finally { Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prev); }
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    /// <summary>
+    /// E2E greedy parity (prompt-lookup mode): with the n-gram lookup draft (zero draft forwards),
+    /// the emitted stream must EXACTLY equal the Vulkan target's non-spec greedy continuation.
+    /// Accepted proposals only ever shortcut tokens the target would have picked anyway, so any
+    /// difference is a BatchVerify / accept / rollback bug. This is the PR2 correctness gate.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_SpecDecode_PromptLookup_GreedyParity_E2E()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(BatchedModel);
+        if (path is null) return;
+
+        const int DecodeTokens = 40;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.Null(hp.LayerHeadDim);   // dense, not Gemma-4
+        Assert.False(hp.IsMoE);
+
+        // ctx must hold the prompt + the decoded tail with headroom.
+        int ctx = Prompt.Length + DecodeTokens + 16;
+        using var target = NewFwd(model, gpu, hp, ctx);
+        Assert.True(target.SupportsBatchVerify,
+            "Dense Qwen3-8B Q4_K_M must report SupportsBatchVerify on the Vulkan path.");
+        Assert.True(target.CanBatchedTrunk,
+            "Qwen3-8B Q4_K_M weights must qualify for the weight-amortized batched trunk.");
+
+        // Non-spec greedy baseline on the target alone.
+        target.ResetCache();
+        var logits = target.Prefill(Prompt);
+        int P = Prompt.Length;
+        var baseline = new List<int>();
+        int tok = Argmax(logits);
+        for (int i = 0; i < DecodeTokens; i++)
+        {
+            baseline.Add(tok);
+            logits = target.Forward(tok, P + i);
+            tok = Argmax(logits);
+        }
+
+        // Prompt-lookup spec decode over the same target — drives BatchVerify + rollback.
+        target.ResetCache();
+        var targetLogits = target.Prefill(Prompt).ToArray();
+        var spec = new SpeculativeDecoder(target, new PromptLookupDraft(), lookahead: 4);
+        spec.Initialize(Prompt, targetLogits);
+
+        var emitted = new List<int>();
+        spec.Decode(DecodeTokens, [], emitted.Add);
+
+        _out.WriteLine($"decoded={emitted.Count} acceptanceRate={spec.AcceptanceRate:P1}");
+        Assert.Equal(baseline, emitted);
+    }
+}


### PR DESCRIPTION
#308 PR2 — the finale: wire `--draft-lookup` (prompt-lookup) speculative decoding on the Vulkan backend.

## Change
The `SpeculativeDecoder` + `PromptLookupDraft` are backend-agnostic; this extends the CLI spec gate to admit `GpuForwardPass { SupportsBatchVerify: true }` (the merged weight-amortized + batched-attention `BatchVerify`) for the lookup path. `--draft-model` on Vulkan (needs a 2nd GpuForwardPass + VRAM mgmt) is a CUDA-only follow-up — **guarded to warn + fall back** to normal generation (never hits the CUDA-specific cast). CUDA/CPU spec paths unchanged; opt-in (default off).

## Verification
- **LOSSLESS**: `VulkanSpecDecodeE2ETests` greedy-parity — spec-on tokens == spec-off greedy tokens **EXACTLY** (Qwen3-8B-Q4_K_M, 40 tokens, **75% acceptance** on a repetitive prompt — exercises the amortized `BatchVerifyBatched` path + accept/reject + `TruncateTo` rollback). 102/102 Vulkan + 51/51 Cli, build clean; review clean (CUDA/CPU no-regression + the Vulkan `--draft-model` guard verified on the disjoint sealed-type hierarchy).

## Honest E2E speedup (the arbiter)
The end-to-end spec speedup is **acceptance- and context-gated** (prompt-lookup's nature, same as CUDA):
- **Win** on high-acceptance / long-context workloads — repetitive, code, copy/edit, structured extraction (output echoes prompt n-grams), riding the verify step's **1.17-1.34×** weight-amortized speedup (at prefill 2048).
- **~baseline-to-slight-slowdown** on low-acceptance *novel* generation at short context (measured Qwen3-8B, novel/thinking output, short ctx: ~8% acceptance → 44.5 vs 50.2 t/s).

The verify STEP is the #308 engineering win; the net E2E benefit scales with prompt-lookup acceptance. `--draft-lookup` is the right tool for lookup-friendly workloads.

## #308 arc complete (7 PRs)
BatchVerify foundation (#338) → batched matvecs Q4_K (#339) / Q6_K (#340) → batched trunk (#341) → batched cheap-ops (#342) → batched attention (#343) → this CLI wiring. Each bit-exact with a parity gate + honest micro-bench. Follow-ups: bf16/q8_0 batched attention; `--draft-model` on Vulkan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
