### PR TITLE
feat(vision): Gemma 4 image input on CUDA partial-offload (#252)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -32,7 +32,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         public string? PromptFile { get; init; }
 
         [CommandOption("--image <PATH>")]
-        [Description("Path to a PNG image for multimodal input (Gemma 4 encoder-free vision). Repeatable for multiple images; reference each with an <image> marker in -p (left-to-right), or omit markers to prepend them. Requires --mmproj and a text prompt (-p). Runs on CPU, CUDA, and Vulkan (full offload).")]
+        [Description("Path to a PNG image for multimodal input (Gemma 4 encoder-free vision). Repeatable for multiple images; reference each with an <image> marker in -p (left-to-right), or omit markers to prepend them. Requires --mmproj and a text prompt (-p). Runs on CPU, CUDA (full + partial offload), and Vulkan (full offload).")]
         public string[]? ImagePaths { get; init; }
 
         [CommandOption("--mmproj")]
@@ -1208,8 +1208,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
     /// own chat template (so BOS / <c>&lt;|turn&gt;</c> / thinking handling matches the text path —
     /// Gemma 4 uses <c>&lt;|turn&gt;role\n…&lt;turn|&gt;</c>, NOT Gemma 3's <c>&lt;start_of_turn&gt;</c>),
     /// then each placeholder token in the token stream is expanded with its image's soft tokens
-    /// in order. With no markers, the images are prepended to the user turn. CPU-only: the
-    /// embedding-injection seam lives on <see cref="ForwardPass"/>.
+    /// in order. With no markers, the images are prepended to the user turn. The
+    /// embedding-injection seam (<see cref="IForwardPass.ForwardEmbedding"/>) is implemented by
+    /// <see cref="ForwardPass"/> (CPU), <see cref="CudaForwardPass"/> (full CUDA offload), and
+    /// <see cref="CudaHybridForwardPass"/> (CUDA partial offload, issue #252).
     /// </summary>
     private static int RunImagePrompt(Settings s,
         IForwardPass fwd, GgufTokenizer tok, ModelHyperparams hp,
@@ -1218,8 +1220,8 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         if (!fwd.SupportsEmbeddingInput)
         {
             AnsiConsole.MarkupLine("[red]Error:[/] the selected backend does not support image embedding input. " +
-                "Image input runs on CPU ([yellow]-g 0[/]) or full CUDA offload ([yellow]-g -1[/] of a model that fits VRAM); " +
-                "partial-offload hybrids and the Vulkan backend are not supported yet.");
+                "Image input runs on CPU ([yellow]-g 0[/]), full CUDA offload ([yellow]-g -1[/]), or CUDA " +
+                "partial-offload ([yellow]-g N[/]); the Vulkan partial-offload hybrid is not supported yet.");
             return 1;
         }
 

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -1793,7 +1793,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// <inheritdoc/>
     /// <remarks>
     /// Gemma 4 only: image input (issue #250) splices vision soft tokens into the decode
-    /// stream. Non-Gemma arches and partial-offload hybrids don't implement the seam.
+    /// stream. The CUDA partial-offload hybrid implements the same seam (issue #252,
+    /// <see cref="CudaHybridForwardPass.ForwardEmbedding"/>); non-Gemma arches and the
+    /// Vulkan partial-offload hybrid don't.
     /// </remarks>
     public bool SupportsEmbeddingInput => _isGemma4Like;
 

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -1931,7 +1931,62 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_hp.HasPerLayerTokenEmbd)
             BuildPerLayerProjectionsCpu(token);
 
-        // Re-upload the (possibly scaled) hidden state to GPU for the GPU half.
+        return RunGemma4Trunk(position);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Gemma 4 only: image input (issue #250/#252) splices vision soft tokens into the decode
+    /// stream. Reported on the CUDA partial-offload hybrid once the per-layer-head-dim Gemma 4
+    /// trunk is present (<see cref="_isGemma4Like"/>); non-Gemma arches don't implement the seam.
+    /// </remarks>
+    public bool SupportsEmbeddingInput => _isGemma4Like;
+
+    /// <summary>
+    /// Forward one position from a PRECOMPUTED embedding (a vision soft token) instead of a
+    /// token-table lookup. The CUDA partial-offload mirror of
+    /// <see cref="ForwardPass.ForwardEmbedding"/> and <see cref="CudaForwardPass.ForwardEmbedding"/>:
+    /// places the supplied embedding into the host hidden buffer and — per gemma4.cpp —
+    /// skips the sqrt(EmbeddingDim) embedding scale (raw embeddings arrive final, gemma4.cpp:182)
+    /// while still building the per-layer (PLE) projections from the padding token (id 0,
+    /// the multimodal branch of build_inp_per_layer). The trunk
+    /// (<see cref="RunGemma4Trunk"/> — GPU layers + CPU layers + KV append + finalise) is
+    /// byte-identical to the token <see cref="Forward"/> path; only the embedding source and
+    /// the PLE token (0 vs the input token) differ. Gemma 4 only.
+    /// </summary>
+    public ReadOnlySpan<float> ForwardEmbedding(ReadOnlySpan<float> embedding, int position)
+    {
+        if (!_isGemma4Like)
+            throw new NotSupportedException(
+                "ForwardEmbedding (image input) is only supported for Gemma 4 on the CUDA backend.");
+        if (embedding.Length != _embDim)
+            throw new ArgumentException(
+                $"embedding length {embedding.Length} != model embedding dim {_embDim}.");
+
+        // 1. Place the precomputed embedding into the host hidden buffer (the trunk's source
+        //    of truth — it re-uploads _cpuHidden to the GPU half). No sqrt(d) scale here:
+        //    raw vision embeddings arrive already final (gemma4.cpp:182).
+        embedding.CopyTo(new Span<float>(_cpuHidden, _embDim));
+
+        // 2. PLE pre-pass from the padding token (multimodal build_inp_per_layer branch);
+        //    the proj MatVec still reads the supplied embedding via _cpuHidden.
+        if (_hp.HasPerLayerTokenEmbd)
+            BuildPerLayerProjectionsCpu(0);
+
+        // 3. Same trunk (GPU+CPU layers + KV append + logits) as the token Forward.
+        return RunGemma4Trunk(position);
+    }
+
+    // ================================================================
+    //  Gemma 4 trunk — shared by ForwardGemma4 (token input) and ForwardEmbedding
+    //  (precomputed vision embedding, issue #252). Assumes _cpuHidden holds the
+    //  pre-trunk hidden state and, for PLE models, _projPerLayer is populated for
+    //  `position`. Re-uploads to the GPU half, runs the GPU + CPU layer loops with
+    //  KV append, finalises norm/output/softcap, and returns the logits.
+    // ================================================================
+    private ReadOnlySpan<float> RunGemma4Trunk(int position)
+    {
+        // Re-upload the hidden state to GPU for the GPU half.
         if (_nGpuLayers > 0)
         {
             float* pinned = _gpu.MapPinned(_pinnedHidden);

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -1301,7 +1301,9 @@ public sealed unsafe class GpuForwardPass : IForwardPass
     /// <inheritdoc/>
     /// <remarks>
     /// Gemma 4 only: image input (issue #252) splices vision soft tokens into the decode
-    /// stream. Other arches and the partial-offload hybrids don't implement the seam.
+    /// stream. Other arches don't implement the seam, and neither does the Vulkan
+    /// partial-offload hybrid (<see cref="HybridForwardPass"/> has no Gemma 4 trunk); the
+    /// CUDA partial-offload hybrid does (<see cref="CudaHybridForwardPass.ForwardEmbedding"/>).
     /// </remarks>
     public bool SupportsEmbeddingInput => _isGemma4;
 

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4VisionCudaHybridE2ETests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4VisionCudaHybridE2ETests.cs
@@ -1,0 +1,200 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using SharpInference.Vision;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Image→text for Gemma 4 on the CUDA partial-offload <see cref="CudaHybridForwardPass"/>
+/// (issue #252): preprocess → encoder-free projector (CPU) → splice soft tokens into the
+/// hybrid decoder via <see cref="CudaHybridForwardPass.ForwardEmbedding"/> → greedy decode.
+/// The partial-offload analogue of <see cref="Gemma4VisionE2ETests"/> (CPU) and the
+/// full-offload <see cref="CudaForwardPass.ForwardEmbedding"/>; it pins the new hybrid
+/// <c>ForwardEmbedding</c> seam, which previously did not exist (vision required CPU
+/// <c>-g 0</c> or full CUDA <c>-g -1</c>).
+///
+/// The load-bearing check is <see cref="Gemma4_CudaHybrid_Image_MatchesCudaFull_Argmax"/>:
+/// the SAME image + prompt run through the hybrid (a mostly-GPU split with a few CPU layers)
+/// and through full offload must produce the SAME greedy argmax stream. The hybrid GPU half
+/// shares kernels with the full path, so the only thing that can diverge is the new
+/// ForwardEmbedding seam (no sqrt(d) scale, PLE-from-token-0, the CPU-tier trunk) — exactly
+/// what this verifies. q4_0 is argmax-stable across the (identical) GPU kernels and the small
+/// CPU tail, so the streams match token-for-token over a short budget.
+///
+/// Uses <c>gemma-4-12b-it-qat-q4_0.gguf</c> (the model the rest of the CUDA 12B suite uses) +
+/// the gemma4uv projector <c>mmproj-gemma-4-12b-it-qat-q4_0.gguf</c>. KV is pinned to fp32 so
+/// the hybrid and full passes share the cache dtype regardless of the auto-narrowing budget.
+/// Silent-skips when CUDA is unavailable or the GGUFs aren't on disk. The orchestrator runs
+/// the heavy GPU verification; the implementation pass only builds.
+/// </summary>
+public sealed class Gemma4VisionCudaHybridE2ETests : IDisposable
+{
+    private readonly ITestOutputHelper _out;
+
+    // Pin fp32 KV so the hybrid and full passes use the same cache dtype (CudaForwardPass
+    // auto-narrows to bf16/q8_0 when fp32 won't fit the budget — see Gemma4Cuda12BForwardPassTests).
+    private readonly string? _prevKvDType = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+
+    public Gemma4VisionCudaHybridE2ETests(ITestOutputHelper output)
+    {
+        _out = output;
+        Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", "fp32");
+    }
+
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", _prevKvDType);
+
+    private const string TextModel = "gemma-4-12b-it-qat-q4_0.gguf";
+    private const string Mmproj = "mmproj-gemma-4-12b-it-qat-q4_0.gguf";
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static string? Find(string file)
+    {
+        foreach (var p in new[] { $@"E:\models\{file}", $@"C:\p\sharpi\models\{file}" })
+            if (File.Exists(p)) return p;
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8 && dir is not null; i++)
+        {
+            var p = Path.Combine(dir, "models", file);
+            if (File.Exists(p)) return p;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// A mostly-GPU split: GPU gets all but the last <paramref name="cpuLayers"/> layers, so the
+    /// 12B runs almost entirely on the GPU (the task's "few tokens, mostly-GPU" guidance — avoid
+    /// heavy CPU). Still exercises both tiers' Gemma 4 ForwardEmbedding trunk (re-upload seam +
+    /// CPU-tier layers + finalise). The byte fields only feed LayerPlacement.Summary;
+    /// RecommendedCtxSize sets the hybrid's max sequence length.
+    /// </summary>
+    private static LayerPlacement MostlyGpuSplit(ModelHyperparams hp, int cpuLayers)
+    {
+        int gpu = hp.NumLayers - cpuLayers;
+        return new LayerPlacement(
+            GpuLayers: gpu,
+            CpuLayers: cpuLayers,
+            GpuWeightBytes: 0,
+            GpuKvBytes: 0,
+            RecommendedCtxSize: 4096);
+    }
+
+    [Fact]
+    public void Gemma4_CudaHybrid_Image_MatchesCudaFull_Argmax()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;                                 // CUDA-gated
+        var textPath = Find(TextModel);
+        var mmprojPath = Find(Mmproj);
+        if (textPath is null || mmprojPath is null) return;      // model-gated
+
+        using var model = GgufModel.Open(textPath);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        Assert.NotNull(hp.LayerHeadDim);                         // real gemma4 GGUF
+        var tok = GgufTokenizer.FromGgufModel(model);
+
+        // Project the image once on the CPU embedder; both passes consume the same soft tokens.
+        using var vision = VisionModel.Open(mmprojPath);
+        var embedder = new GemmaUvVisionEmbedder(vision);
+        int embd = hp.EmbeddingDim;
+        var img = ImagePreprocessor.Preprocess(SolidColor(96, 96, 220, 30, 30), 96, 96, vision);
+        var soft = embedder.Forward(img.Chw, img.Height, img.Width, out int nTok);
+
+        // Image marker ids (gemma4uv runtime wrapping: <|image> ... soft ... <image|>).
+        int imgOpen = tok.SpecialTokens.TryGetValue("<|image>", out var o) ? o : 255999;
+        int imgClose = tok.SpecialTokens.TryGetValue("<image|>", out var c) ? c : 258882;
+
+        // Chat-formatted prompt halves around the image (mirrors Gemma4VisionE2ETests).
+        var pre = tok.Encode("<|turn>user\n");
+        var post = tok.Encode("What color is this image? Answer in one word.<turn|>\n<|turn>model\n");
+        var postIds = post[0] == tok.BosTokenId ? post.Skip(1).ToList() : post.ToList();
+
+        // Full offload (-g -1) reference.
+        List<int> fullOut;
+        using (var full = new CudaForwardPass(model, gpu, hp, maxContextLength: 4096))
+        {
+            Assert.True(full.SupportsEmbeddingInput);
+            fullOut = RunImagePrompt(full, soft, nTok, embd, pre, imgOpen, imgClose, postIds, tok, "FULL");
+        }
+
+        // Partial offload (-g N): all but the last 2 layers on GPU — mostly-GPU, still both tiers.
+        List<int> hybridOut;
+        using (var hybrid = new CudaHybridForwardPass(model, gpu, hp, MostlyGpuSplit(hp, cpuLayers: 2)))
+        {
+            Assert.True(hybrid.SupportsEmbeddingInput,
+                "CudaHybridForwardPass must report SupportsEmbeddingInput for the gemma4 (#252) vision seam.");
+            hybridOut = RunImagePrompt(hybrid, soft, nTok, embd, pre, imgOpen, imgClose, postIds, tok, "HYBRID");
+        }
+
+        // Each path is independently coherent (catches an all-EOS / degenerate seam).
+        AssertCoherent(fullOut, tok.EosTokenId, "full");
+        AssertCoherent(hybridOut, tok.EosTokenId, "hybrid");
+
+        // The load-bearing parity check: hybrid (-g N) == full (-g -1) argmax, token-for-token.
+        Assert.True(fullOut.SequenceEqual(hybridOut),
+            $"CUDA-hybrid (-g N) and CUDA-full (-g -1) ForwardEmbedding decodes diverge — the hybrid " +
+            $"vision seam (no sqrt(d), PLE-from-token-0, CPU-tier trunk) is not faithful to the full path. " +
+            $"full=[{string.Join(",", fullOut)}] (\"{tok.Decode(fullOut)}\") " +
+            $"hybrid=[{string.Join(",", hybridOut)}] (\"{tok.Decode(hybridOut)}\").");
+
+        // Correctness sanity: the solid-red image names "red".
+        Assert.Contains("red", tok.Decode(hybridOut), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private List<int> RunImagePrompt(
+        IForwardPass fwd, float[] soft, int nTok, int embd,
+        IReadOnlyList<int> pre, int imgOpen, int imgClose, IReadOnlyList<int> post,
+        GgufTokenizer tok, string label)
+    {
+        int pos = 0;
+        ReadOnlySpan<float> logits = default;
+        foreach (int id in pre) logits = fwd.Forward(id, pos++);
+        logits = fwd.Forward(imgOpen, pos++);
+        for (int t = 0; t < nTok; t++)
+            logits = fwd.ForwardEmbedding(soft.AsSpan(t * embd, embd), pos++);
+        logits = fwd.Forward(imgClose, pos++);
+        foreach (int id in post) logits = fwd.Forward(id, pos++);
+
+        var outIds = new List<int>();
+        int next = Argmax(logits);
+        for (int i = 0; i < 10 && next != tok.EosTokenId; i++)
+        {
+            outIds.Add(next);
+            logits = fwd.Forward(next, pos++);
+            next = Argmax(logits);
+        }
+        _out.WriteLine($"[{label}] {nTok} soft tokens -> {outIds.Count} decoded: \"{tok.Decode(outIds)}\" {string.Join(",", outIds)}");
+        return outIds;
+    }
+
+    private static void AssertCoherent(List<int> outIds, int eos, string which)
+    {
+        Assert.True(outIds.Count > 0, $"[{which}] decoded nothing (immediate EOS).");
+        Assert.DoesNotContain(eos, outIds);                // we stop before EOS, so none present
+        Assert.True(outIds.Distinct().Count() >= 2,
+            $"[{which}] decode is degenerate (only {outIds.Distinct().Count()} distinct of {outIds.Count}): {string.Join(",", outIds)}");
+    }
+
+    private static byte[] SolidColor(int w, int h, byte r, byte g, byte b)
+    {
+        var buf = new byte[w * h * 3];
+        for (int i = 0; i < w * h; i++) { buf[i * 3] = r; buf[i * 3 + 1] = g; buf[i * 3 + 2] = b; }
+        return buf;
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0; float bv = logits[0];
+        for (int i = 1; i < logits.Length; i++) if (logits[i] > bv) { bv = logits[i]; best = i; }
+        return best;
+    }
+}


### PR DESCRIPTION
Follow-up to #250/#253 — extends Gemma-4 encoder-free vision (`--image`) to **CUDA partial-offload** (`-g N`). It worked on CPU (`-g 0`) and CUDA full-offload (`-g -1`); now it works under partial offload too (run gemma4-12B vision on a CUDA GPU too small for full offload).

## Change
- **`CudaHybridForwardPass.ForwardEmbedding`** + `SupportsEmbeddingInput => _isGemma4Like` — a faithful mirror of the verified `CudaForwardPass.ForwardEmbedding`.
- Factored the gemma4 trunk out of `ForwardGemma4` into a shared **`RunGemma4Trunk`** (re-upload seam + GPU/CPU layer loops + KV append + finalize/softcap/logits) — **byte-identical** (verified vs HEAD; only a stale comment changed). Token path unchanged.
- **Seam contract**: copy the precomputed embedding into `_cpuHidden` with **no sqrt(d)/EmbeddingScale** (raw vision embeddings arrive final, gemma4.cpp:182), build PLE from **padding token 0** (not the input token), run the shared trunk. Gemma-4 is dense in the hybrid → no MoE-expert interaction.
- **CLI**: the `--image` gate was already `SupportsEmbeddingInput`-only, so `-g N` now routes to `CudaHybridForwardPass` and works; updated the stale "CPU/CUDA-full only" message + `--image` help text.

## Verification
- **Argmax parity**: hybrid `-g N` (46 GPU + 2 CPU layers) == full `-g -1` **token-for-token** on a red 96×96 image (both decode "Red"), gemma-4-12b-it-qat-q4_0. New `Gemma4VisionCudaHybridE2ETests` asserts the full sequence (CUDA + model-gated, mostly-GPU so light). CLI e2e: `-g 30 --image` (was erroring) now answers "Red" matching `-g -1`. **10/10 CUDA + 14/14 Vision tests; build clean; review clean** (the trunk factoring verified byte-identical, the seam contract verified vs the reference).

## Scope
CUDA partial-offload only. The **Vulkan partial-offload hybrid** (`HybridForwardPass`) remains unsupported — it has no gemma4 trunk (a separate, larger task: porting `ForwardGemma4` to the Vulkan hybrid). GpuForwardPass (Vulkan full-offload) vision already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
