### PR TITLE
feat(vulkan): narrowed KV (bf16/q8_0) for Gemma 4 (#351 P2)

### DIFF
--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -581,8 +581,10 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             // dtype using its OWN per-layer kvDim (bf16 fp16-packed, q8_0 block_q8_0, else fp32).
             // For E4B the per-layer kvDim is 512 (SWA, head_dim 256) or 1024 (global, head_dim
             // 512) — both even (bf16 ✓) and multiples of 32 (q8_0 blocks align to row boundaries
-            // ✓), already enforced on the model max dims by the ctor guards above. Aliased layers
-            // copy the source handle regardless of dtype.
+            // ✓). The ctor guards above validate the scalar model max dims (hp.HeadDim); the
+            // per-layer SWA/global dims are validated explicitly below so a future gemma variant
+            // with an odd SWA head_dim or a per-layer kvDim not divisible by 32 fails loud rather
+            // than mis-storing. Aliased layers copy the source handle regardless of dtype.
             for (int i = 0; i < hp.NumLayers; i++)
             {
                 int kvSrc = hp.KvSourceLayer is { } ksl ? ksl[i] : -1;
@@ -602,11 +604,19 @@ public sealed unsafe class GpuForwardPass : IForwardPass
                 long layerKvDim = (long)layerKv * layerHd;
                 if (_kvDType == DType.BFloat16)
                 {
+                    if ((layerHd & 1) != 0)
+                        throw new NotSupportedException(
+                            $"bf16 KV requires an even per-layer head dimension; layer {i} has {layerHd}. " +
+                            "Use fp32 KV (issue #324).");
                     _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim), DType.BFloat16);
                     _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim), DType.BFloat16);
                 }
                 else if (_kvDType == DType.Q8_0)
                 {
+                    if ((layerKvDim & 31) != 0)
+                        throw new NotSupportedException(
+                            $"q8_0 KV requires per-layer kvDim % 32 == 0; layer {i} has {layerKv}*{layerHd}. " +
+                            "Use fp32 or bf16 (issue #325).");
                     long layerQ8Bytes = DTypeInfo.ByteSize((long)_maxSeqLen * layerKvDim, DType.Q8_0);
                     long layerWords = (layerQ8Bytes + 3) / 4;
                     _gpuKCache[i] = gpu.Allocate(TensorShape.D1(layerWords));

--- a/src/SharpInference.Engine/GpuForwardPass.cs
+++ b/src/SharpInference.Engine/GpuForwardPass.cs
@@ -318,17 +318,14 @@ public sealed unsafe class GpuForwardPass : IForwardPass
         // The full gemma4 trunk (per-layer head_dim, SWA, dual RoPE + rope_freqs, sandwich
         // norms, V-norm, attn_scale=1.0, final softcap, k_eq_v globals) is implemented in
         // ForwardGemma4 / RunGemma4Layers (issue #309); PLE injection + shared-KV aliasing
-        // are wired in issue #351 (the E4B family). TurboQuant and narrowed KV remain
-        // unsupported on the gemma4 path (later phases) and are rejected up front.
+        // are wired in issue #351 (the E4B family). Narrowed KV (bf16 / q8_0) is wired in
+        // issue #351 Phase 2 — the per-layer append/attention now dtype-branch like the dense
+        // path. TurboQuant remains unsupported on the gemma4 path and is rejected up front.
         _isGemma4 = hp.LayerHeadDim is not null;
         if (_isGemma4)
         {
             if (enableTurboQuant)
                 throw new NotSupportedException("TurboQuant is not supported for Gemma 4 on Vulkan.");
-            if (kvDtype != DType.Float32)
-                throw new NotSupportedException(
-                    "Gemma 4 on Vulkan supports only fp32 KV (the narrowed-KV append/attention shaders " +
-                    "are not wired for per-layer head_dim / SWA). Use --kv-type fp32.");
         }
 
         _model = model;
@@ -542,25 +539,27 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             _evictV = gpu.Allocate(TensorShape.D1(_numKvHeads * _headDim));
 
         }
-        else if (_kvDType == DType.BFloat16)
+        else if (_kvDType == DType.BFloat16 && !_isGemma4)
         {
             // Half-width KV (issue #311): allocate the cache as BFloat16 so byte accounting is
             // honest (2 bytes/elem = the packed-fp16-word byte count). The append/attention
             // shaders bind the buffer as uint[] (2 fp16 per word) regardless of the declared
             // dtype, and index it identically to the fp32 path (no ring modulo).
+            // gemma4 needs PER-LAYER geometry, so it falls through to the _isGemma4 branch.
             for (int i = 0; i < hp.NumLayers; i++)
             {
                 _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), DType.BFloat16);
                 _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * kvDim), DType.BFloat16);
             }
         }
-        else if (_kvDType == DType.Q8_0)
+        else if (_kvDType == DType.Q8_0 && !_isGemma4)
         {
             // Block-quantized KV (issue #325): the cache holds ggml block_q8_0 (34 bytes per 32
             // elements). Vulkan's Allocate(shape, DType) computes bytes via BytesPerElement, which
             // THROWS for quantized dtypes, so allocate a raw uint-word buffer sized to the exact
             // q8_0 byte count (rounded up to whole words). The append/attention shaders bind it as
             // uint[] and index it by block regardless of the declared dtype — same pattern as bf16.
+            // gemma4 needs PER-LAYER geometry, so it falls through to the _isGemma4 branch.
             long q8Bytes = DTypeInfo.ByteSize((long)_maxSeqLen * kvDim, DType.Q8_0); // (count/32)*34
             long words = (q8Bytes + 3) / 4;
             for (int i = 0; i < hp.NumLayers; i++)
@@ -576,8 +575,14 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             // SWA included — is allocated at FULL context (more VRAM than CUDA's SWA ring, but
             // correct). Shared-KV tail layers (issue #351) ALIAS their source layer's K/V handles
             // instead of allocating: the GGUF puts shared layers after their source, so the
-            // source is already allocated (ascending i). Mirrors FillKvCacheArrays. fp32 is
-            // enforced for gemma4 above.
+            // source is already allocated (ascending i). Mirrors FillKvCacheArrays.
+            //
+            // Narrowed KV (issue #351 Phase 2): each owning layer is allocated in the active KV
+            // dtype using its OWN per-layer kvDim (bf16 fp16-packed, q8_0 block_q8_0, else fp32).
+            // For E4B the per-layer kvDim is 512 (SWA, head_dim 256) or 1024 (global, head_dim
+            // 512) — both even (bf16 ✓) and multiples of 32 (q8_0 blocks align to row boundaries
+            // ✓), already enforced on the model max dims by the ctor guards above. Aliased layers
+            // copy the source handle regardless of dtype.
             for (int i = 0; i < hp.NumLayers; i++)
             {
                 int kvSrc = hp.KvSourceLayer is { } ksl ? ksl[i] : -1;
@@ -595,8 +600,23 @@ public sealed unsafe class GpuForwardPass : IForwardPass
                 int layerHd = hp.LayerHeadDim![i];
                 int layerKv = hp.LayerKvHeads is { } lkv ? lkv[i] : _numKvHeads;
                 long layerKvDim = (long)layerKv * layerHd;
-                _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim));
-                _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim));
+                if (_kvDType == DType.BFloat16)
+                {
+                    _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim), DType.BFloat16);
+                    _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim), DType.BFloat16);
+                }
+                else if (_kvDType == DType.Q8_0)
+                {
+                    long layerQ8Bytes = DTypeInfo.ByteSize((long)_maxSeqLen * layerKvDim, DType.Q8_0);
+                    long layerWords = (layerQ8Bytes + 3) / 4;
+                    _gpuKCache[i] = gpu.Allocate(TensorShape.D1(layerWords));
+                    _gpuVCache[i] = gpu.Allocate(TensorShape.D1(layerWords));
+                }
+                else // fp32
+                {
+                    _gpuKCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim));
+                    _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_maxSeqLen * layerKvDim));
+                }
             }
         }
         else
@@ -1589,11 +1609,21 @@ public sealed unsafe class GpuForwardPass : IForwardPass
             _gpu.RecordBarrier();
 
             // f. KV append (KV-owning layers only; full context — no SWA ring modulo). Shared
-            //    layers read the source layer's pages (effLayer) below without appending.
+            //    layers read the source layer's pages (effLayer) below without appending. Dtype-
+            //    branched (issue #351 Phase 2): the bf16/q8_0 shaders take the SAME args as fp32
+            //    and narrow the cache store internally; the fp32 K/V scratch views are the inputs
+            //    regardless of cache dtype.
             if (!kvShared)
             {
-                _gpu.KvAppend(kView, vView, _gpuKCache[layer], _gpuVCache[layer],
-                    (uint)kvDimL, (uint)position, (uint)_maxSeqLen);
+                if (_kvDType == DType.BFloat16)
+                    _gpu.KvAppendBf16(kView, vView, _gpuKCache[layer], _gpuVCache[layer],
+                        (uint)kvDimL, (uint)position, (uint)_maxSeqLen);
+                else if (_kvDType == DType.Q8_0)
+                    _gpu.KvAppendQ8_0(kView, vView, _gpuKCache[layer], _gpuVCache[layer],
+                        (uint)kvDimL, (uint)position, (uint)_maxSeqLen);
+                else
+                    _gpu.KvAppend(kView, vView, _gpuKCache[layer], _gpuVCache[layer],
+                        (uint)kvDimL, (uint)position, (uint)_maxSeqLen);
                 _gpu.RecordBarrier();
             }
 
@@ -1604,12 +1634,25 @@ public sealed unsafe class GpuForwardPass : IForwardPass
 
             // h. Attention against the OWNING layer's cache (effLayer). SWA layers pass the
             //    sliding-window bound (the shared layer's OWN isSwa); global layers pass 0 (full
-            //    causal). Base fp32 Attention (Q4_K-free; fp32 KV).
-            _gpu.Attention(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
-                _attnScoresScratch,
-                (uint)_numHeads, (uint)layerKv, (uint)layerHd,
-                (uint)(position + 1), (uint)_maxSeqLen,
-                window: isSwa ? (uint)_hp.SlidingWindowSize : 0u);
+            //    causal). Dtype-branched (issue #351 Phase 2): bf16/q8_0 use the plain narrowed
+            //    Attention variants (NO split-KV on gemma4), same args as the fp32 path; the
+            //    shaders dequantize the per-layer cache internally. Q4_K-free; per-layer KV dtype.
+            uint window = isSwa ? (uint)_hp.SlidingWindowSize : 0u;
+            if (_kvDType == DType.BFloat16)
+                _gpu.AttentionBf16(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)layerKv, (uint)layerHd,
+                    (uint)(position + 1), (uint)_maxSeqLen, window: window);
+            else if (_kvDType == DType.Q8_0)
+                _gpu.AttentionQ8_0(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)layerKv, (uint)layerHd,
+                    (uint)(position + 1), (uint)_maxSeqLen, window: window);
+            else
+                _gpu.Attention(qView, _gpuKCache[effLayer], _gpuVCache[effLayer], attnOutView,
+                    _attnScoresScratch,
+                    (uint)_numHeads, (uint)layerKv, (uint)layerHd,
+                    (uint)(position + 1), (uint)_maxSeqLen, window: window);
             _gpu.RecordBarrier();
 
             // i. Output projection: _wo[layer] is [embDim, qDimL]; attnOutView has qDimL rows.

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4VulkanNarrowedKvE2ETests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4VulkanNarrowedKvE2ETests.cs
@@ -146,13 +146,7 @@ public sealed class Gemma4VulkanNarrowedKvE2ETests
                 "Narrowed KV is argmax-stable vs fp32 (issue #311 / #325) — a divergence at the " +
                 "first token is a per-layer append/attention dispatch or allocation bug, not store noise.");
 
-            int distinct = 0;
-            for (int i = 0; i < decoded.Length; i++)
-            {
-                bool seen = false;
-                for (int j = 0; j < i; j++) if (decoded[j] == decoded[i]) { seen = true; break; }
-                if (!seen) distinct++;
-            }
+            int distinct = new HashSet<int>(decoded).Count;
             Assert.True(distinct >= 6,
                 $"E4B q4_0 Vulkan KV {kvDtype} {NSteps}-step decode collapsed to {distinct} distinct " +
                 $"token(s): [{string.Join(",", decoded)}]. Output is degenerate.");

--- a/tests/SharpInference.Tests.ForwardPass/Gemma4VulkanNarrowedKvE2ETests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/Gemma4VulkanNarrowedKvE2ETests.cs
@@ -1,0 +1,161 @@
+using SharpInference.Core;
+using SharpInference.Engine;
+using SharpInference.Vulkan;
+using Vortice.Vulkan;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// End-to-end Gemma 4 E4B on the Vulkan <see cref="GpuForwardPass"/> with a NARROWED KV cache
+/// (bf16 / q8_0), the wiring added in issue #351 Phase 2. The per-layer KV allocation and the
+/// RunGemma4Layers append/attention dispatch now dtype-branch (matching the dense path), so the
+/// E4B family can use --kv-type bf16|q8_0 for long context — as it already does on CUDA.
+///
+/// Narrowed KV is argmax-stable but not bit-exact vs fp32 (the established #311 / #325 contract:
+/// bf16 packs two fp16 per word; q8_0 block-quantizes per 32 elems). The reference here is the
+/// SAME Vulkan fp32 GpuForwardPass (so the only variable is the KV store), and the gate is greedy
+/// argmax agreement at the first decoded token plus a non-degenerate, finite short decode. This
+/// mirrors <see cref="Gemma4VulkanPleE2ETests"/> (CPU↔Vulkan argmax parity for the fp32 path).
+///
+/// Uses <c>gemma-4-E4B_q4_0-it.gguf</c> — the QAT q4_0 GGUF with PLE + a KV-share tail. The
+/// per-layer kvDim is 512 (SWA, head_dim 256) or 1024 (global, head_dim 512): both even (bf16) and
+/// multiples of 32 (q8_0). Silent-skips when Vulkan is unavailable, the device is out of memory for
+/// full offload, or the GGUF isn't on disk. NOT run by the implementation pass (the orchestrator
+/// verifies on a real GPU).
+/// </summary>
+public sealed class Gemma4VulkanNarrowedKvE2ETests
+{
+    private const string ModelFile = "gemma-4-E4B_q4_0-it.gguf";
+
+    private static VulkanBackend? TryCreate()
+    {
+        try { return new VulkanBackend(); }
+        catch { return null; }
+    }
+
+    private static string? FindModelPath(string fileName)
+    {
+        string[] absoluteCandidates =
+        {
+            $@"E:\models\{fileName}",
+            $@"C:\p\sharpi\models\{fileName}",
+        };
+        foreach (var p in absoluteCandidates)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var p = Path.Combine(dir, "models", fileName);
+            if (File.Exists(p)) return p;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int ReadIntMetadata(GgufModel model, string key, int fallback)
+    {
+        if (!model.Metadata.TryGetValue(key, out var v) || v is null) return fallback;
+        try { return Convert.ToInt32(v); } catch { return fallback; }
+    }
+
+    private static int Argmax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    private static GpuForwardPass? TryBuild(GgufModel model, VulkanBackend gpu, ModelHyperparams hp, DType kvDtype)
+    {
+        try
+        {
+            return new GpuForwardPass(model, gpu, hp, maxContextLength: 2048, kvDtype: kvDtype);
+        }
+        catch (VkException ex) when (ex.Result == VkResult.ErrorOutOfDeviceMemory)
+        {
+            return null;                                          // OOM-gated
+        }
+    }
+
+    // Greedy-decodes NSteps tokens from a fixed prompt, returning the argmax sequence
+    // (logits[0] = first decoded token). Disposes the pass.
+    private static int[] GreedyDecode(GpuForwardPass fwd, int[] tokens, int nSteps)
+    {
+        var decoded = new int[nSteps];
+        using (fwd)
+        {
+            var logits = fwd.Prefill(tokens);
+            decoded[0] = Argmax(logits);
+            int pos = tokens.Length;
+            for (int i = 1; i < nSteps; i++)
+            {
+                var step = fwd.Forward(decoded[i - 1], pos++);
+                decoded[i] = Argmax(step);
+            }
+        }
+        return decoded;
+    }
+
+    /// <summary>
+    /// bf16 and q8_0 KV must each agree with the fp32 Vulkan reference at the first decoded argmax
+    /// (the tightest pre-drift signal for an argmax-stable store), and the 14-step decode must be
+    /// finite and non-degenerate (≥6 distinct tokens). Pins the issue #351 Phase 2 narrowed-KV
+    /// wiring for the per-layer gemma4 geometry.
+    /// </summary>
+    [Fact]
+    public void Gemma4_E4B_Q4_0_VulkanNarrowedKv_MatchesFp32Argmax()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;                                  // Vulkan-gated
+        var path = FindModelPath(ModelFile);
+        if (path is null) return;                                 // model-gated
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        // Defensive: only meaningful against a real gemma4 GGUF with PLE + a KV-share tail.
+        Assert.NotNull(hp.LayerHeadDim);
+        Assert.True(hp.HasPerLayerTokenEmbd);
+        Assert.NotNull(hp.KvSourceLayer);
+
+        int bosId = ReadIntMetadata(model, "tokenizer.ggml.bos_token_id", fallback: 2);
+        var tokens = new int[] { bosId, 818, 5279, 529, 7001, 563 }; // "The capital of France is"
+        const int NSteps = 14;
+
+        // fp32 Vulkan reference (the only variable across the three runs is the KV store dtype).
+        var fp32Pass = TryBuild(model, gpu, hp, DType.Float32);
+        if (fp32Pass is null) return;                             // OOM-gated
+        var fp32Decoded = GreedyDecode(fp32Pass, tokens, NSteps);
+
+        foreach (var kvDtype in new[] { DType.BFloat16, DType.Q8_0 })
+        {
+            var pass = TryBuild(model, gpu, hp, kvDtype);
+            if (pass is null) return;                             // OOM-gated
+            var decoded = GreedyDecode(pass, tokens, NSteps);
+
+            Assert.True(fp32Decoded[0] == decoded[0],
+                $"E4B q4_0 Vulkan KV {kvDtype} first-argmax disagrees with fp32: " +
+                $"fp32={fp32Decoded[0]} {kvDtype}={decoded[0]}. " +
+                $"fp32 decode=[{string.Join(",", fp32Decoded)}] " +
+                $"{kvDtype} decode=[{string.Join(",", decoded)}]. " +
+                "Narrowed KV is argmax-stable vs fp32 (issue #311 / #325) — a divergence at the " +
+                "first token is a per-layer append/attention dispatch or allocation bug, not store noise.");
+
+            int distinct = 0;
+            for (int i = 0; i < decoded.Length; i++)
+            {
+                bool seen = false;
+                for (int j = 0; j < i; j++) if (decoded[j] == decoded[i]) { seen = true; break; }
+                if (!seen) distinct++;
+            }
+            Assert.True(distinct >= 6,
+                $"E4B q4_0 Vulkan KV {kvDtype} {NSteps}-step decode collapsed to {distinct} distinct " +
+                $"token(s): [{string.Join(",", decoded)}]. Output is degenerate.");
+        }
+    }
+}


### PR DESCRIPTION
## What

Phase 2 of #351: wires `--kv-type bf16|q8_0` for the **gemma4 path** on Vulkan full-offload, giving gemma4 the long-context KV-narrowing it already has on CUDA. **No new shaders** — the Vulkan bf16/q8_0 KV append + attention shaders (#311/#325) already accept per-layer `head_dim`/`numKvHeads`/SWA `window`, so this is pure dispatch wiring.

## Changes (`GpuForwardPass.cs`)
- **ctor**: drop the gemma4 fp32-only KV reject (TurboQuant reject kept).
- **KV alloc**: the uniform bf16/q8_0 branches are now gated `&& !_isGemma4`, so a gemma4 model falls through to the per-layer `_isGemma4` branch — which allocates each KV-owning layer in the active dtype using its **own per-layer kvDim** (bf16 fp16-packed; q8_0 `block_q8_0` raw-word; else fp32). Shared-KV tail layers alias the source handle regardless of dtype (unchanged from P1).
- **`RunGemma4Layers`**: KV append (step f, `!kvShared`) and attention (step h, reads `effLayer` cache) dtype-branch `KvAppendBf16`/`AttentionBf16`, `KvAppendQ8_0`/`AttentionQ8_0`, else fp32 — same per-layer dims + SWA window, no split-KV.

For E4B the per-layer kvDim is 512 (SWA, head_dim 256) / 1024 (global, 512) — both even (bf16) and multiples of 32 (q8_0), satisfied by the existing ctor guards on the model max dims.

## Verification
RTX 4070 Ti, `gemma-4-E4B_q4_0-it.gguf`, `-g -1 --backend vulkan -c 2048`: greedy output with `--kv-type bf16` and `--kv-type q8_0` is **byte-identical to `--kv-type fp32`** over 64 tokens — within (and stronger than) the bf16/q8_0 argmax-stable contract. This exercises the per-layer narrowed alloc + dtype-branched append/attention + shared-KV tail aliasing under a narrowed store. Adds a model-gated narrowed-KV-vs-fp32 parity test. Build clean (TreatWarningsAsErrors, 0 warnings).

## Scope
Builds on #353 (P1 PLE + shared-KV). Remaining #351 phase: partial-offload gemma4 trunk in `HybridForwardPass` (the #252 Vulkan item), still rejected/absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)