### PR TITLE
perf(cuda): raw-Q8_0 GDN-hybrid trunk weights (int8 MMQ/dp4a) — 4.2x prefill on Q8_0-trunk qwen35moe

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sharpi-cli -m models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1` (hybrid) | **113.8** | **23.7** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. Fused GDN scan + batched SDPA, bit-identical. `SHARPI_CPU_MOE=0` forces on-GPU experts. Prefill: GPU MoE op-offload (#390) + on-GPU router (#388) default-on — **+71%** over the CPU MoE path, decode within noise |
+| **CUDA** `-g -1` (hybrid) | **475.4** | **24.5** | 10 attn + 30 GDN on GPU; routed MoE on CPU, shared expert GPU-overlapped. `SHARPI_CPU_MOE=0` forces on-GPU experts. Prefill: GPU MoE op-offload (#390) + on-GPU router (#388) + **raw-Q8_0 trunk** (the all-Q8_0 attn/GDN/shared-expert projections run int8 MMQ instead of a dequant-to-F32 GEMM — **4.2×** prefill over the prior F32-trunk path, `SHARPI_GDN_RAW_Q8_0=0` reverts). Argmax-stable, not byte-exact |
 | Vulkan `-g -1` (hybrid) | 17.3 | 22.8 | 10 attn + 30 GDN on GPU; routed MoE + shared expert on CPU mmap (#356). Decode ~matches CUDA (CPU-routed-expert bound); prefill trails CUDA — per-row CPU FFN not yet batched (#371) |
 | CPU | **11.3** | 9.3 | hybrid GDN/attn, 256 experts / 8 active. Chunk-parallel (FlashQLA) GDN prefill default-on (1.35× over the 8.4 t/s per-token scan; `SHARPI_GDN_CHUNKED_PREFILL=0` to disable). MTP variants keep the byte-exact scan (FP-reorder flips the thinking-boundary token) |
 
@@ -160,7 +160,7 @@ SHARPI_CPU_MOE=1 sharpi-cli -m models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | **114.2** | **21.4** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap. 100% acceptance. Prefill: GPU MoE op-offload (#390) + on-GPU router (#388) default-on — **+74%** over the CPU MoE path, decode within noise |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | **480.2** | **33.3** | needs `SHARPI_CPU_MOE=1`: 30 GDN + 10 attn + shared expert on GPU, routed experts CPU mmap; MTP self-spec (~74% accept, this prompt). Prefill: GPU MoE op-offload (#390) + on-GPU router (#388) + **raw-Q8_0 trunk** (int8 MMQ over the all-Q8_0 attn/GDN/shared-expert projections — **4.2×** prefill over the prior F32-trunk dequant-GEMM, `SHARPI_GDN_RAW_Q8_0=0` reverts). Decode +15% (faster int8 trunk matvec in MTP verify). Argmax-stable |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 15.4 | 9.3 | needs `SHARPI_CPU_MOE=1`; runs on Vulkan (#357). 61% acceptance, but MTP self-spec **regresses** vs ~22 t/s plain MoE decode — routed-expert verify un-amortized on Vulkan (#370). Use `--spec-type none` for speed |
 | CPU `--no-thinking` | 9.1 | **8.5** | GDN/attn + 256-expert MoE + MTP head (#44). 100% acceptance; MoE-MTP batched verify (#45) — routed experts sequential per token, so ~MTP-off parity |
 
@@ -194,7 +194,9 @@ sharpi-cli -m models/Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf \
 
 _CUDA columns re-measured 2026-06-16 with each model's recommended sampling (`scripts/bench-allrows-1k.ps1
 -CudaOnly`): prefill warm at a realistic ~2K-token working context, decode at near-zero ctx (`-NearZero`),
-each after a discarded warm-clock warm-up. The CPU and Vulkan rows are from the prior 2026-06 sweep (prefill
+each after a discarded warm-clock warm-up. The two unsloth Qwen3.6-35B-A3B GDN rows' CUDA prefill/decode were
+re-measured 2026-06-25 for the raw-Q8_0 trunk (4.2× prefill; same 2K-ctx convention, old F32-trunk value
+reproduced the prior 113.x reading). The CPU and Vulkan rows are from the prior 2026-06 sweep (prefill
 ~1K ctx), except the Gemma 4 E4B q4_0 Vulkan row, freshly measured 2026-06-22 with the same convention after
 the #351 gemma4-on-Vulkan work (PLE + shared-KV + narrowed KV). Vulkan rows remain ~35% below their earlier
 numbers — an unexplained regression (CUDA improved on the same box). Llama-4 Scout and Qwen3-Coder

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -182,9 +182,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     // GPU-resident GDN weights (per layer, only populated for GDN-type layers).
     // The new GPU GDN block path (default) uses these.
-    private readonly Tensor[] _gpuWAttnQkv;          // [L] Q4_K [conv_channels, embDim]
-    private readonly Tensor[] _gpuWAttnGate;         // [L] Q4_K [value_dim, embDim]
-    private readonly Tensor[] _gpuWSsmOut;           // [L] Q4_K [embDim, value_dim]
+    private readonly Tensor[] _gpuWAttnQkv;          // [L] raw-quant/F32 [conv_channels, embDim]
+    private readonly Tensor[] _gpuWAttnGate;         // [L] raw-quant/F32 [value_dim, embDim]
+    private readonly Tensor[] _gpuWSsmOut;           // [L] raw-quant/F32 [embDim, value_dim]
     private readonly Tensor[] _gpuWSsmAlpha;         // [L] F32 [num_v_heads, embDim]
     private readonly Tensor[] _gpuWSsmBeta;          // [L] F32 [num_v_heads, embDim]
     private readonly Tensor[] _gpuSsmA;              // [L] F32 [num_v_heads]
@@ -582,6 +582,17 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // SHARPI_GDN_PREFILL_COMPUTE=0 reverts to the byte-exact per-token matvec.
     internal static bool GdnPrefillComputeEnabled =
         Environment.GetEnvironmentVariable("SHARPI_GDN_PREFILL_COMPUTE") != "0";
+    // Keep Q8_0 trunk weights raw on the GPU instead of dequantizing them to F32 at
+    // upload. CUDA has the full raw-Q8_0 kernel suite for both phases — llm_matvec_q8_0
+    // (+ dp4a int8) for decode and llm_mmq_q8_0 (int8 MMQ) / llm_matvec_q8_0_gemm_n for
+    // batched prefill — so the only thing the legacy F32 dequant bought was the
+    // memory-bound llm_matvec_f32_gemm_n path (the prefill #1 GPU cost on Q8_0-trunk
+    // models such as Qwen3.6-35B-A3B-UD: 78% of GPU time) plus 4× the trunk VRAM. The
+    // MMQ/dp4a kernels are argmax-stable, NOT byte-exact (Q8_1 int8 activations), so this
+    // shares the same contract as GdnPrefillComputeEnabled; SHARPI_GDN_RAW_Q8_0=0 reverts
+    // to the F32-dequant upload (the byte-exact reference the bit-parity oracle pins).
+    internal static bool RawQ80WeightsEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_GDN_RAW_Q8_0") != "0";
     // Issue #210: route the k MTP-draft tokens' routed-expert FFN in BatchVerify
     // through the #110 group-by-expert core (BatchedRoutedExperts) instead of the
     // per-token CpuMoeFfnCore loop, so each selected expert's mmap'd gate/up/down
@@ -6745,15 +6756,19 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             result = _gpu.Upload(floats, TensorShape.D1(floats.Length), exact: true);
             _gpuWeightDTypes[result.Handle] = DType.Float32;
         }
-        else if (info.DType == DType.Q4_K || info.DType == DType.Q5_K || info.DType == DType.Q6_K)
+        else if (info.DType == DType.Q4_K || info.DType == DType.Q5_K || info.DType == DType.Q6_K
+                 || (info.DType == DType.Q8_0 && RawQ80WeightsEnabled))
         {
-            // CUDA matvec dispatches on Q4_K / Q5_K / Q6_K via dedicated kernels.
+            // CUDA matvec/MMQ dispatch on Q4_K / Q5_K / Q6_K / Q8_0 via dedicated kernels
+            // (GpuMatMul → MatMul; GpuMatMulBatched → MatMulBatchedMmq). Keeping the weight
+            // raw avoids the F32 dequant's 4× VRAM and the memory-bound F32 GEMM-N path.
             result = _gpu.UploadRaw(data, TensorShape.D1(data.Length), info.DType, exact: true);
             _gpuWeightDTypes[result.Handle] = info.DType;
         }
         else
         {
-            // Q8_0, Q3_K, etc. — CUDA matvec doesn't dispatch on these. Dequantize to F32.
+            // Q3_K, etc. (and Q8_0 under SHARPI_GDN_RAW_Q8_0=0) — no raw GPU matvec used
+            // here, or the reverted reference path. Dequantize to F32.
             int count = (int)info.ElementCount;
             var f32 = new float[count];
             Dequantize.ToFloat32(data, f32, info.DType, count);

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
@@ -26,9 +26,29 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
     // GEMM) is argmax-stable, NOT byte-exact, so pin it OFF for the whole class to keep
     // the batched side on the byte-exact GEMM-N matvec. The MMQ/GEMM kernels' correctness
     // is covered separately by CudaMmqQ4K/Q8_0Tests + CudaGemmQ6K/Q5KTests. Restored in Dispose.
+    // RawQ80WeightsEnabled is pinned OFF for the same reason: keeping Q8_0 trunk weights as
+    // raw makes the sequential reference take the int8 dp4a matvec while the batched side
+    // takes the f32 GEMM-N — argmax-stable but not byte-exact. The F32-dequant upload keeps
+    // both sides on the byte-exact f32 matvec so the batching invariant stays provable, and
+    // (verified) makes this change a byte-for-byte no-op on this oracle.
+    // NOTE: this Carnice oracle is independently pre-existing-RED on master — op-offload
+    // (#390), on-GPU router (#388) and Q3_K dequant-GEMM (#393), all default-on and all
+    // argmax-stable-not-byte-exact, diverge the batched arm from the sequential CPU path.
+    // Pinning RawQ80 off keeps THIS change from adding a further divergence; restoring the
+    // oracle to green (pin those three off, or convert to argmax assertions) is tracked
+    // separately. Restored in Dispose.
     private readonly bool _prevGdnCompute = CudaHybridGdnForwardPass.GdnPrefillComputeEnabled;
-    public CudaHybridGdnBatchedPrefillTests() => CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = false;
-    public void Dispose() => CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = _prevGdnCompute;
+    private readonly bool _prevRawQ80 = CudaHybridGdnForwardPass.RawQ80WeightsEnabled;
+    public CudaHybridGdnBatchedPrefillTests()
+    {
+        CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = false;
+        CudaHybridGdnForwardPass.RawQ80WeightsEnabled = false;
+    }
+    public void Dispose()
+    {
+        CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = _prevGdnCompute;
+        CudaHybridGdnForwardPass.RawQ80WeightsEnabled = _prevRawQ80;
+    }
 
     private static CudaBackend? TryCreate()
     {

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnChunkedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnChunkedPrefillTests.cs
@@ -22,12 +22,22 @@ namespace SharpInference.Tests.ForwardPass;
 public sealed class CudaHybridGdnChunkedPrefillTests : IDisposable
 {
     // Isolate the variable under test: pin the trunk projection matmuls byte-exact
-    // (GdnPrefillComputeEnabled = false) so the ONLY difference between the two arms
-    // is the GDN recurrence kernel (scan vs chunked), not the MMQ/GEMM matmul choice
-    // (which is argmax-stable, not byte-exact). Restored in Dispose.
+    // (GdnPrefillComputeEnabled = false, plus RawQ80WeightsEnabled = false so Q8_0 trunk
+    // weights stay on the F32 matvec rather than the int8 dp4a/MMQ path) so the ONLY
+    // difference between the two arms is the GDN recurrence kernel (scan vs chunked), not
+    // the matmul choice (which is argmax-stable, not byte-exact). Restored in Dispose.
     private readonly bool _prevGdnCompute = CudaHybridGdnForwardPass.GdnPrefillComputeEnabled;
-    public CudaHybridGdnChunkedPrefillTests() => CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = false;
-    public void Dispose() => CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = _prevGdnCompute;
+    private readonly bool _prevRawQ80 = CudaHybridGdnForwardPass.RawQ80WeightsEnabled;
+    public CudaHybridGdnChunkedPrefillTests()
+    {
+        CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = false;
+        CudaHybridGdnForwardPass.RawQ80WeightsEnabled = false;
+    }
+    public void Dispose()
+    {
+        CudaHybridGdnForwardPass.GdnPrefillComputeEnabled = _prevGdnCompute;
+        CudaHybridGdnForwardPass.RawQ80WeightsEnabled = _prevRawQ80;
+    }
 
     private static CudaBackend? TryCreate()
     {


### PR DESCRIPTION
## Summary

The CUDA GDN-hybrid pass (`CudaHybridGdnForwardPass`) dequantized **Q8_0 trunk weights to F32 at upload**, on a stale `// CUDA matvec doesn't dispatch on these` assumption. Every trunk projection — `attn_qkv` / `attn_gate` / `ssm_out`, attention q/k/v/o, and the shared experts — then ran as `llm_matvec_f32_gemm_n`, re-streaming a fat F32 weight with no int8 tensor cores.

Nsight Systems on **Qwen3.6-35B-A3B-UD** (unsloth, whose trunk is *all Q8_0*) made it decisive:

```
78% | 2133 ms | llm_matvec_f32_gemm_n   <- the trunk projections
 9% |  253 ms | llm_mmq_q4k             (Q4_K experts — already MMQ)
 4% |  124 ms | llm_gdn_chunked_prefill (GDN scan — NOT the bottleneck)
```

The backend already ships the full raw-Q8_0 kernel suite: `llm_mmq_q8_0` / `llm_matvec_q8_0_gemm_n` (batched prefill) and `llm_matvec_q8_0` / `_dp4a` (decode). This PR uploads Q8_0 trunk weights **raw** (`UploadRaw`, registering the real dtype) so `GpuMatMulBatched → MatMulBatchedMmq` and `GpuMatMul → MatMul` route them through those kernels — exactly like the existing `Q4_K/Q5_K/Q6_K` raw branch, and the CUDA analogue of the Vulkan `IsRawGpuQuant` fix (#310). It also cuts the trunk VRAM ~4×.

After the fix the same nsys run shows the trunk projections at **28 ms** (`llm_mmq_q8_0`) instead of 2133 ms.

## Measured (RTX 4070 Ti + 7900X, `--cpu-moe -g -1`, 2K-token prompt, same-session A/B)

| Model | Prefill old→new | Decode old→new |
|---|---|---|
| Qwen3.6-35B-A3B-UD | **113.6 → 475.4 t/s (4.2×)** | 21.2 → 24.5 |
| Qwen3.6-35B-A3B-MTP-UD | **113.6 → 480.2 t/s (4.2×)** | 28.9 → 33.3 (MTP, +15%) |

Prefill is now **~89% of llama.cpp CUDA's 537 t/s** (`-ngl 99 -ncmoe 99`) on the same box — the gap closed from **6.9× to 1.12×**. Decode improved +8–16% and is now the remaining gap (~2×; a coordination/expert-bound lever for a later PR).

## Correctness

Greedy output is **argmax-stable, not byte-exact** — the MMQ/dp4a int8-activation contract, the same class as `GdnPrefillComputeEnabled` (already default-on for Q4_K/Q5_K/Q6_K trunks) and every other GPU quant path here. In the A/B the two arms were *identical through the whole prompt and most of the generation*, diverging at a single near-tie. The MMQ/dp4a kernels themselves are independently unit-tested (`CudaMmq*Tests`, and `_dp4a` is the decode path of every dense Q8_0 model).

Gated `SHARPI_GDN_RAW_Q8_0` (default-on); `=0` restores the byte-exact F32 dequant.

## Tests

The two byte-exact GDN-hybrid oracles (`CudaHybridGdnBatchedPrefillTests`, `CudaHybridGdnChunkedPrefillTests`) now pin `RawQ80WeightsEnabled = false` alongside the existing `GdnPrefillComputeEnabled = false`, keeping the trunk on the F32 matvec for the batched-vs-sequential comparison. Verified this change is a **byte-for-byte no-op** on those oracles (the Carnice batched logit was bit-identical to master with the pin on).

### Pre-existing (unrelated) note
The `BatchedPrefill_BitwiseMatchesSequential_Carnice` oracle is **already RED on clean master** (identical failing values with/without this branch): op-offload (#390), on-GPU router (#388) and Q3_K dequant-GEMM (#393) are all default-on and argmax-stable, so the batched arm diverges from the sequential CPU arm. That's a separate oracle-maintenance fix (pin those three off, or move it to argmax assertions) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
