### PR TITLE
fix(vulkan): exact-size batched-verify scratch for variable k (#308 correctness)

### DIFF
--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -1848,8 +1848,14 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     /// </summary>
     private void EnsureBatchVerifyScratch(int k)
     {
-        if (_bvK >= k) return;
-        if (_bvK > 0) FreeBatchVerifyScratch(); // free the prior (fully-allocated) generation
+        // EXACT sizing (not grow-only): BatchVerifyBatched passes the WHOLE [k][dim] buffers to
+        // MatMulBatched, which derives rows/cols = ElementCount/nTok. A grow-only guard (>=) would
+        // reuse an OVERSIZED buffer when a later step has smaller k (k shrinks to 2/3 at the
+        // generation tail, or on a partial prompt-lookup match) → wrong rows/cols → garbage logits
+        // (or an ArgumentException if k doesn't divide the oversized count). Mirror CUDA's exact
+        // `_decodeLogitsCapacity == n` sizing. (Was `>=` — a latent crash/divergence in #308.)
+        if (_bvK == k) return;
+        if (_bvK > 0) FreeBatchVerifyScratch(); // free the prior generation (any size)
 
         int qDim = _numHeads * _headDim;
         int kvDim = _numKvHeads * _headDim;

--- a/tests/SharpInference.Tests.ForwardPass/VulkanSpecBatchVerifyTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/VulkanSpecBatchVerifyTests.cs
@@ -250,6 +250,61 @@ public sealed class VulkanSpecBatchVerifyTests
     }
 
     /// <summary>
+    /// Regression (#308 scratch-sizing): BatchVerify must be correct when k VARIES across calls on
+    /// one instance — k shrinks to 2/3 at the generation tail (and on partial prompt-lookup matches).
+    /// The batched scratch was grow-only (`_bvK >= k`), so a smaller k after a larger one reused an
+    /// OVERSIZED buffer and MatMulBatched derived rows/cols = ElementCount/k against the wrong size →
+    /// garbage logits (or an ArgumentException when k didn't divide the oversized count). This drives
+    /// the batched trunk through k = 4 → 2 → 3 → 6 → 1 on ONE GpuForwardPass and asserts each matches
+    /// the K-loop oracle. Pre-fix the k=2/k=3 steps crash or diverge; the existing fixed-k tests
+    /// missed it because each used a fresh instance with a single k.
+    /// </summary>
+    [Fact]
+    public void Qwen3_8B_Q4K_BatchVerify_VariableK_MatchesSequentialForward()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath(BatchedModel);
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        using var fwd = NewFwd(model, gpu, hp, ctx: 64);
+        Assert.True(fwd.CanBatchedTrunk, "needs the batched trunk to exercise the scratch-sizing path.");
+
+        int P = Prompt.Length;
+        // A fixed token sequence (plausible ids) — the oracle and the batched run use the same first-k.
+        int[] seq = { 9707, 11, 1879, 0, 358, 1079, 264, 4108 };
+
+        // Larger-k first (sizes _bvK=4), then SMALLER k that pre-fix reused the oversized buffer.
+        foreach (int k in new[] { 4, 2, 3, 6, 1 })
+        {
+            var tokens = seq[..k];
+
+            // K-loop oracle from the prefilled state.
+            fwd.ResetCache();
+            fwd.Prefill(Prompt);
+            var reference = new float[k][];
+            for (int i = 0; i < k; i++)
+                reference[i] = fwd.Forward(tokens[i], P + i).ToArray();
+
+            // Batched verify on the SAME instance (so _bvK carries over from the prior k).
+            fwd.TruncateTo(P);
+            float[][] batch = fwd.BatchVerify(tokens, P);
+
+            Assert.Equal(k, batch.Length);
+            for (int i = 0; i < k; i++)
+            {
+                Assert.Equal(Argmax(reference[i]), Argmax(batch[i]));
+                Assert.True(MaxAbsDiff(reference[i], batch[i]) < 1e-4f,
+                    $"k={k} pos={i}: batched diverged from the K-loop oracle (scratch-sizing).");
+            }
+            _out.WriteLine($"variable-k: k={k} OK");
+        }
+    }
+
+    /// <summary>
     /// Rollback oracle — the full speculative-step shape: BatchVerify k tokens (some deliberately
     /// wrong), TruncateTo(P+accepted), then Forward the correction. Post-rollback logits must match
     /// the sequential trajectory that never saw the rejected tokens (catches stale-KV leaks past the


### PR DESCRIPTION
**Shipped correctness fix** for the Vulkan spec-decode path (#341/#344).

## The bug
`EnsureBatchVerifyScratch` sized the batched-verify scratch **grow-only** (`if (_bvK >= k) return;`). But `BatchVerifyBatched` passes the **whole** `[k][dim]` buffers to `MatMulBatched`, which derives `rows/cols = ElementCount/nTok`. When a later step has a **smaller k** than a prior one — which happens **every generation** (k shrinks to 2/3 at the tail as `remaining < lookahead`, and on partial prompt-lookup matches) — the oversized buffer made rows/cols wrong:
- k doesn't divide the oversized count → `ArgumentException` (**hard crash**), or
- k divides evenly → wrong slices → **garbage logits, argmax flips, divergent output** (measured maxAbs ~36 vs the K-loop oracle).

So the shipped `--draft-lookup` (#344) **crashes** at some decode lengths (tail k=3) and **silently diverges** at others (tail k=2). The 40-token e2e test passed only because that acceptance pattern never landed the tail on k∈{2,3}.

## Fix
Exact sizing — reallocate on **any** size change (`_bvK == k`), mirroring CUDA's `EnsureDecodeLogits` `== n` (CUDA was never affected). Reallocs occur only when k actually changes (k is the constant lookahead in steady state; shrinks only at the tail).

## Diagnosis (decisive, evidence-based)
- **K-loop vs batched under the same churn**: forcing `BatchVerifyKLoop` is lossless (firstDiv=-1 at 40 & 120 tokens) while the batched path crashes/diverges → the bug is in `BatchVerifyBatched`, not the (backend-agnostic) decoder/churn.
- **Churned-KV vs fresh-Prefill** byte compare at committed positions: maxAbs=**0.0** → the truncate+re-append churn is byte-perfect (refutes the "KV-churn corrupts the cache" hypothesis).
- Affects fp32 and q8_0 identically (upstream of KV dtype). CUDA unaffected.

## Verification
- New regression test `Qwen3_8B_Q4K_BatchVerify_VariableK_MatchesSequentialForward` drives **k = 4→2→3→6→1 on ONE instance** vs the K-loop oracle (crashes/diverges pre-fix, passes post-fix) — the gap the fixed-k tests missed (each used a fresh instance + single k).
- Full Vulkan spec suite **16/16**; build clean. This also unblocks `--draft-model` on Vulkan (lossless once the scratch is exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
