### PR TITLE
fix(cuda): gate MoE op-offload on _cpuMoe — restore dense-trunk bitwise parity (#390 regression)

### DIFF
--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -1104,6 +1104,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 $"[CudaHybridGdnForwardPass] Dense FFN mode (intermDim={_intermDim}): per-layer ffn_gate/up/down run on CPU from mmap; attn + GDN stay on GPU.");
         }
 
+        // Op-offload (GPU offload of the routed-MoE prefill, #390) only applies to CPU-MoE
+        // models — there are no CPU-resident routed experts to offload on the dense or
+        // experts-on-GPU (SLRU) paths. Clamp the gate to _cpuMoe so its eager scratch/pin
+        // setup, per-call dispatch, AND the chunked-GDN auto-enable (which keys off
+        // _gpuMoePrefill) never engage for those models. Without this, the #390 default-on
+        // flip ran the eager GPU-scratch alloc for the dense 27B-MTP, perturbing cuBLAS
+        // workspace/algo selection enough to break the dense batched-trunk bitwise-parity tests.
+        _gpuMoePrefill &= _cpuMoe;
+
         // Resolve Q3_K_Q8K / Q8_0_Q8K kernel gates. Auto-on when the model has
         // routed-expert weights in that dtype (APEX mixed-precision tier — e.g.
         // Carnice). SHARPI_Q3K_Q8K / SHARPI_Q8_0_Q8K = "1" or "0" override.


### PR DESCRIPTION
## Regression
The #390 default-on flip (`SHARPI_MOE_GPU_PREFILL` default `true`) left `_gpuMoePrefill` true even for models where op-offload **doesn't apply** — the **dense 27B-MTP** and the experts-on-GPU (SLRU) paths. There are no CPU-resident routed experts to offload there, but:
1. the **eager op-offload scratch setup** still ran at load, perturbing cuBLAS workspace/algo selection → a few-ULP shift in the dense batched-trunk prefill;
2. the **chunked-GDN auto-enable** (#388, keyed off `_gpuMoePrefill`) still engaged for dense GDN.

Both broke `CudaHybridGdnBatchedPrefillTests`'s dense-27B-MTP **bitwise-parity** asserts (the batched trunk must be bit-identical to the sequential `Forward` loop). Output stayed argmax-stable, but the invariant was legitimately broken.

Bisected: passed at the pre-series base `41cc97a`, failed once #391 merged; `SHARPI_MOE_GPU_PREFILL=0` restored the bitwise match — pinpointing the eager setup.

## Fix
One line: `_gpuMoePrefill &= _cpuMoe;` after `_cpuMoe` is resolved. Op-offload (GPU offload of the **CPU-MoE** routed-expert prefill) only makes sense for CPU-MoE models, so this makes `_gpuMoePrefill` mean "op-offload actually active" — gating its eager setup, per-call dispatch, and the chunked-GDN auto-enable. Dense / GPU-MoE models keep the byte-exact scan + per-token kernels.

## Verified
- The **4 dense-27B-MTP bitwise tests pass** again (`BatchedFfn_BitwiseMatchesPerTokenFfn`, `BatchedTrunkGpuFfn_BitwiseMatchesSequential` + SnapKv + MultiChunk).
- **Carnice (CPU-MoE) op-offload + chunked-GDN unchanged**: 120/120 ranges registered, prefill 519.6 t/s.

Found while running the MTP test suite during decode-perf work; this fixes a latent correctness-invariant regression in the merged #390/#395 series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)