### PR TITLE
feat(engine): schema/grammar-constrained tool-call argument decoding (#374)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,20 @@ stream. `--no-thinking` disables it at the template level, `--hide-thinking` kee
 `--temp 0.6 --top-p 0.95 --top-k 20`. The server emits reasoning per protocol (Anthropic `thinking`,
 OpenAI `reasoning_content`).
 
+### Tool-call argument grammar (`SHARPI_TOOL_GRAMMAR`, issue #374)
+
+Opt-in constrained decoding that forces a tool call's **arguments** to satisfy the request's JSON Schema,
+expressed in the model's native call syntax. Gemma 4's instruct line emits the call *envelope* correctly
+but, at `temp 0`, substitutes memorized priors for the schema — `get_weather` drops the required `location`
+(emits `{}`), `web_search` invents a `{queries:[…]}` array instead of the schema's `query` string. With the
+flag on, a byte-level grammar over Gemma's `<|tool_call>call:NAME{…}` form masks the sampler so non-conforming
+tokens are unreachable: only declared keys, every required key once, value shapes per type, enums limited to
+the declared set (free string content stays unconstrained). On the same probes the arguments become
+`{"location":"Berlin"}` and `{"query":"…"}`. Enable on the server with `SHARPI_TOOL_GRAMMAR=1` (or
+`SharpInference:ToolGrammar`); default off is byte-identical to unconstrained decoding. Honored by the
+single-user engine (not yet continuous batching); other families (Qwen/Llama JSON) generate unconstrained
+for now via the same per-adapter hook.
+
 ### CLI examples
 
 ```bash

--- a/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
@@ -1,0 +1,905 @@
+using System.Text;
+
+namespace SharpInference.Core.Grammar;
+
+// ── Compiled schema ───────────────────────────────────────────────────────────
+//
+// The parsed ToolSchema is "compiled" once per request into match tables (UTF-8 key/enum bytes,
+// required-key bitmask) so the per-token hot loop never re-encodes strings. Only tools whose schema
+// is FULLY constrainable (every value is a concrete type / typed array / nested typed object — no
+// Any-typed value, no open object) are compiled; a tool that isn't is simply left out of the
+// constraint and generates its arguments unconstrained, so the constraint never blocks generation.
+
+/// <summary>Compiled value-type descriptor (see <see cref="ToolSchemaNode"/>).</summary>
+internal sealed class CompiledNode
+{
+    public required JsonSchemaKind Kind { get; init; }
+    /// <summary>For an enum / boolean / null: the candidate literal byte sequences (≤64).</summary>
+    public byte[][]? Literals { get; init; }
+    /// <summary>True when <see cref="Literals"/> are matched inside the <c>&lt;|"|&gt;</c> quotes (string enum).</summary>
+    public bool QuotedLiterals { get; init; }
+    /// <summary>Element type for an array.</summary>
+    public CompiledNode? Items { get; init; }
+    /// <summary>Nested object shape.</summary>
+    public CompiledObject? Object { get; init; }
+    /// <summary>Integer (no fractional part) vs general number.</summary>
+    public bool IntegerOnly { get; init; }
+}
+
+/// <summary>Compiled object shape: per-property name bytes + value node, plus the required-key mask.</summary>
+internal sealed class CompiledObject
+{
+    public required byte[][] KeyBytes { get; init; }
+    public required CompiledNode[] Values { get; init; }
+    public required ulong RequiredMask { get; init; }
+    public int Count => KeyBytes.Length;
+}
+
+/// <summary>
+/// Constrained-decoding state machine (issue #374) for Gemma 4's native tool-call wire format:
+/// <c>&lt;|tool_call&gt;call:NAME{key:&lt;|"|&gt;val&lt;|"|&gt;,n:3}&lt;tool_call|&gt;</c>.
+///
+/// <para>
+/// It watches the emitted token stream passively until it sees a call open
+/// (<c>&lt;|tool_call&gt;</c>) followed by a known tool name and the argument-object brace
+/// <c>{</c>; from there it constrains the argument object so that only keys declared in that tool's
+/// schema appear, every required key appears exactly once, each value matches its declared shape
+/// (strings in Gemma's <c>&lt;|"|&gt;</c> quotes with free content; numbers/booleans/null bare;
+/// arrays/objects recursively), and enum-typed values are limited to the declared set. The object's
+/// closing <c>}</c> ends constraint and the machine returns to watching, so subsequent text
+/// (<c>&lt;tool_call|&gt;</c>, further calls, plain answer) is unconstrained.
+/// </para>
+///
+/// <para>
+/// Matching is at the byte level for the structural skeleton (so multi-token keys, merged delimiters
+/// like <c>:[</c>/<c>]}</c>, and multi-token numbers/enums all work) and at the token level for the
+/// quote special token and free string content. A token is permitted iff replaying its bytes from
+/// the current state keeps the machine alive.
+/// </para>
+/// </summary>
+public sealed class GemmaToolArgumentConstraint : ITokenConstraint
+{
+    private const int MaxNameScan = 256;    // give up watching a call whose name region runs this long
+    private const int MaxDepth = 32;        // nesting cap; deeper schemas aren't constrained
+
+    private readonly GrammarVocabulary _vocab;
+    private readonly Dictionary<string, CompiledObject> _tools;
+    private readonly int _openMarkerId;     // <|tool_call>
+    private readonly int _quoteId;          // <|"|>
+    private readonly HashSet<int> _forbidden; // EOG ids — never legal inside the argument object
+
+    // Watching state.
+    private bool _armed;                     // saw <|tool_call>, accumulating the name region
+    private readonly StringBuilder _nameBuf = new();
+
+    // Constraining state: an explicit frame stack (pushdown automaton).
+    private Frame[] _stack = new Frame[MaxDepth];
+    private Frame[] _scratch = new Frame[MaxDepth];
+    private int _depth;
+
+    // Masking scratch — a reusable full-vocab logits buffer (allocated on first constrained step).
+    private float[]? _masked;
+    private readonly bool[] _firstByteOk = new bool[256];
+
+    public GemmaToolArgumentConstraint(GrammarVocabulary vocab, IReadOnlyList<ToolSchema> tools)
+    {
+        ArgumentNullException.ThrowIfNull(vocab);
+        ArgumentNullException.ThrowIfNull(tools);
+        _vocab = vocab;
+
+        // Resolve Gemma's structural special tokens. Without the quote token we can't constrain
+        // string values, so leave _tools empty (passive) if it's missing.
+        _ = vocab.TryGetSpecialToken(Gemma4ToolCallAdapter.OpenMarker, out _openMarkerId);
+        _ = vocab.TryGetSpecialToken(Gemma4ToolCallAdapter.Quote, out _quoteId);
+
+        _forbidden = new HashSet<int>(vocab.EogTokenIds);
+
+        _tools = new Dictionary<string, CompiledObject>(StringComparer.Ordinal);
+        if (_openMarkerId > 0 && _quoteId > 0)
+        {
+            foreach (var t in tools)
+            {
+                if (t.Arguments.Open) continue;             // unconstrained body — skip
+                var compiled = TryCompileObject(t.Arguments);
+                if (compiled is not null) _tools[t.Name] = compiled;
+            }
+        }
+
+        // Names we can safely engage on the instant the model finishes typing them (before the '{'),
+        // so a merged "{}" token can't slip an empty argument object past the constraint. A name that
+        // is a strict prefix of another tool name is ambiguous mid-stream (the model might still be
+        // typing the longer one), so it's excluded — those fall back to the '{'-triggered path.
+        _engageNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in _tools.Keys)
+        {
+            bool isPrefixOfAnother = false;
+            foreach (var other in _tools.Keys)
+                if (!ReferenceEquals(name, other) && other.Length > name.Length
+                    && other.StartsWith(name, StringComparison.Ordinal))
+                { isPrefixOfAnother = true; break; }
+            if (!isPrefixOfAnother) _engageNames.Add(name);
+        }
+    }
+
+    private readonly HashSet<string> _engageNames;
+
+    /// <summary>Whether this constraint can ever restrict anything (any tool was constrainable).</summary>
+    public bool HasConstrainableTools => _tools.Count > 0;
+
+    public bool IsConstraining => _depth > 0;
+
+    public void Reset()
+    {
+        _armed = false;
+        _nameBuf.Clear();
+        _depth = 0;
+    }
+
+    // ── Compilation ───────────────────────────────────────────────────────────
+
+    private static CompiledObject? TryCompileObject(ToolSchemaObject obj)
+    {
+        if (obj.Open || obj.Properties.Count is 0 or > 64) return null;
+        var keys = new byte[obj.Properties.Count][];
+        var values = new CompiledNode[obj.Properties.Count];
+        ulong reqMask = 0;
+        for (int i = 0; i < obj.Properties.Count; i++)
+        {
+            var p = obj.Properties[i];
+            if (p.Name.Length == 0) return null;
+            keys[i] = ToolSchema.Utf8(p.Name);
+            var node = TryCompileNode(p.Value);
+            if (node is null) return null;                  // a non-constrainable value → skip the tool
+            values[i] = node;
+            if (p.Required) reqMask |= 1UL << i;
+        }
+        return new CompiledObject { KeyBytes = keys, Values = values, RequiredMask = reqMask };
+    }
+
+    private static readonly byte[][] s_boolLiterals = [ToolSchema.Utf8("true"), ToolSchema.Utf8("false")];
+    private static readonly byte[][] s_nullLiterals = [ToolSchema.Utf8("null")];
+
+    private static CompiledNode? TryCompileNode(ToolSchemaNode node)
+    {
+        switch (node.Kind)
+        {
+            case JsonSchemaKind.String:
+                byte[][]? strEnum = node.EnumValues is { } se ? Encode(se) : null;
+                return new CompiledNode { Kind = JsonSchemaKind.String, Literals = strEnum, QuotedLiterals = strEnum is not null };
+
+            case JsonSchemaKind.Number:
+            case JsonSchemaKind.Integer:
+                byte[][]? numEnum = node.EnumValues is { } ne ? Encode(ne) : null;
+                return new CompiledNode
+                {
+                    Kind = node.Kind,
+                    Literals = numEnum,
+                    QuotedLiterals = false,
+                    IntegerOnly = node.Kind == JsonSchemaKind.Integer,
+                };
+
+            case JsonSchemaKind.Boolean:
+                return new CompiledNode { Kind = JsonSchemaKind.Boolean, Literals = s_boolLiterals };
+
+            case JsonSchemaKind.Null:
+                return new CompiledNode { Kind = JsonSchemaKind.Null, Literals = s_nullLiterals };
+
+            case JsonSchemaKind.Array:
+                // An untyped array (no items) isn't fully constrainable — skip the tool.
+                if (node.Items is null) return null;
+                var item = TryCompileNode(node.Items);
+                return item is null ? null : new CompiledNode { Kind = JsonSchemaKind.Array, Items = item };
+
+            case JsonSchemaKind.Object:
+                if (node.Object is null) return null;
+                var obj = TryCompileObject(node.Object);
+                return obj is null ? null : new CompiledNode { Kind = JsonSchemaKind.Object, Object = obj };
+
+            default:
+                return null;   // Any / unknown — not constrainable
+        }
+    }
+
+    private static byte[][] Encode(IReadOnlyList<string> values)
+    {
+        var r = new byte[values.Count][];
+        for (int i = 0; i < values.Count; i++) r[i] = ToolSchema.Utf8(values[i]);
+        return r;
+    }
+
+    // ── Frame stack ───────────────────────────────────────────────────────────
+
+    private enum FK : byte { Object, Array, Str, StrEnum, Num, Lit }
+
+    private struct Frame
+    {
+        public FK Kind;
+        public int State;
+        public CompiledObject? Obj;     // Object frame
+        public CompiledNode? Node;      // Array (item), StrEnum / Lit (literals), Num
+        public ulong Emitted;           // Object: keys emitted
+        public ulong Cand;              // Object key-match candidates / StrEnum / Lit candidates
+        public int MatchLen;            // chars into current key / literal
+        public bool SeenDigit;          // Num
+        public bool SeenDot;            // Num
+        public bool SeenSign;           // Num
+    }
+
+    // Object sub-states.
+    private const int OExpectKeyOrClose = 0; // key or '}' (if all required emitted)
+    private const int OMatchKey = 1;         // matching a key name (byte-level)
+    private const int OExpectCommaOrClose = 2;
+    private const int OExpectKey = 3;        // after ',', a key is required ('}' not allowed)
+    private const int OExpectOpenBrace = 4;  // top-level object engaged before '{' (early-engage path)
+
+    // Array sub-states.
+    private const int AExpectOpen = 0;       // '['
+    private const int AExpectItemOrClose = 1;
+    private const int AExpectCommaOrClose = 2;
+    private const int AExpectItem = 3;       // after ',', an item is required
+
+    // Str sub-states.
+    private const int SExpectOpen = 0;       // open quote (token-level)
+    private const int SContent = 1;          // free content (token-level)
+
+    // StrEnum sub-states.
+    private const int SeExpectOpen = 0;      // open quote (token-level)
+    private const int SeMatch = 1;           // match enum bytes; close quote ends (mixed)
+
+    // Num sub-states.
+    private const int NStart = 0;
+    private const int NIntDigits = 1;
+    private const int NFracStart = 2;
+    private const int NFracDigits = 3;
+
+    // Lit sub-state: single matching state.
+    private const int LMatch = 0;
+
+    private void PushObject(CompiledObject obj)
+    {
+        ref var f = ref _stack[_depth++];
+        f = default;
+        f.Kind = FK.Object; f.State = OExpectKeyOrClose; f.Obj = obj; f.Emitted = 0;
+    }
+
+    /// <summary>Pushes a nested-object VALUE frame: unlike <see cref="PushObject"/> (top-level body,
+    /// entered past the brace) the opening <c>{</c> hasn't been consumed yet, so it starts in
+    /// <see cref="OExpectOpenBrace"/>.</summary>
+    private bool PushObjectValue(CompiledObject obj)
+    {
+        ref var f = ref _stack[_depth++];
+        f = default;
+        f.Kind = FK.Object; f.State = OExpectOpenBrace; f.Obj = obj; f.Emitted = 0;
+        return true;
+    }
+
+    private bool PushValue(CompiledNode node)
+    {
+        // An object value gets a dedicated Object frame (with its own emitted/required tracking),
+        // dispatched before reserving a slot here so we don't write a frame we'd immediately replace.
+        if (node.Kind == JsonSchemaKind.Object)
+            return node.Object is not null && _depth < MaxDepth && PushObjectValue(node.Object);
+
+        if (_depth >= MaxDepth) return false;
+        ref var f = ref _stack[_depth++];
+        f = default;
+        f.Node = node;
+        switch (node.Kind)
+        {
+            case JsonSchemaKind.String:
+                if (node.Literals is not null) { f.Kind = FK.StrEnum; f.State = SeExpectOpen; f.Cand = AllBits(node.Literals.Length); }
+                else { f.Kind = FK.Str; f.State = SExpectOpen; }
+                break;
+            case JsonSchemaKind.Array:
+                f.Kind = FK.Array; f.State = AExpectOpen;
+                break;
+            default: // Number / Integer / Boolean / Null
+                if (node.Literals is not null) { f.Kind = FK.Lit; f.State = LMatch; f.Cand = AllBits(node.Literals.Length); }
+                else { f.Kind = FK.Num; f.State = NStart; }
+                break;
+        }
+        return true;
+    }
+
+    private static ulong AllBits(int n) => n >= 64 ? ulong.MaxValue : (1UL << n) - 1;
+
+    // ── Public lifecycle ──────────────────────────────────────────────────────
+
+    public void Accept(int token)
+    {
+        if (IsConstraining)
+        {
+            bool ok = RunToken(token);
+            if (!ok || _depth == 0) { _depth = 0; _armed = false; _nameBuf.Clear(); }
+            return;
+        }
+
+        // Watching.
+        if (token == _openMarkerId)
+        {
+            _armed = true; _nameBuf.Clear();
+            return;
+        }
+        if (!_armed) return;
+
+        var bytes = _vocab.TokenBytes(token);
+        // Append decoded text; the name region is ASCII (call:NAME) so a direct byte→char append
+        // is exact for the parts we care about. Watch for the '{' that opens the argument object.
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            char c = (char)bytes[i];
+            if (c == '{')
+            {
+                StartConstraintBody(bytes[(i + 1)..]);
+                return;
+            }
+            _nameBuf.Append(c);
+        }
+
+        // Early engage: the instant the accumulated name exactly matches a (prefix-safe) tool, begin
+        // constraining BEFORE the '{' arrives. This forces the model to open with '{' + a valid first
+        // key, so a merged "{}" token can't drop the required arguments (the issue's get_weather → {}
+        // failure mode). Names that are a prefix of another tool aren't engaged here (ambiguous).
+        if (CurrentName() is { } name && _engageNames.Contains(name) && _tools.TryGetValue(name, out var obj))
+        {
+            _armed = false; _nameBuf.Clear();
+            _depth = 0;
+            PushObject(obj);
+            _stack[0].State = OExpectOpenBrace;   // expect the opening '{' as the first constrained token
+            return;
+        }
+
+        if (_nameBuf.Length > MaxNameScan) { _armed = false; _nameBuf.Clear(); }
+    }
+
+    /// <summary>The bare tool name accumulated so far (leading "call:" stripped), or null if empty.</summary>
+    private string? CurrentName()
+    {
+        string region = _nameBuf.ToString();
+        int colon = region.IndexOf("call:", StringComparison.Ordinal);
+        string name = (colon >= 0 ? region[(colon + "call:".Length)..] : region).Trim();
+        return name.Length == 0 ? null : name;
+    }
+
+    /// <summary>Begins constraining at the argument-object body (the '{' was already emitted, possibly
+    /// merged into the triggering token whose trailing bytes are replayed here).</summary>
+    private void StartConstraintBody(ReadOnlySpan<byte> trailing)
+    {
+        var name = CurrentName();
+        _nameBuf.Clear();
+        _armed = false;
+
+        if (name is null || !_tools.TryGetValue(name, out var obj)) return;  // unknown / non-constrainable
+
+        _depth = 0;
+        PushObject(obj);     // starts in OExpectKeyOrClose (already past '{')
+
+        // Rare: the '{' token carried trailing argument bytes (e.g. "{location"). Replay them now;
+        // if they don't fit the grammar, abandon constraining rather than wedge generation.
+        if (!trailing.IsEmpty && !FeedRawBytes(trailing))
+            _depth = 0;
+    }
+
+    public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+    {
+        if (_depth == 0) return logits;
+
+        var masked = _masked ??= new float[_vocab.VocabSize];
+        if (masked.Length != logits.Length) return logits;     // vocab mismatch — never wedge
+        logits.CopyTo(masked);
+
+        int allowedCount = ComputeMask(masked);
+        // Dead state (no legal token): leave logits untouched so generation never wedges.
+        return allowedCount == 0 ? logits : masked;
+    }
+
+    /// <summary>Sets every forbidden token to -inf in <paramref name="buf"/>; returns the count kept.</summary>
+    private int ComputeMask(float[] buf)
+    {
+        ref var top = ref _stack[_depth - 1];
+        int kept = 0;
+
+        // Token-level tops: free string content and the open/close quote. Handle without a
+        // per-token byte simulation for speed.
+        if (top.Kind == FK.Str && top.State == SContent)
+        {
+            // Any non-forbidden token stays in content; the quote token closes. Forbid only EOG.
+            for (int id = 0; id < buf.Length; id++)
+            {
+                if (_forbidden.Contains(id)) { buf[id] = float.NegativeInfinity; }
+                else kept++;
+            }
+            return kept;
+        }
+        if ((top.Kind == FK.Str && top.State == SExpectOpen)
+            || (top.Kind == FK.StrEnum && top.State == SeExpectOpen))
+        {
+            for (int id = 0; id < buf.Length; id++)
+            {
+                if (id == _quoteId) kept++;
+                else buf[id] = float.NegativeInfinity;
+            }
+            return kept;
+        }
+
+        // General path: prune by allowed first byte, then full-simulate the survivors. The quote
+        // token starts with '<' (outside the structural byte set), so whether it's a legal next token
+        // — opening/closing a string, or opening a string array item — is determined explicitly.
+        Array.Clear(_firstByteOk);
+        bool quoteAllowed = CollectFirstBytes(_depth - 1, _firstByteOk) || IsQuoteAccepted();
+
+        for (int id = 0; id < buf.Length; id++)
+        {
+            var bytes = _vocab.TokenBytes(id);
+            bool candidate;
+            if (id == _quoteId) candidate = quoteAllowed;
+            else if (bytes.Length == 0) candidate = false;
+            else candidate = _firstByteOk[bytes[0]];
+
+            if (candidate && SimulateToken(id))
+                kept++;
+            else
+                buf[id] = float.NegativeInfinity;
+        }
+        return kept;
+    }
+
+    private bool SimulateToken(int token)
+    {
+        int savedDepth = _depth;
+        Array.Copy(_stack, _scratch, _depth);
+        bool ok = RunToken(token);
+        Array.Copy(_scratch, _stack, savedDepth);
+        _depth = savedDepth;
+        return ok;
+    }
+
+    // ── Token execution ───────────────────────────────────────────────────────
+
+    /// <summary>Replays one token's bytes/identity through the machine, mutating the stack. Returns
+    /// false if the token isn't legal from the current state.</summary>
+    private bool RunToken(int tokenId)
+    {
+        if (_depth == 0) return false;
+
+        // The quote is a single special token that delimits a string everywhere it can appear (value
+        // open/close, string-enum open/close, string array-item open). Centralise it so it's matched
+        // at the token level rather than byte-walking its '<|"|>' bytes.
+        if (tokenId == _quoteId) return HandleQuote();
+
+        ref var top = ref _stack[_depth - 1];
+        switch (top.Kind)
+        {
+            case FK.Str when top.State == SExpectOpen:    // string value needs its opening quote
+            case FK.StrEnum when top.State == SeExpectOpen:
+                return false;
+            case FK.Str when top.State == SContent:       // free content: any non-EOG token stays
+                return !_forbidden.Contains(tokenId);
+            case FK.StrEnum when top.State == SeMatch:
+                break;                                    // enum content → byte-walk below
+        }
+
+        // Byte-level walk.
+        return FeedRawBytes(_vocab.TokenBytes(tokenId));
+    }
+
+    /// <summary>Handles the quote special token from the current top frame: opens/closes a string or
+    /// string-enum value, or opens a string array item (the one value whose first token is the quote
+    /// rather than a structural byte). Returns false where a quote isn't legal.</summary>
+    private bool HandleQuote()
+    {
+        ref var top = ref _stack[_depth - 1];
+        switch (top.Kind)
+        {
+            case FK.Str:
+                if (top.State == SExpectOpen) { top.State = SContent; return true; }
+                _depth--; return PostValue();                          // SContent → close
+            case FK.StrEnum:
+                if (top.State == SeExpectOpen) { top.State = SeMatch; return true; }
+                if (!AnyComplete(top.Node!.Literals!, top.Cand, top.MatchLen)) return false;
+                _depth--; return PostValue();                          // SeMatch (complete) → close
+            case FK.Array when top.State is AExpectItemOrClose or AExpectItem:
+            {
+                var item = top.Node!.Items!;
+                if (item.Kind != JsonSchemaKind.String) return false;  // only a string item opens on a quote
+                top.State = AExpectCommaOrClose;                       // resume here after the item
+                if (_depth >= MaxDepth) return false;
+                ref var f = ref _stack[_depth++];
+                f = default; f.Node = item;
+                if (item.Literals is not null) { f.Kind = FK.StrEnum; f.State = SeMatch; f.Cand = AllBits(item.Literals.Length); }
+                else { f.Kind = FK.Str; f.State = SContent; }
+                return true;
+            }
+            default:
+                return false;                                          // quote not legal here
+        }
+    }
+
+    /// <summary>Read-only mirror of <see cref="HandleQuote"/>: whether the quote token is a legal
+    /// next token from the current top frame (used by mask pruning).</summary>
+    private bool IsQuoteAccepted()
+    {
+        ref var top = ref _stack[_depth - 1];
+        return top.Kind switch
+        {
+            FK.Str => top.State is SExpectOpen or SContent,
+            FK.StrEnum => top.State == SeExpectOpen
+                          || (top.State == SeMatch && AnyComplete(top.Node!.Literals!, top.Cand, top.MatchLen)),
+            FK.Array => top.State is AExpectItemOrClose or AExpectItem
+                        && top.Node!.Items!.Kind == JsonSchemaKind.String,
+            _ => false,
+        };
+    }
+
+    /// <summary>Byte-walks a raw byte span through the structural automaton. Used for ordinary
+    /// tokens and for the rare trailing bytes after the opening brace.</summary>
+    private bool FeedRawBytes(ReadOnlySpan<byte> bytes)
+    {
+        int i = 0;
+        while (i < bytes.Length)
+        {
+            if (_depth == 0) return false;                 // closed the object but bytes remain
+            ref var top = ref _stack[_depth - 1];
+
+            // A token-level state reached mid-token (e.g. a string value's open quote) means the
+            // remaining bytes belong to a separate token — not legal within one token.
+            if (IsTokenLevel(top)) return false;
+
+            var r = StepByte(ref top, bytes[i]);
+            switch (r)
+            {
+                case Step.Consume: i++; break;
+                case Step.Retry: break;                    // frame pushed/popped; re-evaluate top
+                default: return false;                     // Reject
+            }
+        }
+        return true;
+    }
+
+    private static bool IsTokenLevel(in Frame f) =>
+        (f.Kind == FK.Str) || (f.Kind == FK.StrEnum && f.State == SeExpectOpen);
+
+    private enum Step { Consume, Retry, Reject }
+
+    private Step StepByte(ref Frame top, byte b)
+    {
+        switch (top.Kind)
+        {
+            case FK.Object: return StepObject(ref top, b);
+            case FK.Array: return StepArray(ref top, b);
+            case FK.Num: return StepNum(ref top, b);
+            case FK.Lit: return StepLit(ref top, b);
+            case FK.StrEnum: return StepStrEnum(ref top, b);   // SeMatch only reaches here
+            default: return Step.Reject;
+        }
+    }
+
+    private static bool IsWs(byte b) => b is (byte)' ' or (byte)'\t' or (byte)'\n' or (byte)'\r';
+
+    // After a value frame pops, resume the parent (object/array) at its post-value state.
+    private bool PostValue()
+    {
+        if (_depth == 0) return true;                      // top-level value (shouldn't happen here)
+        ref var parent = ref _stack[_depth - 1];
+        if (parent.Kind == FK.Object) { parent.State = OExpectCommaOrClose; return true; }
+        if (parent.Kind == FK.Array) { parent.State = AExpectCommaOrClose; return true; }
+        return false;
+    }
+
+    private Step StepObject(ref Frame f, byte b)
+    {
+        var obj = f.Obj!;
+        switch (f.State)
+        {
+            case OExpectOpenBrace:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'{') { f.State = OExpectKeyOrClose; return Step.Consume; }
+                return Step.Reject;
+
+            case OExpectKeyOrClose:
+            case OExpectKey:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'}' && f.State == OExpectKeyOrClose)
+                {
+                    if ((f.Emitted & obj.RequiredMask) != obj.RequiredMask) return Step.Reject;
+                    _depth--; return PostValueOrDone();
+                }
+                // Begin matching a not-yet-emitted key whose first byte == b.
+                ulong cand = 0;
+                for (int i = 0; i < obj.Count; i++)
+                    if ((f.Emitted & (1UL << i)) == 0 && obj.KeyBytes[i].Length > 0 && obj.KeyBytes[i][0] == b)
+                        cand |= 1UL << i;
+                if (cand == 0) return Step.Reject;
+                f.Cand = cand; f.MatchLen = 1; f.State = OMatchKey;
+                return Step.Consume;
+
+            case OMatchKey:
+            {
+                // Continue matching candidate keys.
+                ulong narrowed = 0;
+                for (int i = 0; i < obj.Count; i++)
+                    if ((f.Cand & (1UL << i)) != 0 && obj.KeyBytes[i].Length > f.MatchLen && obj.KeyBytes[i][f.MatchLen] == b)
+                        narrowed |= 1UL << i;
+                if (narrowed != 0) { f.Cand = narrowed; f.MatchLen++; return Step.Consume; }
+
+                // b doesn't continue any candidate: a completed key + ':' finalizes; ws waits.
+                int complete = CompleteIndex(obj.KeyBytes, f.Cand, f.MatchLen);
+                if (IsWs(b)) return complete >= 0 ? Step.Consume : Step.Reject;
+                if (b == (byte)':' && complete >= 0)
+                {
+                    f.Emitted |= 1UL << complete;
+                    f.State = OExpectCommaOrClose;          // resume here after the value
+                    return PushValue(obj.Values[complete]) ? Step.Consume : Step.Reject;
+                }
+                return Step.Reject;
+            }
+
+            case OExpectCommaOrClose:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)',') { f.State = OExpectKey; return Step.Consume; }
+                if (b == (byte)'}')
+                {
+                    if ((f.Emitted & obj.RequiredMask) != obj.RequiredMask) return Step.Reject;
+                    _depth--; return PostValueOrDone();
+                }
+                return Step.Reject;
+
+            default:
+                return Step.Reject;
+        }
+    }
+
+    // Object frame popped: either the whole call is done (depth 0) or it was a nested value.
+    private Step PostValueOrDone()
+    {
+        if (_depth == 0) return Step.Consume;               // top-level object done
+        return PostValue() ? Step.Consume : Step.Reject;
+    }
+
+    private Step StepArray(ref Frame f, byte b)
+    {
+        var item = f.Node!.Items!;
+        switch (f.State)
+        {
+            case AExpectOpen:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'[') { f.State = AExpectItemOrClose; return Step.Consume; }
+                return Step.Reject;
+
+            case AExpectItemOrClose:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)']') { _depth--; return PostValueOrDone(); }
+                f.State = AExpectCommaOrClose;              // resume here after the item
+                return PushValue(item) ? Step.Retry : Step.Reject;
+
+            case AExpectCommaOrClose:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)',') { f.State = AExpectItem; return Step.Consume; }
+                if (b == (byte)']') { _depth--; return PostValueOrDone(); }
+                return Step.Reject;
+
+            case AExpectItem:
+                if (IsWs(b)) return Step.Consume;
+                f.State = AExpectCommaOrClose;
+                return PushValue(item) ? Step.Retry : Step.Reject;
+
+            default:
+                return Step.Reject;
+        }
+    }
+
+    private Step StepNum(ref Frame f, byte b)
+    {
+        bool digit = b is >= (byte)'0' and <= (byte)'9';
+        switch (f.State)
+        {
+            case NStart:
+                if (b == (byte)'-' && !f.SeenSign) { f.SeenSign = true; return Step.Consume; }
+                if (digit) { f.SeenDigit = true; f.State = NIntDigits; return Step.Consume; }
+                return Step.Reject;
+            case NIntDigits:
+                if (digit) return Step.Consume;
+                if (b == (byte)'.' && !f.Node!.IntegerOnly && !f.SeenDot) { f.SeenDot = true; f.State = NFracStart; return Step.Consume; }
+                if (f.SeenDigit) { _depth--; return PostValueRetry(); }   // number ended — parent handles b
+                return Step.Reject;
+            case NFracStart:
+                if (digit) { f.State = NFracDigits; return Step.Consume; }
+                return Step.Reject;
+            case NFracDigits:
+                if (digit) return Step.Consume;
+                _depth--; return PostValueRetry();
+            default:
+                return Step.Reject;
+        }
+    }
+
+    // A bare value (number / literal) ends without consuming its delimiter; pop and let the parent
+    // re-process the current byte.
+    private Step PostValueRetry() => PostValue() ? Step.Retry : Step.Reject;
+
+    private Step StepLit(ref Frame f, byte b)
+    {
+        var lits = f.Node!.Literals!;
+        // If a candidate is already complete and b doesn't continue any, the literal is done.
+        ulong narrowed = 0;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen && lits[i][f.MatchLen] == b)
+                narrowed |= 1UL << i;
+        if (narrowed != 0) { f.Cand = narrowed; f.MatchLen++; return Step.Consume; }
+        if (CompleteIndex(lits, f.Cand, f.MatchLen) >= 0) { _depth--; return PostValueRetry(); }
+        return Step.Reject;
+    }
+
+    private Step StepStrEnum(ref Frame f, byte b)
+    {
+        // SeMatch byte content: narrow the enum candidates.
+        var lits = f.Node!.Literals!;
+        ulong narrowed = 0;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen && lits[i][f.MatchLen] == b)
+                narrowed |= 1UL << i;
+        if (narrowed == 0) return Step.Reject;
+        f.Cand = narrowed; f.MatchLen++; return Step.Consume;
+    }
+
+    // ── First-byte collection (mask pruning) ──────────────────────────────────
+
+    /// <summary>Marks every byte that could legally start the next token from frame
+    /// <paramref name="d"/>, following pop-through for bare values. Returns whether the quote token
+    /// is also a legal next token (string-enum close).</summary>
+    private bool CollectFirstBytes(int d, bool[] set)
+    {
+        bool quote = false;
+        while (d >= 0)
+        {
+            ref var f = ref _stack[d];
+            bool popThrough = false;
+            switch (f.Kind)
+            {
+                case FK.Object:
+                    popThrough = CollectObject(ref f, set);
+                    break;
+                case FK.Array:
+                    popThrough = CollectArray(ref f, set);
+                    break;
+                case FK.Num:
+                    popThrough = CollectNum(ref f, set);
+                    break;
+                case FK.Lit:
+                    popThrough = CollectLit(ref f, set);
+                    break;
+                case FK.StrEnum:
+                    // SeMatch: enum content bytes continue; quote closes if a candidate is complete.
+                    CollectStrEnum(ref f, set, ref quote);
+                    popThrough = false;
+                    break;
+            }
+            if (!popThrough) break;
+            d--;                                            // bare value can end here — parent's bytes also start a token
+        }
+        return quote;
+    }
+
+    private static bool CollectObject(ref Frame f, bool[] set)
+    {
+        var obj = f.Obj!;
+        switch (f.State)
+        {
+            case OExpectOpenBrace:
+                MarkWs(set);
+                set['{'] = true;
+                return false;
+            case OExpectKeyOrClose:
+            case OExpectKey:
+                MarkWs(set);
+                if (f.State == OExpectKeyOrClose && (f.Emitted & obj.RequiredMask) == obj.RequiredMask)
+                    set['}'] = true;
+                for (int i = 0; i < obj.Count; i++)
+                    if ((f.Emitted & (1UL << i)) == 0 && obj.KeyBytes[i].Length > 0)
+                        set[obj.KeyBytes[i][0]] = true;
+                return false;
+            case OMatchKey:
+                MarkWs(set);
+                for (int i = 0; i < obj.Count; i++)
+                    if ((f.Cand & (1UL << i)) != 0 && obj.KeyBytes[i].Length > f.MatchLen)
+                        set[obj.KeyBytes[i][f.MatchLen]] = true;
+                if (CompleteIndex(obj.KeyBytes, f.Cand, f.MatchLen) >= 0) set[':'] = true;
+                return false;
+            case OExpectCommaOrClose:
+                MarkWs(set);
+                set[','] = true;
+                if ((f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static bool CollectArray(ref Frame f, bool[] set)
+    {
+        switch (f.State)
+        {
+            case AExpectOpen: MarkWs(set); set['['] = true; return false;
+            case AExpectItemOrClose:
+                MarkWs(set); set[']'] = true;
+                // An item value starts next — mark its possible first bytes via a probe push.
+                MarkValueFirstBytes(f.Node!.Items!, set);
+                return false;
+            case AExpectCommaOrClose: MarkWs(set); set[','] = true; set[']'] = true; return false;
+            case AExpectItem: MarkWs(set); MarkValueFirstBytes(f.Node!.Items!, set); return false;
+            default: return false;
+        }
+    }
+
+    private static bool CollectNum(ref Frame f, bool[] set)
+    {
+        switch (f.State)
+        {
+            case NStart:
+                if (!f.SeenSign) set['-'] = true;
+                MarkDigits(set);
+                return false;
+            case NIntDigits:
+                MarkDigits(set);
+                if (!f.SeenDot && !f.Node!.IntegerOnly) set['.'] = true;
+                return f.SeenDigit;                          // can end → parent bytes also start tokens
+            case NFracStart:
+                MarkDigits(set);
+                return false;
+            case NFracDigits:
+                MarkDigits(set);
+                return true;                                 // can end
+            default:
+                return false;
+        }
+    }
+
+    private static bool CollectLit(ref Frame f, bool[] set)
+    {
+        var lits = f.Node!.Literals!;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen)
+                set[lits[i][f.MatchLen]] = true;
+        return CompleteIndex(lits, f.Cand, f.MatchLen) >= 0;
+    }
+
+    private static void CollectStrEnum(ref Frame f, bool[] set, ref bool quote)
+    {
+        var lits = f.Node!.Literals!;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen)
+                set[lits[i][f.MatchLen]] = true;
+        if (AnyComplete(lits, f.Cand, f.MatchLen)) quote = true;
+    }
+
+    /// <summary>Marks the possible first bytes of a value node (for array item pruning) by
+    /// inspecting the node type — a read-only sibling of <see cref="PushValue"/>.</summary>
+    private static void MarkValueFirstBytes(CompiledNode node, bool[] set)
+    {
+        switch (node.Kind)
+        {
+            case JsonSchemaKind.Array: set['['] = true; break;
+            case JsonSchemaKind.Object: set['{'] = true; break;
+            case JsonSchemaKind.String: break;             // opens with the quote token, not a byte
+            default:
+                if (node.Literals is { } lits)
+                    foreach (var l in lits) { if (l.Length > 0) set[l[0]] = true; }
+                else { set['-'] = true; MarkDigits(set); }
+                break;
+        }
+    }
+
+    private static void MarkDigits(bool[] set) { for (byte b = (byte)'0'; b <= (byte)'9'; b++) set[b] = true; }
+    private static void MarkWs(bool[] set) { set[' '] = true; set['\t'] = true; set['\n'] = true; set['\r'] = true; }
+
+    // ── Small helpers ─────────────────────────────────────────────────────────
+
+    private static int CompleteIndex(byte[][] lits, ulong cand, int matchLen)
+    {
+        for (int i = 0; i < lits.Length; i++)
+            if ((cand & (1UL << i)) != 0 && lits[i].Length == matchLen) return i;
+        return -1;
+    }
+
+    private static bool AnyComplete(byte[][] lits, ulong cand, int matchLen) => CompleteIndex(lits, cand, matchLen) >= 0;
+}

--- a/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
@@ -147,9 +147,15 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
 
     // ── Compilation ───────────────────────────────────────────────────────────
 
-    private static CompiledObject? TryCompileObject(ToolSchemaObject obj)
+    private static CompiledObject? TryCompileObject(ToolSchemaObject obj) => TryCompileObject(obj, 0);
+
+    // Depth-capped so compilation can't recurse unbounded — the parser already caps nesting, but the
+    // ToolSchema records are public, so a caller that builds a deeply-nested schema in-memory (not via
+    // the parser) would otherwise risk an uncatchable StackOverflow. Past the cap the tool is simply
+    // treated as non-constrainable (null), matching the "loosely-typed → unconstrained" contract.
+    private static CompiledObject? TryCompileObject(ToolSchemaObject obj, int depth)
     {
-        if (obj.Open || obj.Properties.Count is 0 or > 64) return null;
+        if (depth >= MaxDepth || obj.Open || obj.Properties.Count is 0 or > 64) return null;
         var keys = new byte[obj.Properties.Count][];
         var values = new CompiledNode[obj.Properties.Count];
         ulong reqMask = 0;
@@ -158,7 +164,7 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
             var p = obj.Properties[i];
             if (p.Name.Length == 0) return null;
             keys[i] = ToolSchema.Utf8(p.Name);
-            var node = TryCompileNode(p.Value);
+            var node = TryCompileNode(p.Value, depth + 1);
             if (node is null) return null;                  // a non-constrainable value → skip the tool
             values[i] = node;
             if (p.Required) reqMask |= 1UL << i;
@@ -169,8 +175,9 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
     private static readonly byte[][] s_boolLiterals = [ToolSchema.Utf8("true"), ToolSchema.Utf8("false")];
     private static readonly byte[][] s_nullLiterals = [ToolSchema.Utf8("null")];
 
-    private static CompiledNode? TryCompileNode(ToolSchemaNode node)
+    private static CompiledNode? TryCompileNode(ToolSchemaNode node, int depth)
     {
+        if (depth >= MaxDepth) return null;
         switch (node.Kind)
         {
             case JsonSchemaKind.String:
@@ -197,12 +204,12 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
             case JsonSchemaKind.Array:
                 // An untyped array (no items) isn't fully constrainable — skip the tool.
                 if (node.Items is null) return null;
-                var item = TryCompileNode(node.Items);
+                var item = TryCompileNode(node.Items, depth + 1);
                 return item is null ? null : new CompiledNode { Kind = JsonSchemaKind.Array, Items = item };
 
             case JsonSchemaKind.Object:
                 if (node.Object is null) return null;
-                var obj = TryCompileObject(node.Object);
+                var obj = TryCompileObject(node.Object, depth + 1);
                 return obj is null ? null : new CompiledNode { Kind = JsonSchemaKind.Object, Object = obj };
 
             default:
@@ -450,12 +457,13 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
         if ((top.Kind == FK.Str && top.State == SExpectOpen)
             || (top.Kind == FK.StrEnum && top.State == SeExpectOpen))
         {
-            for (int id = 0; id < buf.Length; id++)
-            {
-                if (id == _quoteId) kept++;
-                else buf[id] = float.NegativeInfinity;
-            }
-            return kept;
+            // Only the opening quote is legal — blanket -inf then restore the quote logit (faster
+            // than a branchy per-id loop over the 262k vocab).
+            float quoteLogit = (uint)_quoteId < (uint)buf.Length ? buf[_quoteId] : float.NegativeInfinity;
+            Array.Fill(buf, float.NegativeInfinity);
+            if (float.IsNegativeInfinity(quoteLogit)) return 0;
+            buf[_quoteId] = quoteLogit;
+            return 1;
         }
 
         // General path: prune by allowed first byte, then full-simulate the survivors. The quote
@@ -482,10 +490,13 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
 
     private bool SimulateToken(int token)
     {
+        // Save/restore the active frames around a trial replay. _depth is tiny (1–3 in practice), and
+        // this runs for every surviving candidate token, so a manual copy beats Array.Copy's per-call
+        // overhead.
         int savedDepth = _depth;
-        Array.Copy(_stack, _scratch, _depth);
+        for (int i = 0; i < savedDepth; i++) _scratch[i] = _stack[i];
         bool ok = RunToken(token);
-        Array.Copy(_scratch, _stack, savedDepth);
+        for (int i = 0; i < savedDepth; i++) _stack[i] = _scratch[i];
         _depth = savedDepth;
         return ok;
     }

--- a/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
@@ -104,6 +104,16 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
                 if (compiled is not null) _tools[t.Name] = compiled;
             }
         }
+        else if (tools.Count > 0)
+        {
+            // The caller asked for a constraint (tools present) but this vocabulary doesn't define
+            // Gemma's structural tokens — the constraint is inert. Surface it once so an operator who
+            // enabled SHARPI_TOOL_GRAMMAR on a non-Gemma / mistokenized model isn't left wondering
+            // why arguments are still unconstrained.
+            WarnOnce("no-structural-tokens",
+                "structural tokens <|tool_call> / <|\"|> not found in this vocabulary — tool-grammar is "
+                + "inert for this model (arguments generate unconstrained).");
+        }
 
         // Names we can safely engage on the instant the model finishes typing them (before the '{'),
         // so a merged "{}" token can't slip an empty argument object past the constraint. A name that
@@ -310,6 +320,14 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
         if (IsConstraining)
         {
             bool ok = RunToken(token);
+            // Under both greedy and temperature sampling the engine draws from the masked logits, so
+            // a permitted token must replay cleanly. A rejection here is an invariant violation (a
+            // Filter/Accept divergence — e.g. a mask-vs-simulate bug), distinct from the normal
+            // end-of-object transition (ok && _depth == 0). Flag it once; either way, stop constraining.
+            if (!ok)
+                WarnOnce("accept-divergence",
+                    "a sampled token permitted by the mask was rejected by the grammar — constraint "
+                    + "disabled for the rest of this call (possible Filter/Accept divergence).");
             if (!ok || _depth == 0) { _depth = 0; _armed = false; _nameBuf.Clear(); }
             return;
         }
@@ -375,9 +393,16 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
         PushObject(obj);     // starts in OExpectKeyOrClose (already past '{')
 
         // Rare: the '{' token carried trailing argument bytes (e.g. "{location"). Replay them now;
-        // if they don't fit the grammar, abandon constraining rather than wedge generation.
+        // if they don't fit the grammar, abandon constraining rather than wedge generation. (The
+        // early-engage path avoids this entirely for prefix-unambiguous tool names; a name that's a
+        // prefix of another tool relies on this replay, so surface a failure once.)
         if (!trailing.IsEmpty && !FeedRawBytes(trailing))
+        {
             _depth = 0;
+            WarnOnce($"trailing-replay:{name}",
+                $"could not replay argument bytes after '{{' for tool '{name}' — arguments generate "
+                + "unconstrained for this call.");
+        }
     }
 
     public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
@@ -389,8 +414,19 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
         logits.CopyTo(masked);
 
         int allowedCount = ComputeMask(masked);
-        // Dead state (no legal token): leave logits untouched so generation never wedges.
-        return allowedCount == 0 ? logits : masked;
+        // Dead state (no legal token): leave logits untouched so generation never wedges. A valid
+        // grammar state always has at least one legal token (a key, '}', a value byte, or free
+        // content), so reaching zero indicates the model is at an off-schema point OR a grammar bug —
+        // either way the call continues unconstrained, so flag it once rather than fail silently.
+        if (allowedCount == 0)
+        {
+            ref var top = ref _stack[_depth - 1];
+            WarnOnce($"dead-state:{top.Kind}:{top.State}",
+                $"grammar reached a dead state (no legal token) at kind={top.Kind} state={top.State} "
+                + "— tool arguments continue unconstrained from here.");
+            return logits;
+        }
+        return masked;
     }
 
     /// <summary>Sets every forbidden token to -inf in <paramref name="buf"/>; returns the count kept.</summary>
@@ -403,13 +439,13 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
         // per-token byte simulation for speed.
         if (top.Kind == FK.Str && top.State == SContent)
         {
-            // Any non-forbidden token stays in content; the quote token closes. Forbid only EOG.
-            for (int id = 0; id < buf.Length; id++)
-            {
-                if (_forbidden.Contains(id)) { buf[id] = float.NegativeInfinity; }
-                else kept++;
-            }
-            return kept;
+            // Any non-forbidden token stays in content; the quote token closes. Forbid only EOG —
+            // a tiny set, so mask those ids directly rather than testing all 262k tokens against it.
+            int forbidden = 0;
+            foreach (int id in _forbidden)
+                if ((uint)id < (uint)buf.Length && !float.IsNegativeInfinity(buf[id]))
+                { buf[id] = float.NegativeInfinity; forbidden++; }
+            return buf.Length - forbidden;
         }
         if ((top.Kind == FK.Str && top.State == SExpectOpen)
             || (top.Kind == FK.StrEnum && top.State == SeExpectOpen))
@@ -902,4 +938,16 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
     }
 
     private static bool AnyComplete(byte[][] lits, ulong cand, int matchLen) => CompleteIndex(lits, cand, matchLen) >= 0;
+
+    // One diagnostic per distinct event per process (mirrors JinjaChatTemplate.WarnUnsupportedOnce):
+    // Console.Error is the only channel from this dependency-free Core type, deduped so a recurring
+    // condition can't spam the decode loop. Used for the otherwise-silent degradation paths — an
+    // opt-in best-effort feature must never wedge generation, but a *silent* no-op defeats the point
+    // of enabling it, so each abandonment leaves exactly one breadcrumb.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> s_warned = new();
+    private static void WarnOnce(string key, string message)
+    {
+        if (s_warned.TryAdd(key, 0))
+            Console.Error.WriteLine($"[SharpInference.ToolGrammar] {message}");
+    }
 }

--- a/src/SharpInference.Core/Grammar/ITokenConstraint.cs
+++ b/src/SharpInference.Core/Grammar/ITokenConstraint.cs
@@ -1,0 +1,101 @@
+using System.Collections.Immutable;
+using System.Text;
+
+namespace SharpInference.Core.Grammar;
+
+/// <summary>
+/// A per-request decoding constraint (issue #374). Observes the emitted token stream and, while a
+/// constrained region is active, restricts which tokens may be sampled next so the output is forced
+/// to satisfy a grammar (e.g. a tool call's argument object in the model's native wire syntax).
+///
+/// <para>
+/// Lifecycle, per generated token: the engine calls <see cref="Accept"/> for <b>every</b> emitted
+/// token (so the constraint can detect when a constrained region begins/ends), and — only while
+/// <see cref="IsConstraining"/> is true — calls <see cref="Filter"/> on the logits just before
+/// sampling to mask the tokens the grammar forbids. When <see cref="IsConstraining"/> is false the
+/// engine samples exactly as it would unconstrained, so a request whose generation never enters a
+/// constrained region is byte-identical to the default path.
+/// </para>
+///
+/// <para>Implementations are single-request (the engine serializes generation) and must be
+/// allocation-free on the per-token hot path after a one-time warm-up.</para>
+/// </summary>
+public interface ITokenConstraint
+{
+    /// <summary>
+    /// True when the constraint is currently restricting the vocabulary. The engine applies
+    /// <see cref="Filter"/> only when this is true; otherwise it samples unmasked.
+    /// </summary>
+    bool IsConstraining { get; }
+
+    /// <summary>
+    /// Returns a masked view of <paramref name="logits"/> for the current constrained state: every
+    /// token the grammar forbids is set to negative infinity, leaving the allowed tokens untouched
+    /// so the sampler's downstream pipeline (greedy/temperature/top-k/…) selects only a grammar-legal
+    /// token. The returned span is owned by the constraint and reused across calls — sample from it
+    /// immediately. Only valid to call when <see cref="IsConstraining"/> is true. If the grammar
+    /// reaches a dead state (no legal token), returns <paramref name="logits"/> unchanged so
+    /// generation never wedges.
+    /// </summary>
+    ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits);
+
+    /// <summary>Advance the constraint state by the chosen/emitted token id.</summary>
+    void Accept(int token);
+
+    /// <summary>Reset to the initial (watching) state so the instance can serve a fresh request.</summary>
+    void Reset();
+}
+
+/// <summary>
+/// Read-only view over a model's vocabulary tailored for grammar matching (issue #374): the raw
+/// per-token UTF-8 bytes (built lazily and cached), structural special-token id lookup, and the
+/// end-of-generation id set. Built once per loaded model and shared by every per-request constraint;
+/// the expensive full-vocab byte table is materialised only on first use, so a server that never
+/// enables tool-grammar pays nothing.
+/// </summary>
+public sealed class GrammarVocabulary
+{
+    private readonly ITokenizer _tokenizer;
+    private byte[][]? _tokenBytes;   // lazily built [VocabSize][] of each token's raw bytes
+    private readonly object _buildLock = new();
+
+    public GrammarVocabulary(ITokenizer tokenizer)
+    {
+        ArgumentNullException.ThrowIfNull(tokenizer);
+        _tokenizer = tokenizer;
+        VocabSize = tokenizer.VocabSize;
+    }
+
+    public int VocabSize { get; }
+
+    /// <summary>EOG/EOS token ids — forbidden inside a constrained region (would truncate the call).</summary>
+    public ImmutableArray<int> EogTokenIds => _tokenizer.EogTokenIds;
+
+    /// <summary>Resolve a structural special-token string (e.g. <c>&lt;|"|&gt;</c>) to its vocab id.</summary>
+    public bool TryGetSpecialToken(string name, out int id) =>
+        _tokenizer.SpecialTokens.TryGetValue(name, out id);
+
+    /// <summary>
+    /// The raw UTF-8 bytes a token contributes to the output stream (exactly what
+    /// <see cref="ITokenizer.DecodeBytes"/> returns). Backed by a cache built on first call;
+    /// subsequent calls are allocation-free lookups. Out-of-range ids return an empty span.
+    /// </summary>
+    public ReadOnlySpan<byte> TokenBytes(int id)
+    {
+        var table = _tokenBytes ?? BuildTable();
+        return (uint)id < (uint)table.Length ? table[id] : default;
+    }
+
+    private byte[][] BuildTable()
+    {
+        lock (_buildLock)
+        {
+            if (_tokenBytes is { } existing) return existing;
+            var table = new byte[VocabSize][];
+            for (int i = 0; i < VocabSize; i++)
+                table[i] = _tokenizer.DecodeBytes(i) ?? [];
+            _tokenBytes = table;
+            return table;
+        }
+    }
+}

--- a/src/SharpInference.Core/Grammar/ToolSchema.cs
+++ b/src/SharpInference.Core/Grammar/ToolSchema.cs
@@ -1,0 +1,211 @@
+using System.Text;
+using System.Text.Json;
+
+namespace SharpInference.Core.Grammar;
+
+/// <summary>
+/// The JSON-Schema value kinds a tool argument can take. Mirrors the <c>type</c> keyword of a
+/// JSON Schema; <see cref="Any"/> is the fallback for a missing/unknown/union type (the grammar
+/// leaves such values structurally permissive rather than forbidding generation).
+/// </summary>
+public enum JsonSchemaKind
+{
+    Any = 0,
+    String,
+    Number,
+    Integer,
+    Boolean,
+    Null,
+    Array,
+    Object,
+}
+
+/// <summary>
+/// A value-type descriptor parsed from one JSON-Schema node (recursive). Carries just the
+/// facets the argument grammar enforces: the <see cref="Kind"/>, an optional restricted
+/// <see cref="EnumValues"/> set, the element type for arrays (<see cref="Items"/>), and the
+/// nested shape for objects (<see cref="Object"/>). Free-form facets (descriptions, min/max,
+/// pattern, …) are intentionally dropped — the grammar constrains structure, not content.
+/// </summary>
+public sealed class ToolSchemaNode
+{
+    public JsonSchemaKind Kind { get; }
+
+    /// <summary>
+    /// When non-null, the value is restricted to exactly these rendered token strings (a JSON
+    /// Schema <c>enum</c>). For a <see cref="JsonSchemaKind.String"/> node each entry is the raw
+    /// string (emitted inside the <c>&lt;|"|&gt;</c> quotes); for non-string kinds each entry is the
+    /// bare literal (e.g. a number). Capped at 64 entries (the constraint's bitmask width); a larger
+    /// enum degrades to an unrestricted value of the same kind.
+    /// </summary>
+    public IReadOnlyList<string>? EnumValues { get; }
+
+    /// <summary>Element type for <see cref="JsonSchemaKind.Array"/>; null = unconstrained elements.</summary>
+    public ToolSchemaNode? Items { get; }
+
+    /// <summary>Nested shape for <see cref="JsonSchemaKind.Object"/>; null = unconstrained object body.</summary>
+    public ToolSchemaObject? Object { get; }
+
+    public ToolSchemaNode(
+        JsonSchemaKind kind,
+        IReadOnlyList<string>? enumValues = null,
+        ToolSchemaNode? items = null,
+        ToolSchemaObject? @object = null)
+    {
+        Kind = kind;
+        EnumValues = enumValues is { Count: > 0 and <= 64 } ? enumValues : null;
+        Items = items;
+        Object = @object;
+    }
+
+    /// <summary>A fully-unconstrained value (any well-formed shape). Shared singleton.</summary>
+    public static ToolSchemaNode Any { get; } = new(JsonSchemaKind.Any);
+}
+
+/// <summary>One declared property of an object: its name, value type, and whether it is required.</summary>
+public sealed record ToolSchemaProperty(string Name, ToolSchemaNode Value, bool Required);
+
+/// <summary>
+/// The parsed shape of an object: its ordered declared <see cref="Properties"/>. When
+/// <see cref="Open"/> is true the object body is left unconstrained (no declared properties, or an
+/// explicit <c>additionalProperties: true</c>) — the grammar then only balances braces rather than
+/// restricting keys. Property count is capped at 64 (the constraint's key bitmask width); a wider
+/// object falls back to <see cref="Open"/>.
+/// </summary>
+public sealed class ToolSchemaObject
+{
+    public IReadOnlyList<ToolSchemaProperty> Properties { get; }
+
+    /// <summary>Object body is unconstrained (balance braces only, accept any keys/values).</summary>
+    public bool Open { get; }
+
+    public ToolSchemaObject(IReadOnlyList<ToolSchemaProperty> properties, bool open)
+    {
+        Properties = properties;
+        Open = open || properties.Count is 0 or > 64;
+    }
+}
+
+/// <summary>
+/// A tool's name plus the parsed shape of its argument object. Produced by
+/// <see cref="FromOpenAiFunction"/> from an OpenAI-style function definition and consumed by an
+/// architecture's argument-grammar builder (see
+/// <see cref="IToolCallAdapter.BuildArgumentConstraint"/>).
+/// </summary>
+public sealed record ToolSchema(string Name, ToolSchemaObject Arguments)
+{
+    /// <summary>
+    /// Parses a tool's <c>parameters</c> JSON-Schema object into a <see cref="ToolSchema"/>. A null /
+    /// non-object / malformed schema yields an <see cref="ToolSchemaObject.Open"/> argument object
+    /// (the grammar then constrains nothing for that tool — never blocks generation).
+    /// </summary>
+    public static ToolSchema FromOpenAiFunction(string name, JsonElement? parameters)
+    {
+        if (parameters is not { ValueKind: JsonValueKind.Object } p)
+            return new ToolSchema(name, new ToolSchemaObject([], open: true));
+        return new ToolSchema(name, ParseObject(p));
+    }
+
+    private static ToolSchemaObject ParseObject(JsonElement schema)
+    {
+        var required = new HashSet<string>(StringComparer.Ordinal);
+        if (schema.TryGetProperty("required", out var req) && req.ValueKind == JsonValueKind.Array)
+            foreach (var r in req.EnumerateArray())
+                if (r.ValueKind == JsonValueKind.String && r.GetString() is { } s)
+                    required.Add(s);
+
+        bool open = false;
+        if (schema.TryGetProperty("additionalProperties", out var ap) && ap.ValueKind == JsonValueKind.True)
+            open = true;
+
+        var props = new List<ToolSchemaProperty>();
+        if (schema.TryGetProperty("properties", out var properties)
+            && properties.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var prop in properties.EnumerateObject())
+            {
+                var node = ParseNode(prop.Value);
+                props.Add(new ToolSchemaProperty(prop.Name, node, required.Contains(prop.Name)));
+            }
+        }
+
+        return new ToolSchemaObject(props, open);
+    }
+
+    private static ToolSchemaNode ParseNode(JsonElement node)
+    {
+        if (node.ValueKind != JsonValueKind.Object)
+            return ToolSchemaNode.Any;
+
+        var kind = ParseKind(node);
+
+        // enum: collect the rendered literal strings. Applies regardless of declared kind.
+        IReadOnlyList<string>? enumValues = null;
+        if (node.TryGetProperty("enum", out var en) && en.ValueKind == JsonValueKind.Array)
+        {
+            var vals = new List<string>();
+            foreach (var e in en.EnumerateArray())
+            {
+                string? rendered = e.ValueKind switch
+                {
+                    JsonValueKind.String => e.GetString(),
+                    JsonValueKind.Number => e.GetRawText(),
+                    JsonValueKind.True => "true",
+                    JsonValueKind.False => "false",
+                    JsonValueKind.Null => "null",
+                    _ => null,
+                };
+                if (rendered is { Length: > 0 }) vals.Add(rendered);
+            }
+            if (vals.Count > 0) enumValues = vals;
+            // A string-typed enum stays String (values are quoted); an untyped enum of strings is
+            // also treated as String so the values render inside the quote token.
+            if (kind == JsonSchemaKind.Any && enumValues is not null
+                && en.EnumerateArray().Any(e => e.ValueKind == JsonValueKind.String))
+                kind = JsonSchemaKind.String;
+        }
+
+        ToolSchemaNode? items = null;
+        if (kind == JsonSchemaKind.Array && node.TryGetProperty("items", out var it))
+            items = ParseNode(it);
+
+        ToolSchemaObject? obj = null;
+        if (kind == JsonSchemaKind.Object)
+            obj = ParseObject(node);
+
+        return new ToolSchemaNode(kind, enumValues, items, obj);
+    }
+
+    private static JsonSchemaKind ParseKind(JsonElement node)
+    {
+        if (!node.TryGetProperty("type", out var t))
+            return JsonSchemaKind.Any;
+
+        // "type" may be a single string or an array of strings (a union); take the first concrete
+        // entry for a union and leave Any when nothing maps.
+        string? typeStr = t.ValueKind switch
+        {
+            JsonValueKind.String => t.GetString(),
+            JsonValueKind.Array => t.EnumerateArray()
+                                    .Select(e => e.ValueKind == JsonValueKind.String ? e.GetString() : null)
+                                    .FirstOrDefault(s => s is not null and not "null"),
+            _ => null,
+        };
+
+        return typeStr?.ToLowerInvariant() switch
+        {
+            "string" => JsonSchemaKind.String,
+            "number" => JsonSchemaKind.Number,
+            "integer" => JsonSchemaKind.Integer,
+            "boolean" => JsonSchemaKind.Boolean,
+            "null" => JsonSchemaKind.Null,
+            "array" => JsonSchemaKind.Array,
+            "object" => JsonSchemaKind.Object,
+            _ => JsonSchemaKind.Any,
+        };
+    }
+
+    /// <summary>UTF-8 bytes of <paramref name="s"/> — small helper used when precomputing literal
+    /// match tables for the constraint.</summary>
+    internal static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+}

--- a/src/SharpInference.Core/Grammar/ToolSchema.cs
+++ b/src/SharpInference.Core/Grammar/ToolSchema.cs
@@ -99,15 +99,24 @@ public sealed record ToolSchema(string Name, ToolSchemaObject Arguments)
     /// non-object / malformed schema yields an <see cref="ToolSchemaObject.Open"/> argument object
     /// (the grammar then constrains nothing for that tool — never blocks generation).
     /// </summary>
+    // Cap on schema nesting parsed. Tool schemas come straight from the request body, so an
+    // adversarially/accidentally deep schema must not blow the stack (a .NET StackOverflow is
+    // uncatchable and crashes the process). Past the cap a node degrades to Any / an open object,
+    // which the constraint leaves unconstrained anyway — no correctness loss for realistic schemas.
+    private const int MaxParseDepth = 32;
+
     public static ToolSchema FromOpenAiFunction(string name, JsonElement? parameters)
     {
         if (parameters is not { ValueKind: JsonValueKind.Object } p)
             return new ToolSchema(name, new ToolSchemaObject([], open: true));
-        return new ToolSchema(name, ParseObject(p));
+        return new ToolSchema(name, ParseObject(p, depth: 0));
     }
 
-    private static ToolSchemaObject ParseObject(JsonElement schema)
+    private static ToolSchemaObject ParseObject(JsonElement schema, int depth)
     {
+        if (depth >= MaxParseDepth)
+            return new ToolSchemaObject([], open: true);   // too deep — treat as unconstrained
+
         var required = new HashSet<string>(StringComparer.Ordinal);
         if (schema.TryGetProperty("required", out var req) && req.ValueKind == JsonValueKind.Array)
             foreach (var r in req.EnumerateArray())
@@ -124,7 +133,7 @@ public sealed record ToolSchema(string Name, ToolSchemaObject Arguments)
         {
             foreach (var prop in properties.EnumerateObject())
             {
-                var node = ParseNode(prop.Value);
+                var node = ParseNode(prop.Value, depth + 1);
                 props.Add(new ToolSchemaProperty(prop.Name, node, required.Contains(prop.Name)));
             }
         }
@@ -132,9 +141,9 @@ public sealed record ToolSchema(string Name, ToolSchemaObject Arguments)
         return new ToolSchemaObject(props, open);
     }
 
-    private static ToolSchemaNode ParseNode(JsonElement node)
+    private static ToolSchemaNode ParseNode(JsonElement node, int depth)
     {
-        if (node.ValueKind != JsonValueKind.Object)
+        if (node.ValueKind != JsonValueKind.Object || depth >= MaxParseDepth)
             return ToolSchemaNode.Any;
 
         var kind = ParseKind(node);
@@ -167,11 +176,11 @@ public sealed record ToolSchema(string Name, ToolSchemaObject Arguments)
 
         ToolSchemaNode? items = null;
         if (kind == JsonSchemaKind.Array && node.TryGetProperty("items", out var it))
-            items = ParseNode(it);
+            items = ParseNode(it, depth + 1);
 
         ToolSchemaObject? obj = null;
         if (kind == JsonSchemaKind.Object)
-            obj = ParseObject(node);
+            obj = ParseObject(node, depth + 1);
 
         return new ToolSchemaNode(kind, enumValues, items, obj);
     }

--- a/src/SharpInference.Core/ITokenizer.cs
+++ b/src/SharpInference.Core/ITokenizer.cs
@@ -40,6 +40,14 @@ public interface ITokenizer
     bool AddBosToken { get; }
 
     /// <summary>
+    /// Special-token name → vocab id map (control / user-defined tokens such as Gemma's
+    /// <c>&lt;|"|&gt;</c>, <c>&lt;|tool_call&gt;</c>). Empty for tokenizers that don't expose one.
+    /// Used by grammar-constrained decoding (issue #374) to resolve a model's structural tokens to
+    /// ids; a vocab-backed tokenizer (<see cref="GgufTokenizer"/>) returns the real map.
+    /// </summary>
+    IReadOnlyDictionary<string, int> SpecialTokens => ImmutableDictionary<string, int>.Empty;
+
+    /// <summary>
     /// The <c>(Open, Close)</c> special-token IDs that bracket this model's reasoning stream, or
     /// <c>(-1, -1)</c> when the vocabulary defines none. An engine uses these to split the
     /// reasoning channel out of the user-facing text stream (boundary tokens themselves are

--- a/src/SharpInference.Core/ToolCallAdapter.cs
+++ b/src/SharpInference.Core/ToolCallAdapter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using SharpInference.Core.Grammar;
 
 namespace SharpInference.Core;
 
@@ -108,6 +109,18 @@ public interface IToolCallAdapter
     /// emitting <c>&lt;end_of_turn&gt;</c>). See issue #304.
     /// </summary>
     IReadOnlyList<string> ToolBoundaryStopMarkers => [];
+
+    /// <summary>
+    /// Builds an optional grammar/FSM constraint (issue #374) that forces this model's tool-call
+    /// <em>arguments</em> to satisfy the supplied schemas, expressed in this adapter's native call
+    /// syntax. Returns <c>null</c> when the family has no constrained-decoding support or no
+    /// constrainable tool was supplied — the engine then samples unconstrained (byte-identical to
+    /// the default path). Each adapter owns its wire format (Gemma's bespoke <c>&lt;|"|&gt;</c> form
+    /// vs Qwen/Llama JSON), so the constraint targets the actual emitted tokens, not generic JSON.
+    /// </summary>
+    /// <param name="tools">The active tool definitions (name + parsed argument schema).</param>
+    /// <param name="vocab">Vocabulary view used to resolve structural tokens and match candidates.</param>
+    ITokenConstraint? BuildArgumentConstraint(IReadOnlyList<ToolSchema> tools, GrammarVocabulary vocab) => null;
 }
 
 /// <summary>
@@ -686,6 +699,18 @@ public sealed class Gemma4ToolCallAdapter : IToolCallAdapter
     /// runs on past the (complete, parseable) tool-call block and hallucinates a trailing turn —
     /// issue #304. The block is left intact because the stop token is consumed, not emitted.</remarks>
     public IReadOnlyList<string> ToolBoundaryStopMarkers => s_toolBoundaryStopMarkers;
+
+    /// <inheritdoc/>
+    /// <remarks>Constrains the argument object of Gemma's native
+    /// <c>&lt;|tool_call&gt;call:NAME{...}&lt;tool_call|&gt;</c> wire format (issue #374). Returns
+    /// null when no supplied tool is fully constrainable (then generation is unconstrained).</remarks>
+    public ITokenConstraint? BuildArgumentConstraint(IReadOnlyList<ToolSchema> tools, GrammarVocabulary vocab)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(vocab);
+        var constraint = new GemmaToolArgumentConstraint(vocab, tools);
+        return constraint.HasConstrainableTools ? constraint : null;
+    }
 
     public ToolCallParseResult Parse(string rawOutput)
     {

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -59,6 +59,10 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     private int _pendingCount;
     private int _activeCount;
 
+    // Set once (Interlocked) the first time a constraint-bearing request is seen, so the
+    // tool-grammar-ignored warning (issue #374) is emitted at most once per engine.
+    private int _warnedConstraintIgnored;
+
     private sealed class PendingRequest(string prompt, SamplingParams sp, CancellationToken ct, Channel<GenerateChunk> output)
     {
         public readonly string Prompt = prompt;
@@ -216,6 +220,18 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         string? canonicalHistoryPrefix = null)
     {
         _ = canonicalHistoryPrefix; // intentionally ignored; see XML remarks
+
+        // Grammar-constrained decoding (issue #374) is not wired into the batched sampler — each
+        // sequence is sampled directly from its logits with no per-token mask/advance. Rather than
+        // silently drop the constraint (the request would generate unconstrained tool arguments with
+        // no signal), warn once so an operator who set SHARPI_TOOL_GRAMMAR alongside SHARPI_MAX_BATCH
+        // knows the two don't yet compose. Single-user InferenceEngine honors the constraint.
+        if (sp.Constraint is not null && Interlocked.Exchange(ref _warnedConstraintIgnored, 1) == 0)
+            Console.Error.WriteLine(
+                "[ContinuousBatchingEngine] tool-grammar constraint is ignored under continuous " +
+                "batching (SHARPI_MAX_BATCH); tool-call arguments will be generated unconstrained. " +
+                "Run without batching to use SHARPI_TOOL_GRAMMAR (issue #374).");
+
         var channel = Channel.CreateUnbounded<GenerateChunk>(
             new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
 

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -721,6 +721,12 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     // PrefillMtp / batched verify don't model that, so never engage MTP here.
                     if (imageBytes is { Count: > 0 }) useMtp = false;
 
+                    // Grammar-constrained decoding (#374) masks logits per token, which the MTP
+                    // batched-verify path doesn't model — fall back to per-token decode so the
+                    // constraint sees and gates every sampled token.
+                    var constraint = sp.Constraint;
+                    if (constraint is not null) { useMtp = false; constraint.Reset(); }
+
                     // --spec-draft-n-max parity with llama.cpp (issue #30): the MTP
                     // draft-chain length per step. Unset (0) resolves via
                     // SHARPI_MTP_DRAFT_N → built-in default; MtpDecoder clamps per
@@ -968,9 +974,12 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                     // argmax on-device, carry just the next token id instead of downloading the full
                     // vocab logits every step. gpuNext holds the argmax of the most recent forward;
                     // the first comes from the prefill logits already on the host.
+                    // A constraint masks logits before sampling, so the device-side argmax fast path
+                    // (which never downloads the full vocab) can't be used while one is attached.
                     bool useGpuArgmax = sp.Temperature <= 0f
                         && _fwd.SupportsGpuArgmax
-                        && sp.LogitBias is not { Count: > 0 };
+                        && sp.LogitBias is not { Count: > 0 }
+                        && constraint is null;
                     int gpuNext = useGpuArgmax ? Sampler.Greedy(logits) : 0;
 
                     for (int i = 0; i < sp.MaxNewTokens; i++)
@@ -993,10 +1002,20 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         }
                         else
                         {
+                            // While the constraint is inside a constrained region, sample from the
+                            // masked logits (grammar-forbidden tokens set to -inf); otherwise sample
+                            // the raw logits exactly as the unconstrained path would.
+                            var sampleLogits = constraint is { IsConstraining: true }
+                                ? constraint.Filter(logits)
+                                : logits;
                             next = sp.Temperature <= 0f
-                                ? Sampler.Greedy(logits)
-                                : Sampler.Sample(logits, sp, rng);
+                                ? Sampler.Greedy(sampleLogits)
+                                : Sampler.Sample(sampleLogits, sp, rng);
                         }
+
+                        // Advance the grammar constraint with the just-chosen token (every token,
+                        // so it can detect a tool-call boundary and begin/end constraining).
+                        constraint?.Accept(next);
 
                         // Record every emitted/consumed token (stop tokens included) so the
                         // post-decode snapshot of _prevTokens reflects the full transcript.

--- a/src/SharpInference.Engine/Sampler.cs
+++ b/src/SharpInference.Engine/Sampler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using SharpInference.Core.Grammar;
 
 namespace SharpInference.Engine;
 
@@ -575,6 +576,21 @@ public sealed record SamplingParams
     /// Typically a sliding window of the last N generated tokens.
     /// </summary>
     public IReadOnlyList<int>? PreviousTokens { get; init; }
+
+    /// <summary>
+    /// Optional grammar/FSM constraint applied during decoding (issue #374). The engine advances it
+    /// with every emitted token and, while it reports <see cref="ITokenConstraint.IsConstraining"/>,
+    /// masks the logits to only the tokens it permits before sampling — forcing e.g. a tool call's
+    /// arguments to satisfy the supplied JSON Schema in the model's native call syntax. The
+    /// constraint is stateful and single-request. <c>null</c> (default) = unconstrained decoding,
+    /// byte-identical to the pre-#374 path.
+    /// <para>
+    /// Honored by the single-user <c>InferenceEngine</c> only. <c>ContinuousBatchingEngine</c>
+    /// (<c>SHARPI_MAX_BATCH</c>) does not yet apply it — it samples each batched sequence directly
+    /// and warns once when a constraint-bearing request is admitted.
+    /// </para>
+    /// </summary>
+    public ITokenConstraint? Constraint { get; init; }
 
     /// <summary>
     /// Maximum thinking-mode tokens before the engine forces a <c>&lt;/think&gt;</c> close.

--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -79,6 +79,15 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     {
         opts.ToolGrammar = true;
     }
+
+    // Config-time conflict surface: tool-grammar (#374) is honored only by the single-user engine,
+    // not continuous batching. Warn at boot — when an operator is watching logs — so the conflict
+    // isn't discovered only via the engine's once-per-process runtime warning.
+    if (opts.ToolGrammar && opts.MaxBatchSize > 1)
+        Console.Error.WriteLine(
+            "[SharpInference] SHARPI_TOOL_GRAMMAR is set together with continuous batching " +
+            "(SHARPI_MAX_BATCH > 1); tool-call argument grammar is NOT applied under batching. " +
+            "Run without batching to use it (issue #374).");
 });
 
 var app = builder.Build();

--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -70,6 +70,15 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     {
         opts.DisableThinking = true;
     }
+
+    // SHARPI_TOOL_GRAMMAR ∈ {1, true} enables schema/grammar-constrained tool-call argument
+    // decoding (issue #374). Off by default → byte-identical to unconstrained decoding.
+    var envToolGrammar = Environment.GetEnvironmentVariable("SHARPI_TOOL_GRAMMAR");
+    if (!string.IsNullOrWhiteSpace(envToolGrammar)
+        && (envToolGrammar == "1" || envToolGrammar.Equals("true", StringComparison.OrdinalIgnoreCase)))
+    {
+        opts.ToolGrammar = true;
+    }
 });
 
 var app = builder.Build();

--- a/src/SharpInference.Server/ChatTemplate.cs
+++ b/src/SharpInference.Server/ChatTemplate.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using SharpInference.Core;
+using SharpInference.Core.Grammar;
 
 namespace SharpInference.Server;
 
@@ -92,6 +93,13 @@ public sealed class ChatTemplateRenderer
     /// </summary>
     public IReadOnlyList<int> ToolBoundaryStopTokenIds { get; private set; } = [];
 
+    /// <summary>
+    /// Vocabulary view for grammar-constrained tool-call decoding (issue #374), set at
+    /// <see cref="Configure"/> time. Null until the model is loaded, or when a custom engine factory
+    /// supplied no vocabulary — <see cref="BuildToolArgumentConstraint"/> then returns null.
+    /// </summary>
+    private GrammarVocabulary? _grammarVocabulary;
+
     /// <param name="architecture">Default architecture (used both for fallback and exposed via <see cref="Architecture"/>).</param>
     /// <param name="template">Optional compiled Jinja template; null means "use the hardcoded fallback".</param>
     public ChatTemplateRenderer(string architecture = "qwen2", JinjaChatTemplate? template = null)
@@ -102,6 +110,19 @@ public sealed class ChatTemplateRenderer
     }
 
     /// <summary>
+    /// Builds an argument-grammar constraint (issue #374) for the active tools using the loaded
+    /// model's adapter + vocabulary, or null when the family has no constraint support, no
+    /// vocabulary is available, or no supplied tool is constrainable. Endpoints attach the result to
+    /// <see cref="Engine.SamplingParams.Constraint"/> on a tool-active request when tool-grammar is
+    /// enabled.
+    /// </summary>
+    public ITokenConstraint? BuildToolArgumentConstraint(IReadOnlyList<ToolSchema> tools)
+    {
+        if (_grammarVocabulary is null || tools.Count == 0) return null;
+        return _toolCallAdapter.BuildArgumentConstraint(tools, _grammarVocabulary);
+    }
+
+    /// <summary>
     /// Reconfigures the renderer with model-specific metadata. Called by the built-in
     /// engine loader once the GGUF file has been opened. Safe to call once; subsequent
     /// calls overwrite previous values (used by hot-reload scenarios).
@@ -109,12 +130,14 @@ public sealed class ChatTemplateRenderer
     /// (see <see cref="ToolBoundaryStopTokenIds"/>); null leaves the set empty.
     /// </summary>
     public void Configure(string architecture, JinjaChatTemplate? template,
-        IReadOnlyList<int>? toolBoundaryStopTokenIds = null)
+        IReadOnlyList<int>? toolBoundaryStopTokenIds = null,
+        GrammarVocabulary? grammarVocabulary = null)
     {
         _architecture = architecture;
         _template = template;
         _toolCallAdapter = ToolCallAdapterRegistry.Get(architecture);
         ToolBoundaryStopTokenIds = toolBoundaryStopTokenIds ?? [];
+        _grammarVocabulary = grammarVocabulary;
     }
 
     /// <param name="messages">Messages in order (system, user, assistant, ...).</param>

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -150,6 +150,15 @@ public static class AnthropicEndpoints
         if (req.Tools is { Length: > 0 } && chatTemplate.ToolBoundaryStopTokenIds is { Count: > 0 } toolStops)
             sp = sp with { AdditionalStopTokenIds = [.. toolStops] };
 
+        // Schema/grammar-constrained tool-argument decoding (issue #374): opt-in. Restricts the
+        // sampler to tokens that keep the arguments schema-conformant in the model's native syntax.
+        if (req.Tools is { Length: > 0 } && ToolGrammarHelper.Enabled(opts))
+        {
+            var schemas = ToolGrammarHelper.ToSchemas(req.Tools.Select(t => (t.Name, t.InputSchema)));
+            if (chatTemplate.BuildToolArgumentConstraint(schemas) is { } constraint)
+                sp = sp with { Constraint = constraint };
+        }
+
         var msgId = $"msg_{Guid.NewGuid():N}";
         var modelId = engine.ModelId;
 

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -158,6 +158,18 @@ public static class OpenAiEndpoints
         if (toolsActive && chatTemplate.ToolBoundaryStopTokenIds is { Count: > 0 } toolStops)
             sp = sp with { AdditionalStopTokenIds = [.. toolStops] };
 
+        // Schema/grammar-constrained tool-argument decoding (issue #374): opt-in, and skipped when
+        // the client forces no tool use (tool_choice:"none"). Restricts the sampler to tokens that
+        // keep the arguments schema-conformant in the model's native call syntax.
+        if (toolsActive && req.Tools is { Length: > 0 } && ToolGrammarHelper.Enabled(opts)
+            && !IsToolChoiceNone(req.ToolChoice))
+        {
+            var schemas = ToolGrammarHelper.ToSchemas(
+                req.Tools.Select(t => (t.Function?.Name, t.Function?.Parameters)));
+            if (chatTemplate.BuildToolArgumentConstraint(schemas) is { } constraint)
+                sp = sp with { Constraint = constraint };
+        }
+
         var requestId = $"chatcmpl-{Guid.NewGuid():N}";
         long created = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
@@ -532,6 +544,12 @@ public static class OpenAiEndpoints
         }
         return sb.ToString();
     }
+
+    /// <summary>True when OpenAI <c>tool_choice</c> is the string <c>"none"</c> (no tool use forced
+    /// off) — the one value for which argument-grammar constraint must not engage.</summary>
+    private static bool IsToolChoiceNone(JsonElement? toolChoice) =>
+        toolChoice is { ValueKind: JsonValueKind.String } tc
+        && string.Equals(tc.GetString(), "none", StringComparison.Ordinal);
 
     private static bool HasToolMessages(OaiMessage[]? messages)
     {

--- a/src/SharpInference.Server/Endpoints/ToolGrammarHelper.cs
+++ b/src/SharpInference.Server/Endpoints/ToolGrammarHelper.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Server.Endpoints;
+
+/// <summary>
+/// Shared plumbing for schema/grammar-constrained tool-call decoding (issue #374): the opt-in gate
+/// and the conversion of an endpoint's wire-format tool definitions into the engine's
+/// <see cref="ToolSchema"/> model. Kept endpoint-agnostic so the OpenAI and Anthropic paths build
+/// the constraint identically.
+/// </summary>
+internal static class ToolGrammarHelper
+{
+    /// <summary>
+    /// Whether grammar-constrained tool decoding is enabled — via the
+    /// <see cref="SharpInferenceServerOptions.ToolGrammar"/> option or the
+    /// <c>SHARPI_TOOL_GRAMMAR=1</c> environment variable (mirrors the SHARPI_* env pattern).
+    /// </summary>
+    public static bool Enabled(SharpInferenceServerOptions opts)
+    {
+        if (opts.ToolGrammar) return true;
+        var env = Environment.GetEnvironmentVariable("SHARPI_TOOL_GRAMMAR");
+        return env is "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Parses (name, JSON-Schema) pairs into <see cref="ToolSchema"/>s, skipping nameless entries.</summary>
+    public static List<ToolSchema> ToSchemas(IEnumerable<(string? Name, JsonElement? Parameters)> tools)
+    {
+        var schemas = new List<ToolSchema>();
+        foreach (var (name, parameters) in tools)
+            if (name is { Length: > 0 })
+                schemas.Add(ToolSchema.FromOpenAiFunction(name, parameters));
+        return schemas;
+    }
+}

--- a/src/SharpInference.Server/InferenceEngineLoader.cs
+++ b/src/SharpInference.Server/InferenceEngineLoader.cs
@@ -178,7 +178,12 @@ public static class InferenceEngineLoader
             throw;
         }
 
-        return new LoadedEngine(engine, arch, tokenizer.ChatTemplate, toolBoundaryStopTokenIds);
+        // Grammar-constrained tool-call decoding (issue #374): expose a vocabulary view built from
+        // the model's tokenizer. The full-vocab byte table inside it is materialised lazily on first
+        // constrained request, so this costs nothing unless tool-grammar is actually used.
+        var grammarVocab = new SharpInference.Core.Grammar.GrammarVocabulary(tokenizer);
+
+        return new LoadedEngine(engine, arch, tokenizer.ChatTemplate, toolBoundaryStopTokenIds, grammarVocab);
     }
 
     // ── Backend dispatch ─────────────────────────────────────────────────────

--- a/src/SharpInference.Server/ServiceCollectionExtensions.cs
+++ b/src/SharpInference.Server/ServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ public static class ServiceCollectionExtensions
             // — important for tests that override IInferenceEngine but expect the
             // renderer to use the safe fallback path.
             sp.GetRequiredService<ChatTemplateRenderer>().Configure(
-                loaded.Architecture, loaded.ChatTemplate, loaded.ToolBoundaryStopTokenIds);
+                loaded.Architecture, loaded.ChatTemplate, loaded.ToolBoundaryStopTokenIds, loaded.Grammar);
 
             return loaded.Engine;
         });

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -26,6 +26,16 @@ public sealed class SharpInferenceServerOptions
     /// </summary>
     public bool DisableThinking { get; set; }
 
+    /// <summary>
+    /// Enable schema/grammar-constrained decoding for tool-call arguments (issue #374). When on and
+    /// a tool-active request is served by a family with constraint support (Gemma 4 today), the
+    /// sampler is restricted to tokens that satisfy the supplied JSON Schema in the model's native
+    /// call syntax — required keys can't be dropped, only declared keys/enum values appear, value
+    /// shapes match the declared type. Default off → byte-identical to unconstrained decoding. Also
+    /// turned on by the <c>SHARPI_TOOL_GRAMMAR=1</c> environment variable.
+    /// </summary>
+    public bool ToolGrammar { get; set; }
+
     // ── Model loading ────────────────────────────────────────────────────────
 
     /// <summary>
@@ -334,8 +344,15 @@ public sealed class SamplingDefaults
 /// The chat endpoints add these to the stop set on tool-active requests so the model halts the
 /// instant it finishes its tool calls (issue #304). Null/empty when the family needs none.
 /// </param>
+/// <param name="Grammar">
+/// Vocabulary view used to build grammar-constrained tool-call decoders (issue #374), or null when
+/// the family has no constraint support. The built-in GGUF loader always supplies one; a custom
+/// <see cref="SharpInferenceServerOptions.EngineFactory"/> may leave it null (tool-grammar then
+/// unavailable for that engine).
+/// </param>
 public sealed record LoadedEngine(
     IInferenceEngine Engine,
     string Architecture,
     SharpInference.Core.JinjaChatTemplate? ChatTemplate,
-    IReadOnlyList<int>? ToolBoundaryStopTokenIds = null);
+    IReadOnlyList<int>? ToolBoundaryStopTokenIds = null,
+    SharpInference.Core.Grammar.GrammarVocabulary? Grammar = null);

--- a/tests/SharpInference.Tests.Core/FakeGemmaTokenizer.cs
+++ b/tests/SharpInference.Tests.Core/FakeGemmaTokenizer.cs
@@ -1,0 +1,72 @@
+using System.Collections.Immutable;
+using System.Text;
+using SharpInference.Core;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// A tiny deterministic tokenizer that mimics the relevant facets of Gemma 4's vocabulary for
+/// model-independent grammar tests (issue #374): the tool-call markers and the <c>&lt;|"|&gt;</c>
+/// quote are single special tokens; every other byte is its own single-char token. This lets the
+/// decode-time conformance tests run in CI without the multi-gigabyte GGUF, while still exercising
+/// the multi-token key/enum matching (each key letter arrives as a separate token).
+/// </summary>
+public sealed class FakeGemmaTokenizer : ITokenizer
+{
+    public const int Pad = 0, Bos = 1, Eos = 2, OpenMarker = 3, CloseMarker = 4, Quote = 5;
+    private const int FirstChar = 6;   // single-char tokens occupy [FirstChar, FirstChar+256)
+
+    private readonly Dictionary<string, int> _specials = new(StringComparer.Ordinal)
+    {
+        ["<|tool_call>"] = OpenMarker,
+        ["<tool_call|>"] = CloseMarker,
+        ["<|\"|>"] = Quote,
+    };
+
+    public int VocabSize => FirstChar + 256;
+    public int BosTokenId => Bos;
+    public int EosTokenId => Eos;
+    public int UnknownTokenId => Pad;
+    public int PadTokenId => Pad;
+    public bool AddBosToken => false;
+    public ImmutableArray<int> EogTokenIds => [Eos];
+    public IReadOnlyDictionary<string, int> SpecialTokens => _specials;
+
+    /// <summary>Token id for a single ASCII byte.</summary>
+    public static int Char(char c) => FirstChar + (byte)c;
+
+    public byte[] DecodeBytes(int token)
+    {
+        if (token == OpenMarker) return Encoding.UTF8.GetBytes("<|tool_call>");
+        if (token == CloseMarker) return Encoding.UTF8.GetBytes("<tool_call|>");
+        if (token == Quote) return Encoding.UTF8.GetBytes("<|\"|>");
+        if (token is Bos or Eos or Pad) return [];
+        if (token >= FirstChar && token < FirstChar + 256) return [(byte)(token - FirstChar)];
+        return [];
+    }
+
+    public IReadOnlyList<int> Encode(string text)
+    {
+        var ids = new List<int>();
+        int i = 0;
+        while (i < text.Length)
+        {
+            int matched = -1, matchLen = 0;
+            foreach (var (s, id) in _specials)
+                if (s.Length > matchLen && i + s.Length <= text.Length
+                    && text.AsSpan(i, s.Length).SequenceEqual(s))
+                { matched = id; matchLen = s.Length; }
+
+            if (matched >= 0) { ids.Add(matched); i += matchLen; }
+            else { ids.Add(Char(text[i])); i++; }
+        }
+        return ids;
+    }
+
+    public string Decode(IEnumerable<int> tokens)
+    {
+        var sb = new StringBuilder();
+        foreach (int t in tokens) sb.Append(Encoding.UTF8.GetString(DecodeBytes(t)));
+        return sb.ToString();
+    }
+}

--- a/tests/SharpInference.Tests.Core/ToolGrammarConstraintTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolGrammarConstraintTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Decode-time conformance for the Gemma 4 tool-argument grammar constraint (issue #374). Drives a
+/// real Gemma vocabulary through the constraint and asserts the per-token mask forbids the exact
+/// failure modes the issue describes (dropped required key, hallucinated <c>queries</c> array,
+/// out-of-enum value). Model-gated — skips when the GGUF is absent.
+/// </summary>
+public sealed class ToolGrammarConstraintTests(ITestOutputHelper output)
+{
+    private const string ModelPath = @"E:\models\gemma-4-12b-it-qat-q4_0.gguf";
+
+    private static GgufTokenizer? Tok()
+    {
+        if (!File.Exists(ModelPath)) return null;
+        var m = GgufModel.Open(ModelPath);
+        return GgufTokenizer.FromGgufModel(m);
+    }
+
+    private static ToolSchema Schema(string name, string parametersJson)
+    {
+        using var doc = JsonDocument.Parse(parametersJson);
+        return ToolSchema.FromOpenAiFunction(name, doc.RootElement.Clone());
+    }
+
+    // Feed every token of `text` into the constraint via Accept.
+    private static void Feed(ITokenConstraint c, GgufTokenizer tok, string text)
+    {
+        foreach (int id in tok.Encode(text)) c.Accept(id);
+    }
+
+    private static bool Allowed(ITokenConstraint c, GgufTokenizer tok, int vocab, int tokenId)
+    {
+        Span<float> logits = new float[vocab];   // all zeros
+        var masked = c.Filter(logits);
+        return !float.IsNegativeInfinity(masked[tokenId]);
+    }
+
+    private static int Id(GgufTokenizer tok, string single)
+    {
+        var ids = tok.Encode(single);
+        Assert.Single(ids);
+        return ids[0];
+    }
+
+    [Fact]
+    public void RequiredKey_CannotBeOmitted()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+
+        var schema = Schema("get_weather",
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""");
+        var c = new Gemma4ToolCallAdapter().BuildArgumentConstraint([schema], vocab);
+        Assert.NotNull(c);
+
+        Feed(c!, tok, "<|tool_call>call:get_weather{");
+        Assert.True(c!.IsConstraining);
+
+        int closeBrace = Id(tok, "}");
+        int locationKey = Id(tok, "location");
+        // Required `location` not yet emitted → the model may NOT close the object.
+        Assert.False(Allowed(c, tok, vocab.VocabSize, closeBrace));
+        // …and the `location` key IS reachable.
+        Assert.True(Allowed(c, tok, vocab.VocabSize, locationKey));
+    }
+
+    [Fact]
+    public void WebSearch_ForcesQueryKey_RejectsForeignKeys()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+
+        var schema = Schema("web_search",
+            """{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}""");
+        var c = new Gemma4ToolCallAdapter().BuildArgumentConstraint([schema], vocab)!;
+
+        Feed(c, tok, "<|tool_call>call:web_search{");
+        Assert.True(c.IsConstraining);
+
+        Assert.True(Allowed(c, tok, vocab.VocabSize, Id(tok, "query")));
+        // A key from a DIFFERENT tool's schema is unreachable — only declared keys allowed.
+        Assert.False(Allowed(c, tok, vocab.VocabSize, Id(tok, "location")));
+        // The hallucinated array form `queries` cannot even begin: after consuming `quer`, the only
+        // continuation toward a declared key is `y` (query), never `i` (queries).
+    }
+
+    [Fact]
+    public void StringValue_FreeContentThenCloseQuote()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        int quote = vocab.TryGetSpecialToken("<|\"|>", out int q) ? q : -1;
+        Assert.True(quote > 0);
+
+        var schema = Schema("get_weather",
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""");
+        var c = new Gemma4ToolCallAdapter().BuildArgumentConstraint([schema], vocab)!;
+
+        Feed(c, tok, "<|tool_call>call:get_weather{location:");
+        // Value is a string → only the open quote may follow.
+        Assert.True(Allowed(c, tok, vocab.VocabSize, quote));
+        Assert.False(Allowed(c, tok, vocab.VocabSize, Id(tok, "}")));
+
+        c.Accept(quote);                              // open the string
+        // Inside the string: free content (e.g. "Berlin") allowed; EOS forbidden; quote closes.
+        Assert.True(Allowed(c, tok, vocab.VocabSize, tok.Encode("Berlin")[0]));
+        Assert.True(Allowed(c, tok, vocab.VocabSize, quote));
+        Assert.False(Allowed(c, tok, vocab.VocabSize, tok.EosTokenId));
+
+        Feed(c, tok, "Berlin");
+        c.Accept(quote);                              // close the string
+        // location satisfied → `}` and `,` both legal now.
+        Assert.True(Allowed(c, tok, vocab.VocabSize, Id(tok, "}")));
+        Assert.True(Allowed(c, tok, vocab.VocabSize, Id(tok, ",")));
+
+        c.Accept(Id(tok, "}"));
+        Assert.False(c.IsConstraining);               // object closed → back to watching
+    }
+
+    [Fact]
+    public void EnumValue_RestrictedToDeclaredSet()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        int quote = vocab.TryGetSpecialToken("<|\"|>", out int q) ? q : -1;
+
+        var schema = Schema("get_weather",
+            """{"type":"object","properties":{"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["unit"]}""");
+        var c = new Gemma4ToolCallAdapter().BuildArgumentConstraint([schema], vocab)!;
+
+        Feed(c, tok, "<|tool_call>call:get_weather{unit:");
+        c.Accept(quote);                              // open the enum string
+
+        // Both enum values begin with tokens that are reachable; a foreign letter is not.
+        Assert.True(Allowed(c, tok, vocab.VocabSize, tok.Encode("celsius")[0]));   // 'c…'
+        Assert.True(Allowed(c, tok, vocab.VocabSize, tok.Encode("fahrenheit")[0])); // 'fahren'
+        Assert.False(Allowed(c, tok, vocab.VocabSize, tok.Encode("xenon")[0]));     // 'x…' not an enum prefix
+
+        Feed(c, tok, "celsius");
+        Assert.True(Allowed(c, tok, vocab.VocabSize, quote));   // completed value → close quote allowed
+    }
+
+    [Fact]
+    public void NonGemmaAdapter_BuildsNoConstraint()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        var schema = Schema("get_weather", """{"type":"object","properties":{"location":{"type":"string"}}}""");
+        Assert.Null(ToolCallAdapterRegistry.Get("qwen3").BuildArgumentConstraint([schema], vocab));
+    }
+}

--- a/tests/SharpInference.Tests.Core/ToolGrammarMockTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolGrammarMockTests.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Model-independent decode-time conformance for the Gemma argument-grammar constraint (issue #374)
+/// using <see cref="FakeGemmaTokenizer"/>, so the core masking logic is covered in CI without the
+/// GGUF. Mirrors the failure modes from the issue: dropped required key, foreign/hallucinated key,
+/// out-of-enum value.
+/// </summary>
+public sealed class ToolGrammarMockTests
+{
+    private static (ITokenConstraint c, FakeGemmaTokenizer tok, int vocab) Build(string schemaJson, string toolName)
+    {
+        var tok = new FakeGemmaTokenizer();
+        var vocab = new GrammarVocabulary(tok);
+        using var doc = JsonDocument.Parse(schemaJson);
+        var schema = ToolSchema.FromOpenAiFunction(toolName, doc.RootElement.Clone());
+        var c = new Gemma4ToolCallAdapter().BuildArgumentConstraint([schema], vocab);
+        Assert.NotNull(c);
+        return (c!, tok, vocab.VocabSize);
+    }
+
+    private static void Feed(ITokenConstraint c, FakeGemmaTokenizer tok, string text)
+    {
+        foreach (int id in tok.Encode(text)) c.Accept(id);
+    }
+
+    private static bool Allowed(ITokenConstraint c, int vocab, int tokenId)
+    {
+        Span<float> logits = new float[vocab];
+        var masked = c.Filter(logits);
+        return !float.IsNegativeInfinity(masked[tokenId]);
+    }
+
+    [Fact]
+    public void RequiredKey_CannotClose_UntilEmitted()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<|tool_call>call:get_weather{");
+        Assert.True(c.IsConstraining);
+
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));   // required key missing
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('l')));    // 'l' starts "location"
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('x')));   // no key starts with 'x'
+    }
+
+    [Fact]
+    public void OnlyDeclaredKeys_AreReachable()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}""",
+            "web_search");
+
+        Feed(c, tok, "<|tool_call>call:web_search{");
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('q')));    // 'q' starts "query"
+
+        // Walk "quer"; the only legal continuation is 'y' (query) — never 'i' (queries).
+        Feed(c, tok, "quer");
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('y')));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('i')));
+    }
+
+    [Fact]
+    public void StringValue_OpensWithQuote_FreeContent_Closes()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<|tool_call>call:get_weather{location:");
+        // Value is a string → only the quote may follow.
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Quote));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));
+
+        c.Accept(FakeGemmaTokenizer.Quote);
+        // Free content: any non-EOS token; the quote closes; EOS forbidden mid-call.
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('B')));
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Quote));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Eos));
+
+        Feed(c, tok, "Berlin");
+        c.Accept(FakeGemmaTokenizer.Quote);                 // close string
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));   // required satisfied
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char(',')));
+
+        c.Accept(FakeGemmaTokenizer.Char('}'));
+        Assert.False(c.IsConstraining);                     // object closed → watching
+    }
+
+    [Fact]
+    public void Enum_RestrictsToDeclaredValues()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["unit"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<|tool_call>call:get_weather{unit:");
+        c.Accept(FakeGemmaTokenizer.Quote);                 // open the enum string
+
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('c')));   // celsius
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('f')));   // fahrenheit
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('x')));  // neither
+
+        Feed(c, tok, "celsius");
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Quote));       // value complete → close
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('z')));  // can't extend past the enum
+    }
+
+    [Fact]
+    public void NumberValue_AcceptsDigits_ThenCloses()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"days":{"type":"integer"}},"required":["days"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<|tool_call>call:get_weather{days:");
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('3')));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Quote));      // integer is bare, not quoted
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('.')));  // integer → no decimal point
+
+        c.Accept(FakeGemmaTokenizer.Char('3'));
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('0')));   // more digits
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));   // or close (required satisfied)
+    }
+
+    [Fact]
+    public void EarlyEngage_ForcesOpenBrace_BeforeMergedEmptyObject()
+    {
+        // The constraint must engage the instant the tool name completes — BEFORE the '{' — so a
+        // merged "{}" token (Gemma's empty-args encoding) can't slip past. Here we stop right after
+        // the name and assert the object can only be OPENED (never closed-empty).
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<|tool_call>call:get_weather");   // note: no '{' yet
+        Assert.True(c.IsConstraining);                  // engaged early on the name match
+
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('{')));   // may open the object
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));  // may NOT close it (none opened)
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('l')));  // a key can't precede '{'
+    }
+
+    [Fact]
+    public void NestedObjectValue_ExpectsBrace_ThenConstrainsInnerKeys()
+    {
+        var (c, tok, vocab) = Build(
+            """
+            {"type":"object","properties":{
+               "filter":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}},
+             "required":["filter"]}
+            """,
+            "search");
+
+        Feed(c, tok, "<|tool_call>call:search{filter:");
+        // The value is an object → it must open with '{', not a quote or a bare scalar.
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('{')));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Quote));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('3')));
+
+        c.Accept(FakeGemmaTokenizer.Char('{'));
+        // Inner object: required "city" missing → can't close; 'c' begins the key.
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('c')));
+    }
+
+    [Fact]
+    public void ArrayValue_OpensWithBracket_ConstrainsItems()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"tags":{"type":"array","items":{"type":"string"}}},"required":["tags"]}""",
+            "tagger");
+
+        Feed(c, tok, "<|tool_call>call:tagger{tags:");
+        // Array value → opens with '[', not a quote.
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('[')));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Quote));
+
+        c.Accept(FakeGemmaTokenizer.Char('['));
+        // Inside the array: a string item opens with a quote, or the array closes (empty).
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Quote));
+        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char(']')));
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char('x')));   // bare scalar not valid for a string item
+    }
+
+    [Fact]
+    public void UnknownTool_IsNotConstrained()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        // A call to a tool the constraint doesn't know about stays passive.
+        Feed(c, tok, "<|tool_call>call:some_other_tool{");
+        Assert.False(c.IsConstraining);
+    }
+
+    [Fact]
+    public void Reset_ReturnsToWatching()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<|tool_call>call:get_weather{");
+        Assert.True(c.IsConstraining);
+        c.Reset();
+        Assert.False(c.IsConstraining);
+    }
+}

--- a/tests/SharpInference.Tests.Core/ToolSchemaParseTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolSchemaParseTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using SharpInference.Core.Grammar;
 
@@ -97,5 +98,25 @@ public sealed class ToolSchemaParseTests
     {
         var s = Parse("t", """{"type":"object","properties":{"x":{"type":["string","null"]}}}""");
         Assert.Equal(JsonSchemaKind.String, s.Arguments.Properties[0].Value.Kind);
+    }
+
+    [Fact]
+    public void DeeplyNestedSchema_DoesNotStackOverflow_DegradesPastCap()
+    {
+        // A property nested past the parser's depth cap (via arrays — 1 JSON level each, so we stay
+        // under System.Text.Json's own depth limit) must parse without recursing unbounded and
+        // blowing the stack (a .NET StackOverflowException is uncatchable). Deep levels degrade to
+        // Any rather than recursing forever.
+        const int n = 55;   // > ToolSchema parse cap (32), < System.Text.Json depth limit (64)
+        var sb = new StringBuilder();
+        sb.Append("""{"type":"object","properties":{"x":""");
+        for (int i = 0; i < n; i++) sb.Append("""{"type":"array","items":""");
+        sb.Append("""{"type":"string"}""");
+        for (int i = 0; i < n; i++) sb.Append('}');
+        sb.Append("}}");
+
+        var s = Parse("t", sb.ToString());
+        Assert.Single(s.Arguments.Properties);
+        Assert.Equal(JsonSchemaKind.Array, s.Arguments.Properties[0].Value.Kind);  // top levels parse
     }
 }

--- a/tests/SharpInference.Tests.Core/ToolSchemaParseTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolSchemaParseTests.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Pure (model-independent) tests for JSON-Schema → <see cref="ToolSchema"/> derivation (issue
+/// #374): types, required keys, enums, arrays, nested objects, and the open/unconstrained fallbacks.
+/// </summary>
+public sealed class ToolSchemaParseTests
+{
+    private static ToolSchema Parse(string name, string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return ToolSchema.FromOpenAiFunction(name, doc.RootElement.Clone());
+    }
+
+    [Fact]
+    public void Types_And_Required_AreParsed()
+    {
+        var s = Parse("t", """
+            {"type":"object",
+             "properties":{
+               "location":{"type":"string"},
+               "days":{"type":"integer"},
+               "ratio":{"type":"number"},
+               "active":{"type":"boolean"}},
+             "required":["location"]}
+            """);
+
+        Assert.Equal("t", s.Name);
+        Assert.False(s.Arguments.Open);
+        var props = s.Arguments.Properties;
+        Assert.Equal(4, props.Count);
+
+        Assert.Equal(JsonSchemaKind.String, props[0].Value.Kind);
+        Assert.True(props[0].Required);
+        Assert.Equal(JsonSchemaKind.Integer, props[1].Value.Kind);
+        Assert.False(props[1].Required);
+        Assert.Equal(JsonSchemaKind.Number, props[2].Value.Kind);
+        Assert.Equal(JsonSchemaKind.Boolean, props[3].Value.Kind);
+    }
+
+    [Fact]
+    public void Enum_IsParsed_AsRestrictedSet()
+    {
+        var s = Parse("t", """
+            {"type":"object","properties":{"unit":{"type":"string","enum":["celsius","fahrenheit"]}}}
+            """);
+        var node = s.Arguments.Properties[0].Value;
+        Assert.Equal(JsonSchemaKind.String, node.Kind);
+        Assert.NotNull(node.EnumValues);
+        Assert.Equal(["celsius", "fahrenheit"], node.EnumValues!);
+    }
+
+    [Fact]
+    public void Array_ItemTypeIsParsed()
+    {
+        var s = Parse("t", """
+            {"type":"object","properties":{"tags":{"type":"array","items":{"type":"string"}}}}
+            """);
+        var node = s.Arguments.Properties[0].Value;
+        Assert.Equal(JsonSchemaKind.Array, node.Kind);
+        Assert.NotNull(node.Items);
+        Assert.Equal(JsonSchemaKind.String, node.Items!.Kind);
+    }
+
+    [Fact]
+    public void NestedObject_IsParsedRecursively()
+    {
+        var s = Parse("t", """
+            {"type":"object","properties":{
+               "filter":{"type":"object",
+                         "properties":{"city":{"type":"string"}},
+                         "required":["city"]}}}
+            """);
+        var node = s.Arguments.Properties[0].Value;
+        Assert.Equal(JsonSchemaKind.Object, node.Kind);
+        Assert.NotNull(node.Object);
+        Assert.Single(node.Object!.Properties);
+        Assert.True(node.Object.Properties[0].Required);
+    }
+
+    [Fact]
+    public void NoProperties_OrNullSchema_IsOpen()
+    {
+        Assert.True(Parse("t", """{"type":"object","properties":{}}""").Arguments.Open);
+        Assert.True(ToolSchema.FromOpenAiFunction("t", null).Arguments.Open);
+        // additionalProperties:true → open even with declared properties.
+        Assert.True(Parse("t", """
+            {"type":"object","properties":{"x":{"type":"string"}},"additionalProperties":true}
+            """).Arguments.Open);
+    }
+
+    [Fact]
+    public void UnionType_TakesFirstConcrete_IgnoringNull()
+    {
+        var s = Parse("t", """{"type":"object","properties":{"x":{"type":["string","null"]}}}""");
+        Assert.Equal(JsonSchemaKind.String, s.Arguments.Properties[0].Value.Kind);
+    }
+}


### PR DESCRIPTION
Closes #374.

## What

Opt-in **schema/grammar-constrained decoding** that forces a tool call's *arguments* to satisfy the supplied JSON Schema, expressed in each architecture's **native call syntax**. Default **off** → byte-identical to today. Enabled via `SHARPI_TOOL_GRAMMAR=1` or `SharpInferenceServerOptions.ToolGrammar`. Scoped to **Gemma 4** end-to-end; the adapter hook generalizes to other families (follow-up for Qwen/Llama JSON).

## Why

On `gemma-4-12b-it-qat-q4_0` (temp 0) the call *envelope* is always correct but *arguments* are wrong deterministically — a **model prior**, not an engine bug:

| Prompt | before | after |
|---|---|---|
| "weather in Berlin" (`location` required) | `{}` | `{"location":"Berlin"}` |
| "population of France" (`query: string`) | `{"queries":["…"]}` | `{"query":"…"}` |
| enum `unit∈{celsius,fahrenheit}` | `{}` | `{"location":"Berlin","unit":"celsius"}` |
| `tags: array<string>` | — | `{"tags":["urgent","bug"]}` |

Constrained decoding makes the bad token sequences *unreachable* instead of hoping the model conforms.

## Approach

**Per-adapter grammar.** `IToolCallAdapter.BuildArgumentConstraint(tools, vocab)` (default `null`; Gemma4 override) so each family owns its wire format.

**The hard part — terminal→token mapping.** A byte-level pushdown automaton over Gemma's `<|tool_call>call:NAME{key:<|"|>val<|"|>,n:3}<tool_call|>` syntax. A candidate token is allowed iff replaying its bytes keeps the FSM alive. Matching is byte-level for the structural skeleton (so multi-token keys and **merged delimiters** like `:[` / `]}` work) and token-level for the `<|"|>` quote special token and free string content. The grammar enforces: only declared keys, every required key exactly once, value shape per declared type (strings quoted with free content; numbers/bool/null bare; arrays `[…]`; nested objects `{…}`), and `enum` restriction. It **engages the instant the tool name completes — before `{`** — so Gemma's merged `{}` empty-args token can't slip required arguments past the mask. Allocation-free hot path (reused mask/scratch buffers + first-byte pruning over the 262k vocab; warm constrained request ~0.33s, overhead negligible).

**Engine.** `SamplingParams.Constraint`; the `InferenceEngine` decode loop masks logits while constraining and advances the constraint per token (disables the device-side argmax fast path + MTP for constrained requests). `ContinuousBatchingEngine` warns once and ignores it (not yet wired — noted as follow-up).

**Server.** `ToolGrammar` option + `SHARPI_TOOL_GRAMMAR` env; OpenAI/Anthropic endpoints build the constraint from `req.Tools` on tool-active requests (OpenAI honors `tool_choice:"none"`).

## Verification (CUDA, gemma-4-12b-it-qat-q4_0, temp 0)

All failure cases above flip to correct; **plain text, already-valid calls, and `tool_choice:"none"` are byte-identical to default-off**; streaming honors the constraint.

## Tests

- `ToolSchemaParseTests` — schema derivation (types/required/enum/array/nested).
- `ToolGrammarMockTests` — decode-time conformance via a fake Gemma tokenizer (**CI-runnable, no GGUF**): required-key, foreign-key rejection, string/enum/number/array/nested-object value shapes, early-engage, reset.
- `ToolGrammarConstraintTests` — model-gated conformance against the real GGUF.

190 Tests.Core + 125 Tests.Server pass; full Release build clean under `TreatWarningsAsErrors` (trim/AOT analyzers + InvariantGlobalization on).

## Follow-ups (filed)

- #376 � Qwen/Llama JSON-syntax argument grammars via the same adapter hook.
- #377 � wire the constraint into `ContinuousBatchingEngine` (today it warns + ignores).
- #378 � constrain partially-typed tools (`Any`-typed value / open object currently left unconstrained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
