### PR TITLE
fix(cuda): address Gemini review on the MoE prefill perf series (#388/#390)

### DIFF
--- a/scripts/bench-388-router.ps1
+++ b/scripts/bench-388-router.ps1
@@ -2,7 +2,7 @@
 # Op-offload stays ON (the #390 default) throughout; we toggle SHARPI_MOE_GPU_ROUTER.
 # 2K-token prompt. Prefill is the win; decode should be unchanged (decode uses the CPU router).
 param(
-    [string]$PromptFile = "C:\Users\pekka\AppData\Local\Temp\claude\C--p-sharpi\e585495f-574a-494e-820c-3cfea3d513e6\scratchpad\prefill_prompt.txt",
+    [string]$PromptFile = "prompt.txt",   # a ~2K-token prompt file; pass -PromptFile to override
     [int]$NTokens = 40,
     [int]$TimeoutSec = 900
 )

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -3622,6 +3622,20 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             int ok = 0;
             foreach (var (s, e) in merged)
                 if (_gpu.TryRegisterHostPinned((nint)s, e - s)) { reg.Add((nint)s); ok++; }
+            if (ok < merged.Count)
+            {
+                // Partial registration (e.g. Linux RLIMIT_MEMLOCK / `ulimit -l`) would leave the
+                // un-registered ranges pageable, silently degrading UploadRawIntoAsyncDirect to a
+                // slow synchronous staged copy while _goHostPinned claims otherwise. Don't keep a
+                // half-pinned state: unregister what succeeded and fall back wholesale to the
+                // synchronous mmap upload (_goHostPinned=false) — correct, no perf cliff (Gemini).
+                Console.Error.WriteLine($"[moe-offload] registered only {ok}/{merged.Count} mmap expert-weight ranges (locked-memory limit?) — falling back to synchronous mmap upload.");
+                foreach (var p in reg) _gpu.UnregisterHostPinned(p);
+                _goRegisteredRanges = null;
+                _goPinnedBuf = nint.Zero;
+                _goHostPinned = false;
+                return;
+            }
             _goRegisteredRanges = reg.ToArray();
             _goPinnedBuf = nint.Zero;
             _goHostPinned = true;
@@ -6332,16 +6346,22 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     internal static List<(long start, long end)> MergePageAlignedRanges(
         List<(long ptr, long bytes)> ranges, long pageSize)
     {
-        var aligned = new List<(long start, long end)>(ranges.Count);
+        // Work in UNSIGNED: a host pointer with the high bit set is negative as a signed long,
+        // which would floor the wrong way under signed division and misorder under signed compare
+        // (Gemini). The returned tuples carry the unsigned address bit-pattern in `long` (callers
+        // cast to nint / take end−start, both bit-pattern-correct), so callers are unaffected.
+        ulong upage = (ulong)pageSize;
+        var aligned = new List<(ulong start, ulong end)>(ranges.Count);
         foreach (var (ptr, bytes) in ranges)
         {
             if (bytes <= 0) continue;
-            long s = ptr / pageSize * pageSize;
-            long e = (ptr + bytes + pageSize - 1) / pageSize * pageSize;
+            ulong uptr = (ulong)ptr;
+            ulong s = uptr / upage * upage;
+            ulong e = (uptr + (ulong)bytes + upage - 1) / upage * upage;
             aligned.Add((s, e));
         }
-        aligned.Sort((a, b) => a.start.CompareTo(b.start));
-        var merged = new List<(long start, long end)>(aligned.Count);
+        aligned.Sort((a, b) => a.start.CompareTo(b.start));   // unsigned compare
+        var merged = new List<(ulong start, ulong end)>(aligned.Count);
         foreach (var r in aligned)
         {
             if (merged.Count > 0 && r.start <= merged[^1].end)
@@ -6350,7 +6370,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             }
             else merged.Add(r);
         }
-        return merged;
+        var result = new List<(long start, long end)>(merged.Count);
+        foreach (var (s, e) in merged) result.Add(((long)s, (long)e));
+        return result;
     }
 
     private static void SelectTopKPtr(float* logits, int n, int k,

--- a/tests/SharpInference.Tests.ForwardPass/MergePageAlignedRangesTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/MergePageAlignedRangesTests.cs
@@ -105,6 +105,24 @@ public sealed class MergePageAlignedRangesTests
     }
 
     [Fact]
+    public void HighBitPointer_AlignsViaUnsigned()
+    {
+        // A host pointer with bit 63 set is negative as a signed long; signed division would floor
+        // the wrong way (truncate toward zero) and misorder it. The unsigned alignment must still
+        // floor the start down to the page boundary and ceil the end up (Gemini #390 review).
+        long ptr = unchecked((long)0x8000_0000_0000_0010UL);  // page base + 16 bytes
+        var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(
+            new List<(long ptr, long bytes)> { (ptr, 32) }, Page);
+
+        Assert.Single(merged);
+        long expStart = unchecked((long)0x8000_0000_0000_0000UL);  // floored to the page boundary
+        long expEnd   = unchecked((long)0x8000_0000_0000_1000UL);  // ceiled to the next page
+        Assert.Equal((expStart, expEnd), merged[0]);
+        // end − start is the correct positive byte count (one page) regardless of sign.
+        Assert.Equal(4096L, merged[0].end - merged[0].start);
+    }
+
+    [Fact]
     public void EmptyInput_ProducesNoRanges()
     {
         var merged = CudaHybridGdnForwardPass.MergePageAlignedRanges(


### PR DESCRIPTION
Robustness follow-ups to the merged #391 / #392 / #393, from the Gemini code-assist reviews. None were correctness bugs on win-x64 (verified byte-identical, 120/120 ranges registered), but they harden the cross-platform paths.

## Changes
- **`MergePageAlignedRanges` — unsigned alignment** (Gemini #391 HIGH). A host pointer with bit 63 set is negative as a signed `long`, so signed division floors toward zero (wrong page) and the sort misorders it. Now floor/ceil + sort/merge run in `ulong`; the returned tuples keep the unsigned bit-pattern in `long` (callers cast to `nint` / take `end−start`, both bit-pattern-correct). New `HighBitPointer_AlignsViaUnsigned` test.
- **Partial-registration fallback** (Gemini #391 HIGH). If only some mmap ranges register (e.g. Linux `RLIMIT_MEMLOCK` / `ulimit -l`), the old code still set `_goHostPinned=true`, silently degrading the async DMA to a synchronous staged copy for the un-registered ranges. Now it unregisters what succeeded and falls back wholesale to the synchronous mmap upload (`_goHostPinned=false`) — correct, no half-pinned perf cliff. Happy path unchanged (win-x64 registers 120/120).
- **`bench-388-router.ps1` path** (Gemini #392 MEDIUM): default the prompt to a relative `"prompt.txt"` instead of a hardcoded user temp path.

## Tests / verification
- `MergePageAlignedRangesTests` 11 → 12, all pass (CPU-only).
- GPU sanity: Carnice still registers **120/120**, prefill **491 t/s**, no fallback triggered — happy path intact.

## Deferred
- Gemini #393 MEDIUM (shared-memory optimization of `llm_dequant_q3k_to_f16` to cut redundant global reads): perf-only; the kernel is correct and already a +71% win. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)