### PR TITLE
perf(cuda): opt-in CUDA-graph decode trunk for the GDN-hybrid CPU-MoE path (+ multi-graph backend infra)

### DIFF
--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -1304,6 +1304,12 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         // at that point _graphCapturing is already false, so free those handles too —
         // otherwise "abort" leaks an exec graph and leaves GraphReady stuck true.
         DiscardGraph();
+        // Same post-instantiate-failure case for the multi-graph (per-id) path: a layer's
+        // entry may already be stored when its first LaunchGraphForPosition(id,…) threw.
+        // The caller latches graphs off on abort, so freeing every entry here is correct
+        // (none will be replayed) and prevents a per-layer exec-graph leak until Dispose.
+        // No-op for single-graph users (empty map).
+        DiscardMultiGraphs();
         _graphPosNodes.Clear();
         _graphCaptureSupported = false;
     }

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -1137,6 +1137,22 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// <summary>True once a graph is captured + instantiated and ready to replay.</summary>
     public bool GraphReady => _graphExec != nint.Zero;
 
+    // ── Multi-graph (per-id) capture (Phase 1 of GDN-hybrid decode CUDA-graph trunk) ──
+    // The same capture machinery (_graphCapturing / _graphPosNodes / TrackPositionNode /
+    // _graphCaptureFailed) is shared with the single-graph path above — only one capture
+    // runs at a time. The indexed API captures into per-id entries instead of the single
+    // _capturedGraph/_graphExec, so the engine can later key one graph per trunk layer.
+    private sealed class MultiGraphEntry
+    {
+        public nint CapturedGraph;   // CUgraph
+        public nint GraphExec;       // CUgraphExec
+        public GraphPosNode[] PosNodes = [];
+    }
+    private readonly Dictionary<int, MultiGraphEntry> _multiGraphs = new();
+    // The id of the capture currently open via the indexed API; int.MinValue means either
+    // no capture is open or the legacy single-graph (no-arg) capture is the one in flight.
+    private int _capturingGraphId = int.MinValue;
+
     private enum GraphPosKind { Position, PositionPlus1, SwaWindowStart, SwaWindowEnd }
 
     // One captured kernel node whose params carry per-token-varying position scalars.
@@ -1166,6 +1182,31 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _graphCaptureFailed = false;
         int rc = NvrtcInterop.StreamBeginCapture(_stream, NvrtcInterop.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL);
         if (rc != 0) { _graphCaptureSupported = false; return false; }
+        _graphCapturing = true;
+        return true;
+    }
+
+    /// <summary>
+    /// Begin capturing into the per-id graph slot <paramref name="id"/>. Mirrors the no-arg
+    /// <see cref="TryBeginGraphCapture()"/> but targets the multi-graph store: any existing
+    /// entry for the id is disposed first (the single-graph handles are left untouched).
+    /// Returns false (and disables graphs) if the driver rejects capture.
+    /// </summary>
+    public bool TryBeginGraphCapture(int id)
+    {
+        if (!_graphCaptureSupported || _graphCapturing) return false;
+        Synchronize();                 // drain in-flight H2D/D2H before capture starts
+        if (_multiGraphs.TryGetValue(id, out var existing))
+        {
+            if (existing.GraphExec != nint.Zero) NvrtcInterop.GraphExecDestroy(existing.GraphExec);
+            if (existing.CapturedGraph != nint.Zero) NvrtcInterop.GraphDestroy(existing.CapturedGraph);
+            _multiGraphs.Remove(id);
+        }
+        _graphPosNodes.Clear();
+        _graphCaptureFailed = false;
+        _capturingGraphId = id;
+        int rc = NvrtcInterop.StreamBeginCapture(_stream, NvrtcInterop.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL);
+        if (rc != 0) { _graphCaptureSupported = false; _capturingGraphId = int.MinValue; return false; }
         _graphCapturing = true;
         return true;
     }
@@ -1201,6 +1242,47 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     }
 
     /// <summary>
+    /// End the in-progress per-id capture (opened via <see cref="TryBeginGraphCapture(int)"/>)
+    /// and instantiate it into the multi-graph store under <paramref name="id"/>. Returns
+    /// false if no matching capture is open or on any capture/instantiate error. Mirrors the
+    /// no-arg <see cref="TryEndGraphCaptureAndInstantiate()"/>.
+    /// </summary>
+    public bool TryEndGraphCaptureAndInstantiate(int id)
+    {
+        if (!_graphCapturing || _capturingGraphId != id) return false;
+        int rc = NvrtcInterop.StreamEndCapture(_stream, out nint graph);
+        _graphCapturing = false;
+        _capturingGraphId = int.MinValue;
+        if (rc != 0 || graph == nint.Zero || _graphCaptureFailed)
+        {
+            if (graph != nint.Zero) NvrtcInterop.GraphDestroy(graph);
+            _graphPosNodes.Clear();
+            _graphCaptureSupported = false;
+            return false;
+        }
+        rc = NvrtcInterop.GraphInstantiate(out nint exec, graph, 0);
+        if (rc != 0 || exec == nint.Zero)
+        {
+            NvrtcInterop.GraphDestroy(graph);
+            _graphPosNodes.Clear();
+            _graphCaptureSupported = false;
+            return false;
+        }
+        _multiGraphs[id] = new MultiGraphEntry
+        {
+            CapturedGraph = graph,
+            GraphExec = exec,
+            PosNodes = _graphPosNodes.ToArray(),
+        };
+        _graphPosNodes.Clear();
+        return true;
+    }
+
+    /// <summary>True once the per-id graph <paramref name="id"/> is captured + ready to replay.</summary>
+    public bool GraphReadyFor(int id) =>
+        _multiGraphs.TryGetValue(id, out var e) && e.GraphExec != nint.Zero;
+
+    /// <summary>
     /// Abort an in-progress capture (drains the stream out of capture mode) and give up
     /// on graphs for this backend. Safe to call when not capturing.
     /// </summary>
@@ -1212,6 +1294,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _graphCapturing = false;
             if (g != nint.Zero) NvrtcInterop.GraphDestroy(g);
         }
+        _capturingGraphId = int.MinValue;
         // A failure can also reach here *after* TryEndGraphCaptureAndInstantiate already
         // built _graphExec/_capturedGraph (e.g. the first LaunchGraphForPosition threw):
         // at that point _graphCapturing is already false, so free those handles too —
@@ -1230,10 +1313,31 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     {
         if (_graphExec == nint.Zero)
             throw new InvalidOperationException("LaunchGraphForPosition called before a graph was captured.");
+        LaunchGraphNodes(_graphPosNodes, _graphExec, position);
+    }
 
+    /// <summary>
+    /// Replay the per-id graph <paramref name="id"/> for <paramref name="position"/>: the
+    /// indexed analogue of <see cref="LaunchGraphForPosition(int)"/>, over the entry's own
+    /// node list + exec graph. Throws if no graph was captured for the id.
+    /// </summary>
+    public void LaunchGraphForPosition(int id, int position)
+    {
+        if (!_multiGraphs.TryGetValue(id, out var entry) || entry.GraphExec == nint.Zero)
+            throw new InvalidOperationException(
+                $"LaunchGraphForPosition({id}) called before a graph was captured for that id.");
+        LaunchGraphNodes(entry.PosNodes, entry.GraphExec, position);
+    }
+
+    // Shared replay core: rewrite each tracked node's position-derived scalar params on
+    // <paramref name="graphExec"/>, then launch it on the compute stream. Used by both the
+    // single-graph and per-id LaunchGraphForPosition overloads — behavior is identical to
+    // the original inlined loop.
+    private void LaunchGraphNodes(IReadOnlyList<GraphPosNode> nodes, nint graphExec, int position)
+    {
         nint* cells = stackalloc nint[GraphMaxKernelArgs];
         nint* ptrs  = stackalloc nint[GraphMaxKernelArgs];
-        foreach (var n in _graphPosNodes)
+        foreach (var n in nodes)
         {
             int cnt = n.ArgValues.Length;
             for (int i = 0; i < cnt; i++) cells[i] = n.ArgValues[i];
@@ -1257,12 +1361,12 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
                 KernelParams = (nint)ptrs,
                 Extra = nint.Zero,
             };
-            int rc = NvrtcInterop.GraphExecKernelNodeSetParams(_graphExec, n.Node, &p);
+            int rc = NvrtcInterop.GraphExecKernelNodeSetParams(graphExec, n.Node, &p);
             if (rc != 0)
                 throw new InvalidOperationException($"cuGraphExecKernelNodeSetParams failed: {rc}");
         }
 
-        int lr = NvrtcInterop.GraphLaunch(_graphExec, _stream);
+        int lr = NvrtcInterop.GraphLaunch(graphExec, _stream);
         if (lr != 0)
             throw new InvalidOperationException($"cuGraphLaunch failed: {lr}");
     }
@@ -1271,6 +1375,18 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     {
         if (_graphExec != nint.Zero) { NvrtcInterop.GraphExecDestroy(_graphExec); _graphExec = nint.Zero; }
         if (_capturedGraph != nint.Zero) { NvrtcInterop.GraphDestroy(_capturedGraph); _capturedGraph = nint.Zero; }
+    }
+
+    // Destroy every per-id captured graph so no CUDA handles leak at backend teardown.
+    // Called from the same Dispose path that runs DiscardGraph().
+    private void DiscardMultiGraphs()
+    {
+        foreach (var e in _multiGraphs.Values)
+        {
+            if (e.GraphExec != nint.Zero) NvrtcInterop.GraphExecDestroy(e.GraphExec);
+            if (e.CapturedGraph != nint.Zero) NvrtcInterop.GraphDestroy(e.CapturedGraph);
+        }
+        _multiGraphs.Clear();
     }
 
     // Called by the position-varying op methods immediately after their cuLaunchKernel
@@ -7328,6 +7444,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         if (_graphCapturing)
             NvrtcInterop.StreamEndCapture(_stream, out _);
         DiscardGraph();
+        DiscardMultiGraphs();
 
         CuBlasInterop.Destroy(_handle);
 

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -1205,7 +1205,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _graphPosNodes.Clear();
         _graphCaptureFailed = false;
         _capturingGraphId = id;
-        int rc = NvrtcInterop.StreamBeginCapture(_stream, NvrtcInterop.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL);
+        // RELAXED (mirrors llama.cpp ggml-cuda): the per-layer decode trunk does a one-time
+        // on-demand scratch cudaMalloc on its first capture (settled after warmup); THREAD_LOCAL
+        // ERRORS the capture on that alloc → silent fallback (the ~0% bug). RELAXED tolerates it
+        // (the alloc executes un-captured; subsequent replays reuse the now-grown scratch).
+        int rc = NvrtcInterop.StreamBeginCapture(_stream, NvrtcInterop.CU_STREAM_CAPTURE_MODE_RELAXED);
         if (rc != 0) { _graphCaptureSupported = false; _capturingGraphId = int.MinValue; return false; }
         _graphCapturing = true;
         return true;

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -534,6 +534,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // Pinpoints whether the MoE wall time is the RAM-bound expert dots or the coordination overhead.
     private long _pdRouterTicks, _pdPhaseATicks, _pdPhaseCTicks, _pdSharedTicks;
     private int _pdTokens;
+    // #388: per-layer CUDA-graph of the decode GPU trunk block (eliminates ~600 kernel launches/token
+    // that starve the launch-bound decode). Each layer's pure-GPU trunk (norms + attn/GDN block + residual
+    // adds) is captured into a per-layer graph (keyed by layer index) on the first eligible decode token and
+    // replayed after; the CPU-MoE (Download/CpuMoeFfn/Upload) stays OUTSIDE the graph between replays.
+    // Gated SHARPI_DECODE_CUDA_GRAPH (default OFF). Falls back to direct launches on any capture failure.
+    private static readonly bool _decodeCudaGraph =
+        Environment.GetEnvironmentVariable("SHARPI_DECODE_CUDA_GRAPH") == "1";
+    private bool[]? _layerGraphCaptured;       // per-layer: graph captured+ready
+    private bool _decodeGraphDisabled;         // latched off after any capture failure
     // Sub-phase breakdown of the batched routed-MoE (BatchedRoutedExperts), accumulated
     // across the layer loop and printed once per chunk on the [moe-subphase] line when
     // SHARPI_PREFILL_PROFILE=1. Establishes whether routed-MoE prefill cost is in the
@@ -899,6 +908,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         int L = hp.NumLayers;
         int qDim = _numHeads * _headDim;        // 4096
         int kvDim = _numKvHeads * _headDim;     // 512
+
+        // #388: per-layer decode-trunk graph readiness, only when the gate is on.
+        _layerGraphCaptured = _decodeCudaGraph ? new bool[L] : null;
 
         // SHARPI_KV_DTYPE: fp32 | bf16 (default bf16). Issue #27.
         _kvDType = ParseKvDType(Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE"));
@@ -4130,6 +4142,44 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         }
     }
 
+    /// <summary>
+    /// #388: the pure-GPU decode "trunk block" for one layer — the unit that runs directly OR
+    /// gets captured into a per-layer CUDA graph. Pre-block residual+norm, the attn/GDN block,
+    /// the residual add, then the pre-MoE residual+norm; leaves <c>_gpuNormBuf</c> (the MoE input)
+    /// and <c>_gpuResidual</c> ready for the CPU-MoE step that runs OUTSIDE the graph. Position
+    /// dependence lives only in the attn block's RoPE/KvAppend/Attention kernels, which self-register
+    /// position nodes via TrackPositionNode so graph replay rewrites the position; GDN decode kernels
+    /// mutate state in place (position-independent → capture-once).
+    /// </summary>
+    private void RunDecodeTrunkBlock(int layer, int position, bool isAttn)
+    {
+        // ── Pre-block residual + norm on GPU ────────────────────
+        _gpu.CopyDevice(_gpuResidual, _gpuHidden);
+        _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuAttnNorm[layer], _hp.RmsNormEps);
+
+        if (isAttn)
+        {
+            GpuAttnBlock(layer, position);
+        }
+        else if (_cpuGdn)
+        {
+            CpuGdnBlock(layer, position);
+        }
+        else
+        {
+            GpuGdnBlock(layer, position);
+        }
+
+        // Residual add on GPU
+        _gpu.AddInPlace(_gpuHidden, _gpuResidual);
+
+        if (_traceLayers) TraceGpuTensor(position, layer, isAttn ? "attn-resid" : "gdn-resid", _gpuHidden, _embDim);
+
+        // ── Pre-MoE residual + norm on GPU ──────────────────────
+        _gpu.CopyDevice(_gpuResidual, _gpuHidden);
+        _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuPostAttnNorm[layer], _hp.RmsNormEps);
+    }
+
     /// <summary>Forward one token through the hybrid CUDA + CPU stack.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
@@ -4147,32 +4197,44 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         for (int layer = 0; layer < _hp.NumLayers; layer++)
         {
             long ltp0 = _decodeProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-            // ── Pre-block residual + norm on GPU ────────────────────
-            _gpu.CopyDevice(_gpuResidual, _gpuHidden);
-            _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuAttnNorm[layer], _hp.RmsNormEps);
 
             bool isAttn = _hp.LayerTypes![layer] == LayerType.Attention;
-            if (isAttn)
+            // #388: run the pure-GPU trunk block directly, or via a per-layer CUDA graph
+            // (capture once on the first eligible token, replay at the new position after).
+            // The CPU-MoE stays OUTSIDE the graph (it does an illegal-in-capture Download).
+            bool useGraph = _decodeCudaGraph && !_decodeGraphDisabled && !_cpuGdn
+                && _hp.IsMoE && _layerGraphCaptured is not null;
+            if (useGraph && _layerGraphCaptured![layer] && _gpu.GraphReadyFor(layer))
             {
-                GpuAttnBlock(layer, position);
+                // Steady state: replay this layer's captured trunk at the new position.
+                try { _gpu.LaunchGraphForPosition(layer, position); }
+                catch { _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
             }
-            else if (_cpuGdn)
+            else if (useGraph)
             {
-                CpuGdnBlock(layer, position);
+                // First eligible token for this layer: pre-grow on-demand scratch (capture forbids
+                // cudaMalloc), capture the trunk block (records, no execute), instantiate, then launch.
+                _gpu.EnsureQ81Scratch(Math.Max(_embDim, _expertDim));   // dp4a/Q8_1 input scratch for the trunk matvecs
+                try
+                {
+                    if (_gpu.TryBeginGraphCapture(layer))
+                    {
+                        RunDecodeTrunkBlock(layer, position, isAttn);
+                        if (_gpu.TryEndGraphCaptureAndInstantiate(layer))
+                        {
+                            _gpu.LaunchGraphForPosition(layer, position);
+                            _layerGraphCaptured![layer] = true;
+                        }
+                        else { _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
+                    }
+                    else { _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
+                }
+                catch { _gpu.AbortGraphCapture(); _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
             }
             else
             {
-                GpuGdnBlock(layer, position);
+                RunDecodeTrunkBlock(layer, position, isAttn);
             }
-
-            // Residual add on GPU
-            _gpu.AddInPlace(_gpuHidden, _gpuResidual);
-
-            if (_traceLayers) TraceGpuTensor(position, layer, isAttn ? "attn-resid" : "gdn-resid", _gpuHidden, _embDim);
-
-            // ── Pre-MoE residual + norm on GPU ──────────────────────
-            _gpu.CopyDevice(_gpuResidual, _gpuHidden);
-            _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuPostAttnNorm[layer], _hp.RmsNormEps);
 
             if (_decodeProfile)
             {

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -543,6 +543,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         Environment.GetEnvironmentVariable("SHARPI_DECODE_CUDA_GRAPH") == "1";
     private bool[]? _layerGraphCaptured;       // per-layer: graph captured+ready
     private bool _decodeGraphDisabled;         // latched off after any capture failure
+    private int _decodeTokensSeen;             // warmup counter: capture only after on-demand scratch settles (mirrors llama.cpp's 2-token warmup)
+    private const int GraphWarmupTokens = 2;
+    private bool _graphDiagLogged;             // one-shot [graph-diag] capture-coverage log
     // Sub-phase breakdown of the batched routed-MoE (BatchedRoutedExperts), accumulated
     // across the layer loop and printed once per chunk on the [moe-subphase] line when
     // SHARPI_PREFILL_PROFILE=1. Establishes whether routed-MoE prefill cost is in the
@@ -4184,6 +4187,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     public ReadOnlySpan<float> Forward(int token, int position)
     {
         ThrowIfFaulted();
+        if (_decodeCudaGraph) _decodeTokensSeen++;   // warmup counter for the per-layer trunk graph
         long fwdT0 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         // 1. Embedding → _gpuHidden
         EmbedToken(_gpuHidden, token);
@@ -4203,7 +4207,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             // (capture once on the first eligible token, replay at the new position after).
             // The CPU-MoE stays OUTSIDE the graph (it does an illegal-in-capture Download).
             bool useGraph = _decodeCudaGraph && !_decodeGraphDisabled && !_cpuGdn
-                && _hp.IsMoE && _layerGraphCaptured is not null;
+                && _hp.IsMoE && _layerGraphCaptured is not null
+                && _decodeTokensSeen >= GraphWarmupTokens;   // warmup: let on-demand scratch settle before capturing a stable graph
             if (useGraph && _layerGraphCaptured![layer] && _gpu.GraphReadyFor(layer))
             {
                 // Steady state: replay this layer's captured trunk at the new position.
@@ -4286,6 +4291,13 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             if (_decodeProfile) _pdMoeTicks += System.Diagnostics.Stopwatch.GetTimestamp() - mtp0;
 
             if (_traceLayers) TraceGpuTensor(position, layer, "moe-resid", _gpuHidden, _embDim);
+        }
+
+        if (_decodeCudaGraph && !_graphDiagLogged && _decodeTokensSeen > GraphWarmupTokens && _layerGraphCaptured is not null)
+        {
+            int cap = 0; foreach (bool b in _layerGraphCaptured) if (b) cap++;
+            Console.Error.WriteLine($"[graph-diag] captured {cap}/{_hp.NumLayers} layers, disabled={_decodeGraphDisabled}");
+            _graphDiagLogged = true;
         }
 
         // 4. Advance position counters

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -541,11 +541,6 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // Gated SHARPI_DECODE_CUDA_GRAPH (default OFF). Falls back to direct launches on any capture failure.
     private static readonly bool _decodeCudaGraph =
         Environment.GetEnvironmentVariable("SHARPI_DECODE_CUDA_GRAPH") == "1";
-    // DIAGNOSTIC ONLY (not shipped): skip the per-layer CPU-MoE Download/dots/Upload in decode so
-    // decode t/s measures PURE GPU trunk execution (40 layers + 1 final logits sync), isolating
-    // trunk-execution from the 40 per-layer blocking syncs. Output is garbage; timing is valid.
-    private static readonly bool _decodeTrunkOnly =
-        Environment.GetEnvironmentVariable("SHARPI_DECODE_TRUNK_ONLY") == "1";
     private bool[]? _layerGraphCaptured;       // per-layer: graph captured+ready
     private bool _decodeGraphDisabled;         // latched off after any capture failure
     private int _decodeTokensSeen;             // warmup counter: capture only after on-demand scratch settles (mirrors llama.cpp's 2-token warmup)
@@ -4279,12 +4274,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 // so an explicit Synchronize before it would just stall the host twice.
                 // Pinned overloads (issue #48): skip the _pinnedBuf staging hop.
                 long moeT0 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                if (!_decodeTrunkOnly)   // diagnostic: skip MoE (+ its per-layer sync) to time pure trunk
-                {
-                    _gpu.Download(_gpuNormBuf, (nint)_cpuNormBuf, _embDim);
-                    CpuMoeFfn(layer);
-                    _gpu.UploadInto(_gpuHidden, (nint)_cpuMoeHidden, _embDim);
-                }
+                _gpu.Download(_gpuNormBuf, (nint)_cpuNormBuf, _embDim);
+                CpuMoeFfn(layer);
+                _gpu.UploadInto(_gpuHidden, (nint)_cpuMoeHidden, _embDim);
                 if (_prefillProfile)
                     _profMoeTicks += System.Diagnostics.Stopwatch.GetTimestamp() - moeT0;
             }

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -4153,6 +4153,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// dependence lives only in the attn block's RoPE/KvAppend/Attention kernels, which self-register
     /// position nodes via TrackPositionNode so graph replay rewrites the position; GDN decode kernels
     /// mutate state in place (position-independent → capture-once).
+    /// NOTE: the embedded <c>_traceLayers</c> trace does a Synchronize+Download, which is illegal
+    /// during stream capture — so SHARPI_TRACE_LAYERS + SHARPI_DECODE_CUDA_GRAPH together make the
+    /// first capture fail and latch graphs off (graceful fallback to direct launches). Both are
+    /// developer diagnostics; don't combine them when measuring the graph path.
     /// </summary>
     private void RunDecodeTrunkBlock(int layer, int position, bool isAttn)
     {
@@ -4183,6 +4187,16 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         _gpu.RmsNorm(_gpuNormBuf, _gpuHidden, _gpuPostAttnNorm[layer], _hp.RmsNormEps);
     }
 
+    /// <summary>Latch the decode CUDA-graph path off after a capture/replay failure, logging the
+    /// cause once. The fallback (direct RunDecodeTrunkBlock) is always correct; this only surfaces
+    /// WHY the opt-in graph disabled (a persistent root cause still re-throws via the direct re-run).</summary>
+    private void DisableDecodeGraph(int layer, string reason)
+    {
+        if (!_decodeGraphDisabled)
+            Console.Error.WriteLine($"[graph-diag] decode CUDA-graph disabled at layer {layer}: {reason}");
+        _decodeGraphDisabled = true;
+    }
+
     /// <summary>Forward one token through the hybrid CUDA + CPU stack.</summary>
     public ReadOnlySpan<float> Forward(int token, int position)
     {
@@ -4206,6 +4220,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             // #388: run the pure-GPU trunk block directly, or via a per-layer CUDA graph
             // (capture once on the first eligible token, replay at the new position after).
             // The CPU-MoE stays OUTSIDE the graph (it does an illegal-in-capture Download).
+            // TRADE-OFF (correctness-safe, perf-only; see #401): the attention kernel choice
+            // (single-block vs split-KV) is frozen at capture-time context (short, just after
+            // warmup), so a graphed run keeps the single-block kernel even past the split-KV
+            // threshold. Single-block is the bit-exact reference for any seqLen ≤ maxSeqLen, so
+            // output stays correct — but long-context decode silently forgoes the split-KV speedup.
+            // Acceptable while opt-in/short-ctx; revisit before any default-on (#401).
             bool useGraph = _decodeCudaGraph && !_decodeGraphDisabled && !_cpuGdn
                 && _hp.IsMoE && _layerGraphCaptured is not null
                 && _decodeTokensSeen >= GraphWarmupTokens;   // warmup: let on-demand scratch settle before capturing a stable graph
@@ -4213,13 +4233,19 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             {
                 // Steady state: replay this layer's captured trunk at the new position.
                 try { _gpu.LaunchGraphForPosition(layer, position); }
-                catch { _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
+                catch (Exception ex) { DisableDecodeGraph(layer, $"replay: {ex.Message}"); RunDecodeTrunkBlock(layer, position, isAttn); }
             }
             else if (useGraph)
             {
                 // First eligible token for this layer: pre-grow on-demand scratch (capture forbids
                 // cudaMalloc), capture the trunk block (records, no execute), instantiate, then launch.
-                _gpu.EnsureQ81Scratch(Math.Max(_embDim, _expertDim));   // dp4a/Q8_1 input scratch for the trunk matvecs
+                // Size to the WIDEST vector the trunk quantizes for a dp4a/Q8_1 matvec — not just
+                // _embDim: the attn o-proj input is qDim (_numHeads*_headDim) and the GDN out-proj
+                // input is _gdnValueDim, both > _embDim. Undersizing here would let the first wide
+                // matvec cudaFree+cudaMalloc the grow-only _q81Buf DURING capture; under RELAXED that
+                // alloc passes through and the captured node binds a since-freed pointer → silent
+                // garbage on replay. Sizing it correctly makes correctness independent of the warmup.
+                _gpu.EnsureQ81Scratch(Math.Max(_embDim, Math.Max(_numHeads * _headDim, _gdnValueDim)));
                 try
                 {
                     if (_gpu.TryBeginGraphCapture(layer))
@@ -4230,11 +4256,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                             _gpu.LaunchGraphForPosition(layer, position);
                             _layerGraphCaptured![layer] = true;
                         }
-                        else { _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
+                        else { DisableDecodeGraph(layer, "TryEndGraphCaptureAndInstantiate returned false"); RunDecodeTrunkBlock(layer, position, isAttn); }
                     }
-                    else { _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
+                    else { DisableDecodeGraph(layer, "TryBeginGraphCapture returned false"); RunDecodeTrunkBlock(layer, position, isAttn); }
                 }
-                catch { _gpu.AbortGraphCapture(); _decodeGraphDisabled = true; RunDecodeTrunkBlock(layer, position, isAttn); }
+                catch (Exception ex) { _gpu.AbortGraphCapture(); DisableDecodeGraph(layer, $"capture/launch: {ex.Message}"); RunDecodeTrunkBlock(layer, position, isAttn); }
             }
             else
             {

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -541,6 +541,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // Gated SHARPI_DECODE_CUDA_GRAPH (default OFF). Falls back to direct launches on any capture failure.
     private static readonly bool _decodeCudaGraph =
         Environment.GetEnvironmentVariable("SHARPI_DECODE_CUDA_GRAPH") == "1";
+    // DIAGNOSTIC ONLY (not shipped): skip the per-layer CPU-MoE Download/dots/Upload in decode so
+    // decode t/s measures PURE GPU trunk execution (40 layers + 1 final logits sync), isolating
+    // trunk-execution from the 40 per-layer blocking syncs. Output is garbage; timing is valid.
+    private static readonly bool _decodeTrunkOnly =
+        Environment.GetEnvironmentVariable("SHARPI_DECODE_TRUNK_ONLY") == "1";
     private bool[]? _layerGraphCaptured;       // per-layer: graph captured+ready
     private bool _decodeGraphDisabled;         // latched off after any capture failure
     private int _decodeTokensSeen;             // warmup counter: capture only after on-demand scratch settles (mirrors llama.cpp's 2-token warmup)
@@ -4274,9 +4279,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 // so an explicit Synchronize before it would just stall the host twice.
                 // Pinned overloads (issue #48): skip the _pinnedBuf staging hop.
                 long moeT0 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                _gpu.Download(_gpuNormBuf, (nint)_cpuNormBuf, _embDim);
-                CpuMoeFfn(layer);
-                _gpu.UploadInto(_gpuHidden, (nint)_cpuMoeHidden, _embDim);
+                if (!_decodeTrunkOnly)   // diagnostic: skip MoE (+ its per-layer sync) to time pure trunk
+                {
+                    _gpu.Download(_gpuNormBuf, (nint)_cpuNormBuf, _embDim);
+                    CpuMoeFfn(layer);
+                    _gpu.UploadInto(_gpuHidden, (nint)_cpuMoeHidden, _embDim);
+                }
                 if (_prefillProfile)
                     _profMoeTicks += System.Diagnostics.Stopwatch.GetTimestamp() - moeT0;
             }


### PR DESCRIPTION
## What
Adds an **opt-in** per-layer CUDA-graph of the GDN-hybrid CPU-MoE decode trunk (`SHARPI_DECODE_CUDA_GRAPH=1`, **default OFF**), plus the additive multi-graph backend infra it needs. Default decode is **byte-for-byte unchanged**.

- **Phase 1 — multi-graph backend** (`CudaBackend`, additive): `TryBeginGraphCapture(id)` / `TryEndGraphCaptureAndInstantiate(id)` / `GraphReadyFor(id)` / `LaunchGraphForPosition(id,pos)` backed by a per-id `_multiGraphs` map, sharing the existing capture machinery. The single-graph API (CudaForwardPass/CudaHybridForwardPass) is unchanged except the launch-rewrite loop was extracted verbatim into a shared `LaunchGraphNodes` helper.
- **Phase 2 — gated decode trunk graph** (`CudaHybridGdnForwardPass.Forward`): on the first post-warmup decode token each layer's pure-GPU trunk block (norms + attn/GDN block + residual adds) is captured into a per-layer graph and replayed after; the CPU-MoE (Download/dots/Upload) stays *outside* the graph between replays.

## Result (Carnice Qwen3.6-35B-A3B-MTP, RTX 4070 Ti + 7900X, `-ncmoe`)
- **Byte-identical** greedy output vs direct launches; `[graph-diag]` confirms 40/40 layers captured.
- **+3%** decode (per-token 31.8 → 32.7 t/s). Small *by design*: the decode trunk is GPU-execution-bound, not launch-bound — graphs only remove the launch slice. The real decode lever (faster trunk kernels) is **#400**; further graph follow-ups are **#401**.

## Why it works / key gotchas
- Capture mode is `cudaStreamCaptureModeRelaxed` (mirrors llama.cpp ggml-cuda) — `THREAD_LOCAL` errors on the trunk's one-time scratch `cudaMalloc` → silent fallback. A 2-token warmup ensures a stable captured topology (avoids a replay divergence). Both were found by reading `ggml-cuda.cu`.
- GDN decode kernels are position-independent (mutate state in place → capture-once); attention kernels self-register position-nodes so replay updates only the position scalars.
- Graceful fallback: any capture failure latches off and re-runs the trunk directly. MTP-verify / `BatchForward2` / prefill never use the graph.

## Safety
Default OFF → default path unchanged. Multi-graph infra is additive (single-graph users untouched). Verified existing single-graph decode (Gemma 4 12B) still coherent.

Refs #400 (decode trunk-kernel lever), #401 (graph follow-ups).