### PR TITLE
Add preserve_thinking flag for OpenAI/Anthropic chat endpoints

### DIFF
--- a/src/SharpInference.Server.Host/Program.cs
+++ b/src/SharpInference.Server.Host/Program.cs
@@ -71,6 +71,16 @@ builder.Services.AddSharpInference(builder.Configuration, opts =>
         opts.DisableThinking = true;
     }
 
+    // SHARPI_PRESERVE_THINKING ∈ {1, true} globally keeps prior assistant turns' reasoning in
+    // the chat-template history instead of stripping it, for agentic clients that never send the
+    // per-request preserve_thinking opt-in.
+    var envPreserveThink = Environment.GetEnvironmentVariable("SHARPI_PRESERVE_THINKING");
+    if (!string.IsNullOrWhiteSpace(envPreserveThink)
+        && (envPreserveThink == "1" || envPreserveThink.Equals("true", StringComparison.OrdinalIgnoreCase)))
+    {
+        opts.PreserveThinking = true;
+    }
+
     // SHARPI_TOOL_GRAMMAR ∈ {1, true} enables schema/grammar-constrained tool-call argument
     // decoding (issue #374). Off by default → byte-identical to unconstrained decoding.
     var envToolGrammar = Environment.GetEnvironmentVariable("SHARPI_TOOL_GRAMMAR");

--- a/src/SharpInference.Server/ChatTemplate.cs
+++ b/src/SharpInference.Server/ChatTemplate.cs
@@ -46,6 +46,23 @@ public static partial class ChatTemplate
         result = OrphanCloseRegex().Replace(result, string.Empty);
         return result;
     }
+
+    /// <summary>
+    /// Re-wraps a prior assistant turn's reasoning as a leading <c>&lt;think&gt;...&lt;/think&gt;</c>
+    /// block — the mirror image of <see cref="ScrubAssistantThinking"/> — used when the request opts
+    /// into <c>preserve_thinking</c>. Endpoints carry reasoning out-of-band from the model's answer
+    /// text (OpenAI's <c>reasoning_content</c> field, Anthropic's <c>thinking</c> content block), so
+    /// it has to be re-inlined here before the chat template sees a single content string. No-op when
+    /// there's no reasoning to inject, or <paramref name="content"/> already has its own
+    /// <c>&lt;think&gt;</c> tag (a client echoing the model's literal output rather than the separate
+    /// reasoning channel — nothing to add).
+    /// </summary>
+    public static string InjectThinking(string content, string? reasoning)
+    {
+        if (string.IsNullOrEmpty(reasoning) || content.Contains("<think>", StringComparison.Ordinal))
+            return content;
+        return $"<think>\n{reasoning}\n</think>\n\n{content}";
+    }
 }
 
 /// <summary>

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -84,7 +84,10 @@ public static class AnthropicEndpoints
         // preserve_thinking (per-request) or SHARPI_PRESERVE_THINKING (server-wide) keeps prior
         // assistant turns' thinking content blocks in the rendered history instead of the default
         // ChatTemplate.ScrubAssistantThinking strip — see SharpInferenceServerOptions.PreserveThinking.
-        bool preserveThinking = req.PreserveThinking ?? options.Value.PreserveThinking;
+        // Server-level DisableThinking still wins: an operator who has decided this deployment never
+        // exposes <think> content to the model shouldn't have historical reasoning re-injected either.
+        bool preserveThinking = (req.PreserveThinking ?? options.Value.PreserveThinking)
+                                && !options.Value.DisableThinking;
 
         var adapter = chatTemplate.ToolCallAdapter;
 

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -81,6 +81,11 @@ public static class AnthropicEndpoints
         bool enableThinking = (requestedThinking ?? !chatTemplate.ModelDefaultsThinkingOff)
                               && !options.Value.DisableThinking;
 
+        // preserve_thinking (per-request) or SHARPI_PRESERVE_THINKING (server-wide) keeps prior
+        // assistant turns' thinking content blocks in the rendered history instead of the default
+        // ChatTemplate.ScrubAssistantThinking strip — see SharpInferenceServerOptions.PreserveThinking.
+        bool preserveThinking = req.PreserveThinking ?? options.Value.PreserveThinking;
+
         var adapter = chatTemplate.ToolCallAdapter;
 
         // Image content blocks (issue #253) are collected (base64 → bytes) and replaced by the
@@ -96,13 +101,13 @@ public static class AnthropicEndpoints
         {
             if (req.Tools is { Length: > 0 })
             {
-                var (richMessages, tools) = BuildRichMessageList(req, adapter, images);
+                var (richMessages, tools) = BuildRichMessageList(req, adapter, images, preserveThinking);
                 prompt = chatTemplate.Format(richMessages, enableThinking, tools);
                 canonicalHistoryPrefix = chatTemplate.Format(richMessages, enableThinking, tools, addGenerationPrompt: false);
             }
             else
             {
-                var messages = BuildMessageList(req, images);
+                var messages = BuildMessageList(req, images, preserveThinking);
                 prompt = chatTemplate.Format(messages, enableThinking);
                 canonicalHistoryPrefix = chatTemplate.Format(messages, enableThinking, addGenerationPrompt: false);
             }
@@ -607,7 +612,8 @@ public static class AnthropicEndpoints
     /// Builds the simple (string-content) message list used when no tools are present.
     /// Handles both plain-string and array-of-content-blocks message formats.
     /// </summary>
-    private static List<(string role, string content)> BuildMessageList(AnthropicMessageRequest req, List<byte[]> images)
+    private static List<(string role, string content)> BuildMessageList(
+        AnthropicMessageRequest req, List<byte[]> images, bool preserveThinking)
     {
         var list = new List<(string, string)>();
         var systemText = ExtractTextContent(req.System);
@@ -616,12 +622,61 @@ public static class AnthropicEndpoints
         foreach (var m in req.Messages!)
         {
             var role = m.Role ?? "user";
-            var content = ExtractTextAndImages(m.Content, images);
             if (role == "assistant")
-                content = ChatTemplate.ScrubAssistantThinking(content);
-            list.Add((role, content));
+            {
+                var (text, thinking) = ExtractAssistantTextAndThinking(m.Content, images);
+                var content = preserveThinking
+                    ? ChatTemplate.InjectThinking(text, thinking)
+                    : ChatTemplate.ScrubAssistantThinking(text);
+                list.Add((role, content));
+            }
+            else
+            {
+                list.Add((role, ExtractTextAndImages(m.Content, images)));
+            }
         }
         return list;
+    }
+
+    /// <summary>
+    /// Like <see cref="ExtractTextAndImages"/> but also pulls out <c>thinking</c> content blocks
+    /// separately from <c>text</c> — Anthropic carries an assistant turn's reasoning as its own
+    /// block type, not inlined into the text, so the two channels have to be split before
+    /// <see cref="ChatTemplate.ScrubAssistantThinking"/> / <see cref="ChatTemplate.InjectThinking"/>
+    /// can decide what happens to the reasoning independently of the answer text.
+    /// </summary>
+    private static (string text, string? thinking) ExtractAssistantTextAndThinking(
+        JsonElement? contentEl, List<byte[]> images)
+    {
+        if (contentEl is null) return ("", null);
+        var el = contentEl.Value;
+        if (el.ValueKind == JsonValueKind.String) return (el.GetString() ?? "", null);
+        if (el.ValueKind != JsonValueKind.Array) return ("", null);
+
+        var textSb = new StringBuilder();
+        var thinkingSb = new StringBuilder();
+        foreach (var block in el.EnumerateArray())
+        {
+            if (block.ValueKind != JsonValueKind.Object) continue;
+            var type = block.TryGetProperty("type", out var t) ? t.GetString() : null;
+            if (type == "text")
+            {
+                if (block.TryGetProperty("text", out var tv))
+                    textSb.Append(tv.GetString());
+            }
+            else if (type == "thinking")
+            {
+                if (block.TryGetProperty("thinking", out var tk))
+                    thinkingSb.Append(tk.GetString());
+            }
+            else if (type == "image")
+            {
+                ImageContent.CheckCap(images.Count);
+                images.Add(ParseAnthropicImageBlock(block));
+                textSb.Append(ImageContent.Placeholder);
+            }
+        }
+        return (textSb.ToString(), thinkingSb.Length > 0 ? thinkingSb.ToString() : null);
     }
 
     /// <summary>
@@ -681,7 +736,7 @@ public static class AnthropicEndpoints
     /// the adapter specifies (defaults to role="tool").
     /// </summary>
     private static (List<Dictionary<string, object?>> messages, List<object?>? tools)
-        BuildRichMessageList(AnthropicMessageRequest req, IToolCallAdapter adapter, List<byte[]> images)
+        BuildRichMessageList(AnthropicMessageRequest req, IToolCallAdapter adapter, List<byte[]> images, bool preserveThinking)
     {
         var messages = new List<Dictionary<string, object?>>();
 
@@ -704,7 +759,8 @@ public static class AnthropicEndpoints
             if (contentEl.ValueKind == JsonValueKind.String)
             {
                 var str = contentEl.GetString() ?? "";
-                if (role == "assistant") str = ChatTemplate.ScrubAssistantThinking(str);
+                if (role == "assistant")
+                    str = preserveThinking ? str : ChatTemplate.ScrubAssistantThinking(str);
                 messages.Add(new() { ["role"] = role, ["content"] = str });
             }
             else if (contentEl.ValueKind == JsonValueKind.Array)
@@ -712,6 +768,7 @@ public static class AnthropicEndpoints
                 if (role == "assistant")
                 {
                     var textSb = new StringBuilder();
+                    var thinkingSb = new StringBuilder();
                     var toolCalls = new List<object?>();
 
                     foreach (var block in contentEl.EnumerateArray())
@@ -722,6 +779,11 @@ public static class AnthropicEndpoints
                         {
                             if (block.TryGetProperty("text", out var tv))
                                 textSb.Append(tv.GetString());
+                        }
+                        else if (type == "thinking")
+                        {
+                            if (block.TryGetProperty("thinking", out var tk))
+                                thinkingSb.Append(tk.GetString());
                         }
                         else if (type == "tool_use")
                         {
@@ -738,7 +800,9 @@ public static class AnthropicEndpoints
                         }
                     }
 
-                    string textStr = ChatTemplate.ScrubAssistantThinking(textSb.ToString());
+                    string textStr = preserveThinking
+                        ? ChatTemplate.InjectThinking(textSb.ToString(), thinkingSb.Length > 0 ? thinkingSb.ToString() : null)
+                        : ChatTemplate.ScrubAssistantThinking(textSb.ToString());
                     var msg = new Dictionary<string, object?> { ["role"] = "assistant", ["content"] = textStr };
                     if (toolCalls.Count > 0) msg["tool_calls"] = (object?)toolCalls;
                     messages.Add(msg);
@@ -854,7 +918,14 @@ public sealed record AnthropicMessageRequest(
     float? TopP,
     int? TopK,
     AnthropicThinking? Thinking = null,
-    AnthropicTool[]? Tools = null);
+    AnthropicTool[]? Tools = null,
+    // When true, a prior assistant turn's `thinking` content block is re-inlined as a leading
+    // <think> block instead of being dropped (SharpInferenceServerOptions.PreserveThinking is
+    // the server-wide default when this is absent). Off by default, matching the pre-existing
+    // ChatTemplate.ScrubAssistantThinking behavior — and the pre-existing behavior of silently
+    // dropping `thinking` blocks entirely on the tool-active path. Maps to the wire field
+    // `preserve_thinking` via the server's snake_case JSON naming policy.
+    bool? PreserveThinking = null);
 
 public sealed record AnthropicThinking(string? Type, int? BudgetTokens);
 

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -76,7 +76,10 @@ public static class OpenAiEndpoints
         // preserve_thinking (per-request) or SHARPI_PRESERVE_THINKING (server-wide) keeps prior
         // assistant turns' reasoning in the rendered history instead of the default
         // ChatTemplate.ScrubAssistantThinking strip — see SharpInferenceServerOptions.PreserveThinking.
-        bool preserveThinking = req.PreserveThinking ?? options.Value.PreserveThinking;
+        // Server-level DisableThinking still wins: an operator who has decided this deployment never
+        // exposes <think> content to the model shouldn't have historical reasoning re-injected either.
+        bool preserveThinking = (req.PreserveThinking ?? options.Value.PreserveThinking)
+                                && !options.Value.DisableThinking;
         var adapter = chatTemplate.ToolCallAdapter;
 
         // Tool-aware rendering: if either tool definitions or a history-side

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -72,6 +72,11 @@ public static class OpenAiEndpoints
         // send the per-request flag.
         bool enableThinking = (req.EnableThinking ?? !chatTemplate.ModelDefaultsThinkingOff)
                               && !options.Value.DisableThinking;
+
+        // preserve_thinking (per-request) or SHARPI_PRESERVE_THINKING (server-wide) keeps prior
+        // assistant turns' reasoning in the rendered history instead of the default
+        // ChatTemplate.ScrubAssistantThinking strip — see SharpInferenceServerOptions.PreserveThinking.
+        bool preserveThinking = req.PreserveThinking ?? options.Value.PreserveThinking;
         var adapter = chatTemplate.ToolCallAdapter;
 
         // Tool-aware rendering: if either tool definitions or a history-side
@@ -93,13 +98,13 @@ public static class OpenAiEndpoints
         {
             if (toolsActive)
             {
-                var (richMessages, tools) = BuildRichMessageList(req, adapter, images);
+                var (richMessages, tools) = BuildRichMessageList(req, adapter, images, preserveThinking);
                 prompt = chatTemplate.Format(richMessages, enableThinking, tools);
                 canonicalHistoryPrefix = chatTemplate.Format(richMessages, enableThinking, tools, addGenerationPrompt: false);
             }
             else
             {
-                var messages = BuildMessageList(req.Messages, req.ResponseFormat?.Type, images);
+                var messages = BuildMessageList(req.Messages, req.ResponseFormat?.Type, images, preserveThinking);
                 prompt = chatTemplate.Format(messages, enableThinking);
                 canonicalHistoryPrefix = chatTemplate.Format(messages, enableThinking, addGenerationPrompt: false);
             }
@@ -486,7 +491,7 @@ public static class OpenAiEndpoints
     }
 
     private static List<(string role, string content)> BuildMessageList(
-        OaiMessage[] messages, string? responseFormatType, List<byte[]> images)
+        OaiMessage[] messages, string? responseFormatType, List<byte[]> images, bool preserveThinking)
     {
         var list = new List<(string, string)>(messages.Length + 1);
         if (responseFormatType == "json_object")
@@ -496,7 +501,9 @@ public static class OpenAiEndpoints
             var role = m.Role ?? "user";
             var content = FlattenContent(m.Content, images);
             if (role == "assistant")
-                content = ChatTemplate.ScrubAssistantThinking(content);
+                content = preserveThinking
+                    ? ChatTemplate.InjectThinking(content, m.ReasoningContent)
+                    : ChatTemplate.ScrubAssistantThinking(content);
             list.Add((role, content));
         }
         return list;
@@ -569,7 +576,7 @@ public static class OpenAiEndpoints
     /// <c>role:"tool"</c> message with <c>tool_call_id</c>.
     /// </summary>
     private static (List<Dictionary<string, object?>> messages, List<object?>? tools)
-        BuildRichMessageList(ChatCompletionRequest req, IToolCallAdapter adapter, List<byte[]> images)
+        BuildRichMessageList(ChatCompletionRequest req, IToolCallAdapter adapter, List<byte[]> images, bool preserveThinking)
     {
         var messages = new List<Dictionary<string, object?>>();
 
@@ -586,7 +593,9 @@ public static class OpenAiEndpoints
 
             if (role == "assistant")
             {
-                string textStr = ChatTemplate.ScrubAssistantThinking(content);
+                string textStr = preserveThinking
+                    ? ChatTemplate.InjectThinking(content, m.ReasoningContent)
+                    : ChatTemplate.ScrubAssistantThinking(content);
                 var msg = new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
                     ["role"]    = "assistant",
@@ -662,7 +671,12 @@ public sealed record ChatCompletionRequest(
     [property: JsonPropertyName("enable_thinking")] bool? EnableThinking = null,
     [property: JsonPropertyName("max_thinking_tokens")] int? MaxThinkingTokens = null,
     OaiTool[]? Tools = null,
-    [property: JsonPropertyName("tool_choice")] JsonElement? ToolChoice = null);
+    [property: JsonPropertyName("tool_choice")] JsonElement? ToolChoice = null,
+    // When true, prior assistant turns' reasoning_content is re-inlined as a leading <think>
+    // block instead of being stripped (SharpInferenceServerOptions.PreserveThinking is the
+    // server-wide default when this is absent). Off by default, matching the pre-existing
+    // ChatTemplate.ScrubAssistantThinking behavior.
+    [property: JsonPropertyName("preserve_thinking")] bool? PreserveThinking = null);
 
 /// <summary>
 /// Message in an OpenAI <c>/v1/chat/completions</c> request. Both single-string
@@ -678,7 +692,12 @@ public sealed record OaiMessage(
     JsonElement? Content,
     [property: JsonPropertyName("tool_call_id")] string? ToolCallId = null,
     [property: JsonPropertyName("tool_calls")] OaiToolCall[]? ToolCalls = null,
-    string? Name = null);
+    string? Name = null,
+    // Reasoning from a prior assistant turn, as echoed back by a client that captured it from
+    // this same field on the response (see OaiAssistantMessage.ReasoningContent). Only consulted
+    // when the request sets preserve_thinking; ChatTemplate.InjectThinking re-inlines it as a
+    // leading <think> block ahead of Content.
+    [property: JsonPropertyName("reasoning_content")] string? ReasoningContent = null);
 
 /// <summary>
 /// OpenAI tool definition. <c>function.parameters</c> is the JSON Schema; we keep it

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -27,6 +27,17 @@ public sealed class SharpInferenceServerOptions
     public bool DisableThinking { get; set; }
 
     /// <summary>
+    /// Globally keep prior assistant turns' reasoning in the chat-template history instead of
+    /// stripping it (server-side default for the per-request <c>preserve_thinking</c> flag /
+    /// <c>SHARPI_PRESERVE_THINKING</c>). Off by default: reasoning-model chat templates (Qwen3,
+    /// DeepSeek-R1, ...) are trained assuming historical assistant turns contain no reasoning, so
+    /// <see cref="ChatTemplate.ScrubAssistantThinking"/> strips it unless this (or the per-request
+    /// flag) says otherwise. Useful for agentic clients that never send the per-request opt-in but
+    /// want the model to see its own prior reasoning across turns.
+    /// </summary>
+    public bool PreserveThinking { get; set; }
+
+    /// <summary>
     /// Enable schema/grammar-constrained decoding for tool-call arguments (issue #374). When on and
     /// a tool-active request is served by a family with constraint support (Gemma 4, Qwen and
     /// Qwen3-Coder, Llama-3, DeepSeek), the sampler is restricted to tokens that satisfy the supplied

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -33,7 +33,9 @@ public sealed class SharpInferenceServerOptions
     /// DeepSeek-R1, ...) are trained assuming historical assistant turns contain no reasoning, so
     /// <see cref="ChatTemplate.ScrubAssistantThinking"/> strips it unless this (or the per-request
     /// flag) says otherwise. Useful for agentic clients that never send the per-request opt-in but
-    /// want the model to see its own prior reasoning across turns.
+    /// want the model to see its own prior reasoning across turns. <see cref="DisableThinking"/>
+    /// still wins over this (and over the per-request flag): a deployment that never exposes
+    /// <c>&lt;think&gt;</c> content to the model shouldn't have historical reasoning re-injected either.
     /// </summary>
     public bool PreserveThinking { get; set; }
 

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -1159,7 +1159,8 @@ public sealed class PreserveThinkingTests
     private const string EchoTemplate =
         "{% for m in messages %}[{{ m.role }}:{{ m.content }}]{% endfor %}";
 
-    private static (HttpClient client, FakeInferenceEngine fake) ProbeClient(bool serverPreserveThinking = false)
+    private static (HttpClient client, FakeInferenceEngine fake) ProbeClient(
+        bool serverPreserveThinking = false, bool disableThinking = false)
     {
         var fake = new FakeInferenceEngine("m");
         var renderer = new ChatTemplateRenderer("test", new JinjaChatTemplate(EchoTemplate));
@@ -1168,7 +1169,11 @@ public sealed class PreserveThinkingTests
             {
                 s.AddSingleton(renderer);
                 s.AddSingleton<IInferenceEngine>(fake);
-                s.Configure<SharpInferenceServerOptions>(o => o.PreserveThinking = serverPreserveThinking);
+                s.Configure<SharpInferenceServerOptions>(o =>
+                {
+                    o.PreserveThinking = serverPreserveThinking;
+                    o.DisableThinking = disableThinking;
+                });
             }));
         return (factory.CreateClient(), fake);
     }
@@ -1296,6 +1301,61 @@ public sealed class PreserveThinkingTests
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.NotNull(fake.LastPrompt);
         Assert.Contains("<think>\ntwo plus two is four\n</think>\n\n4", fake.LastPrompt);
+    }
+
+    // ── DisableThinking (SHARPI_NO_THINKING) wins over preserve_thinking ───────
+
+    [Fact]
+    public async Task OpenAi_DisableThinking_OverridesPreserveThinkingRequest()
+    {
+        var (client, fake) = ProbeClient(disableThinking: true);
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            preserve_thinking = true,
+            messages = new object[]
+            {
+                new { role = "user", content = "What is 2+2?" },
+                new { role = "assistant", content = "4", reasoning_content = "two plus two is four" },
+                new { role = "user", content = "And 3+3?" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.DoesNotContain("<think>", fake.LastPrompt);
+        Assert.Contains("[assistant:4]", fake.LastPrompt);
+    }
+
+    [Fact]
+    public async Task Anthropic_DisableThinking_OverridesServerWidePreserveThinking()
+    {
+        var (client, fake) = ProbeClient(serverPreserveThinking: true, disableThinking: true);
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            messages = new object[]
+            {
+                new { role = "user", content = "What is 2+2?" },
+                new
+                {
+                    role = "assistant",
+                    content = new object[]
+                    {
+                        new { type = "thinking", thinking = "two plus two is four" },
+                        new { type = "text", text = "4" },
+                    },
+                },
+                new { role = "user", content = "And 3+3?" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.DoesNotContain("<think>", fake.LastPrompt);
+        Assert.Contains("[assistant:4]", fake.LastPrompt);
     }
 }
 

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -1122,6 +1122,181 @@ public sealed class ChatTemplateScrubTests
         Assert.NotNull(fake.LastPrompt);
         Assert.Contains("<<NOTHINK>>", fake.LastPrompt);
     }
+
+    // ── ChatTemplate.InjectThinking (the mirror of ScrubAssistantThinking) ────
+
+    [Fact]
+    public void InjectThinking_WrapsReasoningAheadOfContent()
+    {
+        Assert.Equal("<think>\nplan\n</think>\n\nanswer", ChatTemplate.InjectThinking("answer", "plan"));
+    }
+
+    [Fact]
+    public void InjectThinking_NoReasoning_ReturnsContentUnchanged()
+    {
+        Assert.Equal("answer", ChatTemplate.InjectThinking("answer", null));
+        Assert.Equal("answer", ChatTemplate.InjectThinking("answer", ""));
+    }
+
+    [Fact]
+    public void InjectThinking_ContentAlreadyHasThinkTag_LeavesUntouched()
+    {
+        var input = "<think>already here</think>answer";
+        Assert.Equal(input, ChatTemplate.InjectThinking(input, "other reasoning"));
+    }
+}
+
+/// <summary>
+/// Wire-level tests for <c>preserve_thinking</c> (per-request) and
+/// <see cref="SharpInferenceServerOptions.PreserveThinking"/> (server-wide default): whether a
+/// prior assistant turn's reasoning survives into the rendered chat-template history instead of
+/// being stripped by <see cref="ChatTemplate.ScrubAssistantThinking"/>.
+/// </summary>
+public sealed class PreserveThinkingTests
+{
+    // Echoes role/content verbatim so the test can see exactly what reached the template,
+    // independent of enable_thinking (unlike ThinkProbeTemplate above, which only probes that flag).
+    private const string EchoTemplate =
+        "{% for m in messages %}[{{ m.role }}:{{ m.content }}]{% endfor %}";
+
+    private static (HttpClient client, FakeInferenceEngine fake) ProbeClient(bool serverPreserveThinking = false)
+    {
+        var fake = new FakeInferenceEngine("m");
+        var renderer = new ChatTemplateRenderer("test", new JinjaChatTemplate(EchoTemplate));
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s =>
+            {
+                s.AddSingleton(renderer);
+                s.AddSingleton<IInferenceEngine>(fake);
+                s.Configure<SharpInferenceServerOptions>(o => o.PreserveThinking = serverPreserveThinking);
+            }));
+        return (factory.CreateClient(), fake);
+    }
+
+    [Fact]
+    public async Task OpenAi_Default_ScrubsPriorAssistantReasoning()
+    {
+        var (client, fake) = ProbeClient();
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            messages = new object[]
+            {
+                new { role = "user", content = "What is 2+2?" },
+                new { role = "assistant", content = "4", reasoning_content = "two plus two is four" },
+                new { role = "user", content = "And 3+3?" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.DoesNotContain("<think>", fake.LastPrompt);
+        Assert.Contains("[assistant:4]", fake.LastPrompt);
+    }
+
+    [Fact]
+    public async Task OpenAi_PreserveThinkingRequest_InjectsReasoningAheadOfContent()
+    {
+        var (client, fake) = ProbeClient();
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            preserve_thinking = true,
+            messages = new object[]
+            {
+                new { role = "user", content = "What is 2+2?" },
+                new { role = "assistant", content = "4", reasoning_content = "two plus two is four" },
+                new { role = "user", content = "And 3+3?" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.Contains("<think>\ntwo plus two is four\n</think>\n\n4", fake.LastPrompt);
+    }
+
+    [Fact]
+    public async Task OpenAi_ServerWidePreserveThinking_AppliesWithoutPerRequestFlag()
+    {
+        var (client, fake) = ProbeClient(serverPreserveThinking: true);
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            messages = new object[]
+            {
+                new { role = "user", content = "hi" },
+                new { role = "assistant", content = "hello", reasoning_content = "greet back" },
+                new { role = "user", content = "again" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.Contains("<think>\ngreet back\n</think>\n\nhello", fake.LastPrompt);
+    }
+
+    [Fact]
+    public async Task Anthropic_Default_DropsPriorAssistantThinkingBlock()
+    {
+        var (client, fake) = ProbeClient();
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            messages = new object[]
+            {
+                new { role = "user", content = "What is 2+2?" },
+                new
+                {
+                    role = "assistant",
+                    content = new object[]
+                    {
+                        new { type = "thinking", thinking = "two plus two is four" },
+                        new { type = "text", text = "4" },
+                    },
+                },
+                new { role = "user", content = "And 3+3?" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.DoesNotContain("<think>", fake.LastPrompt);
+        Assert.Contains("[assistant:4]", fake.LastPrompt);
+    }
+
+    [Fact]
+    public async Task Anthropic_PreserveThinkingRequest_InjectsThinkingBlockAheadOfText()
+    {
+        var (client, fake) = ProbeClient();
+        var req = new
+        {
+            model = "m",
+            max_tokens = 16,
+            preserve_thinking = true,
+            messages = new object[]
+            {
+                new { role = "user", content = "What is 2+2?" },
+                new
+                {
+                    role = "assistant",
+                    content = new object[]
+                    {
+                        new { type = "thinking", thinking = "two plus two is four" },
+                        new { type = "text", text = "4" },
+                    },
+                },
+                new { role = "user", content = "And 3+3?" },
+            },
+        };
+        var resp = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(fake.LastPrompt);
+        Assert.Contains("<think>\ntwo plus two is four\n</think>\n\n4", fake.LastPrompt);
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Adds an opt-in `preserve_thinking` request field (default `false`, matching existing behavior) to `/v1/chat/completions` and `/v1/messages`, plus a server-wide `SharpInferenceServerOptions.PreserveThinking` / `SHARPI_PRESERVE_THINKING` default, so a prior assistant turn's reasoning can be kept in the rendered chat-template history instead of always being stripped by `ChatTemplate.ScrubAssistantThinking`.
- Adds `ChatTemplate.InjectThinking` (the mirror of `ScrubAssistantThinking`) to re-inline reasoning as a leading `<think>...</think>` block, since both wire formats carry it out-of-band from the answer text: OpenAI's `reasoning_content` field (now also accepted as an *input* field on `OaiMessage`) and Anthropic's separate `thinking` content block (previously silently dropped on echo-back, not even scrubbed).
- `preserve_thinking` is always overridden by the existing `DisableThinking` / `SHARPI_NO_THINKING` kill-switch — a deployment that opts out of thinking entirely won't have historical reasoning leak back in via history either (found and fixed during review, see below).

## Review process
Ran an 8-angle finder pass (line-by-line scan, removed-behavior audit, cross-file trace, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) followed by targeted verification on the 3 candidates that survived triage:
- **Fixed**: `preserveThinking` wasn't gated by the server's `DisableThinking` kill-switch — confirmed and fixed.
- **Investigated, no change**: apparent duplication between the new Anthropic thinking-extraction helper and the existing tool-call message builder's inline loop — verified the loops differ enough (tool_use vs. image handling) that unifying them would add more complexity than it removes.
- **Investigated, no change**: an apparent "scrub skipped" case on the Anthropic string-content path under `preserve_thinking=true` — verified this is consistent with, and intentional per, the feature's own design (mirrors how `InjectThinking` treats content that already carries inline `<think>` tags).

## Test plan
- [x] `dotnet test tests/SharpInference.Tests.Server` — 135/135 passing, including new unit tests for `ChatTemplate.InjectThinking` and wire-level integration tests for `preserve_thinking` (per-request and server-wide default) on both endpoints, and for `DisableThinking` overriding it.
- [x] `dotnet build` on `SharpInference.Server` and `SharpInference.Server.Host` — clean (0 errors).


---
_Generated by [Claude Code](https://claude.ai/code/session_015t6x3jCrtpmR8fJ7Z7PhdC)_