### PR TITLE
fix(tests): pin SHARPI_SPLIT_DECODE=0 in >4096 wave-SDPA bitwise parity tests (#419)

### DIFF
--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -1801,7 +1801,11 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     /// <para>Produces bit-identical KV cache and final-token logits to the sequential
     /// per-token <see cref="Forward"/> loop: every batched trunk kernel runs the same
     /// per-row math as its single-token counterpart (proven by the backend per-kernel
-    /// oracles), and the FFN/CPU stages run the identical single-token sequences.</para>
+    /// oracles), and the FFN/CPU stages run the identical single-token sequences.
+    /// Caveat (#419): the parity is against the sequential loop's monolithic single-block
+    /// attention. With flash-decoding split-KV enabled (default at seqLen &gt; 4096, #238)
+    /// the sequential loop reorders the softmax reduction, so parity there is
+    /// argmax-stable rather than bitwise; the parity oracles pin SHARPI_SPLIT_DECODE=0.</para>
     ///
     /// <para><b>Not transactional</b> (mirror of CudaHybridGdnForwardPass): the KV pages are
     /// written as the trunk runs but <c>_kvLength</c> / the CPU KV position counters are
@@ -1991,7 +1995,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
 
         // ── KV append + SDPA (batched). Shared-scores fast path when startPos+n ≤ 4096,
         //    wave-based global-scratch SDPA above (issue #118). Both bit-identical to the
-        //    per-position KvAppend + Attention loop in GpuLayer.
+        //    per-position KvAppend + single-block Attention loop in GpuLayer (see the
+        //    #419 split-KV caveat in the PrefillBatchedTrunk doc).
         KvAppendBatchedKv(kAll, vAll, _gpuKCache[i], _gpuVCache[i], kvDim, startPos, _maxSeqLen, n);
         if (startPos + n <= 4096)
             AttentionBatchedKv(qAll, _gpuKCache[i], _gpuVCache[i], attnOut,

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridBatchedPrefillTests.cs
@@ -453,6 +453,14 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
     /// the wave-based batched SDPA (<c>AttentionBatchedWave</c>, issue #118) inside the
     /// trunk. A small wave budget forces the multi-wave loop. Final-token logits must be
     /// bit-identical to the sequential per-token Forward loop (the deterministic reference).
+    ///
+    /// <para>Issue #419: both arms pin <c>SHARPI_SPLIT_DECODE=0</c>. The hybrid split-KV
+    /// gate (#238) otherwise reroutes the sequential arm's per-token attention to the
+    /// flash-decoding split kernels once seqLen &gt; 4096 — exactly this test's regime —
+    /// whose chunked softmax + LSE combine reorders the reduction (argmax-stable, not
+    /// bitwise). The wave kernel clones the monolithic single-block path, so that is the
+    /// reference it must be compared against; split-vs-single parity has its own oracle
+    /// (<see cref="CudaHybridKvDtypeTests"/>).</para>
     /// </summary>
     [Fact]
     public void BatchedPrefill_Over4096_BitwiseMatchesSequential_Coder()
@@ -463,9 +471,11 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
         if (path is null) return;
 
         var prevBudget = Environment.GetEnvironmentVariable("SHARPI_ATTN_WAVE_BUDGET_MB");
+        var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
         bool prev = CudaHybridForwardPass.BatchedPrefillEnabled;
         try
         {
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", "0"); // read at pass construction; see doc comment
             using var model = GgufModel.Open(path);
             var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
             if (hp.ContextLength < 4400) { _out.WriteLine("SKIP: ctx < 4400"); return; }
@@ -509,6 +519,7 @@ public sealed class CudaHybridBatchedPrefillTests : IDisposable
         {
             CudaHybridForwardPass.BatchedPrefillEnabled = prev;
             Environment.SetEnvironmentVariable("SHARPI_ATTN_WAVE_BUDGET_MB", prevBudget);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
         }
     }
 

--- a/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaHybridGdnBatchedPrefillTests.cs
@@ -315,7 +315,12 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
 
         var prevCpuMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
         var prevBudget = Environment.GetEnvironmentVariable("SHARPI_ATTN_WAVE_BUDGET_MB");
+        var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
         Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
+        // #419 hardening: keep the per-position reference on the monolithic single-block
+        // attention (GdnSplitMinSeq=8192 already exceeds this test's ~4300 ctx today; pin
+        // so a lowered threshold can't silently break bit-parity — split is argmax-stable).
+        Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", "0");
         bool prevBatchedPrefill = CudaHybridGdnForwardPass.BatchedPrefillEnabled;
         bool prevBatchedTrunk = CudaHybridGdnForwardPass.BatchedTrunkEnabled;
         bool prevAttn = CudaHybridGdnForwardPass.BatchedAttnEnabled;
@@ -365,6 +370,7 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
             CudaHybridGdnForwardPass.BatchedAttnEnabled = prevAttn;
             Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
             Environment.SetEnvironmentVariable("SHARPI_ATTN_WAVE_BUDGET_MB", prevBudget);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
         }
     }
 
@@ -905,8 +911,14 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
         var prevCpuMoe = Environment.GetEnvironmentVariable("SHARPI_CPU_MOE");
         var prevBudget = Environment.GetEnvironmentVariable("SHARPI_ATTN_WAVE_BUDGET_MB");
         var prevSnap = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        var prevSplit = Environment.GetEnvironmentVariable("SHARPI_SPLIT_DECODE");
         Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", "1");
         Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "128");
+        // #419 hardening: the sequential reference must stay on the monolithic single-block
+        // attention. Today GdnSplitMinSeq (8192) already exceeds this test's ~4300 ctx, but
+        // pin split decode off so lowering that threshold can't silently break bit-parity
+        // (the flash-decoding split reduction is argmax-stable, not bitwise).
+        Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", "0");
         bool prevBatchedPrefill = CudaHybridGdnForwardPass.BatchedPrefillEnabled;
         bool prevBatchedTrunk = CudaHybridGdnForwardPass.BatchedTrunkEnabled;
         bool prevAttn = CudaHybridGdnForwardPass.BatchedAttnEnabled;
@@ -961,6 +973,7 @@ public sealed class CudaHybridGdnBatchedPrefillTests : IDisposable
             Environment.SetEnvironmentVariable("SHARPI_CPU_MOE", prevCpuMoe);
             Environment.SetEnvironmentVariable("SHARPI_ATTN_WAVE_BUDGET_MB", prevBudget);
             Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevSnap);
+            Environment.SetEnvironmentVariable("SHARPI_SPLIT_DECODE", prevSplit);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #419 — `BatchedPrefill_Over4096_BitwiseMatchesSequential_Coder` failing bitwise parity at N=4231.

**Root cause:** the wave SDPA is innocent. The test's *sequential reference arm* changed underneath it: since #238 (`afe2902`), `CudaHybridForwardPass.AttentionKv` routes per-token attention to the flash-decoding split-KV kernels once `seqLen > HybridSplitMinSeq` (4096). Split-KV's chunked softmax + LSE combine reorders the reduction — argmax-stable but **not** bit-identical to the monolithic single-block path that `AttentionBatchedWave` clones. A 4231-token prompt puts the reference's last ~135 positions on the split path (and the divergence propagates through the residual stream into deeper-layer KV), so bitwise parity became impossible. The test predates #238 by ~190 commits and was never adjusted.

This also explains the bracketing in the issue: the ≤4096 and multi-chunk siblings never cross the threshold, and the GDN twin passes only because `GdnSplitMinSeq` is 8192 (> its ~4300 ctx). Not laptop-specific — deterministic on any CUDA box.

## Changes

- Pin `SHARPI_SPLIT_DECODE=0` for both arms of the Coder >4096 parity test (read at pass construction), mirroring the existing pattern in `CudaHybridKvDtypeTests`; split-vs-single parity keeps its own argmax-stable oracle there.
- Defensively pin the two GDN >4096 bitwise tests (`BatchedAttnWave_…` / `SnapKvActive_BatchedWave_…`) so a future lowering of `GdnSplitMinSeq` can't silently reintroduce this.
- Correct the stale unconditional bit-identity claims in `PrefillBatchedTrunk` / `GpuLayerBatchedTrunk` comments.

No engine code changes — #238's split-KV behavior is intended and separately fenced.

## Verification

- RTX 4070 Laptop (the #419 repro box): the previously failing test now **passes** (11m6s, N=4231, forced multi-wave via `SHARPI_ATTN_WAVE_BUDGET_MB=8`).
- Full solution builds clean (warnings-as-errors).
- GDN test edits are behavior-neutral today (threshold 8192 > test ctx) and skip on this box (model on E: only); compile-verified.
- Review cycle: 8-angle finder + verification pass; refuted candidates (env-var race — collection parallelism is disabled in `xunit.runner.json`; KV-cache-invariant wording) and applied the surviving ones (GDN defensive pins, comment dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EWo1niax1g8A5E79RSALJ