### PR TITLE
perf(cuda): MoE GPU op-offload prefill default-on via register-in-place pin (#390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sharpi-cli -m models/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **144.3** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **241.8** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload default-on (#390, register-in-place pin) — **+54%** over the CPU MoE path, decode within noise (`--gpu-moe-prefill false` to force CPU) |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 18.4 | 12.2 | runs on Vulkan (#357); 47% acceptance. MTP self-spec **regresses** vs plain MoE decode (~22 t/s, cf. 35B-A3B) — routed-expert verify is un-amortized on Vulkan (#370). Lossless; use `--spec-type none` for speed |
 
 #### Qwen3.6-35B-A3B (GDN+MoE) — [unsloth](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) · 22 GB
@@ -146,7 +146,7 @@ sharpi-cli -m models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1` (hybrid) | **67.5** | **23.7** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. Fused GDN scan + batched SDPA, bit-identical. `SHARPI_CPU_MOE=0` forces on-GPU experts |
+| **CUDA** `-g -1` (hybrid) | **109.6** | **23.7** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. Fused GDN scan + batched SDPA, bit-identical. `SHARPI_CPU_MOE=0` forces on-GPU experts. Prefill: GPU MoE op-offload default-on (#390) — **+65%** over the CPU MoE path, decode within noise |
 | Vulkan `-g -1` (hybrid) | 17.3 | 22.8 | 10 attn + 30 GDN on GPU; routed MoE + shared expert on CPU mmap (#356). Decode ~matches CUDA (CPU-routed-expert bound); prefill trails CUDA — per-row CPU FFN not yet batched (#371) |
 | CPU | **11.3** | 9.3 | hybrid GDN/attn, 256 experts / 8 active. Chunk-parallel (FlashQLA) GDN prefill default-on (1.35× over the 8.4 t/s per-token scan; `SHARPI_GDN_CHUNKED_PREFILL=0` to disable). MTP variants keep the byte-exact scan (FP-reorder flips the thinking-boundary token) |
 
@@ -160,7 +160,7 @@ SHARPI_CPU_MOE=1 sharpi-cli -m models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **67.2** | **21.4** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **108.6** | **21.4** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance. Prefill: GPU MoE op-offload default-on (#390) — **+66%** over the CPU MoE path, decode within noise |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 15.4 | 9.3 | needs `SHARPI_CPU_MOE=1`; runs on Vulkan (#357). 61% acceptance, but MTP self-spec **regresses** vs ~22 t/s plain MoE decode — routed-expert verify un-amortized on Vulkan (#370). Use `--spec-type none` for speed |
 | CPU `--no-thinking` | 9.1 | **8.5** | GDN/attn + 256-expert MoE + MTP head (#44). 100% acceptance; MoE-MTP batched verify (#45) — routed experts sequential per token, so ~MTP-off parity |
 

--- a/scripts/bench-390-ab.ps1
+++ b/scripts/bench-390-ab.ps1
@@ -1,0 +1,78 @@
+# Issue #390: GPU op-offload MoE prefill — pinned-buffer A/B for the default-on decision.
+# Measures prefill (long prompt) AND decode (same run) for three configs:
+#   off      — SHARPI_MOE_GPU_PREFILL=0 (CPU MoE prefill; the decode-friendly baseline)
+#   copy     — op-offload ON, 14 GB cudaMallocHost copy   (SHARPI_MOE_PIN_MODE=copy)     [#387 behavior]
+#   register — op-offload ON, cudaHostRegister mmap in place (SHARPI_MOE_PIN_MODE=register) [#390 fix]
+# Goal: register decode within noise of off, while keeping (most of) copy's prefill win.
+param(
+    [string]$Model = "E:\models\Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf",
+    [string]$PromptFile = "C:\Users\pekka\AppData\Local\Temp\claude\C--p-sharpi\e585495f-574a-494e-820c-3cfea3d513e6\scratchpad\prefill_prompt.txt",
+    [int]$NTokens = 80,
+    [int]$TimeoutSec = 900,
+    [string]$Configs = "off,copy,register",   # comma-joined so it survives `pwsh -File` arg tokenizing
+    [switch]$Warmup
+)
+$ConfigList = $Configs -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+if (-not (Test-Path $Model))      { Write-Error "Model not found: $Model"; exit 1 }
+if (-not (Test-Path $PromptFile)) { Write-Error "Prompt file not found: $PromptFile"; exit 1 }
+
+$cliDll  = ".\src\SharpInference.Cli\bin\Release\net10.0\sharpi-cli.dll"
+$dotnet  = (Get-Command dotnet).Source
+$prompt  = Get-Content -Raw $PromptFile
+$env:SHARPI_CPU_MOE = "1"
+
+function Run-One([string]$cfg, [string]$tag) {
+    if ($cfg -eq "off") {
+        $env:SHARPI_MOE_GPU_PREFILL = "0"
+        Remove-Item env:SHARPI_MOE_PIN_MODE -ErrorAction SilentlyContinue
+    } else {
+        $env:SHARPI_MOE_GPU_PREFILL = "1"
+        $env:SHARPI_MOE_PIN_MODE = $cfg   # copy | register
+    }
+    $argList = @("$cliDll","-m","$Model","-f","$PromptFile","--temp","0","-n","$NTokens",
+                 "--single-turn","-g","-1","--backend","cuda","--no-thinking")
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $dotnet
+    $psi.Arguments = ($argList | ForEach-Object { if ($_ -match '\s') { "`"$_`"" } else { $_ } }) -join ' '
+    $psi.RedirectStandardOutput = $true; $psi.RedirectStandardError = $true; $psi.UseShellExecute = $false
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $so = $proc.StandardOutput.ReadToEndAsync(); $se = $proc.StandardError.ReadToEndAsync()
+    $to = $false
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) { try { $proc.Kill($true) } catch {}; $to = $true }
+    $sw.Stop(); $so.Wait(2000)|Out-Null; $se.Wait(2000)|Out-Null
+    $stdout = $so.Result; if ($null -eq $stdout) { $stdout = "" }
+    $stderr = $se.Result; if ($null -eq $stderr) { $stderr = "" }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $pTok=0;$pTps=0.0;$dTok=0;$dTps=0.0;$mtp=$null
+    if ($stdout -match 'Prefill:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s') { $pTok=[int]$matches[1]; $pTps=[double]::Parse($matches[2],$inv) }
+    if ($stdout -match 'Decode:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s')  { $dTok=[int]$matches[1]; $dTps=[double]::Parse($matches[2],$inv) }
+    if ($stdout -match 'MTP accept:\s+([\d\.]+)\s*%') { $mtp=[double]::Parse($matches[1],$inv) }
+    # surface the pin-mode banner the engine prints to stderr
+    $pin = ($stderr -split "`n" | Where-Object { $_ -match 'moe-offload' } | Select-Object -First 1)
+    [PSCustomObject]@{
+        Tag=$tag; Prefill=$pTok; PrefillTps=[Math]::Round($pTps,1)
+        Decode=$dTok; DecodeTps=[Math]::Round($dTps,1)
+        Mtp=if($null -eq $mtp){$null}else{[Math]::Round($mtp,1)}
+        Wall=[Math]::Round($sw.Elapsed.TotalSeconds,1); TimedOut=$to
+        Pin=if($pin){$pin.Trim()}else{""}
+    }
+}
+
+$results = @()
+try {
+    if ($Warmup) { Write-Host "[warmup] off (page-cache warm)" -ForegroundColor DarkGray; Run-One "off" "warmup" | Out-Null }
+    foreach ($c in $ConfigList) {
+        Write-Host "[$c] running..." -ForegroundColor Cyan
+        $results += Run-One $c $c
+    }
+} finally {
+    Remove-Item env:SHARPI_MOE_GPU_PREFILL -ErrorAction SilentlyContinue
+    Remove-Item env:SHARPI_MOE_PIN_MODE    -ErrorAction SilentlyContinue
+}
+$results | Format-Table Tag,Prefill,PrefillTps,Decode,DecodeTps,Mtp,Wall,TimedOut -AutoSize
+$results | ForEach-Object { Write-Host ("  {0,-9} {1}" -f $_.Tag, $_.Pin) -ForegroundColor DarkGray }
+if (-not (Test-Path "bench-out")) { New-Item -ItemType Directory -Path "bench-out" | Out-Null }
+$results | Export-Csv -NoTypeInformation -Path "bench-out\bench-390-ab.csv"
+Write-Host "`nResults -> bench-out\bench-390-ab.csv" -ForegroundColor Green

--- a/scripts/bench-390-models.ps1
+++ b/scripts/bench-390-models.ps1
@@ -1,0 +1,63 @@
+# Issue #390: re-measure the three CUDA GDN-hybrid CPU-MoE README rows with op-offload now
+# DEFAULT-ON (register pin mode + token gate) vs forced-off (the prior CPU-path baseline).
+# 2K-token working-context prompt (matches the README "Prefill t/s" definition). Same session
+# so the off/on delta is hardware/thermal-consistent.
+param(
+    [string]$PromptFile = "C:\Users\pekka\AppData\Local\Temp\claude\C--p-sharpi\e585495f-574a-494e-820c-3cfea3d513e6\scratchpad\prefill_prompt.txt",
+    [int]$NTokens = 60,
+    [int]$TimeoutSec = 900
+)
+$cliDll = ".\src\SharpInference.Cli\bin\Release\net10.0\sharpi-cli.dll"
+$dotnet = (Get-Command dotnet).Source
+$env:SHARPI_CPU_MOE = "1"
+$models = @(
+    @{ Name="Carnice";        Path="E:\models\Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf" }
+    @{ Name="35B-A3B";        Path="E:\models\Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" }
+    @{ Name="35B-A3B-MTP";    Path="E:\models\Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf" }
+)
+
+function Run-One([string]$name, [string]$model, [string]$mode) {
+    if ($mode -eq "off") { $offArg = @("--gpu-moe-prefill","false") } else { $offArg = @() }   # on = rely on new default
+    $argList = @("$cliDll","-m","$model","-f","$PromptFile","--temp","0","-n","$NTokens",
+                 "--single-turn","-g","-1","--backend","cuda","--no-thinking") + $offArg
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $dotnet
+    $psi.Arguments = ($argList | ForEach-Object { if ($_ -match '\s') { "`"$_`"" } else { $_ } }) -join ' '
+    $psi.RedirectStandardOutput = $true; $psi.RedirectStandardError = $true; $psi.UseShellExecute = $false
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $so = $proc.StandardOutput.ReadToEndAsync(); $se = $proc.StandardError.ReadToEndAsync()
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) { try { $proc.Kill($true) } catch {} }
+    $so.Wait(2000)|Out-Null; $se.Wait(2000)|Out-Null
+    $stdout = $so.Result; if ($null -eq $stdout) { $stdout = "" }
+    $stderr = $se.Result; if ($null -eq $stderr) { $stderr = "" }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $pTok=0;$pTps=0.0;$dTok=0;$dTps=0.0;$mtp=$null
+    if ($stdout -match 'Prefill:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s') { $pTok=[int]$matches[1]; $pTps=[double]::Parse($matches[2],$inv) }
+    if ($stdout -match 'Decode:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s')  { $dTok=[int]$matches[1]; $dTps=[double]::Parse($matches[2],$inv) }
+    if ($stdout -match 'MTP accept:\s+([\d\.]+)\s*%') { $mtp=[double]::Parse($matches[1],$inv) }
+    $pin = ($stderr -split "`n" | Where-Object { $_ -match 'moe-offload' } | Select-Object -First 1)
+    [PSCustomObject]@{
+        Model=$name; Mode=$mode; Prefill=$pTok; PrefillTps=[Math]::Round($pTps,1)
+        DecodeTps=[Math]::Round($dTps,1); Mtp=if($null -eq $mtp){$null}else{[Math]::Round($mtp,1)}
+        Pin=if($pin){($pin.Trim() -replace '\[moe-offload\] ','')}else{"(cpu)"}
+    }
+}
+
+$results = @()
+try {
+    foreach ($m in $models) {
+        if (-not (Test-Path $m.Path)) { Write-Host "skip missing $($m.Path)" -ForegroundColor Yellow; continue }
+        foreach ($mode in @("off","on")) {
+            Write-Host "[$($m.Name)/$mode]..." -ForegroundColor Cyan
+            $results += Run-One $m.Name $m.Path $mode
+        }
+    }
+} finally {
+    Remove-Item env:SHARPI_MOE_GPU_PREFILL -ErrorAction SilentlyContinue
+    Remove-Item env:SHARPI_MOE_PIN_MODE    -ErrorAction SilentlyContinue
+}
+$results | Format-Table Model, Mode, Prefill, PrefillTps, DecodeTps, Mtp -AutoSize
+$results | ForEach-Object { Write-Host ("  {0,-13} {1,-3} {2}" -f $_.Model, $_.Mode, $_.Pin) -ForegroundColor DarkGray }
+if (-not (Test-Path "bench-out")) { New-Item -ItemType Directory -Path "bench-out" | Out-Null }
+$results | Export-Csv -NoTypeInformation -Path "bench-out\bench-390-models.csv"
+Write-Host "`nResults -> bench-out\bench-390-models.csv" -ForegroundColor Green

--- a/scripts/bench-390-sweep.ps1
+++ b/scripts/bench-390-sweep.ps1
@@ -1,0 +1,55 @@
+# Issue #390: prefill crossover sweep — find the token count where register-mode op-offload
+# starts beating the CPU MoE prefill (sets the default-on token gate). NTokens kept small so
+# the cell is dominated by prefill, not decode.
+param(
+    [string]$Model = "E:\models\Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf",
+    [string]$PromptDir = "C:\Users\pekka\AppData\Local\Temp\claude\C--p-sharpi\e585495f-574a-494e-820c-3cfea3d513e6\scratchpad",
+    [string]$Prompts = "p96.txt,p192.txt,p384.txt,p768.txt,p1536.txt,prefill_prompt.txt",
+    [string]$Configs = "off,register",
+    [int]$NTokens = 4,
+    [int]$TimeoutSec = 600
+)
+$cliDll = ".\src\SharpInference.Cli\bin\Release\net10.0\sharpi-cli.dll"
+$dotnet = (Get-Command dotnet).Source
+$env:SHARPI_CPU_MOE = "1"
+$promptList = $Prompts -split ',' | ForEach-Object { $_.Trim() }
+$configList = $Configs -split ',' | ForEach-Object { $_.Trim() }
+
+function Run-One([string]$cfg, [string]$pf) {
+    if ($cfg -eq "off") { $env:SHARPI_MOE_GPU_PREFILL = "0"; Remove-Item env:SHARPI_MOE_PIN_MODE -ErrorAction SilentlyContinue }
+    else { $env:SHARPI_MOE_GPU_PREFILL = "1"; $env:SHARPI_MOE_PIN_MODE = $cfg }
+    $argList = @("$cliDll","-m","$Model","-f","$pf","--temp","0","-n","$NTokens",
+                 "--single-turn","-g","-1","--backend","cuda","--no-thinking")
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $dotnet
+    $psi.Arguments = ($argList | ForEach-Object { if ($_ -match '\s') { "`"$_`"" } else { $_ } }) -join ' '
+    $psi.RedirectStandardOutput = $true; $psi.RedirectStandardError = $true; $psi.UseShellExecute = $false
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $so = $proc.StandardOutput.ReadToEndAsync(); $se = $proc.StandardError.ReadToEndAsync()
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) { try { $proc.Kill($true) } catch {} }
+    $so.Wait(2000)|Out-Null; $se.Wait(2000)|Out-Null
+    $stdout = $so.Result; if ($null -eq $stdout) { $stdout = "" }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $pTok=0;$pTps=0.0
+    if ($stdout -match 'Prefill:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s') { $pTok=[int]$matches[1]; $pTps=[double]::Parse($matches[2],$inv) }
+    [PSCustomObject]@{ Config=$cfg; Prompt=(Split-Path $pf -Leaf); Tokens=$pTok; PrefillTps=[Math]::Round($pTps,1) }
+}
+
+$results = @()
+try {
+    foreach ($p in $promptList) {
+        $pf = Join-Path $PromptDir $p
+        if (-not (Test-Path $pf)) { Write-Host "skip missing $pf" -ForegroundColor Yellow; continue }
+        foreach ($c in $configList) {
+            Write-Host "[$c] $p" -ForegroundColor Cyan
+            $results += Run-One $c $pf
+        }
+    }
+} finally {
+    Remove-Item env:SHARPI_MOE_GPU_PREFILL -ErrorAction SilentlyContinue
+    Remove-Item env:SHARPI_MOE_PIN_MODE    -ErrorAction SilentlyContinue
+}
+$results | Sort-Object Tokens, Config | Format-Table Tokens, Config, PrefillTps -AutoSize
+if (-not (Test-Path "bench-out")) { New-Item -ItemType Directory -Path "bench-out" | Out-Null }
+$results | Export-Csv -NoTypeInformation -Path "bench-out\bench-390-sweep.csv"
+Write-Host "`nResults -> bench-out\bench-390-sweep.csv" -ForegroundColor Green

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -235,7 +235,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
         // ── GPU op-offload of the CPU-MoE routed prefill. Wraps SHARPI_MOE_GPU_PREFILL.
         [CommandOption("--gpu-moe-prefill <BOOL>")]
-        [Description("CPU-MoE: run the routed-expert prefill matmuls on the GPU (transient weight upload, like llama.cpp's op-offload) instead of CPU dots. OPT-IN, default OFF; pass 'true' to enable. Sets SHARPI_MOE_GPU_PREFILL. ~+15-44% PREFILL on the CUDA GDN-hybrid CPU-MoE models, but ~-25% DECODE (its ~14 GB pinned weight copy evicts the page cache that single-token decode's CPU expert-streaming relies on) — so it's a win for prefill-heavy workloads only, not interactive/agentic. Argmax-stable (GPU runs the MoE in F32), not bit-identical to CPU. Auto-falls-back to the CPU path if the pinned buffer / GPU scratch can't allocate.")]
+        [Description("CPU-MoE: run the routed-expert prefill matmuls on the GPU (transient weight upload, like llama.cpp's op-offload) instead of CPU dots. Default ON (#390); pass 'false' to force the CPU MoE prefill. Sets SHARPI_MOE_GPU_PREFILL. ~+28-67% PREFILL on the CUDA GDN-hybrid CPU-MoE models, with DECODE within noise of the CPU path — the register-in-place pin mode (SHARPI_MOE_PIN_MODE, default 'register') cudaHostRegisters the expert mmap pages instead of a ~14 GB copy, so no RAM duplicate and no page-cache eviction; a token gate (SHARPI_MOE_GPU_PREFILL_MIN_TOKENS, default 64) keeps tiny prefills + decode on the CPU path. Argmax-stable (GPU runs the MoE in F32), not bit-identical to CPU. Auto-falls-back to the CPU path if the GPU scratch can't allocate.")]
         public bool? GpuMoePrefill { get; init; }
     }
 
@@ -336,7 +336,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             return 1;
         }
 
-        // GPU op-offload of the CPU-MoE routed prefill (default on in the engine). An explicit
+        // GPU op-offload of the CPU-MoE routed prefill (default on in the engine, #390). An explicit
         // --gpu-moe-prefill wins over an inherited SHARPI_MOE_GPU_PREFILL; absence leaves the
         // env (hence the engine default) untouched.
         if (settings.GpuMoePrefill is bool gpuMoePrefill)

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -674,14 +674,25 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // the #100 in-kernel-dequant GEMM, Q4_K/Q5_K/Q6_K/Q8_0) upload raw bytes and dispatch the
     // quantized GEMM; only Float32 weights dequant-stage. NOT bit-exact — argmax-stable (the
     // GPU runs the MoE in F32, *more* precise than the CPU int8 path).
-    //   *** Default OFF because it trades decode for prefill: the ~14 GB pinned cudaMallocHost
-    //   weight copy duplicates the experts in RAM (mmap + pinned), evicting the page cache
-    //   that single-token DECODE's CPU expert-streaming relies on — measured ~-25% decode on
-    //   Carnice (clean A/B) vs the +44% prefill. So it's a win only for prefill-heavy
-    //   workloads; interactive/agentic (decode-heavy) use should leave it off. ***
+    //   *** Default ON (#390). The original opt-in #387 path traded decode for prefill: a ~14 GB
+    //   pinned cudaMallocHost copy duplicated the experts in RAM (mmap + pinned), and that copy
+    //   could evict the page cache single-token DECODE's CPU expert-streaming relies on (the
+    //   measured ~-25% decode blocker). #390 fixes it two ways: (1) the register-in-place pin mode
+    //   (SHARPI_MOE_PIN_MODE=register, now default) cudaHostRegisters the expert mmap pages instead
+    //   of copying — no 14 GB duplicate, no page-cache eviction (measured decode within noise of the
+    //   CPU path, clean A/B); (2) a token gate (_gpuMoePrefillMinTokens) keeps tiny prefills + all
+    //   decode on the byte-exact CPU path, so op-offload engages only where it wins (+28-67% prefill
+    //   from ~120 tokens up). SHARPI_MOE_GPU_PREFILL=0 restores the pure CPU MoE prefill. ***
     // Falls back to the CPU path (the field is cleared) if the scratch can't be allocated —
     // see the ctor. Not readonly: the ctor clears it on a setup failure.
-    private bool _gpuMoePrefill = ResolveGate("SHARPI_MOE_GPU_PREFILL", false);
+    private bool _gpuMoePrefill = ResolveGate("SHARPI_MOE_GPU_PREFILL", true);
+    // #390: op-offload only engages for prefill batches of at least this many tokens. The op-offload
+    // uploads the WHOLE expert tensor (~14 GB) per layer regardless of N, so a tiny batch goes
+    // upload-bound and loses to the CPU MoE (measured register mode: trails CPU below ~50 tokens,
+    // wins +28-67% from ~120 up). Below the gate — and for ALL single-token decode / MTP-verify
+    // steps, which never reach this batched-prefill path anyway — the byte-exact CPU MoE runs.
+    // Env override SHARPI_MOE_GPU_PREFILL_MIN_TOKENS (0 = always engage when op-offload is on).
+    private readonly int _gpuMoePrefillMinTokens = ResolveIntGate("SHARPI_MOE_GPU_PREFILL_MIN_TOKENS", 64);
     private int     _goCap;            // token capacity the GPU-offload scratch is sized for
     private Tensor? _gpuOffNorm;       // [N × embDim] uploaded norm activations (per layer call)
     private Tensor? _gpuOffGather;     // [totalSel × embDim] CSR-ordered gathered routed-token norms (ONE gather)
@@ -725,9 +736,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // genuine pinned allocation reaches full PCIe (~26 GB/s). Copied once at first scratch
     // alloc (~1s, pages already pre-faulted) and freed in FreeGpuOffloadScratch/Dispose.
     private nint    _goPinnedBuf;         // base of the big cudaMallocHost buffer (Zero = not pinned)
-    private byte*[]? _goPinnedGate;       // [L] per-layer gate_exps base inside _goPinnedBuf
+    // In register mode (#390) _goPinnedBuf is nint.Zero and these per-layer pointers alias the
+    // mmap DataPtrs directly; in copy mode they point inside _goPinnedBuf.
+    private byte*[]? _goPinnedGate;       // [L] per-layer gate_exps base (mmap DataPtr in register mode, inside _goPinnedBuf in copy mode)
     private byte*[]? _goPinnedUp;         // [L] per-layer up_exps base
     private byte*[]? _goPinnedDown;       // [L] per-layer down_exps base
+    // #390 register-in-place mode: the page-aligned mmap ranges registered via cudaHostRegister
+    // (no owned buffer). Tracked so FreeGpuOffloadScratch can cudaHostUnregister them. Null in
+    // copy mode (which owns _goPinnedBuf instead). The two modes are mutually exclusive.
+    private nint[]? _goRegisteredRanges;
     private int  _goCurSlot;
     private int  _goPrefetchedLayer = -1;
     private int  _goPrefetchSlot;
@@ -1572,6 +1589,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // request's critical path (tanking its TTFT and polluting single-turn benchmarks).
         // EnsureGpuOffloadScratch is grow-only, so a larger chunk later just re-grows the
         // (small) GPU buffers; the dominant pinned-buffer cost is N-independent and done here.
+        // This eager setup is independent of _gpuMoePrefillMinTokens by design: that gate only
+        // affects whether a given per-call dispatch uses op-offload, not whether the scratch /
+        // pin is built at load.
         if (_gpuMoePrefill)
         {
             int warmChunk = int.TryParse(Environment.GetEnvironmentVariable("SHARPI_PREFILL_CHUNK"),
@@ -2477,8 +2497,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             long lt2 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
             // ── Batched routed experts: CPU grouped-dot (default, byte-exact) or
-            //    GPU op-offload (transient weight upload + GEMM, opt-in, argmax-stable).
-            if (_gpuMoePrefill)
+            //    GPU op-offload (transient weight upload + GEMM, argmax-stable). The op-offload
+            //    only engages for large-enough batches (_gpuMoePrefillMinTokens) — tiny prefills
+            //    go upload-bound on the ~14 GB whole-tensor upload and lose to the CPU path.
+            if (_gpuMoePrefill && N >= _gpuMoePrefillMinTokens)
                 BatchedRoutedExpertsGpuOffload(layer, N);
             else
                 BatchedRoutedExperts(layer, N);
@@ -3375,10 +3397,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         int na = _numActiveExperts;
 
         // ── N-independent static scratch: allocate ONCE and keep across regrows ──
-        // The ~14 GB pinned weight copy + the whole-layer GPU weight buffers + the F32 dequant
-        // staging don't depend on the batch size N, so a later token-count growth must NOT free
-        // and re-copy them — re-building the pinned buffer is multi-second and fragmentation-prone
-        // (Gemini review). Only the per-N gather/scatter/GEMM scratch below re-grows.
+        // The pinned expert-weight DMA source (copy-mode ~14 GB cudaMallocHost buffer, or the
+        // in-place cudaHostRegister of the mmap pages, per SHARPI_MOE_PIN_MODE) + the whole-layer
+        // GPU weight buffers + the F32 dequant staging don't depend on the batch size N, so a later
+        // token-count growth must NOT free and re-build them — re-building the pinned source is
+        // multi-second and fragmentation-prone (Gemini review). Only the per-N gather/scatter/GEMM
+        // scratch below re-grows.
         if (!_goStaticAllocated)
         {
             // Transient weight buffers: an F32 dequant of a [expertDim×embDim] (or [embDim×
@@ -3419,11 +3443,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 _gpuLayerDown[s] = _gpu.AllocateRawBytes(maxLayerDownBytes, DType.Float32);
             }
 
-            // Copy the expert weights ONCE into a truly-pinned cudaMallocHost buffer so
-            // UploadRawIntoAsyncDirect DMAs from page-locked memory at full PCIe bandwidth (~26 GB/s
-            // vs ~13 GB/s for a cudaHostRegister'd file-backed mmap) and the prefetch overlaps
-            // compute. If the (large, ~15 GB) alloc fails we leave _goHostPinned=false and the path
-            // runs fully synchronous (today's UploadRawInto from mmap), with zero regression.
+            // Pin the expert weights as the DMA source for UploadRawIntoAsyncDirect. SHARPI_MOE_PIN_MODE
+            // selects how: "register" (default, #390) cudaHostRegisters the mmap pages in place — zero
+            // RAM copy, decode-safe; "copy" (#387) makes the ~14 GB cudaMallocHost duplicate (faster DMA
+            // but evicts the page cache CPU decode streams from). On any failure it self-falls-back to
+            // the synchronous mmap upload (_goHostPinned=false), with zero regression.
             EnsureExpertWeightsPinned();
             _goStaticAllocated = true;
         }
@@ -3463,17 +3487,20 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     }
 
     /// <summary>
-    /// One-time allocation of a single big pinned (<c>cudaMallocHost</c>) host buffer holding a
-    /// contiguous copy of every MoE layer's gate/up/down expert weights, copied straight from
-    /// the mmap <c>DataPtr</c>s (pages already pre-faulted by the loader). The pinned buffer is
-    /// the DMA source for <see cref="CudaBackend.UploadRawIntoAsyncDirect"/>, so the H2D copy
-    /// runs at full PCIe bandwidth and overlaps compute. Sets <see cref="_goHostPinned"/> on
-    /// success; on ANY failure (alloc returns Zero — typically ENOMEM for the ~15 GB) leaves it
-    /// false so the path stays on the synchronous mmap upload (no regression). Only raw-quant
-    /// layers are copied/DMA'd — Float32 layers host-dequant from the mmap as before, so a
-    /// Float32 layer leaves its per-layer pinned base null and falls back per call. Guarded by
-    /// <see cref="_goPinAttempted"/> so it runs at most once per scratch sizing. The mmap
-    /// (<see cref="_cpuFfnGateExps"/> etc.) is never touched — the CPU-MoE path keeps using it.
+    /// One-time setup of the pinned host DMA source for every MoE layer's gate/up/down expert
+    /// weights, in one of two modes selected by <c>SHARPI_MOE_PIN_MODE</c>: <c>register</c>
+    /// (default, #390) <c>cudaHostRegister</c>s the expert mmap pages in place — no RAM copy, so
+    /// the CPU page cache the decode path streams experts from is never evicted; <c>copy</c>
+    /// (#387) allocates a single big <c>cudaMallocHost</c> buffer (~14 GB) and copies every
+    /// tensor in contiguously (higher DMA bandwidth but evicts that page cache). Either way the
+    /// result is the DMA source for <see cref="CudaBackend.UploadRawIntoAsyncDirect"/>, so the
+    /// H2D copy runs without per-call staging and overlaps compute. Sets <see cref="_goHostPinned"/>
+    /// on success; on ANY failure (e.g. the copy-mode alloc returns Zero — typically ENOMEM for the
+    /// ~14 GB) leaves it false so the path stays on the synchronous mmap upload (no regression).
+    /// Only raw-quant layers are registered/copied/DMA'd — Float32 layers host-dequant from the
+    /// mmap as before, so a Float32 layer leaves its per-layer pinned base null and falls back per
+    /// call. Guarded by <see cref="_goPinAttempted"/> so it runs at most once per scratch sizing.
+    /// The mmap (<see cref="_cpuFfnGateExps"/> etc.) is never touched — the CPU-MoE path keeps using it.
     /// </summary>
     private void EnsureExpertWeightsPinned()
     {
@@ -3507,6 +3534,52 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         }
         if (total <= 0) { _goHostPinned = false; return; }   // nothing raw-quant → mmap path
 
+        // #390: pin mode. "register" (default) = cudaHostRegister the expert mmap pages in place
+        // (zero RAM copy → no page-cache eviction → no decode regression; DMA ~13 GB/s). "copy" =
+        // the original ~14 GB cudaMallocHost duplicate (DMA ~26 GB/s but evicts the page cache CPU
+        // decode streams experts from → ~-25% decode). Default register so op-offload is decode-safe.
+        string pinMode = (Environment.GetEnvironmentVariable("SHARPI_MOE_PIN_MODE") ?? "register")
+            .Trim().ToLowerInvariant();
+
+        _goPinnedGate = new byte*[L];
+        _goPinnedUp   = new byte*[L];
+        _goPinnedDown = new byte*[L];
+
+        if (pinMode == "register")
+        {
+            // Set each raw-quant layer's DMA base straight to the mmap pointer (Float32 / missing →
+            // null, per-layer host-dequant fallback). Collect each tensor's raw byte range, then
+            // page-align + merge them via MergePageAlignedRanges for cudaHostRegister. GGUF tensors
+            // are 32-byte aligned (not page-aligned), so adjacent tensors can share a page — merging
+            // ensures no page is registered twice (a double register returns false → that range
+            // silently DMAs as pageable; merging avoids it).
+            var rawRanges = new List<(long ptr, long bytes)>(3 * L);
+            void Reg(byte* src, DType dt, int rows, int cols, ref byte* slot)
+            {
+                long bytes = PinnedBytes(src, dt, rows, cols);
+                if (bytes == 0) { slot = null; return; }
+                slot = src;
+                rawRanges.Add(((long)src, bytes));
+            }
+            for (int l = 0; l < L; l++)
+            {
+                Reg(_cpuFfnGateExps![l].DataPtr, _cpuFfnGateExps![l].DType, expertDim, embDim, ref _goPinnedGate[l]);
+                Reg(_cpuFfnUpExps![l].DataPtr,   _cpuFfnUpExps![l].DType,   expertDim, embDim, ref _goPinnedUp[l]);
+                Reg(_cpuFfnDownExps![l].DataPtr, _cpuFfnDownExps![l].DType, embDim,    expertDim, ref _goPinnedDown[l]);
+            }
+            var merged = MergePageAlignedRanges(rawRanges, 4096);
+            var reg = new List<nint>(merged.Count);
+            int ok = 0;
+            foreach (var (s, e) in merged)
+                if (_gpu.TryRegisterHostPinned((nint)s, e - s)) { reg.Add((nint)s); ok++; }
+            _goRegisteredRanges = reg.ToArray();
+            _goPinnedBuf = nint.Zero;
+            _goHostPinned = true;
+            Console.Error.WriteLine($"[moe-offload] registered {ok}/{merged.Count} mmap expert-weight ranges in place ({total / (1024.0 * 1024.0 * 1024.0):F2} GiB, cudaHostRegister) — no RAM copy, DMA source for op-offload prefill.");
+            return;
+        }
+
+        // ── "copy" mode (#387): one big pinned cudaMallocHost buffer + copy (max DMA bandwidth) ──
         // 2. Allocate the big pinned buffer. On failure (ENOMEM) fall back to the mmap path.
         nint buf = CudaBackend.AllocatePinnedHost((nuint)total);
         if (buf == nint.Zero)
@@ -3519,9 +3592,6 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // 3. Copy each raw-quant layer's gate/up/down tensor into the buffer, contiguously, and
         //    record the per-layer base pointers the DMA source will use. Float32 layers leave a
         //    null base (per-layer sync host-dequant fallback in BatchedRoutedExpertsGpuOffload).
-        _goPinnedGate = new byte*[L];
-        _goPinnedUp   = new byte*[L];
-        _goPinnedDown = new byte*[L];
         byte* dst = (byte*)buf;
         long off = 0;
         void CopyOne(byte* src, DType dt, int rows, int cols, ref byte* slot)
@@ -3580,9 +3650,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     /// <param name="freeStatic">
     /// <c>false</c> (the per-N regrow path) frees ONLY the batch-size-dependent gather/scatter/GEMM
-    /// scratch, keeping the N-independent static buffers — the ~14 GB pinned weight copy, the
-    /// whole-layer GPU weight buffers, the F32 dequant staging — so a token-count growth doesn't
-    /// re-copy the multi-second pinned buffer (Gemini review). <c>true</c> (full teardown / Dispose)
+    /// scratch, keeping the N-independent static buffers — the pinned expert-weight DMA source
+    /// (copy-mode ~14 GB buffer or the in-place mmap registration, per <c>SHARPI_MOE_PIN_MODE</c>),
+    /// the whole-layer GPU weight buffers, the F32 dequant staging — so a token-count growth doesn't
+    /// re-build the multi-second pinned source (Gemini review). <c>true</c> (full teardown / Dispose)
     /// additionally frees those static buffers and resets the pin + static-alloc state.
     /// </param>
     private void FreeGpuOffloadScratch(bool freeStatic = true)
@@ -3608,12 +3679,19 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
         if (!freeStatic) return;
 
-        // ── N-independent static buffers + the ~14 GB pinned weight copy: only on full teardown ──
-        // (DrainPrefetch above ensured no DMA is still reading the slot buffers / pinned source.)
+        // ── N-independent static buffers + the pinned expert-weight DMA source (copy-mode ~14 GB
+        //    buffer or the in-place mmap registration, per SHARPI_MOE_PIN_MODE): only on full
+        //    teardown ── (DrainPrefetch above ensured no DMA is still reading the slot buffers /
+        //    pinned source.)
         F(ref _gpuOffWGate); F(ref _gpuOffWUp); F(ref _gpuOffWDown);
         if (_hGpuOffDeq != null) { NativeMemory.Free(_hGpuOffDeq); _hGpuOffDeq = null; }
         for (int s = 0; s < 2; s++) { FW(ref _gpuLayerGate[s]); FW(ref _gpuLayerUp[s]); FW(ref _gpuLayerDown[s]); }
         if (_goPinnedBuf != nint.Zero) { CudaBackend.FreePinnedHost(_goPinnedBuf); _goPinnedBuf = nint.Zero; }
+        if (_goRegisteredRanges != null)
+        {
+            foreach (var p in _goRegisteredRanges) _gpu.UnregisterHostPinned(p);
+            _goRegisteredRanges = null;
+        }
         _goPinnedGate = null; _goPinnedUp = null; _goPinnedDown = null;
         _goHostPinned = false;
         _goPinAttempted = false;
@@ -6183,6 +6261,46 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // but humans set these by hand. Anything else still falls through to the auto-default.
         if (bool.TryParse(v, out bool b)) return b;
         return autoDetect;
+    }
+
+    /// <summary>Parse a non-negative integer env override, falling back to <paramref name="dflt"/>
+    /// for an unset/blank/invalid value (used for the op-offload token gate).</summary>
+    private static int ResolveIntGate(string envName, int dflt)
+    {
+        var v = Environment.GetEnvironmentVariable(envName);
+        return int.TryParse(v, out int n) && n >= 0 ? n : dflt;
+    }
+
+    /// <summary>
+    /// Convert raw host byte ranges <c>(ptr, bytes)</c> into page-aligned, sorted, merged
+    /// <c>[start, end)</c> ranges suitable for <c>cudaHostRegister</c> — each input range is
+    /// rounded out to whole <paramref name="pageSize"/> pages (floor start, ceil end), then
+    /// overlapping or exactly-adjacent ranges are coalesced so a page shared by two
+    /// 32-byte-aligned GGUF tensors is never registered twice. Ranges with non-positive
+    /// <c>bytes</c> are skipped. Internal + static so it can be covered by a CPU-only unit test.
+    /// </summary>
+    internal static List<(long start, long end)> MergePageAlignedRanges(
+        List<(long ptr, long bytes)> ranges, long pageSize)
+    {
+        var aligned = new List<(long start, long end)>(ranges.Count);
+        foreach (var (ptr, bytes) in ranges)
+        {
+            if (bytes <= 0) continue;
+            long s = ptr / pageSize * pageSize;
+            long e = (ptr + bytes + pageSize - 1) / pageSize * pageSize;
+            aligned.Add((s, e));
+        }
+        aligned.Sort((a, b) => a.start.CompareTo(b.start));
+        var merged = new List<(long start, long end)>(aligned.Count);
+        foreach (var r in aligned)
+        {
+            if (merged.Count > 0 && r.start <= merged[^1].end)
+            {
+                if (r.end > merged[^1].end) merged[^1] = (merged[^1].start, r.end);
+            }
+            else merged.Add(r);
+        }
+        return merged;
     }
 
     private static void SelectTopKPtr(float* logits, int n, int k,

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -223,12 +223,14 @@ public sealed class SharpInferenceServerOptions
     /// gate, read by <see cref="CudaHybridGdnForwardPass"/> at construction. Uploads each used
     /// expert's host-resident weights to the GPU for the batched prefill matmul (like llama.cpp's
     /// op-offload) instead of running the dots on the CPU. Server analogue of the CLI's
-    /// <c>--gpu-moe-prefill</c>. <b>OPT-IN, default OFF in the engine.</b> <c>true</c> →
-    /// <c>SHARPI_MOE_GPU_PREFILL=1</c> (enable); <c>false</c> → force off; <c>null</c> (default)
-    /// writes nothing, preserving the engine default and any value already in the environment.
-    /// ~+15-44% prefill, but ~-25% decode (its ~14 GB pinned weight copy evicts the page cache
-    /// single-token decode's CPU expert-streaming relies on), so enable only for prefill-heavy
-    /// workloads. Argmax-stable (the GPU runs the MoE in F32), not bit-identical to the CPU path.
+    /// <c>--gpu-moe-prefill</c>. <b>Default ON in the engine (#390).</b> <c>true</c> →
+    /// <c>SHARPI_MOE_GPU_PREFILL=1</c>; <c>false</c> → force the CPU MoE prefill; <c>null</c>
+    /// (default) writes nothing, preserving the engine default and any value already in the
+    /// environment. ~+28-67% prefill with decode within noise of the CPU path: the register-in-place
+    /// pin mode (<c>SHARPI_MOE_PIN_MODE</c>, default <c>register</c>) cudaHostRegisters the expert
+    /// mmap pages instead of a ~14 GB copy (no RAM duplicate, no page-cache eviction), and a token
+    /// gate (<c>SHARPI_MOE_GPU_PREFILL_MIN_TOKENS</c>, default 64) keeps tiny prefills + decode on
+    /// the CPU path. Argmax-stable (the GPU runs the MoE in F32), not bit-identical to the CPU path.
     /// CUDA hybrid + CPU-MoE only; auto-falls-back to the CPU path if its scratch can't allocate.
     /// </summary>
     public bool? GpuMoePrefill { get; set; }

--- a/tests/SharpInference.Tests.ForwardPass/MergePageAlignedRangesTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/MergePageAlignedRangesTests.cs
@@ -1,0 +1,115 @@
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// CPU-only unit tests for <see cref="CudaHybridGdnForwardPass.MergePageAlignedRanges"/> — the
+/// page-align + sort + merge step extracted from the #390 register-in-place MoE pin path. The
+/// arithmetic (floor start, ceil end, coalesce overlapping/adjacent ranges) is off-by-one prone,
+/// so it is exercised here without a GPU. GGUF expert tensors are 32-byte aligned (not
+/// page-aligned), so two adjacent tensors can share a page; merging guarantees no page is
+/// registered twice (a double <c>cudaHostRegister</c> would silently leave that range pageable).
+/// </summary>
+public sealed class MergePageAlignedRangesTests
+{
+    private const long Page = 4096;
+
+    [Fact]
+    public void SingleRange_RoundsOutToWholePages()
+    {
+        // ptr=100, bytes=50 → spans [100,150), rounds out to [0,4096).
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (100, 50) }, Page);
+
+        Assert.Single(merged);
+        Assert.Equal((0L, 4096L), merged[0]);
+    }
+
+    [Fact]
+    public void TwoRangesSharingAPage_MergeIntoOne()
+    {
+        // (0,4000) → [0,4096) and (4090,100) → [4096,8192). They are exactly adjacent at 4096 and
+        // the first also touches the page the second starts in, so both coalesce into [0,8192).
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (0, 4000), (4090, 100) }, Page);
+
+        Assert.Single(merged);
+        Assert.Equal((0L, 8192L), merged[0]);
+    }
+
+    [Fact]
+    public void TwoRangesFarApart_StaySeparate()
+    {
+        // (0,50) → [0,4096) and (1_000_000,50) → [999_424,1_003_520). No shared/adjacent page.
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (0, 50), (1_000_000, 50) }, Page);
+
+        Assert.Equal(2, merged.Count);
+        Assert.Equal((0L, 4096L), merged[0]);
+        Assert.Equal((999_424L, 1_003_520L), merged[1]);
+    }
+
+    [Fact]
+    public void ExactlyAdjacentPageAlignedRanges_Coalesce()
+    {
+        // (0,4096) → [0,4096) and (4096,4096) → [4096,8192). Adjacent (start == prev end) → merge.
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (0, 4096), (4096, 4096) }, Page);
+
+        Assert.Single(merged);
+        Assert.Equal((0L, 8192L), merged[0]);
+    }
+
+    [Fact]
+    public void NonPositiveBytes_AreSkipped()
+    {
+        // A zero-byte and a negative-byte entry are dropped; only the real range survives.
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (0, 0), (4096, -10), (8192, 50) }, Page);
+
+        Assert.Single(merged);
+        Assert.Equal((8192L, 12288L), merged[0]);
+    }
+
+    [Fact]
+    public void UnsortedInput_IsSortedAndMerged()
+    {
+        // Out-of-order input with a shared page in the middle: the far-late range first, then two
+        // that share page 0, then an early standalone. Result must be sorted ascending and merged.
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)>
+            {
+                (1_000_000, 50),  // [999_424, 1_003_520)
+                (4090, 100),      // [4096, 8192)
+                (0, 4000),        // [0, 4096)  — coalesces with the previous into [0, 8192)
+            }, Page);
+
+        Assert.Equal(2, merged.Count);
+        Assert.Equal((0L, 8192L), merged[0]);
+        Assert.Equal((999_424L, 1_003_520L), merged[1]);
+    }
+
+    [Theory]
+    // Small page size (16) makes the floor/ceil rounding easy to read by eye.
+    [InlineData(0, 1, 0, 16)]          // 1 byte → one whole page
+    [InlineData(15, 1, 0, 16)]         // last byte of page 0 → [0,16)
+    [InlineData(16, 1, 16, 32)]        // first byte of page 1 → [16,32)
+    [InlineData(10, 20, 0, 32)]        // spans pages 0 and 1 → [0,32)
+    public void SmallPage_RoundsCorrectly(long ptr, long bytes, long expStart, long expEnd)
+    {
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (ptr, bytes) }, 16);
+
+        Assert.Single(merged);
+        Assert.Equal((expStart, expEnd), merged[0]);
+    }
+
+    [Fact]
+    public void EmptyInput_ProducesNoRanges()
+    {
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)>(), Page);
+
+        Assert.Empty(merged);
+    }
+}


### PR DESCRIPTION
Resolves #390.

## Problem
The #387 GPU op-offload (`SHARPI_MOE_GPU_PREFILL`) was **opt-in** because making it default-on regressed decode ~25%. It pinned the expert weights for fast async DMA by allocating a **~14 GB `cudaMallocHost` buffer and copying** the experts into it — duplicating them in RAM (mmap ~14 GB + pinned ~14 GB ≈ 28 GB on a 64 GB box). That page-locked allocation evicted the OS page cache that **single-token CPU decode's expert-streaming relies on** → decode page-faults.

## Fix (so it can ship default-on)
**1. Register-in-place pin mode** (`SHARPI_MOE_PIN_MODE=register`, new default) — `cudaHostRegister` the existing expert mmap pages as the DMA source instead of copying. No 14 GB duplicate → no page-cache eviction → no decode regression. The backend already had `TryRegisterHostPinned`/`UnregisterHostPinned`; this wires them into the offload path. GGUF tensors are 32-byte aligned (not page-aligned) so adjacent tensors can share a 4 KB page — the ranges are page-aligned, sorted and merged (`MergePageAlignedRanges`, unit-tested) so no page is registered twice. `SHARPI_MOE_PIN_MODE=copy` keeps the #387 max-bandwidth path.

**2. Token gate** (`SHARPI_MOE_GPU_PREFILL_MIN_TOKENS`, default 64) — the op-offload uploads the whole ~14 GB expert tensor per layer regardless of N, so tiny prefills go upload-bound and lose to the CPU path. Below the gate (and for all single-token decode / MTP-verify steps, which never reach this batched-prefill path) the byte-exact CPU MoE runs.

Flips `_gpuMoePrefill` default `false`→`true`; updates the `--gpu-moe-prefill` flag + server `GpuMoePrefill` option docs.

## Measured (RTX 4070 Ti + Ryzen 9 7900X)
2K-token prompt, register default-on vs `--gpu-moe-prefill false`, same session:

| model | prefill on | prefill off | Δ |
|---|--:|--:|--:|
| Carnice | **241.8** | 157.5 | **+54%** |
| Qwen3.6-35B-A3B | **109.6** | 66.4 | **+65%** |
| Qwen3.6-35B-A3B-MTP | **108.6** | 65.6 | **+66%** |

**Decode within noise** of the CPU path on a clean interleaved A/B (Carnice register 31.2 vs off 30.2 t/s). Prefill crossover sweep: register wins from ~120 tokens up (+28–67%); the <~50-token regime is the only loss (sub-second prefill) and is covered by the gate. Register registers **120/120** mmap ranges cleanly. Argmax-stable (GPU runs the MoE in F32), not bit-identical to the CPU dots.

## Tests
- New `MergePageAlignedRangesTests` (11 cases) covering the page-align/merge math (CPU-only).
- Code-reviewed: no Critical/High/Medium findings (drain-before-unregister ordering, double-unregister idempotency, fallback-to-pageable safety, gate state consistency all verified).
- New bench drivers: `bench-390-ab.ps1` (off/copy/register), `bench-390-sweep.ps1` (prefill crossover), `bench-390-models.ps1` (the three README rows).

Follow-up to the broader path toward llama.cpp's 676 t/s remains tracked in #388 (router-on-GPU, grouped GEMM, de-serialized per-layer pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)