### PR TITLE
feat(engine): honor tool-grammar constraint under continuous batching (#377)

### DIFF
--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using SharpInference.Core;
+using SharpInference.Core.Grammar;
 
 namespace SharpInference.Engine;
 
@@ -59,10 +60,6 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     private int _pendingCount;
     private int _activeCount;
 
-    // Set once (Interlocked) the first time a constraint-bearing request is seen, so the
-    // tool-grammar-ignored warning (issue #374) is emitted at most once per engine.
-    private int _warnedConstraintIgnored;
-
     private sealed class PendingRequest(string prompt, SamplingParams sp, CancellationToken ct, Channel<GenerateChunk> output)
     {
         public readonly string Prompt = prompt;
@@ -93,6 +90,12 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         public required Random Rng;
         public required CancellationToken Ct;
         public required long ProjectedTokens;
+        // Per-sequence grammar/FSM constraint (issue #374/#377). Null = unconstrained decoding for
+        // this sequence (the common case). When non-null the batcher advances it with every emitted
+        // token via Accept and, while it reports IsConstraining, masks this sequence's logits row via
+        // Filter before sampling — forcing tool-call arguments to satisfy the schema. The instance is
+        // built per request (ChatTemplateRenderer.BuildToolArgumentConstraint) and is single-request.
+        public ITokenConstraint? Constraint;
         public int TokenCount;
         // Per-sequence stateful UTF-8 decoders: reassembles multi-byte characters
         // split across tokens (CJK, emoji, smart quotes). Independent decoders for
@@ -221,16 +224,9 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
     {
         _ = canonicalHistoryPrefix; // intentionally ignored; see XML remarks
 
-        // Grammar-constrained decoding (issue #374) is not wired into the batched sampler — each
-        // sequence is sampled directly from its logits with no per-token mask/advance. Rather than
-        // silently drop the constraint (the request would generate unconstrained tool arguments with
-        // no signal), warn once so an operator who set SHARPI_TOOL_GRAMMAR alongside SHARPI_MAX_BATCH
-        // knows the two don't yet compose. Single-user InferenceEngine honors the constraint.
-        if (sp.Constraint is not null && Interlocked.Exchange(ref _warnedConstraintIgnored, 1) == 0)
-            Console.Error.WriteLine(
-                "[ContinuousBatchingEngine] tool-grammar constraint is ignored under continuous " +
-                "batching (SHARPI_MAX_BATCH); tool-call arguments will be generated unconstrained. " +
-                "Run without batching to use SHARPI_TOOL_GRAMMAR (issue #374).");
+        // Grammar-constrained decoding (issue #374) is wired into the batched sampler (issue #377):
+        // sp.Constraint flows through admission onto the per-sequence ActiveSeq, where the batcher
+        // masks that sequence's logits row while it is constraining and advances it on every token.
 
         var channel = Channel.CreateUnbounded<GenerateChunk>(
             new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
@@ -324,13 +320,18 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             // on-device argmax tail (#205/#206): it returns just the per-seq (token, logit) and
             // skips the full N×vocab logits D2H + host split. A single sampled or force-closing
             // seq reverts the whole step to the full-logits path (the argmax buffer can't sample).
+            // A sequence that is actively constraining (issue #377) also needs the full logits row to
+            // mask, so it likewise reverts the step — but only WHILE constraining: a constraint-bearing
+            // request keeps the fast path in its unconstrained spans (its tokens still flow through
+            // Accept below from the argmax tail). With no constraint anywhere this is byte-identical.
             bool allGreedy = _fwd.SupportsBatchedGpuArgmax;
             for (int i = 0; i < n && allGreedy; i++)
             {
                 var s = active[i];
                 bool forcedClose = _thinkingEnabled && s.InThinking && s.Sp.MaxThinkingTokens > 0
                                    && s.ThinkingCount >= s.Sp.MaxThinkingTokens && _endThinkTokenId > 0;
-                if (s.Sp.Temperature > 0f || forcedClose) allGreedy = false;
+                if (s.Sp.Temperature > 0f || forcedClose || s.Constraint is { IsConstraining: true })
+                    allGreedy = false;
             }
 
             float[][]? logitsBatch = null;
@@ -363,10 +364,22 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 }
                 else
                 {
+                    // While this sequence's constraint is inside a constrained region, sample from the
+                    // masked logits (grammar-forbidden tokens set to -inf); otherwise sample the raw
+                    // logits exactly as the unconstrained path would (issue #377). The gate above kept
+                    // a constraining seq off the argmax fast path, so logitsBatch is populated here.
+                    var rowLogits = seq.Constraint is { IsConstraining: true } ctr
+                        ? ctr.Filter(logitsBatch![i])
+                        : (ReadOnlySpan<float>)logitsBatch![i];
                     next = seq.Sp.Temperature <= 0f
-                        ? Sampler.Greedy(logitsBatch![i])
-                        : Sampler.Sample(logitsBatch![i], seq.Sp, seq.Rng);
+                        ? Sampler.Greedy(rowLogits)
+                        : Sampler.Sample(rowLogits, seq.Sp, seq.Rng);
                 }
+
+                // Advance the grammar constraint with the just-chosen token (every token, including the
+                // argmax-tail and force-close paths, so it can detect a tool-call boundary and
+                // begin/end constraining). No-op when this sequence has no constraint.
+                seq.Constraint?.Accept(next);
 
                 bool done = seq.StopIds.Contains(next)
                     || seq.TokenCount >= seq.Sp.MaxNewTokens
@@ -700,9 +713,20 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             req.Sp.ResolveStopSet(_tokenizer.EogTokenIds);
         var rng = new Random();
 
+        // Per-request grammar constraint (issue #374/#377). Reset to its watching state so a reused
+        // instance can't carry state across requests, then mask the first sampled token if it is
+        // already constraining (rare — would require the prompt to end mid-call). Advance it with the
+        // first token below, exactly as the decode loop does for every subsequent token.
+        var constraint = req.Sp.Constraint;
+        constraint?.Reset();
+
+        var firstLogits = constraint is { IsConstraining: true } ctr
+            ? ctr.Filter(logits)
+            : (ReadOnlySpan<float>)logits;
         int firstToken = req.Sp.Temperature <= 0f
-            ? Sampler.Greedy(logits)
-            : Sampler.Sample(logits, req.Sp, rng);
+            ? Sampler.Greedy(firstLogits)
+            : Sampler.Sample(firstLogits, req.Sp, rng);
+        constraint?.Accept(firstToken);
 
         if (stopIds.Contains(firstToken))
         {
@@ -738,6 +762,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             Rng = rng,
             Ct = req.Ct,
             ProjectedTokens = p.ProjectedTokens,
+            Constraint = constraint,
             TokenCount = 1,
             InThinking = promptInThinking,
         };

--- a/src/SharpInference.Engine/Sampler.cs
+++ b/src/SharpInference.Engine/Sampler.cs
@@ -585,9 +585,10 @@ public sealed record SamplingParams
     /// constraint is stateful and single-request. <c>null</c> (default) = unconstrained decoding,
     /// byte-identical to the pre-#374 path.
     /// <para>
-    /// Honored by the single-user <c>InferenceEngine</c> only. <c>ContinuousBatchingEngine</c>
-    /// (<c>SHARPI_MAX_BATCH</c>) does not yet apply it — it samples each batched sequence directly
-    /// and warns once when a constraint-bearing request is admitted.
+    /// Honored by both the single-user <c>InferenceEngine</c> and <c>ContinuousBatchingEngine</c>
+    /// (<c>SHARPI_MAX_BATCH</c>, issue #377): under batching the instance is carried per sequence and
+    /// masks only that sequence's logits row each step, so concurrent unconstrained requests are
+    /// unaffected. A single instance must not be shared across concurrent requests.
     /// </para>
     /// </summary>
     public ITokenConstraint? Constraint { get; init; }

--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -79,15 +79,6 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
     {
         opts.ToolGrammar = true;
     }
-
-    // Config-time conflict surface: tool-grammar (#374) is honored only by the single-user engine,
-    // not continuous batching. Warn at boot — when an operator is watching logs — so the conflict
-    // isn't discovered only via the engine's once-per-process runtime warning.
-    if (opts.ToolGrammar && opts.MaxBatchSize > 1)
-        Console.Error.WriteLine(
-            "[SharpInference] SHARPI_TOOL_GRAMMAR is set together with continuous batching " +
-            "(SHARPI_MAX_BATCH > 1); tool-call argument grammar is NOT applied under batching. " +
-            "Run without batching to use it (issue #374).");
 });
 
 var app = builder.Build();

--- a/tests/SharpInference.Tests.ForwardPass/ContinuousBatchingConstraintTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/ContinuousBatchingConstraintTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Immutable;
+using System.Text;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Model-independent wiring tests for grammar-constrained tool-argument decoding under continuous
+/// batching (issue #377). A scripted <see cref="ITokenConstraint"/> and a canned
+/// <see cref="IBatchedForwardPass"/> stand in for the real Gemma grammar + GPU forward pass, so the
+/// per-sequence mask/Accept plumbing is exercised in CI without a GGUF. The grammar correctness
+/// itself is covered by <c>ToolGrammarMockTests</c>/<c>ToolGrammarConstraintTests</c>; here we only
+/// assert that <see cref="ContinuousBatchingEngine"/> (a) masks a constraining sequence's logits row,
+/// (b) advances the constraint on every token, and (c) leaves co-tenant unconstrained sequences
+/// byte-identical to the no-constraint path.
+/// </summary>
+public sealed class ContinuousBatchingConstraintTests
+{
+    // The forward pass always makes 'X' the unconstrained argmax; the constraint, while engaged,
+    // forces 'Y' instead. So a constrained span reads 'Y' and an unconstrained span reads 'X'.
+    private const int Vocab = 128;
+    private static int Tok(char c) => c;
+    private const int PreferX = 'X';
+    private const int ForceY = 'Y';
+
+    /// <summary>Single-byte tokenizer: token id == ASCII byte. EOG is an id no forward ever emits.</summary>
+    private sealed class CharTokenizer : ITokenizer
+    {
+        public int VocabSize => Vocab;
+        public int BosTokenId => 0;
+        public int EosTokenId => 0;          // NUL — the canned forward never produces it
+        public int UnknownTokenId => 0;
+        public int PadTokenId => 0;
+        public bool AddBosToken => false;
+        public ImmutableArray<int> EogTokenIds => [0];
+        public IReadOnlyDictionary<string, int> SpecialTokens { get; } =
+            new Dictionary<string, int>(StringComparer.Ordinal);
+
+        public byte[] DecodeBytes(int token) =>
+            token is > 0 and < Vocab ? [(byte)token] : [];
+
+        public IReadOnlyList<int> Encode(string text)
+        {
+            var ids = new int[text.Length];
+            for (int i = 0; i < text.Length; i++) ids[i] = text[i];
+            return ids;
+        }
+
+        public string Decode(IEnumerable<int> tokens)
+        {
+            var sb = new StringBuilder();
+            foreach (int t in tokens) sb.Append(Encoding.UTF8.GetString(DecodeBytes(t)));
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Begins constraining once <paramref name="EngageAfter"/> tokens have been accepted and stays
+    /// constraining for <paramref name="ForcedLen"/> tokens, masking every logit except
+    /// <see cref="ForceY"/>. Records Accept/Filter counts so the wiring can be asserted.
+    /// </summary>
+    private sealed class ScriptedConstraint(int engageAfter, int forcedLen) : ITokenConstraint
+    {
+        private float[]? _masked;
+        public int AcceptCount { get; private set; }
+        public int FilterCount { get; private set; }
+        public int ResetCount { get; private set; }
+
+        public bool IsConstraining => AcceptCount >= engageAfter && AcceptCount < engageAfter + forcedLen;
+
+        public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+        {
+            FilterCount++;
+            var m = _masked ??= new float[logits.Length];
+            if (m.Length != logits.Length) return logits;
+            logits.CopyTo(m);
+            for (int i = 0; i < m.Length; i++)
+                if (i != ForceY) m[i] = float.NegativeInfinity;
+            return m;
+        }
+
+        public void Accept(int token) => AcceptCount++;
+        public void Reset() { AcceptCount = 0; ResetCount++; }
+    }
+
+    private sealed class FakeCache : ISequenceKvCache { public void Dispose() { } }
+
+    /// <summary>Canned forward pass: every sequence's next-token logits put 'X' on top. Records the
+    /// widest batch it was ever asked to decode so a test can confirm two sequences actually co-resided
+    /// in one batched step (the per-sequence-vs-batch-wide masking guarantee).</summary>
+    private sealed class FakeBatchedForwardPass : IBatchedForwardPass
+    {
+        public bool SnapKvEnabled => false;
+        public long KvBytesPerToken => 1;
+        public int MaxSeqLen => 8192;
+        public bool PrefillDequantCacheActive => false;
+        public bool SupportsBatchedGpuArgmax => true;
+
+        private int _maxBatchWidth;
+        public int MaxBatchWidth => Volatile.Read(ref _maxBatchWidth);
+        private void RecordWidth(int w) { if (w > _maxBatchWidth) _maxBatchWidth = w; }
+
+        private static float[] Row()
+        {
+            var r = new float[Vocab];   // all zeros…
+            r[PreferX] = 1f;            // …except 'X', the unconstrained argmax
+            return r;
+        }
+
+        public ISequenceKvCache CreateCache() => new FakeCache();
+
+        public ReadOnlySpan<float> PrefillWithCache(IReadOnlyList<int> tokens, ISequenceKvCache cache, int startPos = 0)
+            => Row();
+
+        public float[]?[] PrefillPackedMulti(
+            ReadOnlyMemory<int>[] chunks, int[] startPos, ISequenceKvCache[] caches, bool[] wantLogits)
+        {
+            var outp = new float[]?[chunks.Length];
+            for (int i = 0; i < chunks.Length; i++) outp[i] = wantLogits[i] ? Row() : null;
+            return outp;
+        }
+
+        public float[][] BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        {
+            RecordWidth(tokens.Length);
+            var outp = new float[tokens.Length][];
+            for (int i = 0; i < tokens.Length; i++) outp[i] = Row();
+            return outp;
+        }
+
+        public (int Token, float Logit)[] BatchForwardMultiArgmax(int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        {
+            RecordWidth(tokens.Length);
+            var outp = new (int, float)[tokens.Length];
+            for (int i = 0; i < tokens.Length; i++) outp[i] = (PreferX, 1f);
+            return outp;
+        }
+    }
+
+    private static async Task<string> RunOne(ContinuousBatchingEngine engine, string prompt, SamplingParams sp)
+    {
+        var sb = new StringBuilder();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var s in engine.GenerateAsync(prompt, sp, cts.Token))
+            sb.Append(s);
+        return sb.ToString();
+    }
+
+    [Fact]
+    public async Task ConstrainedSequence_IsMasked_WhileConstraining()
+    {
+        using var engine = new ContinuousBatchingEngine(
+            new FakeBatchedForwardPass(), new CharTokenizer(), "test", maxBatchSize: 1);
+
+        // Engage after the first token, force 'Y' for 3 tokens, then release. With 6 emitted tokens
+        // (first + 5 decode; the 6th decode sample is dropped at the MaxNewTokens cutoff) the stream
+        // is: X (unconstrained first) · YYY (masked) · XX (released → model's preferred 'X' again).
+        var scripted = new ScriptedConstraint(engageAfter: 1, forcedLen: 3);
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 6, Constraint = scripted };
+
+        string text = await RunOne(engine, "prompt", sp);
+
+        Assert.Equal("XYYYXX", text);
+        // Reset at admission + Accept on every emitted/sampled token (first + 6 decode samples).
+        Assert.Equal(1, scripted.ResetCount);
+        Assert.True(scripted.AcceptCount >= 6, $"expected ≥6 accepts, got {scripted.AcceptCount}");
+        Assert.Equal(3, scripted.FilterCount);  // masked exactly the 3 constrained steps
+    }
+
+    [Fact]
+    public async Task NoConstraint_IsUnaffected()
+    {
+        using var engine = new ContinuousBatchingEngine(
+            new FakeBatchedForwardPass(), new CharTokenizer(), "test", maxBatchSize: 1);
+
+        var sp = new SamplingParams { Temperature = 0f, MaxNewTokens = 6 };   // Constraint == null
+        string text = await RunOne(engine, "prompt", sp);
+
+        Assert.Equal("XXXXXX", text);   // pure unconstrained greedy = the forward's argmax every step
+    }
+
+    [Fact]
+    public async Task ConstrainedAndUnconstrained_Coexist_PerSequenceMasking()
+    {
+        var fake = new FakeBatchedForwardPass();
+        using var engine = new ContinuousBatchingEngine(fake, new CharTokenizer(), "test", maxBatchSize: 2);
+
+        // The constraint engages only after 5 accepted tokens, by which point BOTH sequences are
+        // co-resident in the batched decode step, so masking the constrained row while the co-tenant
+        // is in the SAME BatchForwardMulti call directly exercises per-sequence (not batch-wide)
+        // masking. Stream A: XXXXX (pre-engage) · YYY (masked) · XXXX (released). Stream B: all X.
+        var spConstrained = new SamplingParams
+        {
+            Temperature = 0f,
+            MaxNewTokens = 12,
+            Constraint = new ScriptedConstraint(engageAfter: 5, forcedLen: 3),
+        };
+        var spPlain = new SamplingParams { Temperature = 0f, MaxNewTokens = 12 };
+
+        var (a, b) = await RunBoth(engine, ("alpha", spConstrained), ("beta", spPlain));
+
+        // The constrained request is masked only in its engaged span; the co-tenant sharing the batch
+        // is byte-identical to the no-constraint path — proof the mask is applied per logits row.
+        Assert.Equal("XXXXXYYYXXXX", a);
+        Assert.Equal("XXXXXXXXXXXX", b);
+        // …and the two genuinely shared a batched decode step (else the above would be vacuous).
+        Assert.Equal(2, fake.MaxBatchWidth);
+    }
+
+    /// <summary>
+    /// Drives two requests so they are enqueued back-to-back BEFORE either is drained — the batcher
+    /// then admits both in one pass and decodes them in a single batched step, making the co-residency
+    /// the masking test depends on reliable rather than scheduling-dependent.
+    /// </summary>
+    private static async Task<(string a, string b)> RunBoth(
+        ContinuousBatchingEngine engine, (string prompt, SamplingParams sp) a, (string prompt, SamplingParams sp) b)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var ea = engine.GenerateAsync(a.prompt, a.sp, cts.Token).GetAsyncEnumerator(cts.Token);
+        var eb = engine.GenerateAsync(b.prompt, b.sp, cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // Kick both iterators before awaiting: GenerateChunksAsync enqueues its request synchronously
+        // at the top of the method, so starting both MoveNextAsync calls queues both requests before
+        // the first result is consumed.
+        var ma = ea.MoveNextAsync();
+        var mb = eb.MoveNextAsync();
+        bool ha = await ma, hb = await mb;
+
+        var sa = new StringBuilder();
+        var sb = new StringBuilder();
+        try
+        {
+            while (ha || hb)
+            {
+                if (ha) { sa.Append(ea.Current); ha = await ea.MoveNextAsync(); }
+                if (hb) { sb.Append(eb.Current); hb = await eb.MoveNextAsync(); }
+            }
+        }
+        finally
+        {
+            await ea.DisposeAsync();
+            await eb.DisposeAsync();
+        }
+        return (sa.ToString(), sb.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

Wires schema/grammar-constrained tool-call argument decoding (#374, PR #375) into `ContinuousBatchingEngine` so it works under multi-user batching (`SHARPI_MAX_BATCH`). Previously `SamplingParams.Constraint` was honored only by the single-user `InferenceEngine`; under batching the constraint was dropped with a one-time stderr warning. Closes #377.

## What changed

- **`ActiveSeq.Constraint`** carries the per-request `ITokenConstraint` through admission (`ActivateSeq`) onto each batched sequence.
- In the batched sample loop, when a sequence reports `IsConstraining` its **own logits row** is masked via `Filter` before sampling, and **every** sequence's chosen token is fed back via `Accept` (on all branches — argmax-tail, force-close `</think>`, sampled — including stop tokens, matching `InferenceEngine`).
- The all-greedy **on-device argmax fast path** reverts to the full-logits path while any sequence is actively constraining (it needs the row to mask). A constraint-bearing sequence keeps the fast path in its *unconstrained* spans, and a batch with no constraint anywhere is untouched → **default-off byte-identical**.
- Per-sequence masking means concurrent **unconstrained** requests sharing the batch are byte-identical to the no-constraint path.
- Removed the now-obsolete once-per-process "ignored under continuous batching" runtime warning and the `Program.cs` boot-time conflict warning.

## Tests

New CI-runnable `ContinuousBatchingConstraintTests` (scripted `ITokenConstraint` + canned `IBatchedForwardPass`, no GGUF):
- masking is applied only while constraining, `Accept` fires on every token, `Reset` once per admission;
- the no-constraint path is unaffected;
- a constrained and an unconstrained request that **provably co-reside in one batched step** (asserts `MaxBatchWidth == 2`) get per-row treatment — the constrained row is masked while the co-tenant stays byte-identical.

`dotnet test tests/SharpInference.Tests.Core` (72 grammar/tool tests) green; new tests green.

## GPU verification (before/after)

Real CUDA run on `gemma-4-12b-it-Q4_K_M.gguf` (`-g -1`, `SHARPI_MAX_BATCH=2`), continuous batching **genuinely engaged** (no single-user fallback — Q4_K_M is GEMM-N-batchable; note the QAT `q4_0` build can't batch and would fall back). `web_search` tool with required string `query`:

| | tool-call arguments |
|---|---|
| **grammar off** (before) | `{"queries":["latest news Mars Perseverance rover 2024 2025", …]}` — hallucinated `queries[]`, **violates schema** |
| **grammar on** (after) | `{"query":"latest news Mars Perseverance rover 2024 2025"}` — schema-conformant |

Two concurrent `get_weather` requests under batch=2 also returned `{"location":"Paris"}` / `{"location":"Tokyo"}` with the required key intact.

Follow-up to #374 / #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)