### PR TITLE
perf(cuda): batched CPU-side prefill for the hybrid passes (#410, opt-in)

### DIFF
--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -1366,7 +1366,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     /// kernel. Everything else falls back to the per-token FFN loop.
     /// </summary>
     private bool UseBatchedCpuMoe(int n) =>
-        BatchedCpuMoePrefillEnabled && _isMoE && _cpuMoe && n >= 2
+        // n >= 4: below a quad the grouped tiers never engage, so the batched stage is
+        // pure overhead (CSR bucketing, Parallel.For scheduling, slab traffic) over the
+        // per-token loop — which IS the sequential fallback for tiny chunks.
+        BatchedCpuMoePrefillEnabled && _isMoE && _cpuMoe && n >= 4
         && !_hasSharedExpert && !_hp.UseSigmoidGating
         // Int-safety (mirror of the GDN pass's cpuMoeBatchSafe guard): Phase B's SiLuMul
         // takes an int element count over [N × numActive × expertDim] — an enormous

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -205,6 +205,25 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // config is gated out (e.g. non-batchable dtype on a given box).
     internal bool LastPrefillWasBatched;
 
+    // ── Issue #410: batched CPU-MoE routed-expert prefill ────────────────────
+    // When ON and the config qualifies (CPU-MoE, no shared expert, softmax gating,
+    // supported expert dtypes), the batched-trunk prefill replaces the per-token
+    // FFN/MoE loop with the GDN pass's CSR-bucketed batched routed-expert scheme
+    // (issues #110/#112/#114): ONE D2H of all N post-FFN-norm rows per layer, host
+    // router + top-k per token, per-expert (token,slot) bucketing, grouped gate/up/
+    // down dots that decode each quantized weight row once per token-quad, then ONE
+    // H2D of the routed outputs. Bit-identical to the per-token path (the 2In/4In
+    // kernels mirror the single-dot accumulation order; the weighted reduce runs in
+    // top-k order). Default OFF until validated (issue #410 constraint); the
+    // per-token loop remains the byte-exact oracle either way.
+    internal static bool BatchedCpuMoePrefillEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_HYBRID_BATCHED_MOE") == "1";
+
+    // Test observable (issue #410): whether the last Prefill's FFN stage ran the batched
+    // CPU-MoE path (vs the per-token loop). Non-vacuous parity assertions, same idea as
+    // LastPrefillWasBatched.
+    internal bool LastPrefillUsedBatchedCpuMoe;
+
     // Test observable (issue #230): the resolved GPU KV-cache dtype. Lets the parity oracle
     // confirm --kv-type actually applied (the cache is genuinely narrowed) instead of passing
     // vacuously if the env plumbing regressed and KV silently stayed fp32 (fp32-vs-fp32 is
@@ -242,6 +261,40 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // H2D, so there is no per-token write-after-read on a shared buffer.
     private Tensor? _pinnedEmbedAll;
     private int _pinnedEmbedAllN;
+
+    // Issue #410: host scratch for the batched CPU-MoE prefill, allocated lazily by
+    // EnsureBatchedMoeScratch(N) (exact-size on N change; the CSR arrays whose size
+    // depends only on numExperts are allocated once). Two dedicated pinned staging
+    // buffers carry the per-layer batched transfers: _bmPinnedNorm (D2H, all N post-
+    // FFN-norm rows) and _bmPinnedRouted (H2D, all N routed-MoE outputs) — distinct
+    // buffers so the routed writes never race the norm reads that Phase A is doing.
+    private Tensor? _bmPinnedNorm;     // pinned [N × embDim] — post-FFN-norm rows (D2H)
+    private Tensor? _bmPinnedRouted;   // pinned [N × embDim] — routed-MoE outputs (H2D)
+    private int   _bmPinnedN;
+    private int*   _bmSelected;        // [N × numActive] — per-token selected experts
+    private float* _bmWeights;         // [N × numActive] — per-token expert weights
+    private int*   _bmExpStart;        // [numExperts+1] — CSR offsets into _bmExpTok*
+    private int*   _bmExpCursor;       // [numExperts]   — CSR fill cursors
+    private int*   _bmUsedExperts;     // [numExperts]   — experts with ≥1 token
+    private int*   _bmExpTokI;         // [N × numActive] — CSR (token) pairs
+    private int*   _bmExpTokK;         // [N × numActive] — CSR (slot) pairs
+    private float* _bmGateAll;         // [N × numActive × expertDim] — gate projections
+    private float* _bmUpAll;           // [N × numActive × expertDim] — up projections
+    private float* _bmDownPartial;     // [N × numActive × embDim] — unweighted down partials
+    private int _bmCapN;               // current token capacity of the N-sized slabs
+
+    // Issue #410 (int8 tier): Q8_KS-prepacked activations for the batched routed dots,
+    // mirroring the GDN pass (issue #107). Each token's norm row (Phase A) and silu'd
+    // gate slice (Phase C) is quantized ONCE and every weight row hits the int-domain
+    // dot kernels — ~4× less activation read traffic plus AVX2-VNNI int8 dots. Gates
+    // resolve like the GDN pass: auto-on per routed dtype, except Q4_K stays off on
+    // AVX-512 hardware where the f32 AVX-512 dot wins (SHARPI_Q3K_Q8K / SHARPI_Q8_0_Q8K /
+    // SHARPI_Q4K_Q8K override). NOT byte-exact vs the f32 dots — the bitwise oracles pin
+    // these OFF; argmax-stability is asserted separately.
+    private readonly bool _q3kQ8KEnabled, _q8_0Q8KEnabled, _q4kQ8KEnabled;
+    private byte* _bmNormAllQ8K;       // [N × _bmQ8KEmbStride] — prepacked norm rows
+    private byte* _bmGateAllQ8K;       // [N × numActive × _bmQ8KExpStride] — prepacked silu'd gates
+    private readonly int _bmQ8KEmbStride, _bmQ8KExpStride;
 
     // Non-transactional fault latch (mirror of CudaHybridGdnForwardPass._faulted):
     // set at batched-prefill entry, cleared only after the KV/position counters have
@@ -388,6 +441,31 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         else
         {
             _cpuMoe = false;
+        }
+
+        // Issue #410 (int8 tier): resolve the Q8_KS activation-prepack gates for the
+        // batched CPU-MoE prefill — the same auto logic as CudaHybridGdnForwardPass
+        // (Q4_K int8 only where AVX-512 is absent; there the f32 AVX-512 dot wins).
+        // Only meaningful under CPU-MoE + the batched prefill flag; left false otherwise
+        // so EnsureBatchedMoeScratch never allocates the prepack slabs.
+        if (_cpuMoe && BatchedCpuMoePrefillEnabled)
+        {
+            _q3kQ8KEnabled = CudaHybridGdnForwardPass.ResolveGate("SHARPI_Q3K_Q8K",
+                CudaHybridGdnForwardPass.HasRoutedExpertsOfDType(model, hp, DType.Q3_K));
+            _q8_0Q8KEnabled = CudaHybridGdnForwardPass.ResolveGate("SHARPI_Q8_0_Q8K",
+                CudaHybridGdnForwardPass.HasRoutedExpertsOfDType(model, hp, DType.Q8_0));
+            _q4kQ8KEnabled = CudaHybridGdnForwardPass.ResolveGate("SHARPI_Q4K_Q8K",
+                CudaHybridGdnForwardPass.HasRoutedExpertsOfDType(model, hp, DType.Q4_K)
+                && !System.Runtime.Intrinsics.Vector512.IsHardwareAccelerated);
+            if (_q3kQ8KEnabled || _q8_0Q8KEnabled || _q4kQ8KEnabled)
+            {
+                _bmQ8KEmbStride = SimdKernels.Q8KSScratchBytes(_embDim);
+                _bmQ8KExpStride = SimdKernels.Q8KSScratchBytes(_expertDim);
+                Console.Error.WriteLine(
+                    $"[CudaHybridForwardPass] Batched CPU-MoE Q8_K-input kernels enabled " +
+                    $"(Q3_K:{_q3kQ8KEnabled} Q8_0:{_q8_0Q8KEnabled} Q4_K:{_q4kQ8KEnabled}). " +
+                    "Override with SHARPI_Q3K_Q8K=0 / SHARPI_Q8_0_Q8K=0 / SHARPI_Q4K_Q8K=0.");
+            }
         }
 
         string kvTag = _kvDType switch { DType.BFloat16 => " [KV bf16]", DType.Q8_0 => " [KV q8_0]", _ => "" };
@@ -1106,6 +1184,7 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     {
         ThrowIfFaulted();
         int n = tokens.Count;
+        LastPrefillUsedBatchedCpuMoe = false;   // set by the #410 FFN stage when it runs
         // Issue #123: batched-trunk prefill for the supported pure-attention configs
         // (non-Gemma4, non-TurboQuant, NEOX RoPE, learned/no QK-norm — never L2). The
         // batched trunk collapses the per-position attention launches whose cost grows
@@ -1230,6 +1309,481 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         _pinnedEmbedAll = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
         _pinnedEmbedAllN = n;
         return _pinnedEmbedAll;
+    }
+
+    // ================================================================
+    //  Issue #410: batched CPU-MoE routed-expert prefill
+    // ================================================================
+
+    private static readonly ParallelOptions s_moeParallelOpts = new()
+    {
+        MaxDegreeOfParallelism = ResolveMoeThreads()
+    };
+
+    private static int ResolveMoeThreads()
+    {
+        var v = Environment.GetEnvironmentVariable("SHARPI_MOE_THREADS");
+        if (int.TryParse(v, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out int n) && n > 0)
+            return n;
+        return Environment.ProcessorCount;
+    }
+
+    // Dot-dispatch shims over the GDN pass's shared kernels (issues #112/#114): decode a
+    // quantized weight row once and dot it against 1/2/4 token inputs. Bit-identical to
+    // repeated single dots — the multi-input kernels mirror the single accumulation order.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float DispatchDot(byte* row, float* input, int cols, DType dtype) =>
+        CudaHybridGdnForwardPass.DispatchDot(row, input, cols, dtype);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDot2In(byte* row, float* in1, float* in2, int cols, DType dtype,
+        out float v1, out float v2) =>
+        CudaHybridGdnForwardPass.DispatchDot2In(row, in1, in2, cols, dtype, out v1, out v2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDot4In(byte* row, float* in0, float* in1, float* in2, float* in3,
+        int cols, DType dtype, out float v0, out float v1, out float v2, out float v3) =>
+        CudaHybridGdnForwardPass.DispatchDot4In(row, in0, in1, in2, in3, cols, dtype,
+            out v0, out v1, out v2, out v3);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float DispatchDotQ8K(byte* row, byte* q8kScratch, int cols, DType dtype) =>
+        CudaHybridGdnForwardPass.DispatchDotQ8K(row, q8kScratch, cols, dtype);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDotQ8K2In(byte* row, byte* s0, byte* s1, int cols, DType dtype,
+        out float v0, out float v1) =>
+        CudaHybridGdnForwardPass.DispatchDotQ8K2In(row, s0, s1, cols, dtype, out v0, out v1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DispatchDotQ8K4In(byte* row, byte* s0, byte* s1, byte* s2, byte* s3,
+        int cols, DType dtype, out float v0, out float v1, out float v2, out float v3) =>
+        CudaHybridGdnForwardPass.DispatchDotQ8K4In(row, s0, s1, s2, s3, cols, dtype,
+            out v0, out v1, out v2, out v3);
+
+    /// <summary>
+    /// Whether the #410 batched CPU-MoE FFN stage handles this prefill. Requires the
+    /// flag, a CPU-MoE routed model, and the configs the batched scheme reproduces
+    /// bit-identically: no shared expert (Qwen3-Coder / OLMoE have none — the shared-
+    /// expert GPU overlap of <see cref="GpuTrunkCpuMoeFfn"/> is not ported), softmax
+    /// gating (the batched weighted reduce runs post-SiLU; sigmoid gating scales
+    /// gate/up PRE-SiLU, a different dataflow), and expert dtypes with a host dot
+    /// kernel. Everything else falls back to the per-token FFN loop.
+    /// </summary>
+    private bool UseBatchedCpuMoe(int n) =>
+        BatchedCpuMoePrefillEnabled && _isMoE && _cpuMoe && n >= 2
+        && !_hasSharedExpert && !_hp.UseSigmoidGating
+        && BatchedCpuMoeWeightsSupported();
+
+    private bool? _bmWeightsSupported;
+
+    // The batched routed-expert dots only cover the dtypes DispatchDot handles, and the
+    // per-row byte stride below assumes cols divides the block size evenly. Checked once
+    // (immutable weights), cached.
+    private bool BatchedCpuMoeWeightsSupported()
+    {
+        if (_bmWeightsSupported is { } cached) return cached;
+        bool ok = _cpuMoeGateInp is not null && _cpuMoeGateExps is not null;
+        for (int i = 0; ok && i < _nGpuLayers; i++)
+            ok = Supported(_cpuMoeGateExps![i], _embDim)
+              && Supported(_cpuMoeUpExps![i],   _embDim)
+              && Supported(_cpuMoeDownExps![i], _expertDim);
+        _bmWeightsSupported = ok;
+        return ok;
+
+        static bool Supported(in CpuWeightRef w, int cols) =>
+            w.DataPtr != null
+            && w.DType is DType.Q3_K or DType.Q4_K or DType.Q5_K or DType.Q6_K
+                        or DType.Q8_0 or DType.Float32
+            && cols % DTypeInfo.BlockSize(w.DType) == 0;
+    }
+
+    /// <summary>
+    /// (Re)allocate the batched CPU-MoE host scratch for <paramref name="n"/> tokens.
+    /// The pinned staging buffers are exact-size (whole-buffer CopyDevice needs equal
+    /// element counts on both sides); the native slabs follow the same policy for
+    /// simplicity. The CSR arrays sized only by numExperts are allocated once.
+    /// </summary>
+    private void EnsureBatchedMoeScratch(int n)
+    {
+        int numExperts = _hp.NumExperts;
+        if (_bmExpStart == null)
+        {
+            _bmExpStart    = (int*)NativeMemory.Alloc((nuint)((numExperts + 1) * sizeof(int)));
+            _bmExpCursor   = (int*)NativeMemory.Alloc((nuint)(numExperts * sizeof(int)));
+            _bmUsedExperts = (int*)NativeMemory.Alloc((nuint)(numExperts * sizeof(int)));
+        }
+        if (_bmCapN != n)
+        {
+            FreeBatchedMoeTokenScratch();
+            long sel = (long)n * _hp.NumActiveExperts;
+            _bmSelected    = (int*)NativeMemory.Alloc((nuint)(sel * sizeof(int)));
+            _bmExpTokI     = (int*)NativeMemory.Alloc((nuint)(sel * sizeof(int)));
+            _bmExpTokK     = (int*)NativeMemory.Alloc((nuint)(sel * sizeof(int)));
+            _bmWeights     = (float*)NativeMemory.Alloc((nuint)(sel * sizeof(float)));
+            _bmGateAll     = (float*)NativeMemory.Alloc((nuint)(sel * _expertDim * sizeof(float)));
+            _bmUpAll       = (float*)NativeMemory.Alloc((nuint)(sel * _expertDim * sizeof(float)));
+            _bmDownPartial = (float*)NativeMemory.Alloc((nuint)(sel * _embDim * sizeof(float)));
+            if (_q3kQ8KEnabled || _q8_0Q8KEnabled || _q4kQ8KEnabled)
+            {
+                _bmNormAllQ8K = (byte*)NativeMemory.Alloc((nuint)((long)n * _bmQ8KEmbStride));
+                _bmGateAllQ8K = (byte*)NativeMemory.Alloc((nuint)(sel * _bmQ8KExpStride));
+            }
+            _bmCapN = n;
+        }
+        if (_bmPinnedN != n)
+        {
+            if (_bmPinnedNorm is { } pn)   { _gpu.Free(pn); _bmPinnedNorm = null; }
+            if (_bmPinnedRouted is { } pr) { _gpu.Free(pr); _bmPinnedRouted = null; }
+            _bmPinnedNorm   = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
+            _bmPinnedRouted = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
+            _bmPinnedN = n;
+        }
+    }
+
+    private void FreeBatchedMoeTokenScratch()
+    {
+        if (_bmSelected    != null) { NativeMemory.Free(_bmSelected);    _bmSelected = null; }
+        if (_bmExpTokI     != null) { NativeMemory.Free(_bmExpTokI);     _bmExpTokI = null; }
+        if (_bmExpTokK     != null) { NativeMemory.Free(_bmExpTokK);     _bmExpTokK = null; }
+        if (_bmWeights     != null) { NativeMemory.Free(_bmWeights);     _bmWeights = null; }
+        if (_bmGateAll     != null) { NativeMemory.Free(_bmGateAll);     _bmGateAll = null; }
+        if (_bmUpAll       != null) { NativeMemory.Free(_bmUpAll);       _bmUpAll = null; }
+        if (_bmDownPartial != null) { NativeMemory.Free(_bmDownPartial); _bmDownPartial = null; }
+        if (_bmNormAllQ8K  != null) { NativeMemory.Free(_bmNormAllQ8K);  _bmNormAllQ8K = null; }
+        if (_bmGateAllQ8K  != null) { NativeMemory.Free(_bmGateAllQ8K);  _bmGateAllQ8K = null; }
+        _bmCapN = 0;
+    }
+
+    private void FreeBatchedMoeScratch()
+    {
+        FreeBatchedMoeTokenScratch();
+        if (_bmExpStart    != null) { NativeMemory.Free(_bmExpStart);    _bmExpStart = null; }
+        if (_bmExpCursor   != null) { NativeMemory.Free(_bmExpCursor);   _bmExpCursor = null; }
+        if (_bmUsedExperts != null) { NativeMemory.Free(_bmUsedExperts); _bmUsedExperts = null; }
+        if (_bmPinnedNorm is { } pn)   { _gpu.Free(pn); _bmPinnedNorm = null; }
+        if (_bmPinnedRouted is { } pr) { _gpu.Free(pr); _bmPinnedRouted = null; }
+        _bmPinnedN = 0;
+    }
+
+    /// <summary>
+    /// Issue #410: the batched CPU-MoE FFN stage of one GPU layer — replaces the
+    /// per-token FFN/MoE loop at the tail of <see cref="GpuLayerBatchedTrunk"/> for
+    /// the configs <see cref="UseBatchedCpuMoe"/> admits. ONE D2H of all
+    /// <paramref name="n"/> post-FFN-norm rows, host router + top-k per token (the
+    /// exact <see cref="CpuMoeRouted"/> head on the same downloaded bytes), the
+    /// CSR-bucketed grouped expert dots of <see cref="BatchedRoutedExpertsCpu"/>,
+    /// then ONE H2D of the routed outputs and a single batched residual add:
+    /// stream = routed + (o-proj + pre-attn residual) — element-for-element the
+    /// values the per-token loop's row-wise AddInPlace produces.
+    /// </summary>
+    private void BatchedCpuMoeFfnStage(int layer, int n, Tensor normAll, Tensor blockOut, Tensor stream)
+    {
+        LastPrefillUsedBatchedCpuMoe = true;
+        int embDim = _embDim;
+        int na = _hp.NumActiveExperts;
+        int numExperts = _hp.NumExperts;
+
+        EnsureBatchedMoeScratch(n);
+
+        // 1. ONE D2H: every token's post-FFN-norm row.
+        _gpu.CopyDevice(_bmPinnedNorm!, normAll);
+        _gpu.Synchronize();
+        float* normHost = _gpu.MapPinned(_bmPinnedNorm!);
+
+        // 2. Router + top-k per token on the host. Same MatVec → Softmax → SelectTopK
+        //    sequence as CpuMoeRouted (sigmoid gating is gated out by UseBatchedCpuMoe)
+        //    on the same downloaded bytes → identical selections and weights.
+        var gateInp = _cpuMoeGateInp![layer];
+        Span<int> sel = stackalloc int[na];
+        Span<float> wts = stackalloc float[na];
+        for (int i = 0; i < n; i++)
+        {
+            float* normI = normHost + (long)i * embDim;
+            SimdKernels.MatVec(_cpuRouterLogits, gateInp.DataPtr, normI, numExperts, embDim, gateInp.DType);
+            SimdKernels.SoftmaxInPlace(_cpuRouterLogits, numExperts);
+            SelectTopK(_cpuRouterLogits, numExperts, na, sel, wts, _hp.NormalizeMoeTopKWeights);
+            for (int k = 0; k < na; k++)
+            {
+                _bmSelected[(long)i * na + k] = sel[k];
+                _bmWeights[(long)i * na + k] = wts[k];
+            }
+        }
+
+        // 3. Routed experts, CSR-bucketed grouped dots.
+        float* routedHost = _gpu.MapPinned(_bmPinnedRouted!);
+        BatchedRoutedExpertsCpu(layer, n, normHost, routedHost);
+        _gpu.UnmapPinned(_bmPinnedRouted!);
+        _gpu.UnmapPinned(_bmPinnedNorm!);
+
+        // 4. ONE H2D into the residual stream (its pre-attn contents are dead once
+        //    blockOut exists), then one batched elementwise add.
+        _gpu.CopyDevice(stream, _bmPinnedRouted!);
+        _gpu.AddInPlace(stream, blockOut);
+    }
+
+    /// <summary>
+    /// Port of <see cref="CudaHybridGdnForwardPass.BatchedRoutedExperts"/> (issues
+    /// #110/#112/#114) for the pure-attention qwen3moe path — f32-input tiers only
+    /// (no Q8_KS prepack yet). Buckets the (token, slot) pairs by selected expert
+    /// (CSR), then reads each expert weight row ONCE and dots it against all its
+    /// bucketed tokens in quads → pairs → single (each tier bit-identical to the
+    /// per-token dot), and finally reduces the unweighted down partials per token in
+    /// top-k order — the same `out += w · dot` accumulation order as
+    /// <see cref="ExpertMatVecDown"/> from a cleared output.
+    /// </summary>
+    private void BatchedRoutedExpertsCpu(int layer, int N, float* normAll, float* routedAll)
+    {
+        int embDim = _embDim;
+        int na = _hp.NumActiveExperts;
+        int expertDim = _expertDim;
+        int numExperts = _hp.NumExperts;
+
+        var gateExps = _cpuMoeGateExps![layer];
+        var upExps   = _cpuMoeUpExps![layer];
+        var downExps = _cpuMoeDownExps![layer];
+        byte* gateP = gateExps.DataPtr; byte* upP = upExps.DataPtr; byte* downP = downExps.DataPtr;
+        DType gateDt = gateExps.DType, upDt = upExps.DType, downDt = downExps.DType;
+
+        int bprG = (embDim    / DTypeInfo.BlockSize(gateDt)) * DTypeInfo.BytesPerBlock(gateDt);
+        int bprU = (embDim    / DTypeInfo.BlockSize(upDt))   * DTypeInfo.BytesPerBlock(upDt);
+        int bprD = (expertDim / DTypeInfo.BlockSize(downDt)) * DTypeInfo.BytesPerBlock(downDt);
+
+        bool useQ8KGate = (_q3kQ8KEnabled && gateDt == DType.Q3_K) || (_q8_0Q8KEnabled && gateDt == DType.Q8_0) || (_q4kQ8KEnabled && gateDt == DType.Q4_K);
+        bool useQ8KUp   = (_q3kQ8KEnabled && upDt   == DType.Q3_K) || (_q8_0Q8KEnabled && upDt   == DType.Q8_0) || (_q4kQ8KEnabled && upDt   == DType.Q4_K);
+        bool useQ8KDown = (_q3kQ8KEnabled && downDt == DType.Q3_K) || (_q8_0Q8KEnabled && downDt == DType.Q8_0) || (_q4kQ8KEnabled && downDt == DType.Q4_K);
+        byte* normAllQ8K = _bmNormAllQ8K; byte* gateAllQ8K = _bmGateAllQ8K;
+        int q8kEmbStride = _bmQ8KEmbStride, q8kExpStride = _bmQ8KExpStride;
+
+        // Bucket (token, slot) pairs by selected expert (CSR layout).
+        int* expStart = _bmExpStart!; int* cursor = _bmExpCursor!; int* used = _bmUsedExperts!;
+        int* selected = _bmSelected!;
+        for (int e = 0; e <= numExperts; e++) expStart[e] = 0;
+        long totalSel = (long)N * na;
+        for (long s = 0; s < totalSel; s++) expStart[selected[s] + 1]++;
+        for (int e = 0; e < numExperts; e++) expStart[e + 1] += expStart[e];
+        for (int e = 0; e < numExperts; e++) cursor[e] = expStart[e];
+        int* expTokI = _bmExpTokI!; int* expTokK = _bmExpTokK!;
+        for (int i = 0; i < N; i++)
+            for (int k = 0; k < na; k++)
+            {
+                int e = selected[(long)i * na + k];
+                int p = cursor[e]++;
+                expTokI[p] = i; expTokK[p] = k;
+            }
+        int numUsed = 0;
+        for (int e = 0; e < numExperts; e++)
+            if (expStart[e + 1] > expStart[e]) used[numUsed++] = e;
+
+        float* gateAll = _bmGateAll!; float* upAll = _bmUpAll!; float* downPartial = _bmDownPartial!;
+
+        // Q8_KS-prepack each token's norm once (shared across all gate/up rows).
+        if (useQ8KGate || useQ8KUp)
+            Parallel.For(0, N, s_moeParallelOpts, i =>
+                SimdKernels.QuantizeRowToQ8KS(normAll + (long)i * embDim, embDim,
+                    normAllQ8K + (long)i * q8kEmbStride));
+
+        // Phase A: gate + up. Parallelize over (used expert, row BLOCK); token quads are
+        // the OUTER loop inside a block so their 4 input rows, loaded into L1/L2 once,
+        // are reused across every weight row of the block (issue #410 row-blocking —
+        // without it the activation re-reads scale as rows × tokens and go L3-bound).
+        // Per-(row, token) math and accumulation order are unchanged → bit-identical.
+        int naL = na, expertDimL = expertDim, embDimL = embDim;
+        int rbA = Math.Clamp(262144 / Math.Max(bprG, bprU), 8, 64);
+        int blocksPerExpA = (expertDim + rbA - 1) / rbA;
+        Parallel.For(0, numUsed * blocksPerExpA, s_moeParallelOpts, idx =>
+        {
+            int u = idx / blocksPerExpA;
+            int e = used[u];
+            int rStart = (idx % blocksPerExpA) * rbA;
+            int rEnd = Math.Min(rStart + rbA, expertDimL);
+            byte* gateBase = gateP + (long)e * expertDimL * bprG;
+            byte* upBase   = upP   + (long)e * expertDimL * bprU;
+            int pStart = expStart[e], pEnd = expStart[e + 1];
+            int p = pStart;
+            for (; p + 3 < pEnd; p += 4)
+            {
+                int i0 = expTokI[p],     k0 = expTokK[p];
+                int i1 = expTokI[p + 1], k1 = expTokK[p + 1];
+                int i2 = expTokI[p + 2], k2 = expTokK[p + 2];
+                int i3 = expTokI[p + 3], k3 = expTokK[p + 3];
+                long o0 = ((long)i0 * naL + k0) * expertDimL;
+                long o1 = ((long)i1 * naL + k1) * expertDimL;
+                long o2 = ((long)i2 * naL + k2) * expertDimL;
+                long o3 = ((long)i3 * naL + k3) * expertDimL;
+                if (useQ8KGate || useQ8KUp)
+                {
+                    byte* q0 = normAllQ8K + (long)i0 * q8kEmbStride, q1 = normAllQ8K + (long)i1 * q8kEmbStride;
+                    byte* q2 = normAllQ8K + (long)i2 * q8kEmbStride, q3 = normAllQ8K + (long)i3 * q8kEmbStride;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDotQ8K4In(gateBase + (long)r * bprG, q0, q1, q2, q3, embDimL, gateDt,
+                            out float a0, out float a1, out float a2, out float a3);
+                        gateAll[o0 + r] = a0; gateAll[o1 + r] = a1; gateAll[o2 + r] = a2; gateAll[o3 + r] = a3;
+                        DispatchDotQ8K4In(upBase + (long)r * bprU, q0, q1, q2, q3, embDimL, upDt,
+                            out a0, out a1, out a2, out a3);
+                        upAll[o0 + r] = a0; upAll[o1 + r] = a1; upAll[o2 + r] = a2; upAll[o3 + r] = a3;
+                    }
+                }
+                else
+                {
+                    float* f0 = normAll + (long)i0 * embDimL, f1 = normAll + (long)i1 * embDimL;
+                    float* f2 = normAll + (long)i2 * embDimL, f3 = normAll + (long)i3 * embDimL;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDot4In(gateBase + (long)r * bprG, f0, f1, f2, f3, embDimL, gateDt,
+                            out float a0, out float a1, out float a2, out float a3);
+                        gateAll[o0 + r] = a0; gateAll[o1 + r] = a1; gateAll[o2 + r] = a2; gateAll[o3 + r] = a3;
+                        DispatchDot4In(upBase + (long)r * bprU, f0, f1, f2, f3, embDimL, upDt,
+                            out a0, out a1, out a2, out a3);
+                        upAll[o0 + r] = a0; upAll[o1 + r] = a1; upAll[o2 + r] = a2; upAll[o3 + r] = a3;
+                    }
+                }
+            }
+            for (; p + 1 < pEnd; p += 2)
+            {
+                int i0 = expTokI[p],     k0 = expTokK[p];
+                int i1 = expTokI[p + 1], k1 = expTokK[p + 1];
+                long o0 = ((long)i0 * naL + k0) * expertDimL;
+                long o1 = ((long)i1 * naL + k1) * expertDimL;
+                for (int r = rStart; r < rEnd; r++)
+                {
+                    float a0, a1;
+                    if (useQ8KGate)
+                        DispatchDotQ8K2In(gateBase + (long)r * bprG, normAllQ8K + (long)i0 * q8kEmbStride,
+                            normAllQ8K + (long)i1 * q8kEmbStride, embDimL, gateDt, out a0, out a1);
+                    else
+                        DispatchDot2In(gateBase + (long)r * bprG, normAll + (long)i0 * embDimL,
+                            normAll + (long)i1 * embDimL, embDimL, gateDt, out a0, out a1);
+                    gateAll[o0 + r] = a0; gateAll[o1 + r] = a1;
+                    if (useQ8KUp)
+                        DispatchDotQ8K2In(upBase + (long)r * bprU, normAllQ8K + (long)i0 * q8kEmbStride,
+                            normAllQ8K + (long)i1 * q8kEmbStride, embDimL, upDt, out a0, out a1);
+                    else
+                        DispatchDot2In(upBase + (long)r * bprU, normAll + (long)i0 * embDimL,
+                            normAll + (long)i1 * embDimL, embDimL, upDt, out a0, out a1);
+                    upAll[o0 + r] = a0; upAll[o1 + r] = a1;
+                }
+            }
+            if (p < pEnd) // odd remainder
+            {
+                int i = expTokI[p], k = expTokK[p];
+                long oBase = ((long)i * naL + k) * expertDimL;
+                for (int r = rStart; r < rEnd; r++)
+                {
+                    gateAll[oBase + r] = useQ8KGate
+                        ? DispatchDotQ8K(gateBase + (long)r * bprG, normAllQ8K + (long)i * q8kEmbStride, embDimL, gateDt)
+                        : DispatchDot(gateBase + (long)r * bprG, normAll + (long)i * embDimL, embDimL, gateDt);
+                    upAll[oBase + r] = useQ8KUp
+                        ? DispatchDotQ8K(upBase + (long)r * bprU, normAllQ8K + (long)i * q8kEmbStride, embDimL, upDt)
+                        : DispatchDot(upBase + (long)r * bprU, normAll + (long)i * embDimL, embDimL, upDt);
+                }
+            }
+        });
+
+        // Phase B: SiLU(gate) * up over the whole contiguous (token × slot × expertDim) block.
+        SimdKernels.SiLuMul(gateAll, upAll, (int)(totalSel * expertDim));
+
+        // Q8_KS-prepack each silu'd gate slice for the down dots.
+        if (useQ8KDown)
+            Parallel.For(0, (int)totalSel, s_moeParallelOpts, s =>
+                SimdKernels.QuantizeRowToQ8KS(gateAll + (long)s * expertDim, expertDim,
+                    gateAllQ8K + (long)s * q8kExpStride));
+
+        // Phase C: down. Parallelize over (used expert, emb-row BLOCK); same row-block
+        // structure as Phase A — a quad's 4 silu'd-gate slices are reused across every
+        // down row of the block. Store unweighted partials.
+        int rbC = Math.Clamp(262144 / bprD, 8, 64);
+        int blocksPerExpC = (embDim + rbC - 1) / rbC;
+        Parallel.For(0, numUsed * blocksPerExpC, s_moeParallelOpts, idx =>
+        {
+            int u = idx / blocksPerExpC;
+            int e = used[u];
+            int rStart = (idx % blocksPerExpC) * rbC;
+            int rEnd = Math.Min(rStart + rbC, embDimL);
+            byte* downBase = downP + (long)e * embDimL * bprD;
+            int pStart = expStart[e], pEnd = expStart[e + 1];
+            int p = pStart;
+            for (; p + 3 < pEnd; p += 4)
+            {
+                long s0 = (long)expTokI[p]     * naL + expTokK[p];
+                long s1 = (long)expTokI[p + 1] * naL + expTokK[p + 1];
+                long s2 = (long)expTokI[p + 2] * naL + expTokK[p + 2];
+                long s3 = (long)expTokI[p + 3] * naL + expTokK[p + 3];
+                if (useQ8KDown)
+                {
+                    byte* q0 = gateAllQ8K + s0 * q8kExpStride, q1 = gateAllQ8K + s1 * q8kExpStride;
+                    byte* q2 = gateAllQ8K + s2 * q8kExpStride, q3 = gateAllQ8K + s3 * q8kExpStride;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDotQ8K4In(downBase + (long)r * bprD, q0, q1, q2, q3, expertDimL, downDt,
+                            out float d0, out float d1, out float d2, out float d3);
+                        downPartial[s0 * embDimL + r] = d0;
+                        downPartial[s1 * embDimL + r] = d1;
+                        downPartial[s2 * embDimL + r] = d2;
+                        downPartial[s3 * embDimL + r] = d3;
+                    }
+                }
+                else
+                {
+                    float* g0 = gateAll + s0 * expertDimL, g1 = gateAll + s1 * expertDimL;
+                    float* g2 = gateAll + s2 * expertDimL, g3 = gateAll + s3 * expertDimL;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDot4In(downBase + (long)r * bprD, g0, g1, g2, g3, expertDimL, downDt,
+                            out float d0, out float d1, out float d2, out float d3);
+                        downPartial[s0 * embDimL + r] = d0;
+                        downPartial[s1 * embDimL + r] = d1;
+                        downPartial[s2 * embDimL + r] = d2;
+                        downPartial[s3 * embDimL + r] = d3;
+                    }
+                }
+            }
+            for (; p + 1 < pEnd; p += 2)
+            {
+                long s0 = (long)expTokI[p]     * naL + expTokK[p];
+                long s1 = (long)expTokI[p + 1] * naL + expTokK[p + 1];
+                for (int r = rStart; r < rEnd; r++)
+                {
+                    float d0, d1;
+                    if (useQ8KDown)
+                        DispatchDotQ8K2In(downBase + (long)r * bprD, gateAllQ8K + s0 * q8kExpStride,
+                            gateAllQ8K + s1 * q8kExpStride, expertDimL, downDt, out d0, out d1);
+                    else
+                        DispatchDot2In(downBase + (long)r * bprD, gateAll + s0 * expertDimL,
+                            gateAll + s1 * expertDimL, expertDimL, downDt, out d0, out d1);
+                    downPartial[s0 * embDimL + r] = d0;
+                    downPartial[s1 * embDimL + r] = d1;
+                }
+            }
+            if (p < pEnd) // odd remainder
+            {
+                long slot = (long)expTokI[p] * naL + expTokK[p];
+                for (int r = rStart; r < rEnd; r++)
+                    downPartial[slot * embDimL + r] = useQ8KDown
+                        ? DispatchDotQ8K(downBase + (long)r * bprD, gateAllQ8K + slot * q8kExpStride, expertDimL, downDt)
+                        : DispatchDot(downBase + (long)r * bprD, gateAll + slot * expertDimL, expertDimL, downDt);
+            }
+        });
+
+        // Reduce: per token, sum the numActive weighted down partials in top-k order —
+        // bit-identical to the sequential `out += w * dot` loop from a cleared output.
+        float* weights = _bmWeights!;
+        Parallel.For(0, N, s_moeParallelOpts, i =>
+        {
+            float* outp = routedAll + (long)i * embDimL;
+            for (int r = 0; r < embDimL; r++)
+            {
+                float sum = 0f;
+                for (int k = 0; k < naL; k++)
+                {
+                    long slot = (long)i * naL + k;
+                    sum += weights[slot] * downPartial[slot * embDimL + r];
+                }
+                outp[r] = sum;
+            }
+        });
     }
 
     /// <summary>
@@ -1452,6 +2006,16 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
 
         // ── FFN norm (batched) over the post-attn residual.
         _gpu.RmsNormBatched(normAll, blockOut, _gpuFfnNorm[i], n, _embDim, _hp.RmsNormEps);
+
+        // ── FFN / MoE stage. Issue #410: when the batched CPU-MoE path qualifies, run the
+        //    routed experts for ALL n tokens in one CSR-bucketed pass (one D2H of normAll,
+        //    host router + grouped expert dots, one H2D of the routed outputs) instead of
+        //    the per-token loop below — bit-identical, just amortized.
+        if (UseBatchedCpuMoe(n))
+        {
+            BatchedCpuMoeFfnStage(i, n, normAll, blockOut, stream);
+            return;
+        }
 
         // ── FFN / MoE stage: per token (issue #123 scope is the trunk). Reuse the exact
         //    single-token GpuMoeFfn/GpuDenseFfn (reads _gpuNormBuf, writes _gpuHidden), then
@@ -3325,6 +3889,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_pinnedHiddenAll is { } pha) { _gpu.Free(pha); _pinnedHiddenAll = null; }
         // Issue #218: batched CPU-embed staging buffer.
         if (_pinnedEmbedAll is { } pea) { _gpu.Free(pea); _pinnedEmbedAll = null; }
+        // Issue #410: batched CPU-MoE prefill scratch (native slabs + pinned staging).
+        FreeBatchedMoeScratch();
 
         for (int i = 0; i < _nGpuLayers; i++)
         {

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -212,10 +212,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // (issues #110/#112/#114): ONE D2H of all N post-FFN-norm rows per layer, host
     // router + top-k per token, per-expert (token,slot) bucketing, grouped gate/up/
     // down dots that decode each quantized weight row once per token-quad, then ONE
-    // H2D of the routed outputs. Bit-identical to the per-token path (the 2In/4In
-    // kernels mirror the single-dot accumulation order; the weighted reduce runs in
-    // top-k order). Default OFF until validated (issue #410 constraint); the
-    // per-token loop remains the byte-exact oracle either way.
+    // H2D of the routed outputs. The f32 tier is bit-identical to the per-token path
+    // (the 2In/4In kernels mirror the single-dot accumulation order; the weighted
+    // reduce runs in top-k order) — but the Q8_KS int8 tier AUTO-ENABLES per expert
+    // dtype (see _q3kQ8KEnabled et al.) and is argmax-stable, NOT byte-exact: pin
+    // SHARPI_Q3K_Q8K=0 / SHARPI_Q8_0_Q8K=0 / SHARPI_Q4K_Q8K=0 for byte parity with
+    // the per-token oracle. Default OFF until validated (issue #410 constraint).
     internal static bool BatchedCpuMoePrefillEnabled =
         Environment.GetEnvironmentVariable("SHARPI_HYBRID_BATCHED_MOE") == "1";
 
@@ -270,7 +272,6 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // buffers so the routed writes never race the norm reads that Phase A is doing.
     private Tensor? _bmPinnedNorm;     // pinned [N × embDim] — post-FFN-norm rows (D2H)
     private Tensor? _bmPinnedRouted;   // pinned [N × embDim] — routed-MoE outputs (H2D)
-    private int   _bmPinnedN;
     private int*   _bmSelected;        // [N × numActive] — per-token selected experts
     private float* _bmWeights;         // [N × numActive] — per-token expert weights
     private int*   _bmExpStart;        // [numExperts+1] — CSR offsets into _bmExpTok*
@@ -446,9 +447,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // Issue #410 (int8 tier): resolve the Q8_KS activation-prepack gates for the
         // batched CPU-MoE prefill — the same auto logic as CudaHybridGdnForwardPass
         // (Q4_K int8 only where AVX-512 is absent; there the f32 AVX-512 dot wins).
-        // Only meaningful under CPU-MoE + the batched prefill flag; left false otherwise
-        // so EnsureBatchedMoeScratch never allocates the prepack slabs.
-        if (_cpuMoe && BatchedCpuMoePrefillEnabled)
+        // Resolved for every CPU-MoE instance regardless of BatchedCpuMoePrefillEnabled:
+        // that static is mutable (tests toggle it between constructions), and gating the
+        // readonly fields on its ctor-time value would silently pin the int8 tier off
+        // for an instance constructed before the flag was enabled. The gates are a cheap
+        // metadata scan; the prepack slabs are only allocated when the path actually runs.
+        if (_cpuMoe)
         {
             _q3kQ8KEnabled = CudaHybridGdnForwardPass.ResolveGate("SHARPI_Q3K_Q8K",
                 CudaHybridGdnForwardPass.HasRoutedExpertsOfDType(model, hp, DType.Q3_K));
@@ -1315,19 +1319,9 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     //  Issue #410: batched CPU-MoE routed-expert prefill
     // ================================================================
 
-    private static readonly ParallelOptions s_moeParallelOpts = new()
-    {
-        MaxDegreeOfParallelism = ResolveMoeThreads()
-    };
-
-    private static int ResolveMoeThreads()
-    {
-        var v = Environment.GetEnvironmentVariable("SHARPI_MOE_THREADS");
-        if (int.TryParse(v, System.Globalization.NumberStyles.Integer,
-                System.Globalization.CultureInfo.InvariantCulture, out int n) && n > 0)
-            return n;
-        return Environment.ProcessorCount;
-    }
+    // Shared with the GDN pass (SHARPI_MOE_THREADS-resolved ParallelOptions), same as
+    // the DispatchDot* kernels below — one resolver, not a fourth per-file copy.
+    private static ParallelOptions s_moeParallelOpts => CudaHybridGdnForwardPass.MoeParallelOpts;
 
     // Dot-dispatch shims over the GDN pass's shared kernels (issues #112/#114): decode a
     // quantized weight row once and dot it against 1/2/4 token inputs. Bit-identical to
@@ -1374,13 +1368,19 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     private bool UseBatchedCpuMoe(int n) =>
         BatchedCpuMoePrefillEnabled && _isMoE && _cpuMoe && n >= 2
         && !_hasSharedExpert && !_hp.UseSigmoidGating
+        // Int-safety (mirror of the GDN pass's cpuMoeBatchSafe guard): Phase B's SiLuMul
+        // takes an int element count over [N × numActive × expertDim] — an enormous
+        // unchunked prefill must fall back rather than silently truncate the cast.
+        && (long)n * _hp.NumActiveExperts * Math.Max(_expertDim, _embDim) <= int.MaxValue
         && BatchedCpuMoeWeightsSupported();
 
     private bool? _bmWeightsSupported;
 
-    // The batched routed-expert dots only cover the dtypes DispatchDot handles, and the
-    // per-row byte stride below assumes cols divides the block size evenly. Checked once
-    // (immutable weights), cached.
+    // The batched routed-expert dots only cover the dtypes whose per-token oracle
+    // (SimdKernels.MatVec) uses the SAME per-row Dot* kernel — Q8_0 is excluded because
+    // MatVec has no fused Q8_0 case (it dequant-falls-back to DotF32, which is not
+    // bit-identical to the batched DotQ8_0). The per-row byte stride below also assumes
+    // cols divides the block size evenly. Checked once (immutable weights), cached.
     private bool BatchedCpuMoeWeightsSupported()
     {
         if (_bmWeightsSupported is { } cached) return cached;
@@ -1395,7 +1395,7 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         static bool Supported(in CpuWeightRef w, int cols) =>
             w.DataPtr != null
             && w.DType is DType.Q3_K or DType.Q4_K or DType.Q5_K or DType.Q6_K
-                        or DType.Q8_0 or DType.Float32
+                        or DType.Float32
             && cols % DTypeInfo.BlockSize(w.DType) == 0;
     }
 
@@ -1430,15 +1430,9 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 _bmNormAllQ8K = (byte*)NativeMemory.Alloc((nuint)((long)n * _bmQ8KEmbStride));
                 _bmGateAllQ8K = (byte*)NativeMemory.Alloc((nuint)(sel * _bmQ8KExpStride));
             }
-            _bmCapN = n;
-        }
-        if (_bmPinnedN != n)
-        {
-            if (_bmPinnedNorm is { } pn)   { _gpu.Free(pn); _bmPinnedNorm = null; }
-            if (_bmPinnedRouted is { } pr) { _gpu.Free(pr); _bmPinnedRouted = null; }
             _bmPinnedNorm   = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
             _bmPinnedRouted = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
-            _bmPinnedN = n;
+            _bmCapN = n;
         }
     }
 
@@ -1453,6 +1447,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_bmDownPartial != null) { NativeMemory.Free(_bmDownPartial); _bmDownPartial = null; }
         if (_bmNormAllQ8K  != null) { NativeMemory.Free(_bmNormAllQ8K);  _bmNormAllQ8K = null; }
         if (_bmGateAllQ8K  != null) { NativeMemory.Free(_bmGateAllQ8K);  _bmGateAllQ8K = null; }
+        if (_bmPinnedNorm is { } pn)   { _gpu.Free(pn); _bmPinnedNorm = null; }
+        if (_bmPinnedRouted is { } pr) { _gpu.Free(pr); _bmPinnedRouted = null; }
         _bmCapN = 0;
     }
 
@@ -1462,9 +1458,6 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_bmExpStart    != null) { NativeMemory.Free(_bmExpStart);    _bmExpStart = null; }
         if (_bmExpCursor   != null) { NativeMemory.Free(_bmExpCursor);   _bmExpCursor = null; }
         if (_bmUsedExperts != null) { NativeMemory.Free(_bmUsedExperts); _bmUsedExperts = null; }
-        if (_bmPinnedNorm is { } pn)   { _gpu.Free(pn); _bmPinnedNorm = null; }
-        if (_bmPinnedRouted is { } pr) { _gpu.Free(pr); _bmPinnedRouted = null; }
-        _bmPinnedN = 0;
     }
 
     /// <summary>
@@ -1612,33 +1605,35 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 long o1 = ((long)i1 * naL + k1) * expertDimL;
                 long o2 = ((long)i2 * naL + k2) * expertDimL;
                 long o3 = ((long)i3 * naL + k3) * expertDimL;
+                // Per-PROJECTION int8/f32 branch (mirrors the pair/single tiers and the
+                // GDN original): gate and up may have different dtypes (mixed-quant
+                // GGUFs), so a merged branch would push a Q8K-less dtype through the
+                // int8 dispatch (throws) or silently override a per-dtype gate.
+                float* f0 = normAll + (long)i0 * embDimL, f1 = normAll + (long)i1 * embDimL;
+                float* f2 = normAll + (long)i2 * embDimL, f3 = normAll + (long)i3 * embDimL;
+                byte* q0 = null, q1 = null, q2 = null, q3 = null;
                 if (useQ8KGate || useQ8KUp)
                 {
-                    byte* q0 = normAllQ8K + (long)i0 * q8kEmbStride, q1 = normAllQ8K + (long)i1 * q8kEmbStride;
-                    byte* q2 = normAllQ8K + (long)i2 * q8kEmbStride, q3 = normAllQ8K + (long)i3 * q8kEmbStride;
-                    for (int r = rStart; r < rEnd; r++)
-                    {
+                    q0 = normAllQ8K + (long)i0 * q8kEmbStride; q1 = normAllQ8K + (long)i1 * q8kEmbStride;
+                    q2 = normAllQ8K + (long)i2 * q8kEmbStride; q3 = normAllQ8K + (long)i3 * q8kEmbStride;
+                }
+                for (int r = rStart; r < rEnd; r++)
+                {
+                    float a0, a1, a2, a3;
+                    if (useQ8KGate)
                         DispatchDotQ8K4In(gateBase + (long)r * bprG, q0, q1, q2, q3, embDimL, gateDt,
-                            out float a0, out float a1, out float a2, out float a3);
-                        gateAll[o0 + r] = a0; gateAll[o1 + r] = a1; gateAll[o2 + r] = a2; gateAll[o3 + r] = a3;
+                            out a0, out a1, out a2, out a3);
+                    else
+                        DispatchDot4In(gateBase + (long)r * bprG, f0, f1, f2, f3, embDimL, gateDt,
+                            out a0, out a1, out a2, out a3);
+                    gateAll[o0 + r] = a0; gateAll[o1 + r] = a1; gateAll[o2 + r] = a2; gateAll[o3 + r] = a3;
+                    if (useQ8KUp)
                         DispatchDotQ8K4In(upBase + (long)r * bprU, q0, q1, q2, q3, embDimL, upDt,
                             out a0, out a1, out a2, out a3);
-                        upAll[o0 + r] = a0; upAll[o1 + r] = a1; upAll[o2 + r] = a2; upAll[o3 + r] = a3;
-                    }
-                }
-                else
-                {
-                    float* f0 = normAll + (long)i0 * embDimL, f1 = normAll + (long)i1 * embDimL;
-                    float* f2 = normAll + (long)i2 * embDimL, f3 = normAll + (long)i3 * embDimL;
-                    for (int r = rStart; r < rEnd; r++)
-                    {
-                        DispatchDot4In(gateBase + (long)r * bprG, f0, f1, f2, f3, embDimL, gateDt,
-                            out float a0, out float a1, out float a2, out float a3);
-                        gateAll[o0 + r] = a0; gateAll[o1 + r] = a1; gateAll[o2 + r] = a2; gateAll[o3 + r] = a3;
+                    else
                         DispatchDot4In(upBase + (long)r * bprU, f0, f1, f2, f3, embDimL, upDt,
                             out a0, out a1, out a2, out a3);
-                        upAll[o0 + r] = a0; upAll[o1 + r] = a1; upAll[o2 + r] = a2; upAll[o3 + r] = a3;
-                    }
+                    upAll[o0 + r] = a0; upAll[o1 + r] = a1; upAll[o2 + r] = a2; upAll[o3 + r] = a3;
                 }
             }
             for (; p + 1 < pEnd; p += 2)
@@ -2010,32 +2005,35 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         // ── FFN / MoE stage. Issue #410: when the batched CPU-MoE path qualifies, run the
         //    routed experts for ALL n tokens in one CSR-bucketed pass (one D2H of normAll,
         //    host router + grouped expert dots, one H2D of the routed outputs) instead of
-        //    the per-token loop below — bit-identical, just amortized.
+        //    the per-token loop — bit-identical in the f32 tier (int8 tier argmax-stable,
+        //    see BatchedCpuMoePrefillEnabled), just amortized.
         if (UseBatchedCpuMoe(n))
         {
             BatchedCpuMoeFfnStage(i, n, normAll, blockOut, stream);
-            return;
         }
-
-        // ── FFN / MoE stage: per token (issue #123 scope is the trunk). Reuse the exact
-        //    single-token GpuMoeFfn/GpuDenseFfn (reads _gpuNormBuf, writes _gpuHidden), then
-        //    add the post-attn residual row and scatter the new hidden back into the stream.
-        for (int t = 0; t < n; t++)
+        else
         {
-            _gpu.CopyDeviceRegion(_gpuNormBuf, 0, normAll, (long)t * _embDim * sizeof(float),
-                                  (long)_embDim * sizeof(float));
-            if (_isMoE)
+            // ── FFN / MoE stage: per token (issue #123 scope is the trunk). Reuse the exact
+            //    single-token GpuMoeFfn/GpuDenseFfn (reads _gpuNormBuf, writes _gpuHidden),
+            //    then add the post-attn residual row and scatter the new hidden back into
+            //    the stream.
+            for (int t = 0; t < n; t++)
             {
-                if (_cpuMoe) GpuTrunkCpuMoeFfn(i);
-                else         GpuMoeFfn(i);
-            }
-            else GpuDenseFfn(i);
+                _gpu.CopyDeviceRegion(_gpuNormBuf, 0, normAll, (long)t * _embDim * sizeof(float),
+                                      (long)_embDim * sizeof(float));
+                if (_isMoE)
+                {
+                    if (_cpuMoe) GpuTrunkCpuMoeFfn(i);
+                    else         GpuMoeFfn(i);
+                }
+                else GpuDenseFfn(i);
 
-            _gpu.CopyDeviceRegion(_gpuResidual, 0, blockOut, (long)t * _embDim * sizeof(float),
-                                  (long)_embDim * sizeof(float));
-            _gpu.AddInPlace(_gpuHidden, _gpuResidual);
-            _gpu.CopyDeviceRegion(stream, (long)t * _embDim * sizeof(float),
-                                  _gpuHidden, 0, (long)_embDim * sizeof(float));
+                _gpu.CopyDeviceRegion(_gpuResidual, 0, blockOut, (long)t * _embDim * sizeof(float),
+                                      (long)_embDim * sizeof(float));
+                _gpu.AddInPlace(_gpuHidden, _gpuResidual);
+                _gpu.CopyDeviceRegion(stream, (long)t * _embDim * sizeof(float),
+                                      _gpuHidden, 0, (long)_embDim * sizeof(float));
+            }
         }
     }
 

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -879,6 +879,50 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     internal static bool BatchedAttnEnabled =
         Environment.GetEnvironmentVariable("SHARPI_BATCHED_ATTN") != "0";
 
+    // ── Issue #410: batched CPU dense-FFN prefill ────────────────────────────
+    // On dense GDN models whose FFN layers stay CPU-mmap'd (27B-MTP: 46 of 64 layers,
+    // ~8.6 GB at Q4_K_M — TryUploadDenseFfnLayers couldn't fit them), the batched-trunk
+    // prefill still ran the dense FFN per token: N × (D2H norm → CpuDenseFfn matvec →
+    // H2D), re-streaming the FFN weights from DRAM for every prompt token. When ON,
+    // those layers instead run ONE D2H of all N norm rows, then grouped gate/up/down
+    // dots that read each quantized weight row ONCE and dot it against all N tokens in
+    // quads (#114) / pairs (#112) / a single — N/tile DRAM passes over the FFN weights
+    // per chunk instead of N — then ONE H2D of the new stream rows. Bit-identical to the
+    // per-token path (the multi-input kernels mirror the single accumulation order).
+    // Default OFF until validated (issue #410 constraint) — and see the KNOWN LIMIT note
+    // on the _bd* scratch fields: without row-blocked kernels the activation cache
+    // traffic currently outweighs the weight-read win. Decode is untouched.
+    internal static bool BatchedCpuDenseFfnEnabled =
+        Environment.GetEnvironmentVariable("SHARPI_BATCHED_CPU_FFN") == "1";
+
+    // Test observable (issue #410): whether the last Prefill ran the batched CPU
+    // dense-FFN stage for at least one layer (vs the per-token fallback loop).
+    internal bool LastPrefillUsedBatchedCpuFfn;
+
+    // Issue #410: host scratch for the batched CPU dense-FFN prefill, allocated lazily
+    // by EnsureBatchedDenseScratch(N) (exact-size on N change). The gate/up slabs are
+    // TILE-sized, not N-sized: the phases process tokens in tiles of _bdTile so the
+    // [tile × intermDim] silu'd-gate slab stays cache-resident while Phase C sweeps the
+    // down rows (untiled at N=810 it is ~56 MB — no L3 holds that, so every down row
+    // re-streamed it from DRAM). Weights are re-read N/tile times per layer instead of
+    // once — still ~tile× fewer weight passes than the per-token loop.
+    //
+    // KNOWN LIMIT (laptop measurement, 2026-07-02, Core Ultra 9 185H / 24 MB L3): the
+    // grouped 1-row × 4-input dots trade the per-token path's weight DRAM traffic for
+    // ACTIVATION cache traffic that tiling does not reduce — every weight row re-reads
+    // its tile's inputs (rows × N × dim × 4 B per layer ≈ 290 GB at N=810), so the
+    // stage measured 1.2 t/s vs the per-token path's DRAM-bound 3.1 t/s there. Closing
+    // this needs register-blocking on the ROW dimension as well (an R×4 multi-row
+    // multi-input kernel that reuses each input load R times), or a BLAS tile path.
+    // Hence the flag stays default-off; re-evaluate on the desktop (issue #410).
+    private float* _bdNormAll;     // [N × embDim]       — FFN-norm inputs (one D2H)
+    private float* _bdResidAll;    // [N × embDim]       — post-block residuals (one D2H)
+    private float* _bdGateAll;     // [tile × intermDim] — gate projections → silu'd
+    private float* _bdUpAll;       // [tile × intermDim] — up projections
+    private float* _bdHiddenAll;   // [N × embDim]       — FFN output + residual (one H2D)
+    private int _bdCapN;
+    private int _bdTile;           // tokens per tile (~8 MB of gate slab, multiple of 4)
+
     public int VocabSize => _hp.VocabSize;
     public int MaxSeqLen => _maxSeqLen;
     public LayerPlacement Placement => _placement;
@@ -1728,6 +1772,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             throw new ArgumentException("Token list is empty", nameof(tokens));
 
         int N = tokens.Count;
+        LastPrefillUsedBatchedCpuFfn = false;   // set by the #410 dense-FFN stage when it runs
 
         // Size the hidden buffer up front so Forward's per-step writes don't
         // each trigger a grow.
@@ -2821,6 +2866,13 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 _gpu.AddInPlace(_gpuBfHiddenAll!, blockOut);
                 _gpu.CopyDeviceRegion(stream, 0, _gpuBfHiddenAll!, 0, (long)N * embDim * sizeof(float));
             }
+            else if (!isMoe && !denseGpuLayer && UseBatchedCpuDenseFfn(layer, N))
+            {
+                // Issue #410: CPU-mmap dense-FFN layer, batched over all N prompt tokens —
+                // one D2H, grouped weight-row dots, one H2D — instead of the per-token
+                // Download → CpuDenseFfn → UploadInto loop below. Bit-identical.
+                BatchedCpuDenseFfnStage(layer, N, moeNorm, blockOut, stream);
+            }
             else
             {
                 for (int i = 0; i < N; i++)
@@ -2910,6 +2962,235 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// <see cref="CpuMoeFfnCore"/> is preserved: identical dot kernels, identical
     /// per-token top-k accumulation order in the final reduce.
     /// </summary>
+    // ================================================================
+    //  Issue #410: batched CPU dense-FFN prefill (dense GDN, e.g. 27B-MTP)
+    // ================================================================
+
+    /// <summary>
+    /// Whether the #410 batched CPU dense-FFN stage handles this layer's prefill FFN.
+    /// Requires the flag, dtypes the grouped dot dispatch covers, block-aligned dims
+    /// (the per-row byte stride assumes cols divides the block size), and int-safe
+    /// scratch element counts (SiLuMul / UploadInto take int counts).
+    /// </summary>
+    private bool UseBatchedCpuDenseFfn(int layer, int n) =>
+        BatchedCpuDenseFfnEnabled && n >= 2
+        && _cpuWFfnGate is not null
+        && (long)n * _intermDim <= int.MaxValue
+        && DenseDotSupported(_cpuWFfnGate[layer], _embDim)
+        && DenseDotSupported(_cpuWFfnUp![layer], _embDim)
+        && DenseDotSupported(_cpuWFfnDown![layer], _intermDim);
+
+    private static bool DenseDotSupported(in CpuWeightRef w, int cols) =>
+        w.DataPtr != null
+        && w.DType is DType.Q3_K or DType.Q4_K or DType.Q5_K or DType.Q6_K
+                    or DType.Q8_0 or DType.Float32
+        && cols % DTypeInfo.BlockSize(w.DType) == 0;
+
+    /// <summary>
+    /// (Re)allocate the batched dense-FFN host scratch for <paramref name="n"/> tokens
+    /// (exact-size on N change). The gate/up slabs are tile-sized: the tile targets
+    /// ~8 MB of silu'd-gate slab (L3-resident on commodity parts), rounded down to a
+    /// multiple of 4 so the quad tier does the bulk of the work.
+    /// </summary>
+    private void EnsureBatchedDenseScratch(int n)
+    {
+        if (_bdCapN == n) return;
+        FreeBatchedDenseScratch();
+        _bdTile = Math.Clamp((int)(8_000_000L / ((long)_intermDim * sizeof(float))), 4, 256) & ~3;
+        nuint emb = (nuint)((long)n * _embDim * sizeof(float));
+        nuint interm = (nuint)((long)_bdTile * _intermDim * sizeof(float));
+        _bdNormAll   = (float*)NativeMemory.Alloc(emb);
+        _bdResidAll  = (float*)NativeMemory.Alloc(emb);
+        _bdHiddenAll = (float*)NativeMemory.Alloc(emb);
+        _bdGateAll   = (float*)NativeMemory.Alloc(interm);
+        _bdUpAll     = (float*)NativeMemory.Alloc(interm);
+        _bdCapN = n;
+    }
+
+    private void FreeBatchedDenseScratch()
+    {
+        if (_bdNormAll   != null) { NativeMemory.Free(_bdNormAll);   _bdNormAll = null; }
+        if (_bdResidAll  != null) { NativeMemory.Free(_bdResidAll);  _bdResidAll = null; }
+        if (_bdHiddenAll != null) { NativeMemory.Free(_bdHiddenAll); _bdHiddenAll = null; }
+        if (_bdGateAll   != null) { NativeMemory.Free(_bdGateAll);   _bdGateAll = null; }
+        if (_bdUpAll     != null) { NativeMemory.Free(_bdUpAll);     _bdUpAll = null; }
+        _bdCapN = 0;
+    }
+
+    /// <summary>
+    /// Issue #410: the batched CPU dense-FFN stage of one CPU-mmap layer inside
+    /// <see cref="PrefillBatchedTrunkGpuFfn"/> — replaces the per-token
+    /// Download → <see cref="CpuDenseFfn"/> → UploadInto loop. ONE D2H of all
+    /// <paramref name="n"/> FFN-norm rows + ONE of the post-block residuals, the
+    /// grouped weight-row dots of <see cref="BatchedCpuDenseFfn"/>, a host residual
+    /// add (fp32 a+b — the same values the per-token GPU AddInPlace produces), then
+    /// ONE H2D of the new residual-stream rows.
+    /// </summary>
+    private void BatchedCpuDenseFfnStage(int layer, int n, Tensor moeNorm, Tensor blockOut, Tensor stream)
+    {
+        LastPrefillUsedBatchedCpuFfn = true;
+        int embDim = _embDim;
+        EnsureBatchedDenseScratch(n);
+
+        _gpu.Download(moeNorm,  (nint)_bdNormAll,  n * embDim);
+        _gpu.Download(blockOut, (nint)_bdResidAll, n * embDim);
+
+        BatchedCpuDenseFfn(layer, n);
+
+        // hidden += resid, matching the per-token AddInPlace(_gpuHidden, _gpuResidual)
+        // operand order (fp32 add is placement-invariant), then one stream upload.
+        float* hid = _bdHiddenAll; float* res = _bdResidAll;
+        Parallel.For(0, n, s_moeParallelOpts, i =>
+        {
+            float* h = hid + (long)i * embDim;
+            float* r = res + (long)i * embDim;
+            for (int c = 0; c < embDim; c++) h[c] += r[c];
+        });
+        _gpu.UploadInto(stream, (nint)_bdHiddenAll, n * embDim);
+    }
+
+    /// <summary>
+    /// Dense sibling of <see cref="BatchedRoutedExperts"/> (issues #110/#112/#114): the
+    /// FFN weights are shared by every token, so there is no bucketing — each gate/up/
+    /// down weight row is read ONCE PER TILE and dotted against the tile's tokens in
+    /// quads → pairs → a single (each tier bit-identical to the per-token dot). Tokens
+    /// are processed in tiles of <see cref="_bdTile"/> so the [tile × intermDim] silu'd-
+    /// gate slab stays cache-resident while Phase C sweeps the down rows (see the
+    /// scratch-field comment for the measured untiled failure mode); the weights are
+    /// re-read N/tile times per layer — still tile× fewer DRAM passes than per-token.
+    /// Reads <see cref="_bdNormAll"/>, writes the FFN output (no residual) to
+    /// <see cref="_bdHiddenAll"/> — the same math as <see cref="CpuDenseFfnAt"/>:
+    /// gate/up matvecs → SiLU·mul → down matvec.
+    /// </summary>
+    private void BatchedCpuDenseFfn(int layer, int N)
+    {
+        int embDim = _embDim, intermDim = _intermDim;
+        var gateW = _cpuWFfnGate![layer];
+        var upW   = _cpuWFfnUp![layer];
+        var downW = _cpuWFfnDown![layer];
+        byte* gateP = gateW.DataPtr; byte* upP = upW.DataPtr; byte* downP = downW.DataPtr;
+        DType gateDt = gateW.DType, upDt = upW.DType, downDt = downW.DType;
+
+        int bprG = (embDim    / DTypeInfo.BlockSize(gateDt)) * DTypeInfo.BytesPerBlock(gateDt);
+        int bprU = (embDim    / DTypeInfo.BlockSize(upDt))   * DTypeInfo.BytesPerBlock(upDt);
+        int bprD = (intermDim / DTypeInfo.BlockSize(downDt)) * DTypeInfo.BytesPerBlock(downDt);
+
+        float* gateAll = _bdGateAll!; float* upAll = _bdUpAll!;
+
+        // Row-block sizes: keep a block's weight rows L2-resident (~256 KB) while the
+        // quad loop cycles them, so each 4-input activation quad loaded into L1/L2 is
+        // reused across the whole row block — the activation traffic that made the
+        // 1-row-per-unit sweep L3-bound (see the KNOWN LIMIT note) divides by the
+        // block height. Quads OUTER, rows INNER; per-(row, token-quad) math and
+        // accumulation order are unchanged → still bit-identical.
+        int rbA = Math.Clamp(262144 / Math.Max(bprG, bprU), 8, 64);
+        int rbC = Math.Clamp(262144 / bprD, 8, 64);
+
+        for (int t0 = 0; t0 < N; t0 += _bdTile)
+        {
+            int T = Math.Min(_bdTile, N - t0);
+            float* normT = _bdNormAll! + (long)t0 * embDim;   // tile's norm rows
+            float* hidT  = _bdHiddenAll! + (long)t0 * embDim; // tile's FFN outputs
+
+            // Phase A: gate + up over the tile. Parallelize over row BLOCKS; inside a
+            // block, token quads are the outer loop so their 4 input rows are reused
+            // across every row of the block.
+            int blocksA = (intermDim + rbA - 1) / rbA;
+            Parallel.For(0, blocksA, s_moeParallelOpts, b =>
+            {
+                int rStart = b * rbA, rEnd = Math.Min(rStart + rbA, intermDim);
+                int i = 0;
+                for (; i + 3 < T; i += 4)
+                {
+                    float* n0 = normT + (long)i * embDim,       n1 = normT + (long)(i + 1) * embDim;
+                    float* n2 = normT + (long)(i + 2) * embDim, n3 = normT + (long)(i + 3) * embDim;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDot4In(gateP + (long)r * bprG, n0, n1, n2, n3, embDim, gateDt,
+                            out float a0, out float a1, out float a2, out float a3);
+                        gateAll[(long)i * intermDim + r]       = a0;
+                        gateAll[(long)(i + 1) * intermDim + r] = a1;
+                        gateAll[(long)(i + 2) * intermDim + r] = a2;
+                        gateAll[(long)(i + 3) * intermDim + r] = a3;
+                        DispatchDot4In(upP + (long)r * bprU, n0, n1, n2, n3, embDim, upDt,
+                            out a0, out a1, out a2, out a3);
+                        upAll[(long)i * intermDim + r]       = a0;
+                        upAll[(long)(i + 1) * intermDim + r] = a1;
+                        upAll[(long)(i + 2) * intermDim + r] = a2;
+                        upAll[(long)(i + 3) * intermDim + r] = a3;
+                    }
+                }
+                for (; i + 1 < T; i += 2)
+                {
+                    float* n0 = normT + (long)i * embDim, n1 = normT + (long)(i + 1) * embDim;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDot2In(gateP + (long)r * bprG, n0, n1, embDim, gateDt,
+                            out float a0, out float a1);
+                        gateAll[(long)i * intermDim + r]       = a0;
+                        gateAll[(long)(i + 1) * intermDim + r] = a1;
+                        DispatchDot2In(upP + (long)r * bprU, n0, n1, embDim, upDt, out a0, out a1);
+                        upAll[(long)i * intermDim + r]       = a0;
+                        upAll[(long)(i + 1) * intermDim + r] = a1;
+                    }
+                }
+                if (i < T) // odd remainder
+                {
+                    float* n0 = normT + (long)i * embDim;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        gateAll[(long)i * intermDim + r] = DispatchDot(gateP + (long)r * bprG, n0, embDim, gateDt);
+                        upAll[(long)i * intermDim + r]   = DispatchDot(upP   + (long)r * bprU, n0, embDim, upDt);
+                    }
+                }
+            });
+
+            // Phase B: SiLU(gate) * up over the tile's contiguous [T × intermDim] block.
+            SimdKernels.SiLuMul(gateAll, upAll, (int)((long)T * intermDim));
+
+            // Phase C: down over the tile, same row-block structure — the 4 silu'd gate
+            // slices of a quad are reused across the block's down rows.
+            int blocksC = (embDim + rbC - 1) / rbC;
+            Parallel.For(0, blocksC, s_moeParallelOpts, b =>
+            {
+                int rStart = b * rbC, rEnd = Math.Min(rStart + rbC, embDim);
+                int i = 0;
+                for (; i + 3 < T; i += 4)
+                {
+                    float* g0 = gateAll + (long)i * intermDim,       g1 = gateAll + (long)(i + 1) * intermDim;
+                    float* g2 = gateAll + (long)(i + 2) * intermDim, g3 = gateAll + (long)(i + 3) * intermDim;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDot4In(downP + (long)r * bprD, g0, g1, g2, g3, intermDim, downDt,
+                            out float d0, out float d1, out float d2, out float d3);
+                        hidT[(long)i * embDim + r]       = d0;
+                        hidT[(long)(i + 1) * embDim + r] = d1;
+                        hidT[(long)(i + 2) * embDim + r] = d2;
+                        hidT[(long)(i + 3) * embDim + r] = d3;
+                    }
+                }
+                for (; i + 1 < T; i += 2)
+                {
+                    float* g0 = gateAll + (long)i * intermDim, g1 = gateAll + (long)(i + 1) * intermDim;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        DispatchDot2In(downP + (long)r * bprD, g0, g1, intermDim, downDt,
+                            out float d0, out float d1);
+                        hidT[(long)i * embDim + r]       = d0;
+                        hidT[(long)(i + 1) * embDim + r] = d1;
+                    }
+                }
+                if (i < T) // odd remainder
+                {
+                    float* g0 = gateAll + (long)i * intermDim;
+                    for (int r = rStart; r < rEnd; r++)
+                        hidT[(long)i * embDim + r] =
+                            DispatchDot(downP + (long)r * bprD, g0, intermDim, downDt);
+                }
+            });
+        }
+    }
+
     private void BatchedRoutedExperts(int layer, int N)
     {
         int embDim = _embDim;
@@ -6449,7 +6730,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float DispatchDot(byte* row, float* input, int cols, DType dtype) =>
+    internal static float DispatchDot(byte* row, float* input, int cols, DType dtype) =>
         dtype switch
         {
             DType.Q3_K    => SimdKernels.DotQ3K(row, input, cols),
@@ -6469,7 +6750,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // holds. Dtypes without a 2In kernel fall back to two single dots (no win, still
     // correct).
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DispatchDot2In(byte* row, float* in1, float* in2, int cols, DType dtype,
+    internal static void DispatchDot2In(byte* row, float* in1, float* in2, int cols, DType dtype,
         out float v1, out float v2)
     {
         switch (dtype)
@@ -6488,7 +6769,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // Bit-identical to two <see cref="DispatchDotQ8K"/> calls. Q8_0 has no expensive
     // unpack, so it falls back to two single dots.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DispatchDotQ8K2In(byte* row, byte* scr1, byte* scr2, int cols, DType dtype,
+    internal static void DispatchDotQ8K2In(byte* row, byte* scr1, byte* scr2, int cols, DType dtype,
         out float v1, out float v2)
     {
         switch (dtype)
@@ -6554,7 +6835,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // int-domain dot kernels. Only Q3_K, Q8_0, and Q4_K are wired today — the
     // caller guards entry via the corresponding useQ8K* flag, so other dtypes
     // throw if they ever reach here.
-    private static float DispatchDotQ8K(byte* row, byte* q8kScratch, int cols, DType dtype) =>
+    internal static float DispatchDotQ8K(byte* row, byte* q8kScratch, int cols, DType dtype) =>
         dtype switch
         {
             DType.Q3_K => SimdKernels.DotQ3K_Q8KS(row, q8kScratch, cols),
@@ -6567,7 +6848,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // is encoded in `target`. Used to auto-enable the matching Q8_K-input kernel
     // gate at model load — see _q3kQ8KEnabled / _q8_0Q8KEnabled. Scans the GGUF
     // tensor index without allocating, so it is cheap to call from the constructor.
-    private static bool HasRoutedExpertsOfDType(GgufModel model, ModelHyperparams hp, DType target)
+    internal static bool HasRoutedExpertsOfDType(GgufModel model, ModelHyperparams hp, DType target)
     {
         if (!hp.IsMoE) return false;
         int L = hp.NumLayers;
@@ -6582,7 +6863,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     // Three-state env-var resolver: "1" forces on, "0" forces off, anything else
     // (including unset) falls through to the auto-detected default.
-    private static bool ResolveGate(string envName, bool autoDetect)
+    internal static bool ResolveGate(string envName, bool autoDetect)
     {
         var v = Environment.GetEnvironmentVariable(envName);
         if (v == "1") return true;
@@ -7236,6 +7517,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         if (_bfUsedExperts != null) NativeMemory.Free(_bfUsedExperts);
         // GPU op-offload routed-prefill scratch (perf/carnice-vnni-moe).
         FreeGpuOffloadScratch();
+        // Issue #410: batched CPU dense-FFN prefill scratch.
+        FreeBatchedDenseScratch();
 
         // CPU buffers — _cpuNormBuf is pinned (issue #48).
         CudaBackend.FreePinnedHost((nint)_cpuNormBuf);

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -895,9 +895,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     internal static bool BatchedCpuDenseFfnEnabled =
         Environment.GetEnvironmentVariable("SHARPI_BATCHED_CPU_FFN") == "1";
 
-    // Test observable (issue #410): whether the last Prefill ran the batched CPU
-    // dense-FFN stage for at least one layer (vs the per-token fallback loop).
-    internal bool LastPrefillUsedBatchedCpuFfn;
+    // Test observable (issue #410): how many layers of the last Prefill ran the batched
+    // CPU dense-FFN stage (vs the per-token fallback loop). A count, not a bool, so the
+    // parity oracles can assert EVERY eligible layer took the batched stage — an
+    // any-layer bool would stay green if a dtype-gate regression silently dropped all
+    // but one layer back to the per-token path.
+    internal int LastPrefillBatchedCpuFfnLayers;
 
     // Issue #410: host scratch for the batched CPU dense-FFN prefill, allocated lazily
     // by EnsureBatchedDenseScratch(N) (exact-size on N change). The gate/up slabs are
@@ -915,11 +918,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // this needs register-blocking on the ROW dimension as well (an R×4 multi-row
     // multi-input kernel that reuses each input load R times), or a BLAS tile path.
     // Hence the flag stays default-off; re-evaluate on the desktop (issue #410).
-    private float* _bdNormAll;     // [N × embDim]       — FFN-norm inputs (one D2H)
-    private float* _bdResidAll;    // [N × embDim]       — post-block residuals (one D2H)
-    private float* _bdGateAll;     // [tile × intermDim] — gate projections → silu'd
-    private float* _bdUpAll;       // [tile × intermDim] — up projections
-    private float* _bdHiddenAll;   // [N × embDim]       — FFN output + residual (one H2D)
+    private float* _bdNormAll;     // pinned [N × embDim] — FFN-norm inputs (one D2H)
+    private float* _bdGateAll;     // [tile × intermDim]  — gate projections → silu'd
+    private float* _bdUpAll;       // [tile × intermDim]  — up projections
+    private float* _bdHiddenAll;   // pinned [N × embDim] — FFN outputs, no residual (one H2D)
     private int _bdCapN;
     private int _bdTile;           // tokens per tile (~8 MB of gate slab, multiple of 4)
 
@@ -1772,7 +1774,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             throw new ArgumentException("Token list is empty", nameof(tokens));
 
         int N = tokens.Count;
-        LastPrefillUsedBatchedCpuFfn = false;   // set by the #410 dense-FFN stage when it runs
+        LastPrefillBatchedCpuFfnLayers = 0;   // counted up by the #410 dense-FFN stage per layer
 
         // Size the hidden buffer up front so Forward's per-step writes don't
         // each trigger a grow.
@@ -2980,10 +2982,13 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         && DenseDotSupported(_cpuWFfnUp![layer], _embDim)
         && DenseDotSupported(_cpuWFfnDown![layer], _intermDim);
 
+    // Q8_0 is excluded: the per-token oracle (SimdKernels.MatVec/MatVecDual) has no
+    // fused Q8_0 case — it dequant-falls-back to DotF32, which is not bit-identical
+    // to the batched DotQ8_0 — so a Q8_0 FFN layer must stay on the per-token path.
     private static bool DenseDotSupported(in CpuWeightRef w, int cols) =>
         w.DataPtr != null
         && w.DType is DType.Q3_K or DType.Q4_K or DType.Q5_K or DType.Q6_K
-                    or DType.Q8_0 or DType.Float32
+                    or DType.Float32
         && cols % DTypeInfo.BlockSize(w.DType) == 0;
 
     /// <summary>
@@ -2997,11 +3002,14 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         if (_bdCapN == n) return;
         FreeBatchedDenseScratch();
         _bdTile = Math.Clamp((int)(8_000_000L / ((long)_intermDim * sizeof(float))), 4, 256) & ~3;
-        nuint emb = (nuint)((long)n * _embDim * sizeof(float));
+        long emb = (long)n * _embDim;
         nuint interm = (nuint)((long)_bdTile * _intermDim * sizeof(float));
-        _bdNormAll   = (float*)NativeMemory.Alloc(emb);
-        _bdResidAll  = (float*)NativeMemory.Alloc(emb);
-        _bdHiddenAll = (float*)NativeMemory.Alloc(emb);
+        // Norm/hidden stage through the Download/UploadInto direct-pointer overloads,
+        // whose contract requires cudaMallocHost memory (pageable degrades to a slow
+        // synchronous staged copy) — same as every other host slab on this path
+        // (_bNormAll/_bHiddenAll…). The gate/up slabs never cross PCIe: plain native.
+        _bdNormAll   = AllocPinnedL(emb);
+        _bdHiddenAll = AllocPinnedL(emb);
         _bdGateAll   = (float*)NativeMemory.Alloc(interm);
         _bdUpAll     = (float*)NativeMemory.Alloc(interm);
         _bdCapN = n;
@@ -3009,9 +3017,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
 
     private void FreeBatchedDenseScratch()
     {
-        if (_bdNormAll   != null) { NativeMemory.Free(_bdNormAll);   _bdNormAll = null; }
-        if (_bdResidAll  != null) { NativeMemory.Free(_bdResidAll);  _bdResidAll = null; }
-        if (_bdHiddenAll != null) { NativeMemory.Free(_bdHiddenAll); _bdHiddenAll = null; }
+        if (_bdNormAll   != null) { CudaBackend.FreePinnedHost((nint)_bdNormAll);   _bdNormAll = null; }
+        if (_bdHiddenAll != null) { CudaBackend.FreePinnedHost((nint)_bdHiddenAll); _bdHiddenAll = null; }
         if (_bdGateAll   != null) { NativeMemory.Free(_bdGateAll);   _bdGateAll = null; }
         if (_bdUpAll     != null) { NativeMemory.Free(_bdUpAll);     _bdUpAll = null; }
         _bdCapN = 0;
@@ -3021,32 +3028,29 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// Issue #410: the batched CPU dense-FFN stage of one CPU-mmap layer inside
     /// <see cref="PrefillBatchedTrunkGpuFfn"/> — replaces the per-token
     /// Download → <see cref="CpuDenseFfn"/> → UploadInto loop. ONE D2H of all
-    /// <paramref name="n"/> FFN-norm rows + ONE of the post-block residuals, the
-    /// grouped weight-row dots of <see cref="BatchedCpuDenseFfn"/>, a host residual
-    /// add (fp32 a+b — the same values the per-token GPU AddInPlace produces), then
-    /// ONE H2D of the new residual-stream rows.
+    /// <paramref name="n"/> FFN-norm rows, the grouped weight-row dots of
+    /// <see cref="BatchedCpuDenseFfn"/>, then ONE H2D of the FFN outputs back into
+    /// <paramref name="moeNorm"/> (dead once its rows are downloaded) and the residual
+    /// add + stream scatter on the GPU — the same batched AddInPlace + CopyDeviceRegion
+    /// tail as the GPU-FFN batched branch, adding the same fp32 values the per-token
+    /// loop's row-wise AddInPlace produces.
     /// </summary>
     private void BatchedCpuDenseFfnStage(int layer, int n, Tensor moeNorm, Tensor blockOut, Tensor stream)
     {
-        LastPrefillUsedBatchedCpuFfn = true;
+        LastPrefillBatchedCpuFfnLayers++;
         int embDim = _embDim;
         EnsureBatchedDenseScratch(n);
 
-        _gpu.Download(moeNorm,  (nint)_bdNormAll,  n * embDim);
-        _gpu.Download(blockOut, (nint)_bdResidAll, n * embDim);
+        _gpu.Download(moeNorm, (nint)_bdNormAll, n * embDim);
 
         BatchedCpuDenseFfn(layer, n);
 
-        // hidden += resid, matching the per-token AddInPlace(_gpuHidden, _gpuResidual)
-        // operand order (fp32 add is placement-invariant), then one stream upload.
-        float* hid = _bdHiddenAll; float* res = _bdResidAll;
-        Parallel.For(0, n, s_moeParallelOpts, i =>
-        {
-            float* h = hid + (long)i * embDim;
-            float* r = res + (long)i * embDim;
-            for (int c = 0; c < embDim; c++) h[c] += r[c];
-        });
-        _gpu.UploadInto(stream, (nint)_bdHiddenAll, n * embDim);
+        // moeNorm ← FFN outputs, += postBlock residual, scatter the stream slice —
+        // moeNorm and blockOut are exact-size [n × embDim] (EnsureBatchedTrunkScratch),
+        // so the whole-tensor AddInPlace element counts match.
+        _gpu.UploadInto(moeNorm, (nint)_bdHiddenAll, n * embDim);
+        _gpu.AddInPlace(moeNorm, blockOut);
+        _gpu.CopyDeviceRegion(stream, 0, moeNorm, 0, (long)n * embDim * sizeof(float));
     }
 
     /// <summary>
@@ -6719,6 +6723,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     {
         MaxDegreeOfParallelism = ResolveMoeThreads()
     };
+
+    // Issue #410: shared with CudaHybridForwardPass's batched CPU-MoE prefill (like the
+    // DispatchDot* kernels) so the SHARPI_MOE_THREADS resolver has one owner per backend.
+    internal static ParallelOptions MoeParallelOpts => s_moeParallelOpts;
 
     private static int ResolveMoeThreads()
     {

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -2975,7 +2975,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     /// scratch element counts (SiLuMul / UploadInto take int counts).
     /// </summary>
     private bool UseBatchedCpuDenseFfn(int layer, int n) =>
-        BatchedCpuDenseFfnEnabled && n >= 2
+        // n >= 4: below a quad the grouped tiers never engage, so the batched stage is
+        // pure overhead over the per-token loop — the sequential fallback for tiny chunks.
+        BatchedCpuDenseFfnEnabled && n >= 4
         && _cpuWFfnGate is not null
         && (long)n * _intermDim <= int.MaxValue
         && DenseDotSupported(_cpuWFfnGate[layer], _embDim)

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedCpuMoePrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedCpuMoePrefillTests.cs
@@ -1,0 +1,342 @@
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using SharpInference.Pipeline;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Issue #410: byte-parity guard for the batched CPU-MoE routed-expert prefill on the
+/// pure-attention MoE CUDA hybrid path (<see cref="CudaHybridForwardPass"/>, Qwen3-Coder-30B).
+/// With <c>SHARPI_HYBRID_BATCHED_MOE=1</c> the batched-trunk prefill replaces the per-token
+/// FFN/MoE loop with the CSR-bucketed batched routed-expert scheme (one D2H of all N norm
+/// rows per layer, host router + grouped gate/up/down dots, one H2D of the routed outputs).
+/// It must produce bit-identical final-token logits to the sequential per-token
+/// <see cref="CudaHybridForwardPass.Forward"/> loop — every tier of the grouped dots mirrors
+/// the single-dot accumulation order (issues #112/#114) and the weighted reduce runs in
+/// top-k order, so the parity contract is byte-exact, not just argmax-stable.
+///
+/// <c>SHARPI_CPU_MOE=1</c> is pinned for both arms so the pass deterministically selects
+/// CPU-MoE regardless of the box's VRAM (the auto-select would otherwise pick GPU-SLRU on
+/// a large card and the batched arm's non-vacuous assertion would fail spuriously).
+///
+/// Skipped silently when CUDA is unavailable, the model isn't on disk, or construction
+/// OOMs — but a failure INSIDE Prefill must FAIL, not skip.
+/// </summary>
+public sealed class CudaHybridBatchedCpuMoePrefillTests : IDisposable
+{
+    private readonly ITestOutputHelper _out;
+    // Issue #162: pin the compute-bound attention-projection path (MMQ/GEMM, argmax-stable
+    // NOT byte-exact) OFF so the oracle isolates the batched CPU-MoE stage against the
+    // byte-exact trunk. Restored in Dispose.
+    private readonly bool _prevHybridCompute = CudaHybridForwardPass.HybridPrefillComputeEnabled;
+    public CudaHybridBatchedCpuMoePrefillTests(ITestOutputHelper o)
+    {
+        _out = o;
+        CudaHybridForwardPass.HybridPrefillComputeEnabled = false;
+    }
+    public void Dispose() => CudaHybridForwardPass.HybridPrefillComputeEnabled = _prevHybridCompute;
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); } catch { return null; }
+    }
+
+    private static string? FindCoderPath() => FirstExisting(
+        @"C:\p\sharpi\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        @"C:\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        @"E:\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf");
+
+    private static string? FirstExisting(params string[] candidates)
+    {
+        foreach (var p in candidates)
+            if (File.Exists(p)) return p;
+        return null;
+    }
+
+    private static CudaHybridForwardPass? TryConstruct(
+        GgufModel model, CudaBackend gpu, ModelHyperparams hp, LayerPlacement placement)
+    {
+        try { return new CudaHybridForwardPass(model, gpu, hp, placement); }
+        catch (InvalidOperationException) { return null; } // OOM / VRAM at construction
+        catch (NotSupportedException) { return null; }
+    }
+
+    private static int FirstBitDiff(float[] a, float[] b)
+    {
+        for (int i = 0; i < a.Length; i++)
+            if (BitConverter.SingleToInt32Bits(a[i]) != BitConverter.SingleToInt32Bits(b[i]))
+                return i;
+        return -1;
+    }
+
+    /// <summary>
+    /// Pin the Q8_KS activation-prepack gates (issue #410 int8 tier) OFF for the scope
+    /// of a bitwise oracle: the int8 dots are argmax-stable, NOT byte-exact vs the f32
+    /// per-token reference (on non-AVX-512 boxes SHARPI_Q4K_Q8K auto-enables and would
+    /// fail the bit-parity assertion spuriously). Restores the previous values on dispose.
+    /// </summary>
+    private static IDisposable PinQ8KOff() => new EnvPin(
+        ("SHARPI_Q3K_Q8K", "0"), ("SHARPI_Q8_0_Q8K", "0"), ("SHARPI_Q4K_Q8K", "0"));
+
+    private sealed class EnvPin : IDisposable
+    {
+        private readonly (string Name, string? Prev)[] _saved;
+        public EnvPin(params (string Name, string Value)[] pins)
+        {
+            _saved = new (string, string?)[pins.Length];
+            for (int i = 0; i < pins.Length; i++)
+            {
+                _saved[i] = (pins[i].Name, Environment.GetEnvironmentVariable(pins[i].Name));
+                Environment.SetEnvironmentVariable(pins[i].Name, pins[i].Value);
+            }
+        }
+        public void Dispose()
+        {
+            foreach (var (name, prev) in _saved)
+                Environment.SetEnvironmentVariable(name, prev);
+        }
+    }
+
+    [Fact]
+    public void BatchedCpuMoePrefill_BitwiseMatchesSequential_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevMoe = CudaHybridForwardPass.BatchedCpuMoePrefillEnabled;
+        var prevCpuMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+        Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+        using var _q8k = PinQ8KOff();   // int8 tiers are argmax-stable, not byte-exact
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var hw = HardwareProfile.Detect(gpu);
+            var placement = TierPlanner.Plan(model, hp, hw, turboQuant: false, requestedCtxSize: ctx);
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts! " +
+                "The five boxing wizards jump quickly.");
+            Assert.True(tokens.Count >= 8, $"Prompt tokenized to only {tokens.Count} tokens.");
+
+            float[] Run(bool batchedMoe)
+            {
+                // Reference arm: everything per-token (the deterministic gold path).
+                // Batched arm: batched trunk + batched CPU-MoE FFN stage.
+                CudaHybridForwardPass.BatchedPrefillEnabled = batchedMoe;
+                CudaHybridForwardPass.BatchedCpuMoePrefillEnabled = batchedMoe;
+                using var fwd = TryConstruct(model, gpu, hp, placement);
+                if (fwd is null) return Array.Empty<float>();
+                var logits = fwd.Prefill(tokens).ToArray();
+                if (batchedMoe)
+                {
+                    // Guard against a vacuous pass: the batched arm must actually run both
+                    // the batched trunk AND the batched CPU-MoE FFN stage, else this compares
+                    // the per-token loop against itself.
+                    Assert.True(fwd.LastPrefillWasBatched,
+                        "Batched arm fell back to the per-token trunk path — the parity check " +
+                        $"would be vacuous. GpuLayers={placement.GpuLayers} CpuLayers={placement.CpuLayers}.");
+                    Assert.True(fwd.LastPrefillUsedBatchedCpuMoe,
+                        "Batched arm did not take the batched CPU-MoE FFN stage (per-token " +
+                        "fallback) — the #410 parity check would be vacuous.");
+                }
+                return logits;
+            }
+
+            float[] seq = Run(false);
+            float[] bat = Run(true);
+            if (seq.Length == 0 || bat.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(seq.Length, bat.Length);
+            int firstDiff = FirstBitDiff(seq, bat);
+            Assert.True(firstDiff < 0,
+                $"Batched CPU-MoE prefill diverges from sequential at index {firstDiff} " +
+                $"(seq={(firstDiff >= 0 ? seq[firstDiff] : 0)} bat={(firstDiff >= 0 ? bat[firstDiff] : 0)}). " +
+                "BatchedCpuMoeFfnStage must be bit-identical to the per-token FFN/MoE loop.");
+            Assert.Equal(Sampler.Greedy(seq), Sampler.Greedy(bat));
+            _out.WriteLine($"OK N={tokens.Count} greedy={Sampler.Greedy(seq)}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.BatchedCpuMoePrefillEnabled = prevMoe;
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
+        }
+    }
+
+    /// <summary>
+    /// Multi-chunk parity (chunked admission shape, issue #183): two Prefill calls with
+    /// startPos continuation must also be bit-identical to the sequential loop — the
+    /// batched CPU-MoE stage is position-independent, but this pins the scratch resize
+    /// (chunk sizes differ) and the KV/counter handoff between chunks.
+    /// </summary>
+    [Fact]
+    public void BatchedCpuMoePrefill_MultiChunk_BitwiseMatchesSequential_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevMoe = CudaHybridForwardPass.BatchedCpuMoePrefillEnabled;
+        var prevCpuMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+        Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+        using var _q8k = PinQ8KOff();   // int8 tiers are argmax-stable, not byte-exact
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var hw = HardwareProfile.Detect(gpu);
+            var placement = TierPlanner.Plan(model, hp, hw, turboQuant: false, requestedCtxSize: ctx);
+
+            var tokens = tokenizer.Encode(
+                "Sphinx of black quartz, judge my vow. Pack my box with five dozen liquor jugs. " +
+                "The quick brown fox jumps over the lazy dog near the riverbank at dawn.");
+            Assert.True(tokens.Count >= 12, $"Prompt tokenized to only {tokens.Count} tokens.");
+            int split = tokens.Count / 2;
+            var chunk1 = tokens.Take(split).ToList();
+            var chunk2 = tokens.Skip(split).ToList();
+
+            float[] Run(bool batchedMoe)
+            {
+                CudaHybridForwardPass.BatchedPrefillEnabled = batchedMoe;
+                CudaHybridForwardPass.BatchedCpuMoePrefillEnabled = batchedMoe;
+                using var fwd = TryConstruct(model, gpu, hp, placement);
+                if (fwd is null) return Array.Empty<float>();
+                fwd.Prefill(chunk1);
+                var logits = fwd.Prefill(chunk2, split).ToArray();
+                if (batchedMoe)
+                    Assert.True(fwd.LastPrefillWasBatched && fwd.LastPrefillUsedBatchedCpuMoe,
+                        "Batched arm fell back to a per-token path — the parity check would be vacuous.");
+                return logits;
+            }
+
+            float[] seq = Run(false);
+            float[] bat = Run(true);
+            if (seq.Length == 0 || bat.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            int firstDiff = FirstBitDiff(seq, bat);
+            Assert.True(firstDiff < 0,
+                $"Multi-chunk batched CPU-MoE prefill diverges from sequential at index {firstDiff}.");
+            Assert.Equal(Sampler.Greedy(seq), Sampler.Greedy(bat));
+            _out.WriteLine($"OK chunks={split}+{tokens.Count - split} greedy={Sampler.Greedy(seq)}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.BatchedCpuMoePrefillEnabled = prevMoe;
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
+        }
+    }
+
+    /// <summary>
+    /// Issue #410 int8 tier: with the Q8_KS activation prepack forced ON
+    /// (SHARPI_Q4K_Q8K=1 etc.), the batched CPU-MoE prefill routes the gate/up (and,
+    /// dtype permitting, down) dots through the int-domain kernels. That path is
+    /// argmax-stable, NOT byte-exact, vs the f32 batched path — assert the contract
+    /// that actually holds: shared top-5 (≥4/5) and logits within a loose fp tolerance,
+    /// the same contract the MMQ compute-routing oracles use.
+    /// </summary>
+    [Fact]
+    public void BatchedCpuMoePrefill_Q8K_ArgmaxStableVsF32_Coder()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindCoderPath();
+        if (path is null) return;
+
+        bool prevBatched = CudaHybridForwardPass.BatchedPrefillEnabled;
+        bool prevMoe = CudaHybridForwardPass.BatchedCpuMoePrefillEnabled;
+        var prevCpuMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
+        Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            int ctx = Math.Min(hp.ContextLength, 4096);
+            var hw = HardwareProfile.Detect(gpu);
+            var placement = TierPlanner.Plan(model, hp, hw, turboQuant: false, requestedCtxSize: ctx);
+
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts! " +
+                "The five boxing wizards jump quickly.");
+            Assert.True(tokens.Count >= 8, $"Prompt tokenized to only {tokens.Count} tokens.");
+
+            CudaHybridForwardPass.BatchedPrefillEnabled = true;
+            CudaHybridForwardPass.BatchedCpuMoePrefillEnabled = true;
+
+            float[] Run(string q8k)
+            {
+                using var pin = new EnvPin(
+                    ("SHARPI_Q3K_Q8K", q8k), ("SHARPI_Q8_0_Q8K", q8k), ("SHARPI_Q4K_Q8K", q8k));
+                using var fwd = TryConstruct(model, gpu, hp, placement);
+                if (fwd is null) return Array.Empty<float>();
+                var logits = fwd.Prefill(tokens).ToArray();
+                Assert.True(fwd.LastPrefillWasBatched && fwd.LastPrefillUsedBatchedCpuMoe,
+                    "Arm fell back to a per-token path — the comparison would be vacuous.");
+                return logits;
+            }
+
+            float[] f32 = Run("0");
+            float[] q8k = Run("1");
+            if (f32.Length == 0 || q8k.Length == 0)
+            {
+                _out.WriteLine("SKIP: construction OOM'd on this box.");
+                return;
+            }
+
+            Assert.Equal(f32.Length, q8k.Length);
+            float maxAbs = 0f;
+            for (int i = 0; i < f32.Length; i++)
+                maxAbs = MathF.Max(maxAbs, MathF.Abs(f32[i] - q8k[i]));
+
+            static HashSet<int> Top5(float[] v)
+            {
+                var idx = new int[v.Length];
+                for (int i = 0; i < idx.Length; i++) idx[i] = i;
+                Array.Sort(idx, (a, b) => v[b].CompareTo(v[a]));
+                var set = new HashSet<int>();
+                for (int i = 0; i < 5 && i < idx.Length; i++) set.Add(idx[i]);
+                return set;
+            }
+            var f32Top = Top5(f32);
+            var q8kTop = Top5(q8k);
+            int overlap = 0;
+            foreach (var t in q8kTop) if (f32Top.Contains(t)) overlap++;
+            Assert.True(overlap >= 4,
+                $"Q8_KS batched top-5 overlaps the f32 batched path in only {overlap}/5 slots (maxAbs={maxAbs:E2}).");
+            Assert.True(maxAbs < 3.0f, $"Q8_KS batched logits deviate too far from f32 (maxAbs={maxAbs:E2}).");
+            _out.WriteLine($"OK top5-overlap={overlap}/5 maxAbs={maxAbs:E2}");
+        }
+        finally
+        {
+            CudaHybridForwardPass.BatchedPrefillEnabled = prevBatched;
+            CudaHybridForwardPass.BatchedCpuMoePrefillEnabled = prevMoe;
+            Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
+        }
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -51,6 +51,7 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
 
     private static string? FindCoderPath() => FirstExisting(
         @"C:\p\sharpi\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        @"C:\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
         @"E:\models\Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf");
 
     private static string? FirstExisting(params string[] candidates)

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
@@ -79,6 +79,7 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
     // Dense GDN-hybrid (no MoE routing) — issue #119 path 1.
     private static string? FindDense27BMtpPath() => FirstExisting(
         @"C:\p\sharpi\models\Qwen3.6-27B-MTP-Q4_K_M.gguf",
+        @"C:\models\Qwen3.6-27B-MTP-Q4_K_M.gguf",
         @"E:\models\Qwen3.6-27B-MTP-Q4_K_M.gguf");
 
     // GDN-hybrid MoE model with Q4_K experts (GPU-SLRU friendly) — issue #119 path 2.
@@ -572,6 +573,83 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
             CudaHybridGdnForwardPass.BatchedPrefillEnabled = prevPrefill;
             CudaHybridGdnForwardPass.BatchedTrunkEnabled = prevTrunk;
             CudaHybridGdnForwardPass.BatchedFfnEnabled = prevFfn;
+        }
+    }
+
+    /// <summary>
+    /// Issue #410: the batched CPU dense-FFN prefill stage (<c>BatchedCpuDenseFfnStage</c>,
+    /// <c>SHARPI_BATCHED_CPU_FFN=1</c>) must be bit-identical to the per-token
+    /// Download → <c>CpuDenseFfn</c> → UploadInto loop it replaces. Both arms run under
+    /// batched prefill + batched trunk with <c>SHARPI_DENSE_FFN_GPU_MARGIN_MB</c> set
+    /// absurdly high so every FFN layer stays CPU-mmap'd (deterministic across boxes —
+    /// otherwise a large card uploads all layers to GPU and the CPU stage never runs);
+    /// only the CPU-FFN strategy differs. The batched arm asserts
+    /// <c>LastPrefillUsedBatchedCpuFfn</c> so a gated-out config fails loudly instead of
+    /// comparing the per-token loop against itself.
+    /// </summary>
+    [Fact]
+    public void BatchedCpuDenseFfn_BitwiseMatchesPerTokenCpuFfn_Dense27BMtp()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindDense27BMtpPath();
+        if (path is null) return;
+
+        bool prevPrefill = CudaHybridGdnForwardPass.BatchedPrefillEnabled;
+        bool prevTrunk = CudaHybridGdnForwardPass.BatchedTrunkEnabled;
+        bool prevCpuFfn = CudaHybridGdnForwardPass.BatchedCpuDenseFfnEnabled;
+        var prevMargin = Environment.GetEnvironmentVariable("SHARPI_DENSE_FFN_GPU_MARGIN_MB");
+        Environment.SetEnvironmentVariable("SHARPI_DENSE_FFN_GPU_MARGIN_MB", "1000000");
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+            if (hp.IsMoE) return; // dense-only path
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            var placement = new LayerPlacement(
+                GpuLayers: hp.NumLayers, CpuLayers: 0, GpuWeightBytes: 0, GpuKvBytes: 0,
+                RecommendedCtxSize: Math.Min(hp.ContextLength, 4096));
+            var tokens = tokenizer.Encode(
+                "The quick brown fox jumps over the lazy dog. " +
+                "Pack my box with five dozen liquor jugs. " +
+                "How razorback-jumping frogs can level six piqued gymnasts!");
+            Assert.True(tokens.Count >= 8);
+
+            // Hold prefill + trunk batching on; toggle ONLY the CPU dense-FFN strategy.
+            CudaHybridGdnForwardPass.BatchedPrefillEnabled = true;
+            CudaHybridGdnForwardPass.BatchedTrunkEnabled = true;
+
+            float[] RunWithCpuFfn(bool batchedCpuFfn)
+            {
+                CudaHybridGdnForwardPass.BatchedCpuDenseFfnEnabled = batchedCpuFfn;
+                using var fwd = new CudaHybridGdnForwardPass(model, gpu, hp, placement);
+                var logits = fwd.Prefill(tokens).ToArray();
+                if (batchedCpuFfn)
+                    Assert.True(fwd.LastPrefillUsedBatchedCpuFfn,
+                        "Batched arm did not take the batched CPU dense-FFN stage (per-token " +
+                        "fallback) — the #410 parity check would be vacuous.");
+                return logits;
+            }
+
+            float[] perToken = RunWithCpuFfn(false);
+            float[] batched  = RunWithCpuFfn(true);
+
+            Assert.Equal(perToken.Length, batched.Length);
+            int firstDiff = -1;
+            for (int i = 0; i < perToken.Length; i++)
+                if (BitConverter.SingleToInt32Bits(perToken[i]) != BitConverter.SingleToInt32Bits(batched[i]))
+                { firstDiff = i; break; }
+            Assert.True(firstDiff < 0,
+                $"Batched CPU dense-FFN prefill diverges from the per-token CPU FFN at index {firstDiff}. " +
+                "BatchedCpuDenseFfnStage must be bit-identical to the per-token CpuDenseFfn loop.");
+            Assert.Equal(Sampler.Greedy(perToken), Sampler.Greedy(batched));
+        }
+        finally
+        {
+            CudaHybridGdnForwardPass.BatchedPrefillEnabled = prevPrefill;
+            CudaHybridGdnForwardPass.BatchedTrunkEnabled = prevTrunk;
+            CudaHybridGdnForwardPass.BatchedCpuDenseFfnEnabled = prevCpuFfn;
+            Environment.SetEnvironmentVariable("SHARPI_DENSE_FFN_GPU_MARGIN_MB", prevMargin);
         }
     }
 

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
@@ -625,9 +625,11 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
                 using var fwd = new CudaHybridGdnForwardPass(model, gpu, hp, placement);
                 var logits = fwd.Prefill(tokens).ToArray();
                 if (batchedCpuFfn)
-                    Assert.True(fwd.LastPrefillUsedBatchedCpuFfn,
-                        "Batched arm did not take the batched CPU dense-FFN stage (per-token " +
-                        "fallback) — the #410 parity check would be vacuous.");
+                    // Every layer is CPU-mmap'd (margin override) and 27B FFN dtypes are
+                    // all batchable, so EVERY layer must take the batched stage — a
+                    // partial count means a dtype-gate regression silently dropped
+                    // layers back to the per-token path.
+                    Assert.Equal(hp.NumLayers, fwd.LastPrefillBatchedCpuFfnLayers);
                 return logits;
             }
 


### PR DESCRIPTION
Addresses both work items of #410 — the CPU-side weight work of the CUDA hybrid passes now batches over the N prompt tokens instead of running per-token. Both paths are **opt-in, default-off** until the desktop A/B lands (issue constraint), and **decode is untouched** (the 27B-MTP decode win is preserved by construction).

## Item 2 — Qwen3-Coder-30B (`CudaHybridForwardPass`, `SHARPI_HYBRID_BATCHED_MOE=1`)

Ports the GDN pass's CSR-bucketed batched routed-expert scheme (#110/#112/#114) into the batched-trunk prefill's FFN stage. Per layer: **one D2H** of all N post-FFN-norm rows, host router + top-k per token, per-expert (token, slot) CSR bucketing, grouped gate/up/down dots (each quantized weight row decoded once per token-quad), **one H2D** + a single batched residual add — replacing N per-token CPU matvecs and N×2 PCIe round-trips per layer.

Includes the **Q8_KS activation-prepack int8 tier** (`SHARPI_Q3K_Q8K` / `SHARPI_Q8_0_Q8K` / `SHARPI_Q4K_Q8K`, same auto logic as the GDN pass — Q4_K int8 only where AVX-512 is absent). The f32 tier is bit-identical to the per-token path; the int8 tier is argmax-stable.

## Item 1 — Qwen3.6-27B-MTP (`CudaHybridGdnForwardPass`, `SHARPI_BATCHED_CPU_FFN=1`)

The CPU-mmap dense-FFN layers of `PrefillBatchedTrunkGpuFfn` (46/64 layers, ~8.6 GB at Q4_K_M) now batch over all N prompt tokens: **one D2H** of the norm rows (pinned staging), grouped gate/up/down dots, **one H2D** of the FFN outputs + GPU residual add — replacing the per-token Download → `CpuDenseFfn` → UploadInto loop. Bit-identical.

## Shared machinery

- **Token tiling** (dense: `[tile × intermDim]` silu'd-gate slab stays cache-resident) and **row-blocking** (token quads outer, ~256 KB L2-resident weight-row blocks inner) — the loop-blocked equivalent of an R×4 fused kernel built from the existing bit-exact `4In`/`2In` dot kernels.
- Reuses the GDN pass's dot dispatchers / gate resolvers / `ParallelOptions` via `internal` promotion instead of duplicating them.

## Correctness

All oracles non-vacuous (they assert the batched stages actually ran):

| Test | Contract |
|---|---|
| `BatchedCpuMoePrefill_BitwiseMatchesSequential_Coder` | bitwise vs sequential `Forward` loop |
| `BatchedCpuMoePrefill_MultiChunk_BitwiseMatchesSequential_Coder` | bitwise across chunk boundary |
| `BatchedCpuMoePrefill_Q8K_ArgmaxStableVsF32_Coder` | int8 tier: 5/5 top-5 overlap, maxAbs 2.8 |
| `BatchedCpuDenseFfn_BitwiseMatchesPerTokenCpuFfn_Dense27BMtp` | bitwise, asserts **every** layer batched |

Review-hardened (second commit): per-projection int8 dispatch on mixed-quant experts, int-overflow admission guard, Q8_0 excluded from batchable dtypes (per-token oracle has no fused Q8_0 kernel), ctor-time static-flag footgun removed, pinned staging + GPU residual add on the dense path, if/else seam, layer-count test observable.

## Perf status — needs the desktop A/B before flipping defaults

Laptop (Core Ultra 9 185H / RTX 4070 Laptop 8 GB) numbers were **not reliable**: sustained-load throttling degraded even the untouched decode path 36% across the session. Plan per #410: `scripts/bench-allrows-1k.ps1 -CudaOnly -Tag 27b-mtp|coder` vs `llama-bench b9529`, warm + interleaved, on the desktop box. Known follow-up levers if still short: fused R×4 multi-row SIMD kernels, int8 for dense gate/up, GPU router (#388 port), small-N dilution gate.

Part of #405 / addresses #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDDvwjdg9sNndPiLhMu8mN