### PR TITLE
perf(cuda): default chunked FlashQLA GDN prefill on with op-offload (#388)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sharpi-cli -m models/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **470.0** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (76% Q3_K + Q4_K/Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload (#390, register-in-place pin) + on-GPU router (#388) + **Q3_K dequant→cuBLAS expert GEMM** (#388; weight read once vs the per-token GEMM-N) default-on — **3.3× over the CPU MoE path** (144→470), decode within noise. (`--gpu-moe-prefill false` / `SHARPI_MOE_GPU_ROUTER=0` / `SHARPI_Q3K_DEQUANT_GEMM=0` force the CPU paths) |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **522.0** | **26.5** | agentic finetune; 80% acceptance (`bench-carnice.ps1`). APEX mixed-precision (76% Q3_K + Q4_K/Q8_0 experts); Q8_KS per-32 int dots auto-enable. Prefill: GPU MoE op-offload (#390, register-in-place pin) + on-GPU router + Q3_K dequant→cuBLAS expert GEMM + **chunked FlashQLA GDN scan** (#388), all default-on with op-offload — **3.6× over the CPU MoE path** (144→522), decode within noise. (`--gpu-moe-prefill false` / `SHARPI_MOE_GPU_ROUTER=0` / `SHARPI_Q3K_DEQUANT_GEMM=0` / `SHARPI_GDN_CHUNKED_PREFILL=0` force the CPU/byte-exact paths) |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 18.4 | 12.2 | runs on Vulkan (#357); 47% acceptance. MTP self-spec **regresses** vs plain MoE decode (~22 t/s, cf. 35B-A3B) — routed-expert verify is un-amortized on Vulkan (#370). Lossless; use `--spec-type none` for speed |
 
 #### Qwen3.6-35B-A3B (GDN+MoE) — [unsloth](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) · 22 GB

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -793,15 +793,20 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // fast path, resolve the GDN recurrence with the chunk-parallel
     // chunk_gated_delta_rule kernel (CudaBackend.GdnChunkedPrefill) instead of the
     // sequential GdnRecurrenceScan. The chunked form is numerically equal to the scan
-    // only up to FP reduction order (NOT byte-exact), so it is OFF by default — the
-    // bit-parity oracles keep validating the byte-exact scan — and only engages on the
-    // prefill (clean state-carry) path: GdnBlockBatched short-circuits to the byte-exact
-    // ring-capturing scan whenever snapRing is set (if (snapRing) … else if
-    // (GdnChunkedPrefillEnabled) …), so decode and batched-verify ring capture stay on the scan.
-    // Mirrors HybridGdnForwardPass.GdnChunkedPrefillEnabled. SHARPI_GDN_CHUNKED_PREFILL=1
-    // opts in; CudaHybridGdnChunkedPrefillTests A/B-toggles it.
-    internal static bool GdnChunkedPrefillEnabled =
-        Environment.GetEnvironmentVariable("SHARPI_GDN_CHUNKED_PREFILL") == "1";
+    // only up to FP reduction order (NOT byte-exact). It only engages on the prefill
+    // (clean state-carry) path: GdnBlockBatched short-circuits to the byte-exact
+    // ring-capturing scan whenever snapRing is set (if (snapRing) … else if (chunked) …),
+    // so decode and batched-verify ring capture always stay on the scan.
+    //   #388: this is now AUTO-ON when the GPU MoE op-offload is active (_gpuMoePrefill) —
+    //   that prefill path is already argmax-stable (the routed MoE runs in F32/int8, not
+    //   the CPU's byte-exact dots), so the chunked GDN's FP-reorder is consistent and free
+    //   (measured ~+8% Carnice prefill). When op-offload is OFF (byte-exact CPU MoE) the
+    //   scan is kept. Tri-state SHARPI_GDN_CHUNKED_PREFILL: "1" forces chunked even with
+    //   op-offload off, "0" forces the byte-exact scan, unset = auto. The test sets the
+    //   override directly. Mirrors HybridGdnForwardPass's chunked gate (which excludes MTP).
+    internal static bool? GdnChunkedPrefillOverride =
+        Environment.GetEnvironmentVariable("SHARPI_GDN_CHUNKED_PREFILL") switch
+        { "1" => true, "0" => false, _ => null };
 
     // Issue #114-B: batch the per-position KV-append + SDPA into one launch each
     // (CudaBackend.AttentionBatched). Only used when the chunk stays on the
@@ -2209,7 +2214,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                     zStride: valDim, oStride: valDim, nTok: N,
                     ringScan: _gpuGdnRingScan, ringScanFloatOffset: (long)gdnIdx * scanF,
                     ringSlotStride: numGdn * scanF, nCapture: nCapture);
-            else if (GdnChunkedPrefillEnabled)
+            else if (GdnChunkedPrefillOverride ?? _gpuMoePrefill)
                 _gpu.GdnChunkedPrefill(
                     scanState, qHeadAll, kHeadAll, qkvConvAll,
                     alphaAll, betaAll, _gpuSsmA[layer], _gpuSsmDtBias[layer], _gpuSsmNormW[layer],

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnChunkedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnChunkedPrefillTests.cs
@@ -6,7 +6,7 @@ namespace SharpInference.Tests.ForwardPass;
 
 /// <summary>
 /// Parity guard for the opt-in FlashQLA chunked GDN prefill on the CUDA hybrid path
-/// (<see cref="CudaHybridGdnForwardPass.GdnChunkedPrefillEnabled"/>). Inside the
+/// (<see cref="CudaHybridGdnForwardPass.GdnChunkedPrefillOverride"/>). Inside the
 /// batched-prefill fast path, the chunk-parallel <c>chunk_gated_delta_rule</c> kernel
 /// (<see cref="CudaBackend.GdnChunkedPrefill"/>) replaces the sequential
 /// <c>GdnRecurrenceScan</c>. Unlike the other batched-prefill oracles
@@ -68,7 +68,7 @@ public sealed class CudaHybridGdnChunkedPrefillTests : IDisposable
     }
 
     /// <summary>
-    /// The chunked-prefill GDN recurrence (<c>GdnChunkedPrefillEnabled = true</c>) must
+    /// The chunked-prefill GDN recurrence (<c>GdnChunkedPrefillOverride = true</c>) must
     /// produce <b>argmax-identical, finite</b> final-token logits versus the sequential
     /// scan (<c>= false</c>, the default). Both arms run under batched prefill + trunk +
     /// GDN-scan (the chunked kernel lives inside the <c>BatchedGdnScanEnabled</c> fast
@@ -100,7 +100,7 @@ public sealed class CudaHybridGdnChunkedPrefillTests : IDisposable
         bool prevPrefill = CudaHybridGdnForwardPass.BatchedPrefillEnabled;
         bool prevTrunk = CudaHybridGdnForwardPass.BatchedTrunkEnabled;
         bool prevScan = CudaHybridGdnForwardPass.BatchedGdnScanEnabled;
-        bool prevChunked = CudaHybridGdnForwardPass.GdnChunkedPrefillEnabled;
+        bool? prevChunked = CudaHybridGdnForwardPass.GdnChunkedPrefillOverride;
         try
         {
             using var model = GgufModel.Open(path);
@@ -124,7 +124,7 @@ public sealed class CudaHybridGdnChunkedPrefillTests : IDisposable
 
             float[] RunWith(bool chunked)
             {
-                CudaHybridGdnForwardPass.GdnChunkedPrefillEnabled = chunked;
+                CudaHybridGdnForwardPass.GdnChunkedPrefillOverride = chunked;
                 using var fwd = new CudaHybridGdnForwardPass(model, gpu, hp, placement);
                 return fwd.Prefill(tokens).ToArray();
             }
@@ -153,7 +153,7 @@ public sealed class CudaHybridGdnChunkedPrefillTests : IDisposable
             CudaHybridGdnForwardPass.BatchedPrefillEnabled = prevPrefill;
             CudaHybridGdnForwardPass.BatchedTrunkEnabled = prevTrunk;
             CudaHybridGdnForwardPass.BatchedGdnScanEnabled = prevScan;
-            CudaHybridGdnForwardPass.GdnChunkedPrefillEnabled = prevChunked;
+            CudaHybridGdnForwardPass.GdnChunkedPrefillOverride = prevChunked;
             Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
         }
     }


### PR DESCRIPTION
Part of #388 — the next lever after the merged op-offload/router/Q3_K work. With those, the Carnice **trunk** (GDN recurrence + attention + projections) became the dominant prefill phase (~54%).

## Change
The chunk-parallel GDN prefill (`GdnChunkedPrefill`, FlashQLA `chunk_gated_delta_rule`) already existed but was opt-in (`SHARPI_GDN_CHUNKED_PREFILL=1`). Make it **auto-on when the GPU MoE op-offload is active** (`_gpuMoePrefill`, default since #390): that prefill path is already argmax-stable (routed MoE runs F32/int8), so the chunked GDN's FP-reduction-order difference is consistent and free. Op-offload OFF keeps the byte-exact scan; verify/decode ring-capture always uses the scan.

Tri-state gate `GdnChunkedPrefillOverride` (`bool?`): `SHARPI_GDN_CHUNKED_PREFILL` `1` forces chunked, `0` forces the scan, unset = auto (`override ?? _gpuMoePrefill`).

## Measured (RTX 4070 Ti, Carnice, 2K prompt, warm)
- Trunk **2284 → 2034 ms**; prefill **~470 → ~522 t/s (+8%)**.
- Byte-identical greedy output vs the scan; MTP acceptance unchanged (60%).
- op-offload OFF verified to keep the scan (trunk 2548 ms, byte-exact CPU MoE path).

**Cumulative #388/#390 series: Carnice MoE prefill 144 → 522 t/s (3.6×)** — within **1.30×** of llama.cpp's 676 pp512 (4.7× under at the start).

## Tests
- `CudaHybridGdnChunkedPrefillTests` (20 cases) pass: chunked greedy == scan greedy, multi-chunk state-carry exercised. The parity test sets the override directly so it stays authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)