### PR TITLE
feat: support Ornith-1.0 agentic-coding models (Qwen3.5/Gemma4 finetunes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,20 @@ dotnet publish src/SharpInference.Server.Host -c Release -r win-x64
 dotnet run --project benchmarks/SharpInference.Bench -c Release -- --filter '*'
 
 # Models: scripts/download-model.ps1 fetches known presets (smollm2, vibethinker,
-# qwen3-8b, olmoe-1b-7b, qwen3-coder-30b-a3b, qwen36-35b-a3b[-mtp], gemma4-12b-qat,
-# gemma4-e4b-qat, llama4-scout, z-image-turbo[-q8], realesrgan-x4, ...). Run with
-# `-Model <name>` (PowerShell). See the script header for the full ValidateSet.
+# qwen3-8b, olmoe-1b-7b, qwen3-coder-30b-a3b, qwen36-35b-a3b[-mtp], ornith-9b/-35b,
+# gemma4-12b-qat, gemma4-e4b-qat, llama4-scout, z-image-turbo[-q8], realesrgan-x4, ...).
+# Run with `-Model <name>` (PowerShell). See the script header for the full ValidateSet.
+
+# Ornith-1.0 (DeepReinforce, MIT) — agentic-coding "self-scaffolding" RL finetunes of
+# Qwen3.5 / Gemma 4 bases, NOT a new architecture. Self-scaffolding is a training-time
+# technique; at inference they're ordinary transformers. GGUF arches reduce to ones
+# already dispatched: 9B = dense `qwen35`, 35B/397B = `qwen35moe` (so the MoE variants
+# ride the existing Gated-DeltaNet + sparse-attention MoE path, incl. --cpu-moe, and the
+# qwen35moe QwenToolCallAdapter). They're tagged image-text-to-text, but the Qwen3.5
+# vision projector is unimplemented — the text GGUF path is text-only, which is what the
+# coding use case needs. `download-model.ps1 -Model ornith-9b` (Q4_K_M, ~5.6 GB).
+dotnet run --project src/SharpInference.Cli -c Release -- \
+  -m models/deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf -g -1 -p "Write a Python LRU cache."
 
 # Image generation with upscaling (Z-Image-Turbo + RRDBNet). ImageCommand auto-detects
 # Z-Image vs FLUX from the model. Z-Image uses a Qwen3-4B text encoder; FLUX uses CLIP-L + T5.

--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -5,6 +5,7 @@
     Downloads from HuggingFace to the models/ directory. Skips if already present.
     Supports: smollm2, vibethinker, qwen3-8b, olmoe-1b-7b, llama31-70b, qwen3-coder-30b-a3b, qwen36-35b-a3b,
               qwen36-27b-mtp, qwen36-27b-mtp-q5, qwen36-35b-a3b-mtp, carnice-35b-a3b-mtp,
+              ornith-9b, ornith-35b,
               gemma4-12b-qat, gemma4-12b-q4km, gemma4-e4b-qat, gemma4-12b-agentic,
               llama4-scout, z-image-turbo, z-image-turbo-q8, realesrgan-x4
 .PARAMETER Model
@@ -23,6 +24,8 @@
     .\download-model.ps1 -Model qwen36-27b-mtp-q5       # Qwen3.6 27B-MTP Q5_K_M (18.5 GB) — higher-quality variant for the MTP bench row
     .\download-model.ps1 -Model qwen36-35b-a3b-mtp -DestDir E:\models  # Qwen3.6 35B-A3B-MTP UD-Q4_K_M (22.7 GB) — MoE MTP perf target for issue #25
     .\download-model.ps1 -Model carnice-35b-a3b-mtp -DestDir E:\models  # Carnice (Qwen3.6-35B-A3B-MTP, agentic/tool-calling) APEX-MTP I-Compact (17.3 GB)
+    .\download-model.ps1 -Model ornith-9b              # Ornith-1.0-9B Q4_K_M (~5.6 GB) — DeepReinforce agentic-coding finetune of Qwen3.5 (dense qwen35 arch)
+    .\download-model.ps1 -Model ornith-35b -DestDir E:\models  # Ornith-1.0-35B Q4_K_M (~21 GB) — agentic-coding MoE on the existing qwen35moe path
     .\download-model.ps1 -Model gemma4-12b-qat -DestDir E:\models  # Gemma 4 12B-it QAT q4_0 + vision/audio mmproj (~7.2 GB) — issue #124 PRIMARY (official quantization-aware-trained)
     .\download-model.ps1 -Model gemma4-12b-q4km -DestDir E:\models # Gemma 4 12B-it Q4_K_M (~7.3 GB) — issue #124 fallback / K-quant cross-check
     .\download-model.ps1 -Model gemma4-e4b-qat -DestDir E:\models  # Gemma 4 E4B-it QAT q4_0 (~5.15 GB) — fast small Gemma (~1.6× decode vs Q8_0)
@@ -35,6 +38,7 @@
 param(
     [ValidateSet("smollm2", "vibethinker", "vibethinker-q4", "qwen3-8b", "qwen3-0.6b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
                  "qwen36-27b-mtp", "qwen36-27b-mtp-q5", "qwen36-35b-a3b-mtp", "carnice-35b-a3b-mtp",
+                 "ornith-9b", "ornith-35b",
                  "gemma4-12b-qat", "gemma4-12b-q4km", "gemma4-e4b-qat", "gemma4-12b-agentic",
                  "llama4-scout", "z-image-turbo", "z-image-turbo-q8", "realesrgan-x4")]
     [string]$Model,
@@ -160,6 +164,39 @@ $Models = @{
         Urls  = @("https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF/resolve/main/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Compact.gguf")
         Size  = "17.3 GB"
         Phase = "assistant (agentic/tool-calling orchestrator on the qwen35moe MTP path)"
+    }
+    # ── Ornith-1.0 (DeepReinforce, MIT) — agentic-coding finetunes ────────────
+    # Ornith-1.0 is NOT a new architecture: it's DeepReinforce's "self-scaffolding"
+    # RL post-train of existing Qwen3.5 / Gemma 4 bases. Self-scaffolding (the model
+    # learns to emit its own task harness alongside solution rollouts) is a TRAINING
+    # technique — at inference these are ordinary autoregressive transformers and need
+    # no special runtime support. HF arches: 9B = `qwen3_5` (dense), 35B/397B =
+    # `qwen3_5_moe`. After llama.cpp conversion the GGUF arch strings are `qwen35`
+    # (dense) and `qwen35moe` (MoE), both already dispatched by ModelGraph — so the
+    # MoE variants ride the existing Gated-DeltaNet + sparse-attention MoE path and
+    # tool-calling via the qwen35moe QwenToolCallAdapter. (The models are tagged
+    # image-text-to-text; the Qwen3.5 vision projector is not yet implemented, so the
+    # text GGUF path here is text-only — fine for the agentic-coding use case.)
+    #
+    # Sources are bartowski's GGUF republishes (deterministic `<ns>_<model>-<Quant>.gguf`
+    # naming). Ornith-1.0-9B is the edge target (43.1 Terminal-Bench 2.1, 69.4 SWE-Bench
+    # Verified). If the 9B GGUF carries GDN tensors the hybrid-SSM probe activates
+    # automatically; otherwise it loads as a plain dense qwen35 transformer.
+    "ornith-9b" = @{
+        Files = @("deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf")
+        Urls  = @("https://huggingface.co/bartowski/deepreinforce-ai_Ornith-1.0-9B-GGUF/resolve/main/deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf")
+        Size  = "~5.6 GB"
+        Phase = "agentic coding (Qwen3.5-based dense, qwen35 arch)"
+    }
+    # Ornith-1.0-35B — qwen35moe (Qwen3.5 35B-A3B base): runs on the existing hybrid
+    # Gated-DeltaNet + sparse-attention MoE path (same arch as qwen36-35b-a3b), incl.
+    # --cpu-moe expert offload. MTP-augmented community quants exist separately and
+    # would ride the MtpDecoder path.
+    "ornith-35b" = @{
+        Files = @("deepreinforce-ai_Ornith-1.0-35B-Q4_K_M.gguf")
+        Urls  = @("https://huggingface.co/bartowski/deepreinforce-ai_Ornith-1.0-35B-GGUF/resolve/main/deepreinforce-ai_Ornith-1.0-35B-Q4_K_M.gguf")
+        Size  = "~21 GB"
+        Phase = "agentic coding (qwen35moe MoE path)"
     }
     # ── Gemma 4 12B (dense gemma4_unified) — issue #124 ───────────────────────
     # Google's official quantization-aware-trained (QAT) 4-bit weights. Stored as

--- a/tests/SharpInference.Tests.Core/Ornith10ArchitectureTests.cs
+++ b/tests/SharpInference.Tests.Core/Ornith10ArchitectureTests.cs
@@ -1,0 +1,109 @@
+using SharpInference.Core;
+namespace SharpInference.Tests.Core;
+
+// Ornith-1.0 (DeepReinforce, MIT) is an agentic-coding "self-scaffolding" RL
+// post-train of existing Qwen3.5 / Gemma 4 bases — NOT a new architecture. After
+// llama.cpp GGUF conversion its arch strings are the ones SharpInference already
+// dispatches: `qwen35moe` (the 35B / 397B MoE variants) and dense `qwen35` (the 9B).
+// These tests pin that routing so an Ornith GGUF lands on the existing hybrid
+// Gated-DeltaNet + sparse-attention MoE path (35B/397B) and the dense path (9B)
+// without any model-specific code.
+public sealed class Ornith10ArchitectureTests
+{
+    // Ornith-1.0-35B / -397B: HF arch `qwen3_5_moe` → GGUF arch `qwen35moe`.
+    // Hyperparams mirror the Qwen3.5 35B-A3B base it was trained from.
+    [Fact]
+    public void Ornith35BMoe_RoutesToHybridSsmMoEPath()
+    {
+        var md = new Dictionary<string, object>
+        {
+            ["general.architecture"]                       = "qwen35moe",
+            ["qwen35moe.block_count"]                       = 40,
+            ["qwen35moe.embedding_length"]                  = 2048,
+            ["qwen35moe.context_length"]                    = 262_144,
+            ["qwen35moe.attention.head_count"]              = 16,
+            ["qwen35moe.attention.head_count_kv"]           = 2,
+            ["qwen35moe.attention.key_length"]              = 256,
+            ["qwen35moe.attention.layer_norm_rms_epsilon"]  = 1e-6f,
+            ["qwen35moe.full_attention_interval"]           = 4,
+            ["qwen35moe.rope.dimension_count"]              = 64,
+            ["qwen35moe.expert_count"]                      = 256,
+            ["qwen35moe.expert_used_count"]                 = 8,
+            ["qwen35moe.ssm.conv_kernel"]                   = 4,
+            ["qwen35moe.ssm.group_count"]                   = 16,
+            ["qwen35moe.ssm.inner_size"]                    = 4096,
+            ["qwen35moe.ssm.state_size"]                    = 128,
+            ["qwen35moe.ssm.time_step_rank"]                = 32,
+        };
+
+        var hp = ModelHyperparams.FromGgufMetadata(md);
+
+        // Ornith-35B must take the existing hybrid GDN + MoE path — no new arch handling.
+        Assert.True(hp.IsHybridSsm);
+        Assert.True(hp.IsMoE);
+        Assert.True(hp.IsNeoxRope);
+        Assert.Equal(256, hp.NumExperts);
+        Assert.Equal(8, hp.NumActiveExperts);
+        Assert.NotNull(hp.LayerTypes);
+        Assert.NotNull(hp.Gdn);
+        // 1-in-4 full-attention interleave (the rest Gated-DeltaNet).
+        Assert.Equal(LayerType.Attention,     hp.LayerTypes![3]);
+        Assert.Equal(LayerType.GatedDeltaNet, hp.LayerTypes[0]);
+    }
+
+    // Ornith-1.0-9B: HF arch `qwen3_5` (dense) → GGUF arch `qwen35`. Recognized as a
+    // NEOX-RoPE dense transformer; not MoE, and not hybrid unless GDN tensors are present.
+    [Fact]
+    public void Ornith9BDense_IsRecognizedAsNeoxDense()
+    {
+        var md = new Dictionary<string, object>
+        {
+            ["general.architecture"]                   = "qwen35",
+            ["qwen35.block_count"]                     = 48,
+            ["qwen35.embedding_length"]                = 4096,
+            ["qwen35.attention.head_count"]            = 32,
+            ["qwen35.attention.head_count_kv"]         = 8,
+            ["qwen35.attention.key_length"]            = 128,
+            ["qwen35.attention.layer_norm_rms_epsilon"] = 1e-6f,
+        };
+
+        var hp = ModelHyperparams.FromGgufMetadata(md);
+
+        Assert.True(hp.IsNeoxRope);     // qwen35 is in the NEOX rope set
+        Assert.False(hp.IsMoE);
+        Assert.False(hp.IsHybridSsm);   // no GDN tensors → plain dense path
+        Assert.Null(hp.LayerTypes);
+        Assert.Null(hp.Gdn);
+        Assert.Equal(48, hp.NumLayers);
+    }
+
+    // If the 9B (or any dense qwen35) ships Gated-DeltaNet tensors, GgufModel.Open
+    // injects `_sharpi.is_hybrid_ssm` and the hybrid path activates automatically.
+    [Fact]
+    public void Ornith9BDense_ActivatesHybridWhenGdnTensorsProbed()
+    {
+        var md = new Dictionary<string, object>
+        {
+            ["general.architecture"]                   = "qwen35",
+            ["_sharpi.is_hybrid_ssm"]                  = true,
+            ["qwen35.block_count"]                     = 48,
+            ["qwen35.embedding_length"]                = 4096,
+            ["qwen35.attention.head_count"]            = 32,
+            ["qwen35.attention.head_count_kv"]         = 8,
+            ["qwen35.attention.key_length"]            = 128,
+            ["qwen35.attention.layer_norm_rms_epsilon"] = 1e-6f,
+            ["qwen35.full_attention_interval"]         = 4,
+            ["qwen35.ssm.conv_kernel"]                 = 4,
+            ["qwen35.ssm.group_count"]                 = 16,
+            ["qwen35.ssm.inner_size"]                  = 4096,
+            ["qwen35.ssm.state_size"]                  = 128,
+            ["qwen35.ssm.time_step_rank"]              = 32,
+        };
+
+        var hp = ModelHyperparams.FromGgufMetadata(md);
+
+        Assert.True(hp.IsHybridSsm);
+        Assert.NotNull(hp.LayerTypes);
+        Assert.NotNull(hp.Gdn);
+    }
+}


### PR DESCRIPTION
## What & why

[Ornith-1.0](https://deep-reinforce.com/ornith_1_0.html) (DeepReinforce, MIT, Jun 2026) is a self-scaffolding RL post-train of existing **Qwen3.5 / Gemma 4** bases — **not a new architecture**. Self-scaffolding is a training-time technique; at inference the models are ordinary autoregressive transformers whose GGUF arch strings reduce to ones `ModelGraph` already dispatches:

| Model | HF arch | GGUF arch | SharpInference path |
|---|---|---|---|
| Ornith-1.0-9B | `qwen3_5` (dense) | `qwen35` | dense path |
| Ornith-1.0-35B / -397B | `qwen3_5_moe` | `qwen35moe` | existing hybrid Gated-DeltaNet + sparse-attention MoE (incl. `--cpu-moe`, `qwen35moe` `QwenToolCallAdapter`) |

So the MoE variants ride the existing path with **no new forward-pass code**. This PR adds the plumbing to fetch and validate them.

## Changes
- **`scripts/download-model.ps1`** — `ornith-9b` (Q4_K_M, ~5.6 GB) and `ornith-35b` (Q4_K_M, ~21 GB) presets, wired into `ValidateSet` / SYNOPSIS / examples.
- **`tests/SharpInference.Tests.Core/Ornith10ArchitectureTests.cs`** — 3 tests pinning that Ornith's arch strings route correctly: `qwen35moe` → hybrid-SSM + MoE + NEOX, dense `qwen35` → plain dense, and dense + GDN-probe → hybrid.
- **`CLAUDE.md`** — documents the family and its inference path.

## Testing
- `dotnet test tests/SharpInference.Tests.Core` — Ornith tests pass (3/3); filtered ModelHyperparams/Ornith/ToolCallAdapter run green (59/59).
- PowerShell not available in the sandbox, so the script was validated by structural review against sibling entries only.

## Known limitations (tracked in #411)
- **Download URLs are unverified.** Filenames follow bartowski's deterministic convention but HF was proxy-blocked during authoring; the exact `resolve/main/...` paths and whether the 35B quant is sharded still need a live check. The download loop's `curl -o` lacks `--fail`, so a 404 silently saves an error page as a `.gguf`.
- **Vision is out of scope.** The models are tagged `image-text-to-text`, but the Qwen3.5 vision projector is unimplemented (only Gemma 4's `gemma4uv`). The text GGUF path is text-only — sufficient for agentic coding.

Closes part of #411 (dispatch groundwork); end-to-end validation with real weights tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz6XuKmPYF4APx6fxAXC9q)_