### PR TITLE
perf(cuda): Q3_K routed-expert prefill via dequant→cuBLAS GEMM (#388)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sharpi-cli -m models/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **275.4** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (Q3_K + Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload (#390, register-in-place pin) **+ on-GPU router** (#388) default-on — **+75%** over the CPU MoE path (157→275), decode within noise (`--gpu-moe-prefill false` / `SHARPI_MOE_GPU_ROUTER=0` to force CPU) |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **470.0** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (76% Q3_K + Q4_K/Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload (#390, register-in-place pin) + on-GPU router (#388) + **Q3_K dequant→cuBLAS expert GEMM** (#388; weight read once vs the per-token GEMM-N) default-on — **3.3× over the CPU MoE path** (144→470), decode within noise. (`--gpu-moe-prefill false` / `SHARPI_MOE_GPU_ROUTER=0` / `SHARPI_Q3K_DEQUANT_GEMM=0` force the CPU paths) |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 18.4 | 12.2 | runs on Vulkan (#357); 47% acceptance. MTP self-spec **regresses** vs plain MoE decode (~22 t/s, cf. 35B-A3B) — routed-expert verify is un-amortized on Vulkan (#370). Lossless; use `--spec-type none` for speed |
 
 #### Qwen3.6-35B-A3B (GDN+MoE) — [unsloth](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) · 22 GB

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -239,6 +239,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _dequantQ6KF16Kernel;
     private nint   _dequantQ6KF16SoaKernel;  // #204: dequant over the Q6_K SoA layout
     private nint   _dequantQ5KF16Kernel;   // #162: same path for Q5_K_M mixes
+    private nint   _dequantQ3KF16Kernel;   // #388: Q3_K weight → fp16 (Carnice MoE routed experts, AoS only)
     private nint   _dequantQ40F16Kernel;   // #124: Q4_0 weight → fp16 (Gemma 4 12B QAT)
     private nint   _f32ToF16Kernel;
     // Issue #141 (MMQ): int8 tensor-core Q8_0×Q8_1 matmul — weight read once as
@@ -2561,9 +2562,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         EnsureImageKernels();
         if (!_imageKernelsAvailable)
             throw new NotSupportedException("NVRTC kernels are not available on this system.");
-        if (weightDType is not (DType.Q8_0 or DType.Q4_K or DType.Q6_K or DType.Q5_K or DType.Q4_0))
+        if (weightDType is not (DType.Q8_0 or DType.Q4_0 or DType.Q4_K or DType.Q3_K or DType.Q6_K or DType.Q5_K))
             throw new NotSupportedException(
-                $"CUDA MatMulBatchedGemm: weight dtype {weightDType} not supported (Q8_0, Q4_0, Q4_K, Q5_K, or Q6_K).");
+                $"CUDA MatMulBatchedGemm: weight dtype {weightDType} not supported (Q8_0, Q4_0, Q3_K, Q4_K, Q5_K, or Q6_K).");
         if (nTok <= 0)
             throw new ArgumentOutOfRangeException(nameof(nTok), nTok, "nTok must be > 0.");
         if (outputAll.ElementCount % nTok != 0 || inputAll.ElementCount % nTok != 0)
@@ -2575,7 +2576,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         int cols = (int)(inputAll.ElementCount / nTok);
         // Q8_0 sub-block is 32 elements; Q4_K/Q5_K/Q6_K super-block is 256. Each dequant
         // kernel loops over the row in its native block size, so cols must align to it.
-        int colAlign = weightDType is DType.Q4_K or DType.Q5_K or DType.Q6_K ? 256 : 32;
+        int colAlign = weightDType is DType.Q4_K or DType.Q5_K or DType.Q6_K or DType.Q3_K ? 256 : 32;
         if ((cols % colAlign) != 0)
             throw new InvalidOperationException(
                 $"CUDA MatMulBatchedGemm ({weightDType}) requires cols % {colAlign} == 0 (got {cols}).");
@@ -2600,6 +2601,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
                 DType.Q4_K => _soaQ4kHandles.ContainsKey(matrix.Handle) ? _dequantQ4KF16SoaKernel : _dequantQ4KF16Kernel,
                 DType.Q6_K => _soaQ6kHandles.ContainsKey(matrix.Handle) ? _dequantQ6KF16SoaKernel : _dequantQ6KF16Kernel,   // #162/#204
                 DType.Q5_K => _dequantQ5KF16Kernel,   // #162
+                DType.Q3_K => _dequantQ3KF16Kernel,   // #388 (AoS only — routed MoE experts)
                 DType.Q4_0 => _soaQ40Handles.ContainsKey(matrix.Handle) ? _dequantQ40F16SoaKernel : _dequantQ40F16Kernel,   // #124/#173
                 _          => _soaHandles.ContainsKey(matrix.Handle) ? _dequantQ80F16SoaKernel : _dequantQ80F16Kernel,
             };
@@ -6773,6 +6775,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _dequantQ6KF16Kernel   = GetKernelFunc("llm_dequant_q6k_to_f16");
         _dequantQ6KF16SoaKernel = GetKernelFunc("llm_dequant_q6k_to_f16_soa");   // #204
         _dequantQ5KF16Kernel   = GetKernelFunc("llm_dequant_q5k_to_f16");
+        _dequantQ3KF16Kernel   = GetKernelFunc("llm_dequant_q3k_to_f16");   // #388
         _dequantQ40F16Kernel   = GetKernelFunc("llm_dequant_q4_0_to_f16");   // #124
         _headNormPureBatchedKernel = GetKernelFunc("llm_head_norm_pure_batched");   // #124
         _f32ToF16Kernel        = GetKernelFunc("llm_f32_to_f16");

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -4303,6 +4303,63 @@ extern ""C"" __global__ void llm_dequant_q4k_to_f16(
     }
 }
 
+// ── Dequant Q3_K → FP16 (issue #388) ───────────────────────────────────────
+// Standalone dequant of the 110-byte Q3_K super-block to a row-major [rows×cols]
+// fp16 temp that cuBLAS GEMMs, mirroring llm_dequant_q4k_to_f16's output layout
+// and llm_matvec_q3k_gemm_n's decode (same 110-byte AoS format + 6-bit scale aux
+// unpack). One block of 256 threads per row; thread tid is element e_local in the
+// 256-elem super-block, decoded as s=tid>>5, lane=tid&31 — the SAME (s,lane)→
+// element mapping the matvec uses (input[base + s*32 + lane]), so f16(weight)×act
+// via cuBLAS matches the in-kernel F32 GEMM-N dot (argmax-stable, fp16-rounded).
+extern ""C"" __global__ void llm_dequant_q3k_to_f16(
+    const unsigned int* __restrict__ weights,
+    unsigned short* __restrict__ out,    // [rows * cols] fp16
+    int rows, int cols)
+{
+    int row = (int)blockIdx.x;
+    if (row >= rows) return;
+    unsigned int tid = threadIdx.x;          // 0..255 = element within super-block
+    int num_blocks = cols >> 8;              // cols / 256
+    long row_base_bytes = (long)row * (long)num_blocks * 110L;
+    long out_row = (long)row * (long)cols;
+
+    int s     = (int)(tid >> 5);             // 0..7 sub-block
+    int lane  = (int)(tid & 31u);            // 0..31
+    int group = lane >> 4;                    // 0/1
+    int si    = 2 * s + group;               // scale index 0..15
+    int half  = s >> 2;
+    int shift = (s & 3) * 2;
+    unsigned int m = 1u << s;
+
+    const unsigned int kmask1 = 0x03030303u;
+    const unsigned int kmask2 = 0x0f0f0f0fu;
+
+    for (int block = 0; block < num_blocks; block++) {
+        long b0 = row_base_bytes + (long)block * 110L;
+
+        unsigned int dlo = sharpi_byte_at(weights, b0 + 108);
+        unsigned int dhi = sharpi_byte_at(weights, b0 + 109);
+        float dAll = sharpi_fp16_to_fp32(dlo | (dhi << 8));
+
+        unsigned int a0 = sharpi_byte_at(weights,b0+96)|(sharpi_byte_at(weights,b0+97)<<8)|(sharpi_byte_at(weights,b0+98)<<16)|(sharpi_byte_at(weights,b0+99)<<24);
+        unsigned int a1 = sharpi_byte_at(weights,b0+100)|(sharpi_byte_at(weights,b0+101)<<8)|(sharpi_byte_at(weights,b0+102)<<16)|(sharpi_byte_at(weights,b0+103)<<24);
+        unsigned int tmp= sharpi_byte_at(weights,b0+104)|(sharpi_byte_at(weights,b0+105)<<8)|(sharpi_byte_at(weights,b0+106)<<16)|(sharpi_byte_at(weights,b0+107)<<24);
+        unsigned int aux[4];
+        aux[2] = ((a0 >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+        aux[3] = ((a1 >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+        aux[0] = (a0 & kmask2) | (((tmp >> 0) & kmask1) << 4);
+        aux[1] = (a1 & kmask2) | (((tmp >> 2) & kmask1) << 4);
+
+        int sc = (int)((aux[si >> 2] >> ((si & 3) * 8)) & 0xFFu) - 32;   // signed 6-bit − 32
+        unsigned int qsb = sharpi_byte_at(weights, b0 + 32 + half * 32 + lane);
+        unsigned int hmb = sharpi_byte_at(weights, b0 + lane);
+        int qval = (int)((qsb >> shift) & 3u) - ((hmb & m) != 0u ? 0 : 4);
+
+        float val = dAll * (float)sc * (float)qval;
+        out[out_row + (long)block * 256 + (int)tid] = (unsigned short)sharpi_fp32_to_fp16(val);
+    }
+}
+
 // ── Dequant Q4_K → FP16 over the scale-pre-unpacked SoA weight (issue #156) ──
 // SoA twin of llm_dequant_q4k_to_f16: same d*sc*nibble − dmin*mn decode, only the
 // (scale, min) come from the pre-unpacked SoA bytes (sblk[si] / sblk[8+si]) and

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -6424,6 +6424,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 case DType.Q6_K when (cols & 0xff) == 0:
                 case DType.Q5_K when (cols & 0xff) == 0:
                     _gpu.MatMulBatchedGemm(outputAll, matrix, inputAll, nTok, dt); return;
+                case DType.Q3_K when Q3kDequantGemmEnabled && (cols & 0xff) == 0:
+                    _gpu.MatMulBatchedGemm(outputAll, matrix, inputAll, nTok, dt); return;
             }
         }
         _gpu.MatMulBatched(outputAll, matrix, inputAll, nTok, dt);
@@ -6433,6 +6435,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // costs exceed the matvec re-stream's k× weight reads. 8 = the verify-batch
     // ceiling; prefill chunks run at hundreds, so the regimes are well separated.
     private const int MatMulComputeBatchMinN = 8;
+
+    // #388: route prefill-scale Q3_K (routed MoE experts) through the dequant→fp16→cuBLAS GEMM
+    // (weight read once) instead of the per-token-re-reading GEMM-N. Argmax-stable (fp16-rounded
+    // weight, same class as the Q5_K/Q6_K dequant-GEMM). SHARPI_Q3K_DEQUANT_GEMM=0 → GEMM-N.
+    private static readonly bool Q3kDequantGemmEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_Q3K_DEQUANT_GEMM") != "0";
 
     /// Issue #121: true when <paramref name="matrix"/>'s dtype is one of the dtypes
     /// <see cref="CudaBackend.MatMulBatched"/> implements a GEMM-N kernel for. Gates the

--- a/tests/SharpInference.Tests.ForwardPass/CudaDequantGemmQ3KTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDequantGemmQ3KTests.cs
@@ -1,0 +1,119 @@
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Cuda;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #388: parity for the Q3_K dequant→fp16→cuBLAS GEMM
+/// (<see cref="CudaBackend.MatMulBatchedGemm"/> with <see cref="DType.Q3_K"/>, kernel
+/// <c>llm_dequant_q3k_to_f16</c>). Carnice's MoE routed experts are ~76% Q3_K, and Q3_K
+/// was the only quant excluded from every fast GEMM path — it fell back to the per-token
+/// re-reading <c>llm_matvec_q3k_gemm_n</c>. This path dequants each Q3_K weight to an fp16
+/// temp ONCE and cuBLAS-GEMMs it (the same fast path Q5_K/Q6_K experts already use),
+/// collapsing the routed-MoE prefill cost.
+///
+/// A small Q3_K weight matrix [rows×cols] and an fp32 activation batch [nTok×cols] are
+/// multiplied on the GPU (dequant kernel → fp16 → GemmEx) and on the CPU
+/// (<see cref="SimdKernels.DotQ3K"/>, the fp32 dequant-and-dot reference). Both GPU operands
+/// are fp16-rounded, so it tracks the fp32 reference to a loose per-RMS tolerance
+/// (argmax-stable — same accuracy class as the Q5_K/Q6_K dequant-GEMM, NOT bit-exact). This
+/// validates the new <c>llm_dequant_q3k_to_f16</c> element decode (hmask high-bit, the qs
+/// 2-bit unpack, the kmask1/kmask2 6-bit scale unpack) and the row-major fp16 output layout
+/// the GemmEx consumes, isolated from a model.
+///
+/// Silent no-op on hosts without CUDA, matching the other Cuda* test files.
+/// </summary>
+public sealed unsafe class CudaDequantGemmQ3KTests
+{
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    private static ushort HalfToUshort(Half h) => BitConverter.HalfToUInt16Bits(h);
+
+    /// <summary>Build a <paramref name="rows"/>×<paramref name="cols"/> Q3_K matrix
+    /// (110 B / 256-element super-block: 32 hmask, 64 qs, 12 scale bytes, fp16 d). Any byte
+    /// pattern is a valid 3-bit packing, so the quant/hmask/scale regions are random; only d
+    /// is kept in a realistic small-magnitude range. Mirrors <c>CudaGemmQ3KTests</c>.</summary>
+    private static byte[] BuildQ3KMatrix(int rows, int cols, Random rng)
+    {
+        int blocksPerRow = cols / 256;
+        int bytesPerRow = blocksPerRow * 110;
+        var bytes = new byte[(long)rows * bytesPerRow];
+        for (int r = 0; r < rows; r++)
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                long off = (long)r * bytesPerRow + (long)b * 110;
+                for (int i = 0; i < 108; i++) bytes[off + i] = (byte)rng.Next(256);
+                ushort dHalf = HalfToUshort((Half)(float)(rng.NextDouble() * 0.04 + 0.005));
+                bytes[off + 108] = (byte)(dHalf & 0xFF);
+                bytes[off + 109] = (byte)(dHalf >> 8);
+            }
+        return bytes;
+    }
+
+    [Fact]
+    public void MatMulBatchedGemm_Q3K_TracksCpuReference()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        // Square, a wide multi-superblock batch, a tall single-superblock batch, and a
+        // partial-tile (non-multiple-of-8 rows) case. cols are 256-aligned (Q3_K super-block).
+        foreach ((int rows, int cols, int nTok) in new[]
+                 { (256, 256, 8), (1024, 512, 12), (128, 2560, 64), (300, 256, 5) })
+        {
+            var rng = new Random(20260625 + rows * 31 + cols * 7 + nTok);
+            byte[] weightBytes = BuildQ3KMatrix(rows, cols, rng);
+
+            var acts = new float[(long)nTok * cols];
+            for (int i = 0; i < acts.Length; i++)
+                acts[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            // CPU reference: out[t*rows + r] = Σ W[r]·acts[t]  (fp32, exact-byte Q3_K).
+            int bytesPerRow = (cols / 256) * 110;
+            var cpuOut = new float[nTok * rows];
+            fixed (byte* wPtr = weightBytes)
+            fixed (float* aPtr = acts)
+            {
+                for (int t = 0; t < nTok; t++)
+                    for (int r = 0; r < rows; r++)
+                        cpuOut[t * rows + r] = SimdKernels.DotQ3K(wPtr + (long)r * bytesPerRow, aPtr + (long)t * cols, cols);
+            }
+
+            var gpuW = gpu.UploadRaw(weightBytes, TensorShape.D1(weightBytes.Length), DType.Q3_K);
+            var gpuX = gpu.Upload(acts, TensorShape.D1(acts.Length));
+            var gpuY = gpu.Allocate(TensorShape.D1((long)nTok * rows));
+
+            gpu.MatMulBatchedGemm(gpuY, gpuW, gpuX, nTok, DType.Q3_K);
+            gpu.Synchronize();
+
+            var gpuOut = new float[nTok * rows];
+            gpu.Download(gpuY, gpuOut);
+            gpu.Free(gpuW);
+            gpu.Free(gpuX);
+            gpu.Free(gpuY);
+
+            double sumSq = 0;
+            for (int i = 0; i < cpuOut.Length; i++) sumSq += (double)cpuOut[i] * cpuOut[i];
+            float refRms = (float)Math.Sqrt(sumSq / cpuOut.Length);
+
+            int mismatches = 0;
+            float maxAbs = 0;
+            for (int i = 0; i < cpuOut.Length; i++)
+            {
+                float diff = MathF.Abs(gpuOut[i] - cpuOut[i]);
+                maxAbs = MathF.Max(maxAbs, diff);
+                if (diff > 0.04f * refRms) mismatches++;
+            }
+            Console.WriteLine(
+                $"GEMM-Q3K(dequant) rows={rows} cols={cols} nTok={nTok}: maxAbs={maxAbs:E2} refRms={refRms:E2} mismatches={mismatches}/{cpuOut.Length}");
+            Assert.True(mismatches <= cpuOut.Length / 100 + 1,
+                $"Q3_K dequant-GEMM drifted from fp32 reference: {mismatches}/{cpuOut.Length} beyond 4% of RMS ({refRms:E3}), maxAbs={maxAbs:E3}.");
+        }
+    }
+}


### PR DESCRIPTION
Part of #388. **Stacked on #392** (base = `feat/388-router-on-gpu`, which is itself on #391).

## Problem
Q3_K is the **only** quant excluded from every fast GPU GEMM path (MMQ, dequant-GEMM, weight-stationary all skip it). So Q3_K MoE experts fell back to `llm_matvec_q3k_gemm_n`, which puts the token on `blockIdx.y` and **re-reads the weight once per token** (only L2 reuse) — bandwidth-bound. Carnice's routed experts are **~76% Q3_K**, making this ~50% of its prefill (a 3909 ms GPU drain at N=2033).

## Fix
Add `llm_dequant_q3k_to_f16` (mirrors the proven `llm_matvec_q3k_gemm_n` element decode exactly — hmask high-bit, 2-bit qs unpack, kmask1/kmask2 6-bit scale aux — but writes the row-major fp16 layout cuBLAS consumes) and route Q3_K through the existing `MatMulBatchedGemm` (dequant the weight to fp16 **once**, then cuBLAS GemmEx) — the same fast path Q5_K/Q6_K experts already use. ~5× less HBM traffic than the per-token re-read.

## Measured (RTX 4070 Ti + Ryzen 9 7900X, 2K prompt, Carnice, warm)
| | routed-MoE | prefill |
|---|--:|--:|
| GEMM-N (off) | 4264 ms | 275 t/s |
| **dequant-GEMM (on)** | **1143 ms** | **470 t/s (+71%)** |

**Cumulative with #390 + on-GPU router: Carnice 144 → 470 t/s (3.3×)** — now within **1.44×** of llama.cpp's 676 t/s (was 4.7× at the start). Q4_K models (35B-A3B: 113.8 vs 112.8) are unaffected — no Q3_K experts.

## Safety
- **Argmax-stable** (fp16-rounded weight, same accuracy class as the Q5_K/Q6_K dequant-GEMM) — verified **byte-identical** Carnice output vs the GEMM-N path.
- New `CudaDequantGemmQ3KTests` parity test: tracks the CPU `DotQ3K` fp32 reference to 4%-of-RMS (mirrors the Q5_K dequant-GEMM test). **Passes.**
- Gated by `SHARPI_Q3K_DEQUANT_GEMM` (default on); `=0`, an unsupported dtype, or non-256-aligned cols → byte-identical GEMM-N fallback.
- Code-reviewed: reviewer wrote an exhaustive 256-element trace confirming the new kernel decode is **provably identical** to both `llm_matvec_q3k_gemm_n` and the CPU `DotQ3K` reference. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)