### PR TITLE
feat(core): JSON-syntax tool-argument grammar for Qwen/Llama/DeepSeek (#376)

### DIFF
--- a/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
@@ -2,39 +2,6 @@ using System.Text;
 
 namespace SharpInference.Core.Grammar;
 
-// ── Compiled schema ───────────────────────────────────────────────────────────
-//
-// The parsed ToolSchema is "compiled" once per request into match tables (UTF-8 key/enum bytes,
-// required-key bitmask) so the per-token hot loop never re-encodes strings. Only tools whose schema
-// is FULLY constrainable (every value is a concrete type / typed array / nested typed object — no
-// Any-typed value, no open object) are compiled; a tool that isn't is simply left out of the
-// constraint and generates its arguments unconstrained, so the constraint never blocks generation.
-
-/// <summary>Compiled value-type descriptor (see <see cref="ToolSchemaNode"/>).</summary>
-internal sealed class CompiledNode
-{
-    public required JsonSchemaKind Kind { get; init; }
-    /// <summary>For an enum / boolean / null: the candidate literal byte sequences (≤64).</summary>
-    public byte[][]? Literals { get; init; }
-    /// <summary>True when <see cref="Literals"/> are matched inside the <c>&lt;|"|&gt;</c> quotes (string enum).</summary>
-    public bool QuotedLiterals { get; init; }
-    /// <summary>Element type for an array.</summary>
-    public CompiledNode? Items { get; init; }
-    /// <summary>Nested object shape.</summary>
-    public CompiledObject? Object { get; init; }
-    /// <summary>Integer (no fractional part) vs general number.</summary>
-    public bool IntegerOnly { get; init; }
-}
-
-/// <summary>Compiled object shape: per-property name bytes + value node, plus the required-key mask.</summary>
-internal sealed class CompiledObject
-{
-    public required byte[][] KeyBytes { get; init; }
-    public required CompiledNode[] Values { get; init; }
-    public required ulong RequiredMask { get; init; }
-    public int Count => KeyBytes.Length;
-}
-
 /// <summary>
 /// Constrained-decoding state machine (issue #374) for Gemma 4's native tool-call wire format:
 /// <c>&lt;|tool_call&gt;call:NAME{key:&lt;|"|&gt;val&lt;|"|&gt;,n:3}&lt;tool_call|&gt;</c>.
@@ -100,7 +67,7 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
             foreach (var t in tools)
             {
                 if (t.Arguments.Open) continue;             // unconstrained body — skip
-                var compiled = TryCompileObject(t.Arguments);
+                var compiled = ToolSchemaCompiler.TryCompileObject(t.Arguments);
                 if (compiled is not null) _tools[t.Name] = compiled;
             }
         }
@@ -143,85 +110,6 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
         _armed = false;
         _nameBuf.Clear();
         _depth = 0;
-    }
-
-    // ── Compilation ───────────────────────────────────────────────────────────
-
-    private static CompiledObject? TryCompileObject(ToolSchemaObject obj) => TryCompileObject(obj, 0);
-
-    // Depth-capped so compilation can't recurse unbounded — the parser already caps nesting, but the
-    // ToolSchema records are public, so a caller that builds a deeply-nested schema in-memory (not via
-    // the parser) would otherwise risk an uncatchable StackOverflow. Past the cap the tool is simply
-    // treated as non-constrainable (null), matching the "loosely-typed → unconstrained" contract.
-    private static CompiledObject? TryCompileObject(ToolSchemaObject obj, int depth)
-    {
-        if (depth >= MaxDepth || obj.Open || obj.Properties.Count is 0 or > 64) return null;
-        var keys = new byte[obj.Properties.Count][];
-        var values = new CompiledNode[obj.Properties.Count];
-        ulong reqMask = 0;
-        for (int i = 0; i < obj.Properties.Count; i++)
-        {
-            var p = obj.Properties[i];
-            if (p.Name.Length == 0) return null;
-            keys[i] = ToolSchema.Utf8(p.Name);
-            var node = TryCompileNode(p.Value, depth + 1);
-            if (node is null) return null;                  // a non-constrainable value → skip the tool
-            values[i] = node;
-            if (p.Required) reqMask |= 1UL << i;
-        }
-        return new CompiledObject { KeyBytes = keys, Values = values, RequiredMask = reqMask };
-    }
-
-    private static readonly byte[][] s_boolLiterals = [ToolSchema.Utf8("true"), ToolSchema.Utf8("false")];
-    private static readonly byte[][] s_nullLiterals = [ToolSchema.Utf8("null")];
-
-    private static CompiledNode? TryCompileNode(ToolSchemaNode node, int depth)
-    {
-        if (depth >= MaxDepth) return null;
-        switch (node.Kind)
-        {
-            case JsonSchemaKind.String:
-                byte[][]? strEnum = node.EnumValues is { } se ? Encode(se) : null;
-                return new CompiledNode { Kind = JsonSchemaKind.String, Literals = strEnum, QuotedLiterals = strEnum is not null };
-
-            case JsonSchemaKind.Number:
-            case JsonSchemaKind.Integer:
-                byte[][]? numEnum = node.EnumValues is { } ne ? Encode(ne) : null;
-                return new CompiledNode
-                {
-                    Kind = node.Kind,
-                    Literals = numEnum,
-                    QuotedLiterals = false,
-                    IntegerOnly = node.Kind == JsonSchemaKind.Integer,
-                };
-
-            case JsonSchemaKind.Boolean:
-                return new CompiledNode { Kind = JsonSchemaKind.Boolean, Literals = s_boolLiterals };
-
-            case JsonSchemaKind.Null:
-                return new CompiledNode { Kind = JsonSchemaKind.Null, Literals = s_nullLiterals };
-
-            case JsonSchemaKind.Array:
-                // An untyped array (no items) isn't fully constrainable — skip the tool.
-                if (node.Items is null) return null;
-                var item = TryCompileNode(node.Items, depth + 1);
-                return item is null ? null : new CompiledNode { Kind = JsonSchemaKind.Array, Items = item };
-
-            case JsonSchemaKind.Object:
-                if (node.Object is null) return null;
-                var obj = TryCompileObject(node.Object, depth + 1);
-                return obj is null ? null : new CompiledNode { Kind = JsonSchemaKind.Object, Object = obj };
-
-            default:
-                return null;   // Any / unknown — not constrainable
-        }
-    }
-
-    private static byte[][] Encode(IReadOnlyList<string> values)
-    {
-        var r = new byte[values.Count][];
-        for (int i = 0; i < values.Count; i++) r[i] = ToolSchema.Utf8(values[i]);
-        return r;
     }
 
     // ── Frame stack ───────────────────────────────────────────────────────────

--- a/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
@@ -348,17 +348,30 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
         Array.Clear(_firstByteOk);
         CollectFirstBytes(_depth - 1, _firstByteOk);
 
+        // Fast-path free string content. Inside a JSON string value (SContent) the close delimiter and
+        // escape are ordinary bytes, so CollectStr marks all 256 first-bytes — without this every step
+        // would SimulateToken (frame copy + byte walk) the WHOLE vocabulary (150k+ tokens on Qwen/Llama),
+        // costing ~seconds/token. But a token that contains neither '"' nor '\' is pure content that
+        // can only keep the string open, so it's legal without simulation; only tokens that could close
+        // or escape need the full replay. Disabled mid-escape (the next byte is consumed literally), so
+        // those tokens fall back to SimulateToken. This is the byte-level analogue of the Gemma sibling's
+        // token-level free-content shortcut.
+        bool fastStrContent;
+        {
+            ref var top = ref _stack[_depth - 1];
+            fastStrContent = top.Kind == FK.Str && top.State == SContent && !top.Escaped;
+        }
+
         int kept = 0;
         for (int id = 0; id < buf.Length; id++)
         {
             var bytes = _vocab.TokenBytes(id);
             // Empty-byte tokens (EOG / control) never advance the structure — forbidding them keeps
             // an end-of-generation token from truncating the call mid-object.
-            bool candidate = bytes.Length != 0 && _firstByteOk[bytes[0]];
-            if (candidate && SimulateToken(id))
-                kept++;
-            else
-                buf[id] = float.NegativeInfinity;
+            if (bytes.Length == 0 || !_firstByteOk[bytes[0]]) { buf[id] = float.NegativeInfinity; continue; }
+            bool ok = (fastStrContent && !ContainsQuoteOrBackslash(bytes)) || SimulateToken(id);
+            if (ok) kept++;
+            else buf[id] = float.NegativeInfinity;
         }
 
         // Belt-and-suspenders: forbid every EOG id regardless of its bytes (a tokenizer whose EOS
@@ -368,6 +381,13 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
             { buf[id] = float.NegativeInfinity; kept--; }
 
         return kept;
+    }
+
+    private static bool ContainsQuoteOrBackslash(ReadOnlySpan<byte> bytes)
+    {
+        for (int i = 0; i < bytes.Length; i++)
+            if (bytes[i] is (byte)'"' or (byte)'\\') return true;
+        return false;
     }
 
     private bool SimulateToken(int token)

--- a/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
@@ -1,0 +1,932 @@
+using System.Text;
+
+namespace SharpInference.Core.Grammar;
+
+/// <summary>
+/// The tool-call envelope a <see cref="JsonToolArgumentConstraint"/> targets — i.e. how the model
+/// wraps the call and where the argument object lives relative to the tool name.
+/// </summary>
+internal enum JsonToolEnvelope
+{
+    /// <summary>
+    /// The call is one JSON object whose <c>name</c> field selects the tool and whose
+    /// <c>arguments</c>/<c>parameters</c> field is the argument object — Qwen
+    /// (<c>&lt;tool_call&gt;{"name":"X","arguments":{…}}&lt;/tool_call&gt;</c>) and Llama-3
+    /// (<c>&lt;|python_tag|&gt;{"name":"X","parameters":{…}}</c>).
+    /// </summary>
+    NameValueObject,
+
+    /// <summary>
+    /// The tool name is bare text terminated by a separator token, after which the argument object
+    /// is emitted directly — DeepSeek
+    /// (<c>&lt;|tool_call_begin|&gt;NAME&lt;|tool_sep|&gt;{…}&lt;|tool_call_end|&gt;</c>).
+    /// </summary>
+    NameThenSeparator,
+}
+
+/// <summary>
+/// Constrained-decoding state machine (issue #376) for the families that emit <b>standard JSON</b>
+/// tool-call arguments — Qwen (<c>&lt;tool_call&gt;{json}&lt;/tool_call&gt;</c>), Llama-3
+/// (<c>&lt;|python_tag|&gt;{json}</c>), and DeepSeek
+/// (<c>NAME&lt;|tool_sep|&gt;{json}</c>) — the JSON sibling of
+/// <see cref="GemmaToolArgumentConstraint"/>. It watches the emitted stream until a call opens and a
+/// known tool's argument object begins, then constrains that object so only declared keys appear,
+/// every required key appears exactly once, each value matches its declared shape (JSON strings in
+/// double quotes with free escaped content, bare numbers/booleans/null, <c>[…]</c> arrays and nested
+/// <c>{…}</c> objects), and enum-typed values stay in the declared set. The closing <c>}</c> ends
+/// constraint and the machine returns to watching, so the trailing envelope and any later text are
+/// unconstrained.
+///
+/// <para>
+/// Unlike Gemma's bespoke wire format — where the string delimiter is a single <c>&lt;|"|&gt;</c>
+/// special token — JSON's structural bytes (<c>{ } [ ] " : ,</c>) are ordinary bytes the model's BPE
+/// freely merges with content and whitespace (e.g. one token carries <c>{"</c>, another <c>":</c>,
+/// another <c>"}}</c>, and the empty object is a single <c>{}</c> token). So matching is entirely at
+/// the byte level: a token is permitted iff replaying its bytes from the current state keeps the
+/// machine alive. The constraint engages the instant the argument key's colon is seen — BEFORE the
+/// <c>{</c> — so a merged <c>{}</c> token can't drop the required arguments.
+/// </para>
+///
+/// <para>Default-off byte-identical: if no supplied tool is fully constrainable, or the structural
+/// open-marker token isn't in the vocabulary, the constraint is inert and generation is unconstrained.</para>
+/// </summary>
+public sealed class JsonToolArgumentConstraint : ITokenConstraint
+{
+    private const int MaxDepth = 32;        // nesting cap; deeper schemas aren't constrained
+    private const int MaxPreambleScan = 512; // give up watching a call whose preamble runs this long
+
+    private readonly GrammarVocabulary _vocab;
+    private readonly Dictionary<string, CompiledObject> _tools;
+    private readonly HashSet<int> _forbidden;       // EOG ids — never legal inside the argument object
+    private readonly int _openMarkerId;             // arms watching (e.g. <tool_call> / <|python_tag|>)
+    private readonly int _separatorId;              // NameThenSeparator: ends the bare name (DeepSeek)
+    private readonly JsonToolEnvelope _envelope;
+    private readonly byte[][] _argsKeys;            // NameValueObject: "arguments"/"parameters" bytes
+    private static readonly byte[] s_nameKey = Encoding.UTF8.GetBytes("name");
+
+    // Watching / preamble state.
+    private bool _armed;                            // saw the open marker, scanning the preamble
+    private int _watchState;                        // preamble FSM state (W* constants)
+    private readonly StringBuilder _keyBuf = new();  // current preamble key
+    private readonly StringBuilder _nameBuf = new(); // captured tool name
+    private bool _wEscaped;                          // preamble string escape flag
+    private int _skipDepth;                          // WSkipValue brace/bracket balance
+    private int _skipKind;                           // WSkipValue: 0=undecided 1=string 2=balanced 3=bare
+    private int _preambleLen;                        // bytes scanned since arming (runaway guard)
+
+    // Constraining state: an explicit frame stack (pushdown automaton).
+    private Frame[] _stack = new Frame[MaxDepth];
+    private Frame[] _scratch = new Frame[MaxDepth];
+    private int _depth;
+
+    // Masking scratch — a reusable full-vocab logits buffer (allocated on first constrained step).
+    private float[]? _masked;
+    private readonly bool[] _firstByteOk = new bool[256];
+
+    internal JsonToolArgumentConstraint(
+        GrammarVocabulary vocab,
+        IReadOnlyList<ToolSchema> tools,
+        string openMarker,
+        JsonToolEnvelope envelope,
+        IReadOnlyList<string>? argsKeys = null,
+        string? separatorMarker = null)
+    {
+        ArgumentNullException.ThrowIfNull(vocab);
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentException.ThrowIfNullOrEmpty(openMarker);
+        _vocab = vocab;
+        _envelope = envelope;
+        _argsKeys = (argsKeys ?? ["arguments", "parameters"]).Select(Encoding.UTF8.GetBytes).ToArray();
+
+        _forbidden = new HashSet<int>(vocab.EogTokenIds);
+        _ = vocab.TryGetSpecialToken(openMarker, out _openMarkerId);
+        _separatorId = -1;
+        if (separatorMarker is { Length: > 0 })
+            _ = vocab.TryGetSpecialToken(separatorMarker, out _separatorId);
+
+        _tools = new Dictionary<string, CompiledObject>(StringComparer.Ordinal);
+        bool haveMarker = _openMarkerId > 0
+            && (_envelope != JsonToolEnvelope.NameThenSeparator || _separatorId > 0);
+        if (haveMarker)
+        {
+            foreach (var t in tools)
+            {
+                if (t.Arguments.Open) continue;                 // unconstrained body — skip
+                var compiled = ToolSchemaCompiler.TryCompileObject(t.Arguments);
+                if (compiled is not null) _tools[t.Name] = compiled;
+            }
+        }
+        else if (tools.Count > 0)
+        {
+            // The caller asked for a constraint but this vocabulary doesn't define the family's
+            // structural open marker — the constraint is inert. Surface it once so an operator who
+            // enabled SHARPI_TOOL_GRAMMAR on a mismatched model isn't left wondering why arguments
+            // are still unconstrained.
+            WarnOnce($"no-open-marker:{openMarker}",
+                $"open marker '{openMarker}' not found in this vocabulary — tool-grammar is inert for "
+                + "this model (arguments generate unconstrained).");
+        }
+    }
+
+    /// <summary>Whether this constraint can ever restrict anything (any tool was constrainable).</summary>
+    public bool HasConstrainableTools => _tools.Count > 0;
+
+    public bool IsConstraining => _depth > 0;
+
+    public void Reset()
+    {
+        _armed = false;
+        _depth = 0;
+        ResetPreamble();
+    }
+
+    private void ResetPreamble()
+    {
+        _watchState = WStart;
+        _keyBuf.Clear();
+        _nameBuf.Clear();
+        _wEscaped = false;
+        _skipDepth = 0;
+        _skipKind = 0;
+        _preambleLen = 0;
+    }
+
+    // ── Frame stack ───────────────────────────────────────────────────────────
+
+    private enum FK : byte { Object, Array, Str, StrEnum, Num, Lit }
+
+    private struct Frame
+    {
+        public FK Kind;
+        public int State;
+        public CompiledObject? Obj;     // Object frame
+        public CompiledNode? Node;      // Array (item), StrEnum / Lit (literals), Num
+        public ulong Emitted;           // Object: keys emitted
+        public ulong Cand;              // Object key-match / StrEnum / Lit candidates
+        public int MatchLen;            // chars into current key / literal
+        public int PendingKey;          // Object: key index whose value to push at ':'
+        public bool SeenDigit;          // Num
+        public bool SeenDot;            // Num
+        public bool SeenSign;           // Num
+        public bool Escaped;            // Str content: previous byte was '\'
+    }
+
+    // Object sub-states.
+    private const int OExpectOpenBrace = 0;   // engaged before '{' (early-engage path)
+    private const int OExpectKeyOrClose = 1;  // '"' to open a key, or '}' if all required emitted
+    private const int OExpectKey = 2;         // after ',', a key is required ('}' not allowed)
+    private const int OKeyContent = 3;        // matching a key name (byte-level); '"' closes
+    private const int OExpectColon = 4;       // ':'
+    private const int OExpectCommaOrClose = 5;
+
+    // Array sub-states.
+    private const int AExpectOpen = 0;        // '['
+    private const int AExpectItemOrClose = 1;
+    private const int AExpectCommaOrClose = 2;
+    private const int AExpectItem = 3;        // after ',', an item is required
+
+    // Str sub-states.
+    private const int SExpectOpen = 0;        // open '"'
+    private const int SContent = 1;           // free content until unescaped '"'
+
+    // StrEnum sub-states.
+    private const int SeExpectOpen = 0;       // open '"'
+    private const int SeMatch = 1;            // match enum bytes; '"' closes
+
+    // Num sub-states.
+    private const int NStart = 0;
+    private const int NIntDigits = 1;
+    private const int NFracStart = 2;
+    private const int NFracDigits = 3;
+
+    // Lit sub-state.
+    private const int LMatch = 0;
+
+    // Preamble (watching) sub-states.
+    private const int WStart = 0;        // before envelope '{' (NameValueObject) / scanning name (NameThenSeparator)
+    private const int WKeyExpect = 1;    // '"' opens a key, '}' gives up
+    private const int WKeyContent = 2;   // accumulate key bytes until '"'
+    private const int WColon = 3;        // ':'
+    private const int WValueStart = 4;   // dispatch on the captured key
+    private const int WNameString = 5;   // read the "name" string value
+    private const int WSkipValue = 6;    // skip an unrelated key's value (balanced)
+    private const int WAfterValue = 7;   // ',' continues, '}' gives up
+
+    private void PushObject(CompiledObject obj, int state)
+    {
+        ref var f = ref _stack[_depth++];
+        f = default;
+        f.Kind = FK.Object; f.State = state; f.Obj = obj; f.Emitted = 0;
+    }
+
+    private bool PushValue(CompiledNode node)
+    {
+        if (_depth >= MaxDepth) return false;
+        if (node.Kind == JsonSchemaKind.Object)
+        {
+            if (node.Object is null) return false;
+            PushObject(node.Object, OExpectOpenBrace);
+            return true;
+        }
+        ref var f = ref _stack[_depth++];
+        f = default;
+        f.Node = node;
+        switch (node.Kind)
+        {
+            case JsonSchemaKind.String:
+                if (node.Literals is not null) { f.Kind = FK.StrEnum; f.State = SeExpectOpen; f.Cand = AllBits(node.Literals.Length); }
+                else { f.Kind = FK.Str; f.State = SExpectOpen; }
+                break;
+            case JsonSchemaKind.Array:
+                f.Kind = FK.Array; f.State = AExpectOpen;
+                break;
+            default: // Number / Integer / Boolean / Null
+                if (node.Literals is not null) { f.Kind = FK.Lit; f.State = LMatch; f.Cand = AllBits(node.Literals.Length); }
+                else { f.Kind = FK.Num; f.State = NStart; }
+                break;
+        }
+        return true;
+    }
+
+    private static ulong AllBits(int n) => n >= 64 ? ulong.MaxValue : (1UL << n) - 1;
+
+    // ── Public lifecycle ──────────────────────────────────────────────────────
+
+    public void Accept(int token)
+    {
+        if (IsConstraining)
+        {
+            bool ok = !_forbidden.Contains(token) && RunToken(token);
+            // The engine draws from the masked logits, so a permitted token must replay cleanly. A
+            // rejection here is an invariant violation (a Filter/Accept divergence); flag it once and
+            // stop constraining either way (a normal end-of-object is ok && _depth == 0).
+            if (!ok)
+                WarnOnce("accept-divergence",
+                    "a sampled token permitted by the mask was rejected by the grammar — constraint "
+                    + "disabled for the rest of this call (possible Filter/Accept divergence).");
+            if (!ok || _depth == 0) { _depth = 0; _armed = false; ResetPreamble(); }
+            return;
+        }
+
+        // Watching.
+        if (!_armed)
+        {
+            if (token == _openMarkerId) { _armed = true; ResetPreamble(); }
+            return;
+        }
+
+        // NameThenSeparator: the name is bare text up to the separator token, then the argument
+        // object is emitted directly — engage on the separator so the NEXT token (the object open)
+        // is already masked.
+        if (_envelope == JsonToolEnvelope.NameThenSeparator)
+        {
+            if (token == _separatorId)
+            {
+                if (EngageOnTool()) _armed = false; else Disarm();
+                return;
+            }
+            AppendName(_vocab.TokenBytes(token));
+            if (_nameBuf.Length > MaxPreambleScan) Disarm();
+            return;
+        }
+
+        // Walk the token's bytes through the preamble FSM; engage at the argument key's colon so the
+        // following token (which opens the object) is masked — a merged "{}" can't slip the required
+        // arguments past. The colon is consumed by the watcher; the rest of this token replays into
+        // the constrained machine (covers a tokenizer that merges ':' with the opening '{').
+        var bytes = _vocab.TokenBytes(token);
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (++_preambleLen > MaxPreambleScan) { Disarm(); return; }
+            var r = WatchByte(bytes[i]);
+            if (r == WatchResult.Disarm) { Disarm(); return; }
+            if (r == WatchResult.Engage)
+            {
+                _armed = false;
+                if (i + 1 < bytes.Length && !FeedRawBytes(bytes[(i + 1)..]))
+                {
+                    _depth = 0;
+                    WarnOnce("trailing-replay",
+                        "could not replay argument bytes after the key colon — arguments generate "
+                        + "unconstrained for this call.");
+                }
+                return;
+            }
+        }
+    }
+
+    private void AppendName(ReadOnlySpan<byte> bytes)
+    {
+        for (int i = 0; i < bytes.Length; i++) _nameBuf.Append((char)bytes[i]);
+    }
+
+    private void Disarm() { _armed = false; ResetPreamble(); }
+
+    public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+    {
+        if (_depth == 0) return logits;
+
+        var masked = _masked ??= new float[_vocab.VocabSize];
+        if (masked.Length != logits.Length) return logits;     // vocab mismatch — never wedge
+        logits.CopyTo(masked);
+
+        int allowedCount = ComputeMask(masked);
+        if (allowedCount == 0)
+        {
+            ref var top = ref _stack[_depth - 1];
+            WarnOnce($"dead-state:{top.Kind}:{top.State}",
+                $"grammar reached a dead state (no legal token) at kind={top.Kind} state={top.State} "
+                + "— tool arguments continue unconstrained from here.");
+            return logits;
+        }
+        return masked;
+    }
+
+    /// <summary>Sets every forbidden token to -inf in <paramref name="buf"/>; returns the count kept.</summary>
+    private int ComputeMask(float[] buf)
+    {
+        Array.Clear(_firstByteOk);
+        CollectFirstBytes(_depth - 1, _firstByteOk);
+
+        int kept = 0;
+        for (int id = 0; id < buf.Length; id++)
+        {
+            var bytes = _vocab.TokenBytes(id);
+            // Empty-byte tokens (EOG / control) never advance the structure — forbidding them keeps
+            // an end-of-generation token from truncating the call mid-object.
+            bool candidate = bytes.Length != 0 && _firstByteOk[bytes[0]];
+            if (candidate && SimulateToken(id))
+                kept++;
+            else
+                buf[id] = float.NegativeInfinity;
+        }
+
+        // Belt-and-suspenders: forbid every EOG id regardless of its bytes (a tokenizer whose EOS
+        // decodes to ordinary text could otherwise pass first-byte pruning inside a free string).
+        foreach (int id in _forbidden)
+            if ((uint)id < (uint)buf.Length && !float.IsNegativeInfinity(buf[id]))
+            { buf[id] = float.NegativeInfinity; kept--; }
+
+        return kept;
+    }
+
+    private bool SimulateToken(int token)
+    {
+        int savedDepth = _depth;
+        for (int i = 0; i < savedDepth; i++) _scratch[i] = _stack[i];
+        bool ok = FeedRawBytes(_vocab.TokenBytes(token));
+        for (int i = 0; i < savedDepth; i++) _stack[i] = _scratch[i];
+        _depth = savedDepth;
+        return ok;
+    }
+
+    // ── Token execution ───────────────────────────────────────────────────────
+
+    private bool RunToken(int tokenId) => _depth != 0 && FeedRawBytes(_vocab.TokenBytes(tokenId));
+
+    /// <summary>Byte-walks a raw byte span through the structural automaton, mutating the stack.</summary>
+    private bool FeedRawBytes(ReadOnlySpan<byte> bytes)
+    {
+        int i = 0;
+        while (i < bytes.Length)
+        {
+            if (_depth == 0) return false;                 // closed the object but bytes remain
+            ref var top = ref _stack[_depth - 1];
+            var r = StepByte(ref top, bytes[i]);
+            switch (r)
+            {
+                case Step.Consume: i++; break;
+                case Step.Retry: break;                    // frame pushed/popped; re-evaluate top
+                default: return false;                     // Reject
+            }
+        }
+        return true;
+    }
+
+    private enum Step { Consume, Retry, Reject }
+
+    private Step StepByte(ref Frame top, byte b)
+    {
+        switch (top.Kind)
+        {
+            case FK.Object: return StepObject(ref top, b);
+            case FK.Array: return StepArray(ref top, b);
+            case FK.Str: return StepStr(ref top, b);
+            case FK.StrEnum: return StepStrEnum(ref top, b);
+            case FK.Num: return StepNum(ref top, b);
+            case FK.Lit: return StepLit(ref top, b);
+            default: return Step.Reject;
+        }
+    }
+
+    private static bool IsWs(byte b) => b is (byte)' ' or (byte)'\t' or (byte)'\n' or (byte)'\r';
+
+    // After a value frame pops, resume the parent (object/array) at its post-value state.
+    private bool PostValue()
+    {
+        if (_depth == 0) return true;
+        ref var parent = ref _stack[_depth - 1];
+        if (parent.Kind == FK.Object) { parent.State = OExpectCommaOrClose; return true; }
+        if (parent.Kind == FK.Array) { parent.State = AExpectCommaOrClose; return true; }
+        return false;
+    }
+
+    private Step PostValueOrDone()
+    {
+        if (_depth == 0) return Step.Consume;              // top-level object done
+        return PostValue() ? Step.Consume : Step.Reject;
+    }
+
+    private Step PostValueRetry() => PostValue() ? Step.Retry : Step.Reject;
+
+    private Step StepObject(ref Frame f, byte b)
+    {
+        var obj = f.Obj!;
+        switch (f.State)
+        {
+            case OExpectOpenBrace:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'{') { f.State = OExpectKeyOrClose; return Step.Consume; }
+                return Step.Reject;
+
+            case OExpectKeyOrClose:
+            case OExpectKey:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'}' && f.State == OExpectKeyOrClose)
+                {
+                    if ((f.Emitted & obj.RequiredMask) != obj.RequiredMask) return Step.Reject;
+                    _depth--; return PostValueOrDone();
+                }
+                if (b == (byte)'"')
+                {
+                    // Begin a key: candidates are every not-yet-emitted key.
+                    ulong cand = 0;
+                    for (int i = 0; i < obj.Count; i++)
+                        if ((f.Emitted & (1UL << i)) == 0) cand |= 1UL << i;
+                    if (cand == 0) return Step.Reject;     // all keys emitted; only '}' is legal
+                    f.Cand = cand; f.MatchLen = 0; f.State = OKeyContent;
+                    return Step.Consume;
+                }
+                return Step.Reject;
+
+            case OKeyContent:
+                if (b == (byte)'"')
+                {
+                    int complete = CompleteIndex(obj.KeyBytes, f.Cand, f.MatchLen);
+                    if (complete < 0) return Step.Reject;  // closing quote at a non-key-boundary
+                    f.Emitted |= 1UL << complete;
+                    f.PendingKey = complete;
+                    f.State = OExpectColon;
+                    return Step.Consume;
+                }
+                else
+                {
+                    ulong narrowed = 0;
+                    for (int i = 0; i < obj.Count; i++)
+                        if ((f.Cand & (1UL << i)) != 0 && obj.KeyBytes[i].Length > f.MatchLen && obj.KeyBytes[i][f.MatchLen] == b)
+                            narrowed |= 1UL << i;
+                    if (narrowed == 0) return Step.Reject;
+                    f.Cand = narrowed; f.MatchLen++;
+                    return Step.Consume;
+                }
+
+            case OExpectColon:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)':')
+                {
+                    f.State = OExpectCommaOrClose;          // resume here after the value
+                    return PushValue(obj.Values[f.PendingKey]) ? Step.Consume : Step.Reject;
+                }
+                return Step.Reject;
+
+            case OExpectCommaOrClose:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)',') { f.State = OExpectKey; return Step.Consume; }
+                if (b == (byte)'}')
+                {
+                    if ((f.Emitted & obj.RequiredMask) != obj.RequiredMask) return Step.Reject;
+                    _depth--; return PostValueOrDone();
+                }
+                return Step.Reject;
+
+            default:
+                return Step.Reject;
+        }
+    }
+
+    private Step StepArray(ref Frame f, byte b)
+    {
+        var item = f.Node!.Items!;
+        switch (f.State)
+        {
+            case AExpectOpen:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'[') { f.State = AExpectItemOrClose; return Step.Consume; }
+                return Step.Reject;
+
+            case AExpectItemOrClose:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)']') { _depth--; return PostValueOrDone(); }
+                f.State = AExpectCommaOrClose;              // resume here after the item
+                return PushValue(item) ? Step.Retry : Step.Reject;
+
+            case AExpectCommaOrClose:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)',') { f.State = AExpectItem; return Step.Consume; }
+                if (b == (byte)']') { _depth--; return PostValueOrDone(); }
+                return Step.Reject;
+
+            case AExpectItem:
+                if (IsWs(b)) return Step.Consume;
+                f.State = AExpectCommaOrClose;
+                return PushValue(item) ? Step.Retry : Step.Reject;
+
+            default:
+                return Step.Reject;
+        }
+    }
+
+    private Step StepStr(ref Frame f, byte b)
+    {
+        switch (f.State)
+        {
+            case SExpectOpen:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'"') { f.State = SContent; return Step.Consume; }
+                return Step.Reject;
+
+            case SContent:
+                if (f.Escaped) { f.Escaped = false; return Step.Consume; }
+                if (b == (byte)'\\') { f.Escaped = true; return Step.Consume; }
+                if (b == (byte)'"') { _depth--; return PostValueOrDone(); }  // close string
+                return Step.Consume;                        // free content byte
+
+            default:
+                return Step.Reject;
+        }
+    }
+
+    private Step StepStrEnum(ref Frame f, byte b)
+    {
+        var lits = f.Node!.Literals!;
+        switch (f.State)
+        {
+            case SeExpectOpen:
+                if (IsWs(b)) return Step.Consume;
+                if (b == (byte)'"') { f.State = SeMatch; f.MatchLen = 0; return Step.Consume; }
+                return Step.Reject;
+
+            case SeMatch:
+                if (b == (byte)'"')
+                {
+                    if (CompleteIndex(lits, f.Cand, f.MatchLen) < 0) return Step.Reject;
+                    _depth--; return PostValueOrDone();
+                }
+                ulong narrowed = 0;
+                for (int i = 0; i < lits.Length; i++)
+                    if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen && lits[i][f.MatchLen] == b)
+                        narrowed |= 1UL << i;
+                if (narrowed == 0) return Step.Reject;
+                f.Cand = narrowed; f.MatchLen++;
+                return Step.Consume;
+
+            default:
+                return Step.Reject;
+        }
+    }
+
+    private Step StepNum(ref Frame f, byte b)
+    {
+        bool digit = b is >= (byte)'0' and <= (byte)'9';
+        switch (f.State)
+        {
+            case NStart:
+                if (b == (byte)'-' && !f.SeenSign) { f.SeenSign = true; return Step.Consume; }
+                if (digit) { f.SeenDigit = true; f.State = NIntDigits; return Step.Consume; }
+                return Step.Reject;
+            case NIntDigits:
+                if (digit) return Step.Consume;
+                if (b == (byte)'.' && !f.Node!.IntegerOnly && !f.SeenDot) { f.SeenDot = true; f.State = NFracStart; return Step.Consume; }
+                if (f.SeenDigit) { _depth--; return PostValueRetry(); }
+                return Step.Reject;
+            case NFracStart:
+                if (digit) { f.State = NFracDigits; return Step.Consume; }
+                return Step.Reject;
+            case NFracDigits:
+                if (digit) return Step.Consume;
+                _depth--; return PostValueRetry();
+            default:
+                return Step.Reject;
+        }
+    }
+
+    private Step StepLit(ref Frame f, byte b)
+    {
+        var lits = f.Node!.Literals!;
+        ulong narrowed = 0;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen && lits[i][f.MatchLen] == b)
+                narrowed |= 1UL << i;
+        if (narrowed != 0) { f.Cand = narrowed; f.MatchLen++; return Step.Consume; }
+        if (CompleteIndex(lits, f.Cand, f.MatchLen) >= 0) { _depth--; return PostValueRetry(); }
+        return Step.Reject;
+    }
+
+    // ── Preamble (watching) byte FSM ──────────────────────────────────────────
+
+    private enum WatchResult { Continue, Engage, Disarm }
+
+    /// <summary>Walks one preamble byte for the NameValueObject envelope, returning whether the
+    /// argument object now opens (engage), the call should be abandoned (disarm), or scanning
+    /// continues.</summary>
+    private WatchResult WatchByte(byte b)
+    {
+        switch (_watchState)
+        {
+            case WStart:
+                if (IsWs(b)) return WatchResult.Continue;
+                if (b == (byte)'{') { _watchState = WKeyExpect; return WatchResult.Continue; }
+                return WatchResult.Disarm;
+
+            case WKeyExpect:
+                if (IsWs(b)) return WatchResult.Continue;
+                if (b == (byte)'"') { _keyBuf.Clear(); _wEscaped = false; _watchState = WKeyContent; return WatchResult.Continue; }
+                return WatchResult.Disarm;                  // '}' or junk before any key → no args
+
+            case WKeyContent:
+                if (_wEscaped) { _keyBuf.Append((char)b); _wEscaped = false; return WatchResult.Continue; }
+                if (b == (byte)'\\') { _wEscaped = true; return WatchResult.Continue; }
+                if (b == (byte)'"') { _watchState = WColon; return WatchResult.Continue; }
+                _keyBuf.Append((char)b);
+                return WatchResult.Continue;
+
+            case WColon:
+                if (IsWs(b)) return WatchResult.Continue;
+                if (b == (byte)':')
+                {
+                    // The args key's colon is the engage point: push the object frame now so the next
+                    // token is masked. The colon is consumed; any remaining token bytes replay into
+                    // the machine. A non-args key falls through to its value.
+                    if (CurrentKeyIsArgsKey())
+                        return EngageOnTool() ? WatchResult.Engage : WatchResult.Disarm;
+                    _watchState = WValueStart; return WatchResult.Continue;
+                }
+                return WatchResult.Disarm;
+
+            case WValueStart:                               // key is NOT the args key (engaged above)
+                if (IsWs(b)) return WatchResult.Continue;
+                if (KeyBufEquals(s_nameKey))
+                {
+                    if (b != (byte)'"') return WatchResult.Disarm;   // name must be a string
+                    _nameBuf.Clear(); _wEscaped = false; _watchState = WNameString;
+                    return WatchResult.Continue;
+                }
+                // Some other key — skip its value and resume at the next key.
+                _skipDepth = 0; _skipKind = 0; _wEscaped = false; _watchState = WSkipValue;
+                return SkipValueByte(b);
+
+            case WNameString:
+                if (_wEscaped) { _nameBuf.Append((char)b); _wEscaped = false; return WatchResult.Continue; }
+                if (b == (byte)'\\') { _wEscaped = true; return WatchResult.Continue; }
+                if (b == (byte)'"') { _watchState = WAfterValue; return WatchResult.Continue; }
+                _nameBuf.Append((char)b);
+                return WatchResult.Continue;
+
+            case WSkipValue:
+                return SkipValueByte(b);
+
+            case WAfterValue:
+                if (IsWs(b)) return WatchResult.Continue;
+                if (b == (byte)',') { _keyBuf.Clear(); _watchState = WKeyExpect; return WatchResult.Continue; }
+                return WatchResult.Disarm;                  // '}' (envelope closed, no args) or junk
+
+            default:
+                return WatchResult.Disarm;
+        }
+    }
+
+    private bool CurrentKeyIsArgsKey()
+    {
+        foreach (var k in _argsKeys) if (KeyBufEquals(k)) return true;
+        return false;
+    }
+
+    /// <summary>Engages the constrained machine on the identified tool's argument object, starting in
+    /// <see cref="OExpectOpenBrace"/> so an explicit '{' is forced and a merged "{}" can't drop the
+    /// required arguments. Returns false (caller disarms) for an unknown / non-constrainable tool.
+    /// Assumes the canonical name-before-arguments key order; a model that emitted the arguments first
+    /// with two-plus tools active leaves the name uncaptured and degrades to unconstrained.</summary>
+    private bool EngageOnTool()
+    {
+        string name = _nameBuf.ToString().Trim();
+        if (name.Length == 0 && _tools.Count == 1)
+            name = _tools.Keys.First();                     // single tool, no name needed (DeepSeek/bare)
+        if (!_tools.TryGetValue(name, out var obj)) return false;
+
+        _depth = 0;
+        PushObject(obj, OExpectOpenBrace);
+        return true;
+    }
+
+    /// <summary>Skips one JSON value during preamble scanning (an unrelated envelope key's value),
+    /// balancing strings/objects/arrays so the next key is found correctly. On the value's end
+    /// transitions to <see cref="WAfterValue"/>; a bare scalar's terminating ',' or '}' is left for
+    /// <see cref="WAfterValue"/> to consume.</summary>
+    private WatchResult SkipValueByte(byte b)
+    {
+        switch (_skipKind)
+        {
+            case 0:                                          // undecided — classify the value
+                if (IsWs(b)) return WatchResult.Continue;
+                if (b == (byte)'"') { _skipKind = 1; _wEscaped = false; return WatchResult.Continue; }
+                if (b is (byte)'{' or (byte)'[') { _skipKind = 2; _skipDepth = 1; return WatchResult.Continue; }
+                _skipKind = 3;                               // bare scalar
+                return WatchResult.Continue;
+
+            case 1:                                          // string
+                if (_wEscaped) { _wEscaped = false; return WatchResult.Continue; }
+                if (b == (byte)'\\') { _wEscaped = true; return WatchResult.Continue; }
+                if (b == (byte)'"') { _watchState = WAfterValue; return WatchResult.Continue; }
+                return WatchResult.Continue;
+
+            case 2:                                          // balanced object/array (string-aware)
+                if (b == (byte)'"') { _skipKind = 4; _wEscaped = false; return WatchResult.Continue; }
+                if (b is (byte)'{' or (byte)'[') _skipDepth++;
+                else if (b is (byte)'}' or (byte)']')
+                {
+                    if (--_skipDepth == 0) { _watchState = WAfterValue; return WatchResult.Continue; }
+                }
+                return WatchResult.Continue;
+
+            case 4:                                          // string inside a balanced value
+                if (_wEscaped) { _wEscaped = false; return WatchResult.Continue; }
+                if (b == (byte)'\\') { _wEscaped = true; return WatchResult.Continue; }
+                if (b == (byte)'"') _skipKind = 2;
+                return WatchResult.Continue;
+
+            default:                                         // 3: bare scalar — ends at a delimiter
+                if (b is (byte)',' or (byte)'}' or (byte)']')
+                {
+                    _watchState = WAfterValue;
+                    return WatchByte(b);                     // re-process the delimiter in WAfterValue
+                }
+                return WatchResult.Continue;
+        }
+    }
+
+    private bool KeyBufEquals(byte[] ascii)
+    {
+        if (_keyBuf.Length != ascii.Length) return false;
+        for (int i = 0; i < ascii.Length; i++) if (_keyBuf[i] != (char)ascii[i]) return false;
+        return true;
+    }
+
+    // ── First-byte collection (mask pruning) ──────────────────────────────────
+
+    private void CollectFirstBytes(int d, bool[] set)
+    {
+        while (d >= 0)
+        {
+            ref var f = ref _stack[d];
+            bool popThrough = false;
+            switch (f.Kind)
+            {
+                case FK.Object: CollectObject(ref f, set); break;
+                case FK.Array: CollectArray(ref f, set); break;
+                case FK.Str: CollectStr(ref f, set); break;
+                case FK.StrEnum: CollectStrEnum(ref f, set); break;
+                case FK.Num: popThrough = CollectNum(ref f, set); break;
+                case FK.Lit: popThrough = CollectLit(ref f, set); break;
+            }
+            if (!popThrough) break;
+            d--;                                            // bare value can end here — parent bytes also start a token
+        }
+    }
+
+    private static void CollectObject(ref Frame f, bool[] set)
+    {
+        var obj = f.Obj!;
+        switch (f.State)
+        {
+            case OExpectOpenBrace: MarkWs(set); set['{'] = true; break;
+            case OExpectKeyOrClose:
+            case OExpectKey:
+                MarkWs(set);
+                if (f.State == OExpectKeyOrClose && (f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
+                // A key opens with '"' whenever any key remains unemitted.
+                for (int i = 0; i < obj.Count; i++)
+                    if ((f.Emitted & (1UL << i)) == 0) { set['"'] = true; break; }
+                break;
+            case OKeyContent:
+                // Either a content byte continuing a candidate key, or '"' if a candidate is complete.
+                for (int i = 0; i < obj.Count; i++)
+                    if ((f.Cand & (1UL << i)) != 0 && obj.KeyBytes[i].Length > f.MatchLen)
+                        set[obj.KeyBytes[i][f.MatchLen]] = true;
+                if (CompleteIndex(obj.KeyBytes, f.Cand, f.MatchLen) >= 0) set['"'] = true;
+                break;
+            case OExpectColon: MarkWs(set); set[':'] = true; break;
+            case OExpectCommaOrClose:
+                MarkWs(set); set[','] = true;
+                if ((f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
+                break;
+        }
+    }
+
+    private static void CollectArray(ref Frame f, bool[] set)
+    {
+        switch (f.State)
+        {
+            case AExpectOpen: MarkWs(set); set['['] = true; break;
+            case AExpectItemOrClose:
+                MarkWs(set); set[']'] = true;
+                MarkValueFirstBytes(f.Node!.Items!, set);
+                break;
+            case AExpectCommaOrClose: MarkWs(set); set[','] = true; set[']'] = true; break;
+            case AExpectItem: MarkWs(set); MarkValueFirstBytes(f.Node!.Items!, set); break;
+        }
+    }
+
+    private static void CollectStr(ref Frame f, bool[] set)
+    {
+        if (f.State == SExpectOpen) { MarkWs(set); set['"'] = true; return; }
+        // SContent: any byte is legal content (and '"' closes, '\' escapes) — mark all so the
+        // simulate pass (authoritative) decides which tokens stay alive.
+        for (int i = 0; i < 256; i++) set[i] = true;
+    }
+
+    private static void CollectStrEnum(ref Frame f, bool[] set)
+    {
+        if (f.State == SeExpectOpen) { MarkWs(set); set['"'] = true; return; }
+        var lits = f.Node!.Literals!;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen)
+                set[lits[i][f.MatchLen]] = true;
+        if (CompleteIndex(lits, f.Cand, f.MatchLen) >= 0) set['"'] = true;
+    }
+
+    private static bool CollectNum(ref Frame f, bool[] set)
+    {
+        switch (f.State)
+        {
+            case NStart:
+                if (!f.SeenSign) set['-'] = true;
+                MarkDigits(set);
+                return false;
+            case NIntDigits:
+                MarkDigits(set);
+                if (!f.SeenDot && !f.Node!.IntegerOnly) set['.'] = true;
+                return f.SeenDigit;
+            case NFracStart:
+                MarkDigits(set);
+                return false;
+            case NFracDigits:
+                MarkDigits(set);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool CollectLit(ref Frame f, bool[] set)
+    {
+        var lits = f.Node!.Literals!;
+        for (int i = 0; i < lits.Length; i++)
+            if ((f.Cand & (1UL << i)) != 0 && lits[i].Length > f.MatchLen)
+                set[lits[i][f.MatchLen]] = true;
+        return CompleteIndex(lits, f.Cand, f.MatchLen) >= 0;
+    }
+
+    private static void MarkValueFirstBytes(CompiledNode node, bool[] set)
+    {
+        switch (node.Kind)
+        {
+            case JsonSchemaKind.Array: set['['] = true; break;
+            case JsonSchemaKind.Object: set['{'] = true; break;
+            case JsonSchemaKind.String: set['"'] = true; break;   // JSON strings open with a '"' byte
+            default:
+                if (node.Literals is { } lits)
+                    foreach (var l in lits) { if (l.Length > 0) set[l[0]] = true; }
+                else { set['-'] = true; MarkDigits(set); }
+                break;
+        }
+    }
+
+    private static void MarkDigits(bool[] set) { for (byte b = (byte)'0'; b <= (byte)'9'; b++) set[b] = true; }
+    private static void MarkWs(bool[] set) { set[' '] = true; set['\t'] = true; set['\n'] = true; set['\r'] = true; }
+
+    // ── Small helpers ─────────────────────────────────────────────────────────
+
+    private static int CompleteIndex(byte[][] lits, ulong cand, int matchLen)
+    {
+        for (int i = 0; i < lits.Length; i++)
+            if ((cand & (1UL << i)) != 0 && lits[i].Length == matchLen) return i;
+        return -1;
+    }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> s_warned = new();
+    private static void WarnOnce(string key, string message)
+    {
+        if (s_warned.TryAdd(key, 0))
+            Console.Error.WriteLine($"[SharpInference.ToolGrammar] {message}");
+    }
+}

--- a/src/SharpInference.Core/Grammar/ToolSchemaCompiler.cs
+++ b/src/SharpInference.Core/Grammar/ToolSchemaCompiler.cs
@@ -1,0 +1,127 @@
+namespace SharpInference.Core.Grammar;
+
+// ── Compiled schema ───────────────────────────────────────────────────────────
+//
+// A parsed ToolSchema is "compiled" once per request into match tables (UTF-8 key/enum bytes,
+// required-key bitmask) so the per-token hot loop never re-encodes strings. The compiled form is
+// wire-format-agnostic — both the Gemma constraint (GemmaToolArgumentConstraint, bespoke
+// <|"|>-quoted syntax) and the JSON constraint (JsonToolArgumentConstraint, standard JSON for
+// Qwen/Llama/DeepSeek) consume the same CompiledObject/CompiledNode and only differ in how they
+// walk the structural bytes. Only tools whose schema is FULLY constrainable (every value is a
+// concrete type / typed array / nested typed object — no Any-typed value, no open object) are
+// compiled; a tool that isn't is left out of the constraint and generates its arguments
+// unconstrained, so the constraint never blocks generation.
+
+/// <summary>Compiled value-type descriptor (see <see cref="ToolSchemaNode"/>).</summary>
+internal sealed class CompiledNode
+{
+    public required JsonSchemaKind Kind { get; init; }
+    /// <summary>For an enum / boolean / null: the candidate literal byte sequences (≤64).</summary>
+    public byte[][]? Literals { get; init; }
+    /// <summary>True when <see cref="Literals"/> are matched as a quoted string (string enum).</summary>
+    public bool QuotedLiterals { get; init; }
+    /// <summary>Element type for an array.</summary>
+    public CompiledNode? Items { get; init; }
+    /// <summary>Nested object shape.</summary>
+    public CompiledObject? Object { get; init; }
+    /// <summary>Integer (no fractional part) vs general number.</summary>
+    public bool IntegerOnly { get; init; }
+}
+
+/// <summary>Compiled object shape: per-property name bytes + value node, plus the required-key mask.</summary>
+internal sealed class CompiledObject
+{
+    public required byte[][] KeyBytes { get; init; }
+    public required CompiledNode[] Values { get; init; }
+    public required ulong RequiredMask { get; init; }
+    public int Count => KeyBytes.Length;
+}
+
+/// <summary>
+/// Compiles a parsed <see cref="ToolSchemaObject"/> into the match tables the argument-grammar
+/// state machines drive. Shared by every architecture's constraint so the "which schemas are
+/// constrainable" rule lives in exactly one place. Returns <c>null</c> for any schema that isn't
+/// fully constrainable (open body, an <c>Any</c>-typed value, an untyped array, …) — the caller
+/// then leaves that tool unconstrained.
+/// </summary>
+internal static class ToolSchemaCompiler
+{
+    // Depth-capped so compilation can't recurse unbounded — the parser already caps nesting, but the
+    // ToolSchema records are public, so a caller that builds a deeply-nested schema in-memory (not via
+    // the parser) would otherwise risk an uncatchable StackOverflow. Past the cap the tool is simply
+    // treated as non-constrainable (null), matching the "loosely-typed → unconstrained" contract.
+    private const int MaxDepth = 32;
+
+    private static readonly byte[][] s_boolLiterals = [ToolSchema.Utf8("true"), ToolSchema.Utf8("false")];
+    private static readonly byte[][] s_nullLiterals = [ToolSchema.Utf8("null")];
+
+    public static CompiledObject? TryCompileObject(ToolSchemaObject obj) => TryCompileObject(obj, 0);
+
+    private static CompiledObject? TryCompileObject(ToolSchemaObject obj, int depth)
+    {
+        if (depth >= MaxDepth || obj.Open || obj.Properties.Count is 0 or > 64) return null;
+        var keys = new byte[obj.Properties.Count][];
+        var values = new CompiledNode[obj.Properties.Count];
+        ulong reqMask = 0;
+        for (int i = 0; i < obj.Properties.Count; i++)
+        {
+            var p = obj.Properties[i];
+            if (p.Name.Length == 0) return null;
+            keys[i] = ToolSchema.Utf8(p.Name);
+            var node = TryCompileNode(p.Value, depth + 1);
+            if (node is null) return null;                  // a non-constrainable value → skip the tool
+            values[i] = node;
+            if (p.Required) reqMask |= 1UL << i;
+        }
+        return new CompiledObject { KeyBytes = keys, Values = values, RequiredMask = reqMask };
+    }
+
+    private static CompiledNode? TryCompileNode(ToolSchemaNode node, int depth)
+    {
+        if (depth >= MaxDepth) return null;
+        switch (node.Kind)
+        {
+            case JsonSchemaKind.String:
+                byte[][]? strEnum = node.EnumValues is { } se ? Encode(se) : null;
+                return new CompiledNode { Kind = JsonSchemaKind.String, Literals = strEnum, QuotedLiterals = strEnum is not null };
+
+            case JsonSchemaKind.Number:
+            case JsonSchemaKind.Integer:
+                byte[][]? numEnum = node.EnumValues is { } ne ? Encode(ne) : null;
+                return new CompiledNode
+                {
+                    Kind = node.Kind,
+                    Literals = numEnum,
+                    QuotedLiterals = false,
+                    IntegerOnly = node.Kind == JsonSchemaKind.Integer,
+                };
+
+            case JsonSchemaKind.Boolean:
+                return new CompiledNode { Kind = JsonSchemaKind.Boolean, Literals = s_boolLiterals };
+
+            case JsonSchemaKind.Null:
+                return new CompiledNode { Kind = JsonSchemaKind.Null, Literals = s_nullLiterals };
+
+            case JsonSchemaKind.Array:
+                // An untyped array (no items) isn't fully constrainable — skip the tool.
+                if (node.Items is null) return null;
+                var item = TryCompileNode(node.Items, depth + 1);
+                return item is null ? null : new CompiledNode { Kind = JsonSchemaKind.Array, Items = item };
+
+            case JsonSchemaKind.Object:
+                if (node.Object is null) return null;
+                var obj = TryCompileObject(node.Object, depth + 1);
+                return obj is null ? null : new CompiledNode { Kind = JsonSchemaKind.Object, Object = obj };
+
+            default:
+                return null;   // Any / unknown — not constrainable
+        }
+    }
+
+    private static byte[][] Encode(IReadOnlyList<string> values)
+    {
+        var r = new byte[values.Count][];
+        for (int i = 0; i < values.Count; i++) r[i] = ToolSchema.Utf8(values[i]);
+        return r;
+    }
+}

--- a/src/SharpInference.Core/ToolCallAdapter.cs
+++ b/src/SharpInference.Core/ToolCallAdapter.cs
@@ -319,6 +319,21 @@ public sealed class QwenToolCallAdapter(string architecture) : IToolCallAdapter
     public string Architecture { get; } = architecture;
     public int MaxOpenTagLength => OpenMarker.Length;
 
+    /// <inheritdoc/>
+    /// <remarks>Constrains the JSON argument object of Qwen's
+    /// <c>&lt;tool_call&gt;{"name":"NAME","arguments":{...}}&lt;/tool_call&gt;</c> wire format
+    /// (issue #376). Inert (returns null) when no supplied tool is constrainable, when
+    /// <c>&lt;tool_call&gt;</c> isn't a vocabulary token, or when the model emits the Qwen3.6 XML
+    /// shape instead of JSON (the constraint simply never engages).</remarks>
+    public ITokenConstraint? BuildArgumentConstraint(IReadOnlyList<ToolSchema> tools, GrammarVocabulary vocab)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(vocab);
+        var c = new JsonToolArgumentConstraint(
+            vocab, tools, OpenMarker, JsonToolEnvelope.NameValueObject, argsKeys: ["arguments", "parameters"]);
+        return c.HasConstrainableTools ? c : null;
+    }
+
     public ToolCallParseResult Parse(string rawOutput)
     {
         var calls = new List<ParsedToolCall>();
@@ -472,6 +487,19 @@ public sealed class LlamaToolCallAdapter : IToolCallAdapter
     public string Architecture => "llama";
     public int MaxOpenTagLength => OpenMarker.Length;
 
+    /// <inheritdoc/>
+    /// <remarks>Constrains the JSON argument object of Llama-3's
+    /// <c>&lt;|python_tag|&gt;{"name":"NAME","parameters":{...}}</c> wire format (issue #376). Inert
+    /// (null) when no tool is constrainable or <c>&lt;|python_tag|&gt;</c> isn't a vocabulary token.</remarks>
+    public ITokenConstraint? BuildArgumentConstraint(IReadOnlyList<ToolSchema> tools, GrammarVocabulary vocab)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(vocab);
+        var c = new JsonToolArgumentConstraint(
+            vocab, tools, OpenMarker, JsonToolEnvelope.NameValueObject, argsKeys: ["parameters", "arguments"]);
+        return c.HasConstrainableTools ? c : null;
+    }
+
     public ToolCallParseResult Parse(string rawOutput)
     {
         var calls = new List<ParsedToolCall>();
@@ -565,6 +593,21 @@ public sealed class DeepSeekToolCallAdapter : IToolCallAdapter
 
     public string Architecture => "deepseek2";
     public int MaxOpenTagLength => OuterOpen.Length;
+
+    /// <inheritdoc/>
+    /// <remarks>Constrains the JSON argument object of DeepSeek's
+    /// <c>&lt;|tool_call_begin|&gt;NAME&lt;|tool_sep|&gt;{...}&lt;|tool_call_end|&gt;</c> wire format
+    /// (issue #376): the name is bare text up to <c>&lt;|tool_sep|&gt;</c>, then the argument object
+    /// is emitted directly. Inert (null) when no tool is constrainable or those structural tokens are
+    /// absent from the vocabulary.</remarks>
+    public ITokenConstraint? BuildArgumentConstraint(IReadOnlyList<ToolSchema> tools, GrammarVocabulary vocab)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(vocab);
+        var c = new JsonToolArgumentConstraint(
+            vocab, tools, InnerOpen, JsonToolEnvelope.NameThenSeparator, separatorMarker: Separator);
+        return c.HasConstrainableTools ? c : null;
+    }
 
     public ToolCallParseResult Parse(string rawOutput)
     {

--- a/tests/SharpInference.Tests.Core/FakeJsonTokenizer.cs
+++ b/tests/SharpInference.Tests.Core/FakeJsonTokenizer.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using System.Text;
+using SharpInference.Core;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// A tiny deterministic tokenizer that mimics the facets of a real Qwen/Llama BPE vocabulary the
+/// JSON tool-argument grammar depends on (issue #376): the call markers are single special tokens,
+/// every byte is also available as a single-char token, AND a handful of <b>merged</b> structural
+/// tokens (<c>{"</c>, <c>":</c>, <c>"}</c>, <c>{}</c>, …) mirror how a real BPE fuses JSON
+/// punctuation with adjacent quotes/whitespace. The merged tokens are what make byte-level matching
+/// (rather than token-level) mandatory — a single token can open a string and start its content, or
+/// be the whole empty object <c>{}</c>. <see cref="EncodeMerged"/> lets a test request the
+/// realistic merged tokenization explicitly.
+/// </summary>
+public sealed class FakeJsonTokenizer : ITokenizer
+{
+    public const int Pad = 0, Bos = 1, Eos = 2;
+
+    private readonly Dictionary<string, int> _specials = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _merged = new(StringComparer.Ordinal);
+    private readonly int _singleBase;
+
+    // Realistic BPE-style merges of JSON punctuation with adjacent quotes / whitespace / braces.
+    private static readonly string[] MergedPieces =
+    [
+        "{\"", "\":", "\",", "\"}", "\"]", "{}", "[]", "\":\"", ",\"", " {\"", "\"}}", "\": ", "\", ",
+    ];
+
+    public FakeJsonTokenizer()
+    {
+        int id = 3;
+        foreach (var s in new[] { "<tool_call>", "</tool_call>", "<|python_tag|>", "<|tool_sep|>", "<|tool_call_begin|>", "<|tool_call_end|>" })
+            _specials[s] = id++;
+        foreach (var s in MergedPieces)
+            _merged[s] = id++;
+        _singleBase = id;
+    }
+
+    public int VocabSize => _singleBase + 256;
+    public int BosTokenId => Bos;
+    public int EosTokenId => Eos;
+    public int UnknownTokenId => Pad;
+    public int PadTokenId => Pad;
+    public bool AddBosToken => false;
+    public ImmutableArray<int> EogTokenIds => [Eos];
+    public IReadOnlyDictionary<string, int> SpecialTokens => _specials;
+
+    /// <summary>Token id for a single ASCII byte.</summary>
+    public int Char(char c) => _singleBase + (byte)c;
+
+    /// <summary>Token id for a registered merged structural piece (e.g. <c>{"</c> or <c>{}</c>).</summary>
+    public int Merged(string piece) => _merged[piece];
+
+    public byte[] DecodeBytes(int token)
+    {
+        foreach (var (s, id) in _specials) if (id == token) return Encoding.UTF8.GetBytes(s);
+        foreach (var (s, id) in _merged) if (id == token) return Encoding.UTF8.GetBytes(s);
+        if (token is Bos or Eos or Pad) return [];
+        if (token >= _singleBase && token < _singleBase + 256) return [(byte)(token - _singleBase)];
+        return [];
+    }
+
+    /// <summary>Greedy longest-match tokenization over specials ∪ merged pieces, else single chars.</summary>
+    public IReadOnlyList<int> Encode(string text)
+    {
+        var ids = new List<int>();
+        int i = 0;
+        while (i < text.Length)
+        {
+            int matched = -1, matchLen = 0;
+            foreach (var table in new[] { _specials, _merged })
+                foreach (var (s, id) in table)
+                    if (s.Length > matchLen && i + s.Length <= text.Length
+                        && text.AsSpan(i, s.Length).SequenceEqual(s))
+                    { matched = id; matchLen = s.Length; }
+
+            if (matched >= 0) { ids.Add(matched); i += matchLen; }
+            else { ids.Add(Char(text[i])); i++; }
+        }
+        return ids;
+    }
+
+    /// <summary>Encodes <paramref name="text"/> but forces the named merged pieces to be used (the
+    /// default greedy Encode already prefers them; this is an explicit alias for test readability).</summary>
+    public IReadOnlyList<int> EncodeMerged(string text) => Encode(text);
+
+    public string Decode(IEnumerable<int> tokens)
+    {
+        var sb = new StringBuilder();
+        foreach (int t in tokens) sb.Append(Encoding.UTF8.GetString(DecodeBytes(t)));
+        return sb.ToString();
+    }
+}

--- a/tests/SharpInference.Tests.Core/JsonToolGrammarConstraintTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonToolGrammarConstraintTests.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Decode-time conformance for the JSON tool-argument grammar constraint (issue #376) against a REAL
+/// Qwen vocabulary, so the byte-level matching is exercised over the actual BPE merges (where a
+/// single token carries <c>{"</c>, <c>":</c>, <c>"}}</c>, or the whole <c>{}</c>). Model-gated —
+/// skips when the GGUF is absent. The grammar logic itself is covered model-free by
+/// <see cref="JsonToolGrammarMockTests"/>; this asserts the same invariants survive a production
+/// tokenizer.
+/// </summary>
+public sealed class JsonToolGrammarConstraintTests(ITestOutputHelper output)
+{
+    private static readonly string[] s_modelPaths =
+    [
+        @"E:\models\Qwen3.6-27B-MTP-Q4_K_M.gguf",
+        @"E:\models\Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    ];
+
+    private static GgufTokenizer? Tok()
+    {
+        foreach (var p in s_modelPaths)
+            if (File.Exists(p))
+            {
+                var m = GgufModel.Open(p);
+                return GgufTokenizer.FromGgufModel(m);
+            }
+        return null;
+    }
+
+    private static ToolSchema Schema(string name, string parametersJson)
+    {
+        using var doc = JsonDocument.Parse(parametersJson);
+        return ToolSchema.FromOpenAiFunction(name, doc.RootElement.Clone());
+    }
+
+    private static void Feed(ITokenConstraint c, GgufTokenizer tok, string text)
+    {
+        foreach (int id in tok.Encode(text)) c.Accept(id);
+    }
+
+    private static bool Allowed(ITokenConstraint c, int vocab, int tokenId)
+    {
+        Span<float> logits = new float[vocab];
+        var masked = c.Filter(logits);
+        return !float.IsNegativeInfinity(masked[tokenId]);
+    }
+
+    // The single token that emits exactly `s` (asserts it's one token so the test reasons about it).
+    private static int Single(GgufTokenizer tok, string s)
+    {
+        var ids = tok.Encode(s);
+        Assert.Single(ids);
+        return ids[0];
+    }
+
+    private const string Weather =
+        """{"type":"object","properties":{"location":{"type":"string"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}""";
+
+    [Fact]
+    public void EngagesAtArgsColon_RejectsMergedEmptyObject()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        var c = new QwenToolCallAdapter("qwen3").BuildArgumentConstraint([Schema("get_weather", Weather)], vocab);
+        Assert.NotNull(c);
+
+        Feed(c!, tok, "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": ");
+        Assert.True(c!.IsConstraining);   // engaged at the args-key colon
+
+        // The merged "{}" empty-object token must be rejected (it would drop the required location);
+        // the merged '{"' that opens the object and a key is allowed.
+        Assert.False(Allowed(c, vocab.VocabSize, Single(tok, "{}")));
+        Assert.True(Allowed(c, vocab.VocabSize, Single(tok, "{\"")));
+    }
+
+    [Fact]
+    public void RequiredKey_CannotBeOmitted_ForeignKeyRejected()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        var c = new QwenToolCallAdapter("qwen3").BuildArgumentConstraint([Schema("get_weather", Weather)], vocab)!;
+
+        Feed(c, tok, "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"");
+        // Now matching a key. 'location'/'unit' are declared; a foreign key letter must be unreachable.
+        var loc = tok.Encode("location");
+        var unit = tok.Encode("unit");
+        Assert.True(Allowed(c, vocab.VocabSize, loc[0]));   // 'location…' reachable
+        Assert.True(Allowed(c, vocab.VocabSize, unit[0]));  // 'unit…' reachable
+        // A key from a different tool's schema ('city') is not a declared key here.
+        Assert.False(Allowed(c, vocab.VocabSize, tok.Encode("zzz")[0]));
+    }
+
+    [Fact]
+    public void EnumValue_RestrictedToDeclaredSet()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        var c = new QwenToolCallAdapter("qwen3").BuildArgumentConstraint([Schema("get_weather", Weather)], vocab)!;
+
+        // Reach the 'unit' enum value's opening quote, then assert only enum prefixes are allowed.
+        Feed(c, tok, "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"unit\": ");
+        Assert.True(c.IsConstraining);
+        // A bare (unquoted) value is illegal for a string enum — the value must open with a quote.
+        Assert.False(Allowed(c, vocab.VocabSize, tok.Encode("5")[0]));
+    }
+
+    [Fact]
+    public void NonJsonOutput_DoesNotEngage()
+    {
+        var tok = Tok();
+        if (tok is null) { output.WriteLine("missing model — skip"); return; }
+        var vocab = new GrammarVocabulary(tok);
+        var c = new QwenToolCallAdapter("qwen3").BuildArgumentConstraint([Schema("get_weather", Weather)], vocab)!;
+
+        // Qwen3.6 also emits an XML <function=…> shape — the JSON constraint must stay inert on it.
+        Feed(c, tok, "<tool_call>\n<function=get_weather>");
+        Assert.False(c.IsConstraining);
+    }
+}

--- a/tests/SharpInference.Tests.Core/JsonToolGrammarMockTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonToolGrammarMockTests.cs
@@ -1,0 +1,274 @@
+using System.Text.Json;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Model-independent decode-time conformance for the JSON tool-argument grammar constraint
+/// (issue #376) using <see cref="FakeJsonTokenizer"/>, so the byte-level masking is covered in CI
+/// without a multi-gigabyte GGUF. Mirrors <see cref="ToolGrammarMockTests"/> (the Gemma sibling) for
+/// the standard-JSON families: required key, foreign-key rejection, enum, string-with-escapes,
+/// number, nested object, array, the merged-{} early-engage, and the Qwen/Llama/DeepSeek envelopes.
+/// </summary>
+public sealed class JsonToolGrammarMockTests
+{
+    private static (ITokenConstraint c, FakeJsonTokenizer tok, int vocab) Build(
+        string schemaJson, string toolName, IToolCallAdapter? adapter = null)
+    {
+        var tok = new FakeJsonTokenizer();
+        var vocab = new GrammarVocabulary(tok);
+        using var doc = JsonDocument.Parse(schemaJson);
+        var schema = ToolSchema.FromOpenAiFunction(toolName, doc.RootElement.Clone());
+        var c = (adapter ?? new QwenToolCallAdapter("qwen3")).BuildArgumentConstraint([schema], vocab);
+        Assert.NotNull(c);
+        return (c!, tok, vocab.VocabSize);
+    }
+
+    private static void Feed(ITokenConstraint c, FakeJsonTokenizer tok, string text)
+    {
+        foreach (int id in tok.Encode(text)) c.Accept(id);
+    }
+
+    private static bool Allowed(ITokenConstraint c, int vocab, int tokenId)
+    {
+        Span<float> logits = new float[vocab];
+        var masked = c.Filter(logits);
+        return !float.IsNegativeInfinity(masked[tokenId]);
+    }
+
+    // The canonical Qwen preamble up to and including the args key's colon — engagement point.
+    private const string QwenPreamble = "<tool_call>{\"name\":\"get_weather\",\"arguments\":";
+
+    [Fact]
+    public void EngagesAtArgsColon_EarlyEngage_RejectsMergedEmptyObject()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, QwenPreamble);     // ends right after `"arguments":`
+        Assert.True(c.IsConstraining);  // engaged at the colon, BEFORE the '{'
+
+        // Only an explicit '{' (optionally as part of a merged '{"') may open the object — a merged
+        // "{}" token (Qwen's empty-args encoding) is rejected because it would drop the required key.
+        Assert.True(Allowed(c, vocab, tok.Char('{')));
+        Assert.True(Allowed(c, vocab, tok.Merged("{\"")));
+        Assert.False(Allowed(c, vocab, tok.Merged("{}")));
+        Assert.False(Allowed(c, vocab, tok.Char('}')));
+    }
+
+    [Fact]
+    public void RequiredKey_CannotClose_UntilEmitted()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, QwenPreamble + "{");
+        Assert.False(Allowed(c, vocab, tok.Char('}')));   // required key missing
+        Assert.True(Allowed(c, vocab, tok.Char('"')));    // a key opens with '"'
+        Assert.False(Allowed(c, vocab, tok.Char('x')));   // a key cannot start with a bare letter
+    }
+
+    [Fact]
+    public void OnlyDeclaredKeys_AreReachable()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}""",
+            "web_search");
+
+        Feed(c, tok, "<tool_call>{\"name\":\"web_search\",\"arguments\":{\"");
+        // Inside the key now: only 'q' (query) continues; never 'i' (a hallucinated 'queries').
+        Assert.True(Allowed(c, vocab, tok.Char('q')));
+        Assert.False(Allowed(c, vocab, tok.Char('z')));
+        Feed(c, tok, "quer");
+        Assert.True(Allowed(c, vocab, tok.Char('y')));
+        Assert.False(Allowed(c, vocab, tok.Char('i')));
+    }
+
+    [Fact]
+    public void StringValue_OpensWithQuote_FreeContent_Closes()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, QwenPreamble + "{\"location\"");
+        Assert.True(Allowed(c, vocab, tok.Char(':')));
+        Feed(c, tok, ":");
+        // Value is a string → only '"' (or ws) may open it; not a bare letter or '}'.
+        Assert.True(Allowed(c, vocab, tok.Char('"')));
+        Assert.False(Allowed(c, vocab, tok.Char('}')));
+        Assert.False(Allowed(c, vocab, tok.Char('B')));
+
+        Feed(c, tok, "\"");
+        // Free content: any byte stays; '"' closes; EOS forbidden mid-call.
+        Assert.True(Allowed(c, vocab, tok.Char('B')));
+        Assert.True(Allowed(c, vocab, tok.Char('"')));
+        Assert.False(Allowed(c, vocab, FakeJsonTokenizer.Eos));
+
+        Feed(c, tok, "Berlin\"");
+        Assert.True(Allowed(c, vocab, tok.Char('}')));    // required satisfied → may close
+        Assert.True(Allowed(c, vocab, tok.Char(',')));
+
+        Feed(c, tok, "}");
+        Assert.False(c.IsConstraining);                   // object closed → back to watching
+    }
+
+    [Fact]
+    public void EscapedQuote_DoesNotCloseStringEarly()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}""",
+            "echo");
+
+        Feed(c, tok, "<tool_call>{\"name\":\"echo\",\"arguments\":{\"text\":\"a");
+        Assert.True(c.IsConstraining);
+        // A backslash-escaped quote stays INSIDE the string. If the escape were ignored, this '"'
+        // would close the string and the 'b' below would diverge and disable the constraint — so the
+        // post-'b' IsConstraining check is what proves the escape was honored. ('}' is meaningless
+        // here: inside a free string it is ordinary content, not an object close.)
+        Feed(c, tok, "\\\"");                             // the two bytes \ and "
+        Assert.True(c.IsConstraining);
+        Feed(c, tok, "b\"");                              // content 'b', then an unescaped closing '"'
+        Assert.True(c.IsConstraining);                    // cleanly back at object level — not disabled
+        Assert.True(Allowed(c, vocab, tok.Char('}')));    // required satisfied → the object may close
+        Feed(c, tok, "}");
+        Assert.False(c.IsConstraining);                   // clean close
+    }
+
+    [Fact]
+    public void Enum_RestrictsToDeclaredValues()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["unit"]}""",
+            "get_weather");
+
+        Feed(c, tok, QwenPreamble + "{\"unit\":\"");
+        Assert.True(Allowed(c, vocab, tok.Char('c')));    // celsius
+        Assert.True(Allowed(c, vocab, tok.Char('f')));    // fahrenheit
+        Assert.False(Allowed(c, vocab, tok.Char('x')));   // neither
+
+        Feed(c, tok, "celsius");
+        Assert.True(Allowed(c, vocab, tok.Char('"')));    // value complete → close
+        Assert.False(Allowed(c, vocab, tok.Char('z')));   // can't extend past the enum
+    }
+
+    [Fact]
+    public void NumberValue_AcceptsDigits_ThenCloses()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"days":{"type":"integer"}},"required":["days"]}""",
+            "get_weather");
+
+        Feed(c, tok, QwenPreamble + "{\"days\":");
+        Assert.True(Allowed(c, vocab, tok.Char('3')));
+        Assert.False(Allowed(c, vocab, tok.Char('"')));   // integer is bare, not quoted
+        Assert.False(Allowed(c, vocab, tok.Char('.')));   // integer → no decimal point
+
+        Feed(c, tok, "3");
+        Assert.True(Allowed(c, vocab, tok.Char('0')));    // more digits
+        Assert.True(Allowed(c, vocab, tok.Char('}')));    // or close (required satisfied)
+    }
+
+    [Fact]
+    public void NestedObjectValue_ExpectsBrace_ThenConstrainsInnerKeys()
+    {
+        var (c, tok, vocab) = Build(
+            """
+            {"type":"object","properties":{
+               "filter":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}},
+             "required":["filter"]}
+            """,
+            "search");
+
+        Feed(c, tok, "<tool_call>{\"name\":\"search\",\"arguments\":{\"filter\":");
+        Assert.True(Allowed(c, vocab, tok.Char('{')));    // object value opens with '{'
+        Assert.False(Allowed(c, vocab, tok.Char('"')));   // not a string
+        Assert.False(Allowed(c, vocab, tok.Char('3')));   // not a number
+
+        Feed(c, tok, "{");
+        Assert.False(Allowed(c, vocab, tok.Char('}')));   // inner required "city" missing
+        Assert.True(Allowed(c, vocab, tok.Char('"')));    // inner key opens with '"'
+    }
+
+    [Fact]
+    public void ArrayValue_OpensWithBracket_ConstrainsItems()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"tags":{"type":"array","items":{"type":"string"}}},"required":["tags"]}""",
+            "tagger");
+
+        Feed(c, tok, "<tool_call>{\"name\":\"tagger\",\"arguments\":{\"tags\":");
+        Assert.True(Allowed(c, vocab, tok.Char('[')));    // array opens with '['
+        Assert.False(Allowed(c, vocab, tok.Char('"')));
+
+        Feed(c, tok, "[");
+        Assert.True(Allowed(c, vocab, tok.Char('"')));    // a string item opens with '"'
+        Assert.True(Allowed(c, vocab, tok.Char(']')));    // or close (empty array)
+        Assert.False(Allowed(c, vocab, tok.Char('5')));   // a bare number isn't a string item
+    }
+
+    [Fact]
+    public void UnknownTool_IsNotConstrained()
+    {
+        var (c, tok, _) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, "<tool_call>{\"name\":\"some_other_tool\",\"arguments\":");
+        Assert.False(c.IsConstraining);   // name not in the constrainable set → stays passive
+    }
+
+    [Fact]
+    public void Reset_ReturnsToWatching()
+    {
+        var (c, tok, _) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather");
+
+        Feed(c, tok, QwenPreamble + "{");
+        Assert.True(c.IsConstraining);
+        c.Reset();
+        Assert.False(c.IsConstraining);
+    }
+
+    [Fact]
+    public void Llama_PythonTagEnvelope_ParametersKey()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather", new LlamaToolCallAdapter());
+
+        Feed(c, tok, "<|python_tag|>{\"name\":\"get_weather\",\"parameters\":");
+        Assert.True(c.IsConstraining);                    // Llama uses "parameters", not "arguments"
+        Assert.False(Allowed(c, vocab, tok.Merged("{}"))); // still early-engaged
+        Assert.True(Allowed(c, vocab, tok.Char('{')));
+    }
+
+    [Fact]
+    public void DeepSeek_NameThenSeparatorEnvelope()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}""",
+            "get_weather", new DeepSeekToolCallAdapter());
+
+        // DeepSeek: <|tool_call_begin|>NAME<|tool_sep|>{json}. Name is bare text up to the separator.
+        Feed(c, tok, "<|tool_call_begin|>get_weather<|tool_sep|>");
+        Assert.True(c.IsConstraining);                    // engaged on the separator
+        Assert.True(Allowed(c, vocab, tok.Char('{')));
+        Assert.False(Allowed(c, vocab, tok.Merged("{}"))); // required key still enforced
+    }
+
+    [Fact]
+    public void NonConstrainableTool_BuildsNoConstraint()
+    {
+        var tok = new FakeJsonTokenizer();
+        var vocab = new GrammarVocabulary(tok);
+        // An open object (no properties) isn't constrainable → adapter returns null.
+        using var doc = JsonDocument.Parse("""{"type":"object"}""");
+        var schema = ToolSchema.FromOpenAiFunction("noop", doc.RootElement.Clone());
+        Assert.Null(new QwenToolCallAdapter("qwen3").BuildArgumentConstraint([schema], vocab));
+    }
+}


### PR DESCRIPTION
## Summary

Extends schema/grammar-constrained tool-call argument decoding (#374, PR #375) to the families that emit **standard JSON** — Qwen (`<tool_call>{json}</tool_call>`), Llama-3 (`<|python_tag|>{json}`), and DeepSeek (`NAME<|tool_sep|>{json}`) — the JSON sibling of `GemmaToolArgumentConstraint`. Closes #376.

## What changed

- **`JsonToolArgumentConstraint`** — a byte-level pushdown automaton over standard JSON: `{"key":"value",...}` with double-quoted keys/strings (`\`-escape aware), bare numbers/booleans/null, `[...]` arrays, nested `{...}` objects, and `enum` restriction. Matching is **fully byte-level** because a real BPE merges structural bytes with content/whitespace — one token carries `{"`, another `":`, another `"}}`, and the empty object is a single `{}` token (verified by probing the real Qwen vocab).
- **Early-engage at the argument key's colon** (`"arguments":` / `"parameters":`) pushes the object frame in `OExpectOpenBrace` so the *next* token is masked — a merged `{}` token can't drop the required arguments (the #374 failure mode, in JSON form).
- **Two envelopes**, parameterized per family:
  - `NameValueObject` (Qwen/Llama): a preamble parser walks `{"name":"X","argskey":{` to capture the tool name and find the args object; `argskey` is `arguments` (Qwen) or `parameters` (Llama).
  - `NameThenSeparator` (DeepSeek): bare name up to `<|tool_sep|>`, then the args object directly.
  Wired via `QwenToolCallAdapter` / `LlamaToolCallAdapter` / `DeepSeekToolCallAdapter`.`BuildArgumentConstraint`.
- **Shared compile logic extracted** — `CompiledObject`/`CompiledNode` + `TryCompile*` moved out of `GemmaToolArgumentConstraint` into `ToolSchemaCompiler`, used by both constraints (DRY, and sets up #378 to modify one place). The Gemma constraint now calls it; all 72 prior Gemma grammar/adapter tests stay green — behavior-preserving.
- **EOG forbidden inside the region** — empty-byte pruning plus an explicit EOG mask pass, so an EOS that decodes to ordinary text can't slip through a free string and truncate the call.
- **Default-off byte-identical** — inert when no tool is constrainable, when the open marker isn't a vocabulary token, or when the model emits a non-JSON shape (Qwen3.6's XML `<function=>` never engages).

## Tests

- **CI mock (`JsonToolGrammarMockTests`, 14)** — `FakeJsonTokenizer` provides single-byte tokens **plus realistic merged structural pieces** (`{"`, `":`, `{}`, …). Covers: required key can't close early, foreign-key rejection, enum, **string with `\"` escape**, number, nested object, array, the merged-`{}` early-engage, and the Qwen/Llama/DeepSeek envelopes.
- **Model-gated (`JsonToolGrammarConstraintTests`, 4)** — drives the constraint over a **real Qwen3.6 BPE vocabulary** (production merges: `{}`, `{"`, `":`), asserting it engages at the colon, rejects merged `{}`, allows `{"`, enforces declared keys, restricts the enum, and stays inert on the XML form.

`90 grammar/tool tests green`; full solution builds clean under `TreatWarningsAsErrors` + trim/AOT analyzers.

### Note on GPU e2e

A live generation A/B (like #377's) isn't included: the on-disk Qwen3.6 emits the **XML** tool shape (the JSON constraint correctly stays inert on it), and no JSON-emitting Qwen/Llama that fits VRAM was available. The model-gated test instead exercises the byte-level matching against the real production tokenizer.

### Follow-up

Qwen3-Coder's `<parameter=…>` **XML** wrapper isn't JSON and is left for a separate matcher (its adapter has no override → arguments generate unconstrained, never wrong) — the issue flagged this as possibly separate.

Follow-up to #374 / #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)