### PR TITLE
perf(cuda): run the CPU-MoE prefill router on the GPU (#388)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sharpi-cli -m models/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **241.8** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload default-on (#390, register-in-place pin) — **+54%** over the CPU MoE path, decode within noise (`--gpu-moe-prefill false` to force CPU) |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **275.4** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload (#390, register-in-place pin) **+ on-GPU router** (#388) default-on — **+75%** over the CPU MoE path (157→275), decode within noise (`--gpu-moe-prefill false` / `SHARPI_MOE_GPU_ROUTER=0` to force CPU) |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 18.4 | 12.2 | runs on Vulkan (#357); 47% acceptance. MTP self-spec **regresses** vs plain MoE decode (~22 t/s, cf. 35B-A3B) — routed-expert verify is un-amortized on Vulkan (#370). Lossless; use `--spec-type none` for speed |
 
 #### Qwen3.6-35B-A3B (GDN+MoE) — [unsloth](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) · 22 GB
@@ -146,7 +146,7 @@ sharpi-cli -m models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1` (hybrid) | **109.6** | **23.7** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. Fused GDN scan + batched SDPA, bit-identical. `SHARPI_CPU_MOE=0` forces on-GPU experts. Prefill: GPU MoE op-offload default-on (#390) — **+65%** over the CPU MoE path, decode within noise |
+| **CUDA** `-g -1` (hybrid) | **113.8** | **23.7** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. Fused GDN scan + batched SDPA, bit-identical. `SHARPI_CPU_MOE=0` forces on-GPU experts. Prefill: GPU MoE op-offload (#390) + on-GPU router (#388) default-on — **+71%** over the CPU MoE path, decode within noise |
 | Vulkan `-g -1` (hybrid) | 17.3 | 22.8 | 10 attn + 30 GDN on GPU; routed MoE + shared expert on CPU mmap (#356). Decode ~matches CUDA (CPU-routed-expert bound); prefill trails CUDA — per-row CPU FFN not yet batched (#371) |
 | CPU | **11.3** | 9.3 | hybrid GDN/attn, 256 experts / 8 active. Chunk-parallel (FlashQLA) GDN prefill default-on (1.35× over the 8.4 t/s per-token scan; `SHARPI_GDN_CHUNKED_PREFILL=0` to disable). MTP variants keep the byte-exact scan (FP-reorder flips the thinking-boundary token) |
 
@@ -160,7 +160,7 @@ SHARPI_CPU_MOE=1 sharpi-cli -m models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **108.6** | **21.4** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance. Prefill: GPU MoE op-offload default-on (#390) — **+66%** over the CPU MoE path, decode within noise |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **114.2** | **21.4** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance. Prefill: GPU MoE op-offload (#390) + on-GPU router (#388) default-on — **+74%** over the CPU MoE path, decode within noise |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 15.4 | 9.3 | needs `SHARPI_CPU_MOE=1`; runs on Vulkan (#357). 61% acceptance, but MTP self-spec **regresses** vs ~22 t/s plain MoE decode — routed-expert verify un-amortized on Vulkan (#370). Use `--spec-type none` for speed |
 | CPU `--no-thinking` | 9.1 | **8.5** | GDN/attn + 256-expert MoE + MTP head (#44). 100% acceptance; MoE-MTP batched verify (#45) — routed experts sequential per token, so ~MTP-off parity |
 

--- a/scripts/bench-388-router.ps1
+++ b/scripts/bench-388-router.ps1
@@ -1,0 +1,46 @@
+# Issue #388 (router-on-GPU lever): measure the CPU-MoE prefill router moved to the GPU.
+# Op-offload stays ON (the #390 default) throughout; we toggle SHARPI_MOE_GPU_ROUTER.
+# 2K-token prompt. Prefill is the win; decode should be unchanged (decode uses the CPU router).
+param(
+    [string]$PromptFile = "C:\Users\pekka\AppData\Local\Temp\claude\C--p-sharpi\e585495f-574a-494e-820c-3cfea3d513e6\scratchpad\prefill_prompt.txt",
+    [int]$NTokens = 40,
+    [int]$TimeoutSec = 900
+)
+$cliDll = ".\src\SharpInference.Cli\bin\Release\net10.0\sharpi-cli.dll"
+$dotnet = (Get-Command dotnet).Source
+$env:SHARPI_CPU_MOE = "1"
+$models = @(
+    @{ Name="Carnice";     Path="E:\models\Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf" }
+    @{ Name="35B-A3B";     Path="E:\models\Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" }
+    @{ Name="35B-A3B-MTP"; Path="E:\models\Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf" }
+)
+function Run-One([string]$name, [string]$model, [string]$router) {
+    if ($router -eq "off") { $env:SHARPI_MOE_GPU_ROUTER = "0" } else { Remove-Item env:SHARPI_MOE_GPU_ROUTER -ErrorAction SilentlyContinue }
+    $argList = @("$cliDll","-m","$model","-f","$PromptFile","--temp","0","-n","$NTokens",
+                 "--single-turn","-g","-1","--backend","cuda","--no-thinking")
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $dotnet
+    $psi.Arguments = ($argList | ForEach-Object { if ($_ -match '\s') { "`"$_`"" } else { $_ } }) -join ' '
+    $psi.RedirectStandardOutput = $true; $psi.RedirectStandardError = $true; $psi.UseShellExecute = $false
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $so = $proc.StandardOutput.ReadToEndAsync(); $se = $proc.StandardError.ReadToEndAsync()
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) { try { $proc.Kill($true) } catch {} }
+    $so.Wait(2000)|Out-Null; $se.Wait(2000)|Out-Null
+    $stdout = $so.Result; if ($null -eq $stdout) { $stdout = "" }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $pTok=0;$pTps=0.0;$dTps=0.0
+    if ($stdout -match 'Prefill:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s') { $pTok=[int]$matches[1]; $pTps=[double]::Parse($matches[2],$inv) }
+    if ($stdout -match 'Decode:\s+(\d+)\s+tokens,\s+([\d\.]+)\s+t/s')  { $dTps=[double]::Parse($matches[2],$inv) }
+    [PSCustomObject]@{ Model=$name; Router=$router; Prefill=$pTok; PrefillTps=[Math]::Round($pTps,1); DecodeTps=[Math]::Round($dTps,1) }
+}
+$results = @()
+try {
+    foreach ($m in $models) {
+        if (-not (Test-Path $m.Path)) { Write-Host "skip $($m.Path)" -ForegroundColor Yellow; continue }
+        foreach ($r in @("off","on")) { Write-Host "[$($m.Name)/router-$r]..." -ForegroundColor Cyan; $results += Run-One $m.Name $m.Path $r }
+    }
+} finally { Remove-Item env:SHARPI_MOE_GPU_ROUTER -ErrorAction SilentlyContinue }
+$results | Format-Table Model, Router, Prefill, PrefillTps, DecodeTps -AutoSize
+if (-not (Test-Path "bench-out")) { New-Item -ItemType Directory -Path "bench-out" | Out-Null }
+$results | Export-Csv -NoTypeInformation -Path "bench-out\bench-388-router.csv"
+Write-Host "`nResults -> bench-out\bench-388-router.csv" -ForegroundColor Green

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -574,6 +574,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private Tensor? _gpuStreamAll;     // [N × embDim] inter-layer residual stream for all tokens
     private float* _bResidAll;         // [bCap × embDim] pinned — per-token MoE residual (postBlock hidden)
     private float* _bNormAll;          // [bCap × embDim] pinned — per-token post-attn-norm (MoE input)
+    private float* _btRouterAll;       // [N × numExperts] router-logit readback (CPU-MoE GPU-router, #388)
     private float* _bSharedAll;        // [bCap × embDim] pinned — per-token shared-expert out (unscaled)
     private float* _bHiddenAll;        // [bCap × embDim] pinned — combined hidden, uploaded to _gpuStreamAll
     private float* _bRoutedAll;        // [bCap × embDim] — routed-expert accumulator (host only)
@@ -608,6 +609,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private Tensor? _gpuBtNorm;      // [N × embDim] attn-norm output (block input)
     private Tensor? _gpuBtBlockOut;  // [N × embDim] block output → postBlock (resid)
     private Tensor? _gpuBtMoeNorm;   // [N × embDim] post-attn-norm (MoE input)
+    private Tensor? _gpuBtRouterAll; // [N × numExperts] batched router logits (CPU-MoE GPU-router, #388)
     private Tensor? _gpuBtShared;    // [N × embDim] shared-expert output (unscaled)
     private Tensor? _gpuBtQkv;       // [N × convChannels] GDN joint QKV
     private Tensor? _gpuBtZ;         // [N × valueDim] GDN z-gate
@@ -686,6 +688,14 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // Falls back to the CPU path (the field is cleared) if the scratch can't be allocated —
     // see the ctor. Not readonly: the ctor clears it on a setup failure.
     private bool _gpuMoePrefill = ResolveGate("SHARPI_MOE_GPU_PREFILL", true);
+    // #388: run the CPU-MoE prefill router matvec on the GPU (batched GEMM over the on-GPU
+    // post-attn norm) instead of the per-token CPU matvec (~16% of CPU-MoE prefill). RAW logits
+    // download; softmax + top-k stay on the host. Argmax-stable vs the CPU matvec (same FP class
+    // as BatchedGpuMoeFfn's already-default GPU router). SHARPI_MOE_GPU_ROUTER=0 forces CPU.
+    private readonly bool _gpuRouterPrefill = ResolveGate("SHARPI_MOE_GPU_ROUTER", true);
+    // Set per layer by TrunkLayerBatched: true when it issued the GPU router GEMM+download for
+    // this layer, so PrefillBatchedCpuMoe's router loop reads _btRouterAll instead of matvec'ing.
+    private bool _btRouterGpuValid;
     // #390: op-offload only engages for prefill batches of at least this many tokens. The op-offload
     // uploads the WHOLE expert tensor (~14 GB) per layer regardless of N, so a tiny batch goes
     // upload-bound and loses to the CPU MoE (measured register mode: trails CPU below ~50 tokens,
@@ -1243,6 +1253,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 }
                 else
                 {
+                    // #388: also upload the small (F32, ~2 MiB/layer) router weight to GPU so the
+                    // prefill router matvec can run on-GPU (SHARPI_MOE_GPU_ROUTER); the routed
+                    // expert weights still stream from CPU mmap. _cpuFfnGateInp stays resolved for
+                    // the CPU-router fallback (SHARPI_MOE_GPU_ROUTER=0 / sequential trunk).
+                    if (_gpuRouterPrefill)
+                        _gpuWGateInp[i] = UploadWeight($"blk.{i}.ffn_gate_inp.weight");
                     _cpuFfnGateInp![i] = ResolveCpuWeight($"blk.{i}.ffn_gate_inp.weight");
                     _cpuFfnGateExps![i] = ResolveCpuWeight($"blk.{i}.ffn_gate_exps.weight");
                     _cpuFfnUpExps![i] = ResolveCpuWeight($"blk.{i}.ffn_up_exps.weight");
@@ -1779,6 +1795,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
         _bResidAll  = AllocPinnedL(perTokEmb);
         _bNormAll   = AllocPinnedL(perTokEmb);
+        if (_cpuMoe && _gpuRouterPrefill)
+            _btRouterAll = AllocPinnedL((long)N * _numExperts);   // #388: pinned for fast D2H of the GPU router logits
         _bSharedAll = AllocPinnedL(perTokEmb);
         _bHiddenAll = AllocPinnedL(perTokEmb);
         _bRoutedAll = AllocL(perTokEmb);
@@ -1850,6 +1868,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         _gpuBtNorm     = A((long)N * embDim);
         _gpuBtBlockOut = A((long)N * embDim);
         _gpuBtMoeNorm  = A((long)N * embDim);
+        if (_cpuMoe && _gpuRouterPrefill)
+            _gpuBtRouterAll = A((long)N * _numExperts);   // batched router logits (#388, CPU-MoE GPU-router)
         if (_cpuMoe)
             _gpuBtShared = A((long)N * embDim);   // shared-expert out (CPU-MoE combine only)
         _gpuBtQkv      = A((long)N * _gdnConvChannels);
@@ -1883,7 +1903,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private void FreeBatchedTrunkScratch()
     {
         void F(ref Tensor? t) { if (t is { } v) { _gpu.Free(v); t = null; } }
-        F(ref _gpuBtNorm); F(ref _gpuBtBlockOut); F(ref _gpuBtMoeNorm); F(ref _gpuBtShared);
+        F(ref _gpuBtNorm); F(ref _gpuBtBlockOut); F(ref _gpuBtMoeNorm); F(ref _gpuBtRouterAll); F(ref _gpuBtShared);
         F(ref _gpuBtQkv); F(ref _gpuBtZ); F(ref _gpuBtAlpha); F(ref _gpuBtBeta); F(ref _gpuBtGdnOut);
         F(ref _gpuBtQGate); F(ref _gpuBtQ); F(ref _gpuBtGate); F(ref _gpuBtK); F(ref _gpuBtV); F(ref _gpuBtAttnOut);
         F(ref _gpuBtSGate); F(ref _gpuBtSUp);
@@ -2094,7 +2114,18 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         GpuMatMulBatched(shared, _gpuWDownShexp[layer], _gpuBtSGate!, N);
         _gpu.DownloadAsync(shared, (nint)_bSharedAll, (int)((long)N * embDim));
 
-        _gpu.Synchronize();   // drain all queued D2H: resid/norm/shared now host-valid
+        // #388: batched GPU router GEMM, overlapping the trunk's D2H. RAW logits → host (softmax +
+        // top-k run on the host in PrefillBatchedCpuMoe, reading _btRouterAll). Skipped (→ CPU router)
+        // when the router weight isn't batched-GEMM-supported. moeNorm (_gpuBtMoeNorm) is valid here.
+        _btRouterGpuValid = _gpuRouterPrefill && _cpuMoe && _gpuBtRouterAll is not null
+                            && BatchedMatMulSupported(_gpuWGateInp[layer]);
+        if (_btRouterGpuValid)
+        {
+            GpuMatMulBatched(_gpuBtRouterAll!, _gpuWGateInp[layer], moeNorm, N);
+            _gpu.DownloadAsync(_gpuBtRouterAll!, (nint)_btRouterAll, (int)((long)N * _numExperts));
+        }
+
+        _gpu.Synchronize();   // drain all queued D2H: resid/norm/shared (+ router) now host-valid
     }
 
     /// <summary>Batched GDN block: projections over N tokens; fused sequential-scan
@@ -2375,6 +2406,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     {
         if (_bResidAll  != null) { CudaBackend.FreePinnedHost((nint)_bResidAll);  _bResidAll = null; }
         if (_bNormAll   != null) { CudaBackend.FreePinnedHost((nint)_bNormAll);   _bNormAll = null; }
+        if (_btRouterAll != null) { CudaBackend.FreePinnedHost((nint)_btRouterAll); _btRouterAll = null; }
         if (_bSharedAll != null) { CudaBackend.FreePinnedHost((nint)_bSharedAll); _bSharedAll = null; }
         if (_bHiddenAll != null) { CudaBackend.FreePinnedHost((nint)_bHiddenAll); _bHiddenAll = null; }
         if (_bRoutedAll != null) { NativeMemory.Free(_bRoutedAll); _bRoutedAll = null; }
@@ -2465,6 +2497,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             //    Both produce host _bResidAll / _bNormAll / _bSharedAll, then the
             //    batched MoE below runs identically. The batched trunk is bit-identical
             //    to the sequential one (same kernels, same per-row FP reduction).
+            // #388: cleared here so the sequential-trunk path (which never issues the GPU
+            // router GEMM) leaves it false → the host router loop below matvecs on the CPU.
+            // TrunkLayerBatched sets it true per layer when it ran the batched router.
+            _btRouterGpuValid = false;
             if (BatchedTrunkEnabled && !_cpuGdn)
             {
                 TrunkLayerBatched(layer, N, startPos, isAttn, snapKvActive, wStart);
@@ -2481,10 +2517,24 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             for (int i = 0; i < N; i++)
             {
                 float* normI = _bNormAll + (long)i * embDim;
-                SimdKernels.MatVec(_cpuRouterLogits, routerW.DataPtr, normI,
-                    _numExperts, embDim, routerW.DType);
-                SimdKernels.SoftmaxInPlace(_cpuRouterLogits, _numExperts);
-                SelectTopKPtr(_cpuRouterLogits, _numExperts, na, sel, wts, _hp.NormalizeMoeTopKWeights);
+                // #388: router logits from the GPU batched GEMM (TrunkLayerBatched downloaded
+                // them into _btRouterAll) when available; else the per-token CPU matvec.
+                // Softmax + top-k run on the host either way; the shexp dot below is unchanged
+                // (it still reads normI from the host post-attn norm).
+                float* logitsI;
+                if (_btRouterGpuValid)
+                {
+                    logitsI = _btRouterAll + (long)i * _numExperts;
+                    SimdKernels.SoftmaxInPlace(logitsI, _numExperts);
+                }
+                else
+                {
+                    logitsI = _cpuRouterLogits;
+                    SimdKernels.MatVec(_cpuRouterLogits, routerW.DataPtr, normI,
+                        _numExperts, embDim, routerW.DType);
+                    SimdKernels.SoftmaxInPlace(_cpuRouterLogits, _numExperts);
+                }
+                SelectTopKPtr(logitsI, _numExperts, na, sel, wts, _hp.NormalizeMoeTopKWeights);
                 for (int k = 0; k < na; k++)
                 {
                     _bSelected[(long)i * na + k] = sel[k];
@@ -6992,6 +7042,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 {
                     _gpu.Free(_gpuWGateInp[i]);
                     _gpu.Free(_gpuWGateInpShexp[i]);
+                }
+                else if (_gpuRouterPrefill && _gpuWGateInp[i] is { } routerW)
+                {
+                    _gpu.Free(routerW);   // #388: router weight uploaded for the GPU prefill router
                 }
             }
             if (_hp.LayerTypes![i] == LayerType.Attention)


### PR DESCRIPTION
Part of #388 (the path toward llama.cpp's 676 t/s). **Stacked on #391** (base = `feat/390-moe-prefill-default-on`).

## Problem
After #390 made the GPU op-offload default-on, a profile of the GDN-hybrid CPU-MoE prefill (Carnice, N=2033, 8306 ms) showed the **router** as the 2nd-biggest phase at **1303 ms (~16%)** — it ran the router matvec (`norm × routerWᵀ`) + softmax + top-k + shexp-gate on the CPU, per token per layer.

| phase | ms (before) |
|---|--:|
| routed-MoE GEMM (GPU) | 4253 |
| **router (HOST)** | **1303** |
| trunk (GPU) | 2231 |
| combine | 56 |

## Fix
Move the router matvec to a single **batched GPU GEMM** over the on-GPU post-attn norm (already resident as `_gpuBtMoeNorm`), mirroring the on-GPU router the full-GPU-MoE path (`BatchedGpuMoeFfn`) already uses by default. RAW logits are downloaded; softmax + top-k + shexp stay on the host (cheap; avoids N per-row GPU softmax launches). The GEMM is enqueued before the trunk's existing `Synchronize`, so it **overlaps the trunk D2H**. In CPU-MoE mode the small (F32, ~2 MiB/layer) router weight is now uploaded to GPU; routed expert weights still stream from CPU mmap.

The router phase drops **1303 → 278 ms**.

## Measured (RTX 4070 Ti + Ryzen 9 7900X, 2K prompt, op-offload on, router on vs off)
| model | prefill on | off | Δ |
|---|--:|--:|--:|
| Carnice | **275.4** | 239.8 | **+15%** |
| Qwen3.6-35B-A3B | **113.8** | 104.4 | **+9%** |
| Qwen3.6-35B-A3B-MTP | **114.2** | 104.6 | **+9%** |

Cumulative with #390 (vs the CPU MoE path): **Carnice 157 → 275 t/s (+75%)**. Decode unchanged (it uses the CPU router).

## Safety
- **Argmax-stable** vs the CPU matvec (same FP class as the full-GPU-MoE router) — verified **byte-identical** output on Carnice. Softmax is monotonic, so top-k selection is identical whether logits come from the GPU GEMM or the CPU matvec.
- Gated by `SHARPI_MOE_GPU_ROUTER` (default on). `=0`, an unsupported router dtype, or the sequential trunk → byte-exact CPU-matvec fallback (new buffers simply not allocated/used).
- Code-reviewed: **no findings** (flag lifetime, alloc/free symmetry, scratch sizing, null-safety, fallback parity all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)