### PR TITLE
test: zero-alloc Half→bits conversion in Q8_0 matrix builder (PR #418 review follow-up)

### DIFF
--- a/tests/SharpInference.Tests.ForwardPass/SimdKernelsMatVecQ8_0Tests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SimdKernelsMatVecQ8_0Tests.cs
@@ -67,7 +67,7 @@ public sealed unsafe class SimdKernelsMatVecQ8_0Tests
                 int off = r * bytesPerRow + b * bytesPerBlock;
 
                 float d = (float)(rng.NextDouble() * 0.09 + 0.01);
-                ushort dHalf = BitConverter.ToUInt16(BitConverter.GetBytes((Half)d), 0);
+                ushort dHalf = BitConverter.HalfToUInt16Bits((Half)d);
                 bytes[off + 0] = (byte)(dHalf & 0xFF);
                 bytes[off + 1] = (byte)(dHalf >> 8);
 


### PR DESCRIPTION
Applies the single finding from the gemini-code-assist review on #418 (posted after the merge): `BitConverter.HalfToUInt16Bits((Half)d)` replaces `BitConverter.ToUInt16(BitConverter.GetBytes((Half)d), 0)` in `BuildQ8_0Matrix`, removing a per-block-iteration `byte[]` allocation in the test helper. Test-only; `SimdKernelsMatVecQ8_0Tests` 7/7 after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQWoZhyJGDF7xWkdT2r9o6