### PR TITLE
fix(ornith,server): validate #411 on real weights; fix max_tokens stop-reason misreport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,21 @@ dotnet run --project benchmarks/SharpInference.Bench -c Release -- --filter '*'
 # Ornith-1.0 (DeepReinforce, MIT) — agentic-coding "self-scaffolding" RL finetunes of
 # Qwen3.5 / Gemma 4 bases, NOT a new architecture. Self-scaffolding is a training-time
 # technique; at inference they're ordinary transformers. GGUF arches reduce to ones
-# already dispatched: 9B = dense `qwen35`, 35B/397B = `qwen35moe` (so the MoE variants
-# ride the existing Gated-DeltaNet + sparse-attention MoE path, incl. --cpu-moe, and the
-# qwen35moe QwenToolCallAdapter). They're tagged image-text-to-text, but the Qwen3.5
-# vision projector is unimplemented — the text GGUF path is text-only, which is what the
-# coding use case needs. `download-model.ps1 -Model ornith-9b` (Q4_K_M, ~5.6 GB).
+# already dispatched: 9B = `qwen35`, 35B/397B = `qwen35moe`. Validated end-to-end
+# (issue #411): the bartowski 9B Q4_K_M GGUF actually ships GDN tensors, so
+# `_sharpi.is_hybrid_ssm` auto-activates and it takes the SAME hybrid Gated-DeltaNet +
+# attention path as the 35B/397B MoE variants (24 GDN + 8 full-attention layers,
+# full_attention_interval=4) — not a plain dense transformer as the arch name alone
+# suggests. Full CUDA offload (-g -1) fits comfortably in 8 GB VRAM (~3 GB weights
+# uploaded; GDN state + dense FFN run on CPU by design of CudaHybridGdnForwardPass).
+# Chat template loads via JinjaChatTemplate and tool calls parse via the qwen35moe-style
+# QwenToolCallAdapter (Qwen3.6 XML `<function=..><parameter=..>` inside `<tool_call>`).
+# They're tagged image-text-to-text, but the Qwen3.5 vision projector is unimplemented —
+# the text GGUF path is text-only, which is what the coding use case needs.
+# `download-model.ps1 -Model ornith-9b` (Q4_K_M, 5.5 GB).
 dotnet run --project src/SharpInference.Cli -c Release -- \
-  -m models/deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf -g -1 -p "Write a Python LRU cache."
+  -m models/deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf -g -1 \
+  --temp 0.6 --top-p 0.95 --top-k 20 -p "Write a Python LRU cache."
 
 # Image generation with upscaling (Z-Image-Turbo + RRDBNet). ImageCommand auto-detects
 # Z-Image vs FLUX from the model. Z-Image uses a Qwen3-4B text encoder; FLUX uses CLIP-L + T5.

--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -24,8 +24,8 @@
     .\download-model.ps1 -Model qwen36-27b-mtp-q5       # Qwen3.6 27B-MTP Q5_K_M (18.5 GB) — higher-quality variant for the MTP bench row
     .\download-model.ps1 -Model qwen36-35b-a3b-mtp -DestDir E:\models  # Qwen3.6 35B-A3B-MTP UD-Q4_K_M (22.7 GB) — MoE MTP perf target for issue #25
     .\download-model.ps1 -Model carnice-35b-a3b-mtp -DestDir E:\models  # Carnice (Qwen3.6-35B-A3B-MTP, agentic/tool-calling) APEX-MTP I-Compact (17.3 GB)
-    .\download-model.ps1 -Model ornith-9b              # Ornith-1.0-9B Q4_K_M (~5.6 GB) — DeepReinforce agentic-coding finetune of Qwen3.5 (dense qwen35 arch)
-    .\download-model.ps1 -Model ornith-35b -DestDir E:\models  # Ornith-1.0-35B Q4_K_M (~21 GB) — agentic-coding MoE on the existing qwen35moe path
+    .\download-model.ps1 -Model ornith-9b              # Ornith-1.0-9B Q4_K_M (5.5 GB) — DeepReinforce agentic-coding finetune of Qwen3.5 (hybrid GDN+attention, qwen35 arch)
+    .\download-model.ps1 -Model ornith-35b -DestDir E:\models  # Ornith-1.0-35B Q4_K_M (19.9 GB) — agentic-coding MoE on the existing qwen35moe path
     .\download-model.ps1 -Model gemma4-12b-qat -DestDir E:\models  # Gemma 4 12B-it QAT q4_0 + vision/audio mmproj (~7.2 GB) — issue #124 PRIMARY (official quantization-aware-trained)
     .\download-model.ps1 -Model gemma4-12b-q4km -DestDir E:\models # Gemma 4 12B-it Q4_K_M (~7.3 GB) — issue #124 fallback / K-quant cross-check
     .\download-model.ps1 -Model gemma4-e4b-qat -DestDir E:\models  # Gemma 4 E4B-it QAT q4_0 (~5.15 GB) — fast small Gemma (~1.6× decode vs Q8_0)
@@ -179,14 +179,19 @@ $Models = @{
     # text GGUF path here is text-only — fine for the agentic-coding use case.)
     #
     # Sources are bartowski's GGUF republishes (deterministic `<ns>_<model>-<Quant>.gguf`
-    # naming). Ornith-1.0-9B is the edge target (43.1 Terminal-Bench 2.1, 69.4 SWE-Bench
-    # Verified). If the 9B GGUF carries GDN tensors the hybrid-SSM probe activates
-    # automatically; otherwise it loads as a plain dense qwen35 transformer.
+    # naming; URLs verified against the live repos 2026-07-04 — both Q4_K_M quants are
+    # single files, only the 35B bf16 is sharded). Ornith-1.0-9B is the edge target (43.1
+    # Terminal-Bench 2.1, 69.4 SWE-Bench Verified). Validated end-to-end (issue #411):
+    # the GGUF DOES carry GDN tensors, so the hybrid-SSM probe activates automatically —
+    # it takes the same hybrid Gated-DeltaNet + attention path as the 35B/397B MoE
+    # variants (24 GDN + 8 full-attention layers), not a plain dense transformer.
+    # -g -1 fits comfortably in 8 GB VRAM.
     "ornith-9b" = @{
         Files = @("deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf")
         Urls  = @("https://huggingface.co/bartowski/deepreinforce-ai_Ornith-1.0-9B-GGUF/resolve/main/deepreinforce-ai_Ornith-1.0-9B-Q4_K_M.gguf")
-        Size  = "~5.6 GB"
-        Phase = "agentic coding (Qwen3.5-based dense, qwen35 arch)"
+        Size  = "5.5 GB"
+        SizeGB = 5.5
+        Phase = "agentic coding (Qwen3.5-based hybrid GDN+attention, qwen35 arch)"
     }
     # Ornith-1.0-35B — qwen35moe (Qwen3.5 35B-A3B base): runs on the existing hybrid
     # Gated-DeltaNet + sparse-attention MoE path (same arch as qwen36-35b-a3b), incl.
@@ -195,7 +200,8 @@ $Models = @{
     "ornith-35b" = @{
         Files = @("deepreinforce-ai_Ornith-1.0-35B-Q4_K_M.gguf")
         Urls  = @("https://huggingface.co/bartowski/deepreinforce-ai_Ornith-1.0-35B-GGUF/resolve/main/deepreinforce-ai_Ornith-1.0-35B-Q4_K_M.gguf")
-        Size  = "~21 GB"
+        Size  = "19.9 GB"
+        SizeGB = 19.9
         Phase = "agentic coding (qwen35moe MoE path)"
     }
     # ── Gemma 4 12B (dense gemma4_unified) — issue #124 ───────────────────────
@@ -361,7 +367,8 @@ function Download-File {
         New-Item -ItemType Directory -Path $parent -Force | Out-Null
     }
     if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
-        & curl.exe -L -o $path -C - --progress-bar $url
+        # --fail: without it a 404 saves the HTML error page as the .gguf
+        & curl.exe -L --fail -o $path -C - --progress-bar $url
         if ($LASTEXITCODE -ne 0) { throw "curl exited with code $LASTEXITCODE" }
     }
     else {

--- a/src/SharpInference.Core/ToolCallAdapter.cs
+++ b/src/SharpInference.Core/ToolCallAdapter.cs
@@ -142,6 +142,7 @@ public static class ToolCallAdapterRegistry
             ["qwen2"]      = new QwenToolCallAdapter("qwen2"),
             ["qwen3"]      = new QwenToolCallAdapter("qwen3"),
             ["qwen3moe"]   = new QwenToolCallAdapter("qwen3moe"),
+            ["qwen35"]     = new QwenToolCallAdapter("qwen35"),
             ["qwen35moe"]  = new QwenToolCallAdapter("qwen35moe"),
 
             // Qwen3-Coder: bare <function=name>...</function> with no <tool_call>

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -479,7 +479,10 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
             prefilling.Clear();
             foreach (var seq in active)
             {
-                if (fatal is null) FlushAndComplete(seq);
+                // Engine shutdown mid-generation (e.g. Dispose()) cuts these sequences off
+                // involuntarily, not via a natural stop token — report it as truncated so
+                // the client doesn't see a false "stop"/"end_turn" for incomplete content.
+                if (fatal is null) FlushAndComplete(seq, truncatedByMaxTokens: true);
                 else seq.Output.Writer.TryComplete(fatal);
                 seq.Cache.Dispose();
                 Interlocked.Decrement(ref _activeCount);

--- a/src/SharpInference.Engine/ContinuousBatchingEngine.cs
+++ b/src/SharpInference.Engine/ContinuousBatchingEngine.cs
@@ -381,13 +381,17 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
                 // begin/end constraining). No-op when this sequence has no constraint.
                 seq.Constraint?.Accept(next);
 
-                bool done = seq.StopIds.Contains(next)
+                bool stoppedByStopToken = seq.StopIds.Contains(next);
+                bool cancelled = seq.Ct.IsCancellationRequested;
+                bool done = stoppedByStopToken
                     || seq.TokenCount >= seq.Sp.MaxNewTokens
-                    || seq.Ct.IsCancellationRequested;
+                    || cancelled;
 
                 if (done)
                 {
-                    FlushAndComplete(seq);
+                    // Only "not a stop token and not cancelled" can mean the MaxNewTokens
+                    // disjunct fired — the three conditions are mutually exhaustive above.
+                    FlushAndComplete(seq, truncatedByMaxTokens: !stoppedByStopToken && !cancelled);
                     RetireSeq(seq);
                     active.RemoveAt(i);
                 }
@@ -684,7 +688,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         Interlocked.Decrement(ref _activeCount);
     }
 
-    private static void FlushAndComplete(ActiveSeq seq)
+    private static void FlushAndComplete(ActiveSeq seq, bool truncatedByMaxTokens = false)
     {
         var textTail = seq.TextDec.Flush();
         if (textTail.Length > 0)
@@ -692,6 +696,7 @@ public sealed class ContinuousBatchingEngine : IInferenceEngine, IDisposable
         var thinkTail = seq.ThinkDec.Flush();
         if (thinkTail.Length > 0)
             seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Thinking, thinkTail));
+        seq.Output.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Stop, "", TruncatedByMaxTokens: truncatedByMaxTokens));
         seq.Output.Writer.TryComplete();
     }
 

--- a/src/SharpInference.Engine/GenerateChunk.cs
+++ b/src/SharpInference.Engine/GenerateChunk.cs
@@ -23,6 +23,19 @@ public enum GenerateChunkKind
     /// <see cref="IInferenceEngine.GenerateAsync"/> adapter) ignore it.
     /// </summary>
     Usage,
+
+    /// <summary>
+    /// Out-of-band chunk emitted once, at the very end of a successful (non-cancelled,
+    /// non-errored) generation — after all Text/Thinking chunks. Its
+    /// <see cref="GenerateChunk.Text"/> is empty; <see cref="GenerateChunk.TruncatedByMaxTokens"/>
+    /// tells the caller whether decoding stopped because the token budget
+    /// (<c>SamplingParams.MaxNewTokens</c>) was exhausted rather than a natural stop
+    /// token/EOS. Endpoints use this to report <c>finish_reason: "length"</c> /
+    /// <c>stop_reason: "max_tokens"</c> instead of <c>"stop"</c>/<c>"end_turn"</c> when the
+    /// response was cut off mid-thought with no tool call in progress. Engines that don't
+    /// emit this chunk (e.g. test doubles) leave callers defaulting to "not truncated".
+    /// </summary>
+    Stop,
 }
 
 /// <summary>
@@ -32,7 +45,9 @@ public enum GenerateChunkKind
 /// never emitted as content — they're protocol markers consumed by the engine.
 /// <para>
 /// <see cref="PromptTokens"/> is meaningful only on a <see cref="GenerateChunkKind.Usage"/>
-/// chunk (0 on Text/Thinking chunks).
+/// chunk (0 on Text/Thinking chunks). <see cref="TruncatedByMaxTokens"/> is meaningful only
+/// on a <see cref="GenerateChunkKind.Stop"/> chunk (false on Text/Thinking/Usage chunks).
 /// </para>
 /// </summary>
-public readonly record struct GenerateChunk(GenerateChunkKind Kind, string Text, int PromptTokens = 0);
+public readonly record struct GenerateChunk(
+    GenerateChunkKind Kind, string Text, int PromptTokens = 0, bool TruncatedByMaxTokens = false);

--- a/src/SharpInference.Engine/IInferenceEngine.cs
+++ b/src/SharpInference.Engine/IInferenceEngine.cs
@@ -36,12 +36,14 @@ public interface IInferenceEngine
     /// <summary>
     /// Generate typed chunks from a pre-formatted prompt string. Each chunk is tagged as
     /// user-facing <see cref="GenerateChunkKind.Text"/>, internal
-    /// <see cref="GenerateChunkKind.Thinking"/> reasoning, or a single out-of-band
+    /// <see cref="GenerateChunkKind.Thinking"/> reasoning, a single out-of-band
     /// <see cref="GenerateChunkKind.Usage"/> metadata chunk (emitted once, before any text,
-    /// carrying the prompt-token count). The boundary tokens
-    /// (<c>&lt;think&gt;</c> / <c>&lt;/think&gt;</c>) are consumed by the engine and never
-    /// surface in chunk text. Requests are serialized — concurrent calls block until
-    /// the current request finishes.
+    /// carrying the prompt-token count), or a single out-of-band
+    /// <see cref="GenerateChunkKind.Stop"/> chunk (emitted once, after all text/thinking, on
+    /// any non-cancelled/non-errored completion — carries whether the MaxNewTokens budget
+    /// was exhausted). The boundary tokens (<c>&lt;think&gt;</c> / <c>&lt;/think&gt;</c>) are
+    /// consumed by the engine and never surface in chunk text. Requests are serialized —
+    /// concurrent calls block until the current request finishes.
     /// </summary>
     /// <param name="canonicalHistoryPrefix">
     /// Optional chat-template render of the request's message history rendered with

--- a/src/SharpInference.Engine/InferenceEngine.cs
+++ b/src/SharpInference.Engine/InferenceEngine.cs
@@ -943,6 +943,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                             // transcript against slot 0 so the next turn's SelectSlot can rematch.
                             if (_slotTokens is not null) _slotTokens[0] = snapMtp;
                         }
+                        // MtpDecoder.Decode never invokes emitToken for the stop token itself
+                        // (documented contract), so decodeTokens reaching MaxNewTokens here means
+                        // the budget was exhausted before a stop token was seen.
+                        channel.Writer.TryWrite(new GenerateChunk(
+                            GenerateChunkKind.Stop, "", TruncatedByMaxTokens: decodeTokens >= sp.MaxNewTokens));
                         channel.Writer.TryComplete();
                         return;
                     }
@@ -981,6 +986,11 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         && sp.LogitBias is not { Count: > 0 }
                         && constraint is null;
                     int gpuNext = useGpuArgmax ? Sampler.Greedy(logits) : 0;
+
+                    // Assume the budget was exhausted unless the loop finds an explicit stop
+                    // token below; that's the only other way out of the loop (cancellation
+                    // throws and skips the Stop-chunk write entirely).
+                    bool hitMaxTokens = true;
 
                     for (int i = 0; i < sp.MaxNewTokens; i++)
                     {
@@ -1025,7 +1035,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         if (ttftMs < 0) ttftMs = swReq.ElapsedMilliseconds;
                         decodeTokens++;
 
-                        if (stopIds.Contains(next)) break;
+                        if (stopIds.Contains(next)) { hitMaxTokens = false; break; }
 
                         // Counter update mirrors RunCommand.DecodeLoop: reset on each <think>
                         // open, otherwise increment whenever inThinking was true on entry to
@@ -1113,6 +1123,7 @@ public sealed class InferenceEngine : IInferenceEngine, IDisposable, IAsyncDispo
                         if (activeSlotIdx >= 0) _slotTokens![activeSlotIdx] = snap;
                     }
 
+                    channel.Writer.TryWrite(new GenerateChunk(GenerateChunkKind.Stop, "", TruncatedByMaxTokens: hitMaxTokens));
                     channel.Writer.TryComplete();
                 }
                 catch (Exception ex)

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -253,12 +253,8 @@ public static class AnthropicEndpoints
             contentList.Add(new AContent("text", Text: ""));
 
         // A trailing unterminated tool call was surfaced as text (not a tool_use block); report
-        // max_tokens so the client sees it was cut off. Mirrors the streaming path. Falls back to
-        // the engine's own Stop-chunk signal when the response was truncated mid-thought/text with
-        // no tool call in progress (issue #411 follow-up: was always "end_turn" before).
-        var stopReason = toolCalls.Count > 0 ? "tool_use"
-                       : truncatedCall ? "max_tokens"
-                       : truncatedByMaxTokens ? "max_tokens" : "end_turn";
+        // max_tokens so the client sees it was cut off. Mirrors the streaming path.
+        var stopReason = DetermineStopReason(toolCalls.Count > 0, truncatedCall, truncatedByMaxTokens);
 
         var response = new AnthropicMessageResponse(
             msgId, "message", "assistant",
@@ -574,13 +570,8 @@ public static class AnthropicEndpoints
             catch (IOException) { /* response stream closed */ }
         }
 
-        // message_delta. Falls back to the engine's own Stop-chunk signal when the response was
-        // truncated mid-thought/text with no tool call in progress (issue #411 follow-up: was
-        // always "end_turn" before).
-        var stopReason = hasToolCalls
-            ? "tool_use"
-            : truncatedToolCall ? "max_tokens"
-            : truncatedByMaxTokens ? "max_tokens" : "end_turn";
+        // message_delta
+        var stopReason = DetermineStopReason(hasToolCalls, truncatedToolCall, truncatedByMaxTokens);
         var msgDelta = new AMessageDeltaEvent("message_delta",
             new AMessageDelta(stopReason, null), new AUsage(promptTokens, outputTokens));
         await WriteAnthropicEvent(ctx.Response, "message_delta",
@@ -610,6 +601,13 @@ public static class AnthropicEndpoints
         var b64 = Convert.ToBase64String(bytes);
         return b64.Length > 32 ? b64[..32] : b64;
     }
+
+    /// <summary>Shared priority order for the streaming and non-streaming handlers: a tool call
+    /// in progress always wins, then any form of budget truncation, else a natural end_turn.</summary>
+    private static string DetermineStopReason(bool hasToolCalls, bool truncatedCall, bool truncatedByMaxTokens) =>
+        hasToolCalls ? "tool_use"
+        : truncatedCall || truncatedByMaxTokens ? "max_tokens"
+        : "end_turn";
 
     /// <summary>Pre-built empty JSON object used for the <c>input</c> field of tool_use blocks.</summary>
     private static readonly JsonElement EmptyJsonObject = JsonDocument.Parse("{}").RootElement.Clone();

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -188,6 +188,7 @@ public static class AnthropicEndpoints
         var textSb = new StringBuilder();
         int totalOutputTokens = 0;
         int promptTokens = 0;
+        bool truncatedByMaxTokens = false;
 
         try
         {
@@ -196,6 +197,11 @@ public static class AnthropicEndpoints
                 if (chunk.Kind == GenerateChunkKind.Usage)
                 {
                     promptTokens = chunk.PromptTokens;
+                    continue;
+                }
+                if (chunk.Kind == GenerateChunkKind.Stop)
+                {
+                    truncatedByMaxTokens = chunk.TruncatedByMaxTokens;
                     continue;
                 }
                 totalOutputTokens++;
@@ -247,9 +253,12 @@ public static class AnthropicEndpoints
             contentList.Add(new AContent("text", Text: ""));
 
         // A trailing unterminated tool call was surfaced as text (not a tool_use block); report
-        // max_tokens so the client sees it was cut off. Mirrors the streaming path.
+        // max_tokens so the client sees it was cut off. Mirrors the streaming path. Falls back to
+        // the engine's own Stop-chunk signal when the response was truncated mid-thought/text with
+        // no tool call in progress (issue #411 follow-up: was always "end_turn" before).
         var stopReason = toolCalls.Count > 0 ? "tool_use"
-                       : truncatedCall ? "max_tokens" : "end_turn";
+                       : truncatedCall ? "max_tokens"
+                       : truncatedByMaxTokens ? "max_tokens" : "end_turn";
 
         var response = new AnthropicMessageResponse(
             msgId, "message", "assistant",
@@ -437,6 +446,7 @@ public static class AnthropicEndpoints
         }
 
         bool truncatedToolCall = false;
+        bool truncatedByMaxTokens = false;
         try
         {
             await foreach (var chunk in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
@@ -447,6 +457,11 @@ public static class AnthropicEndpoints
                 if (chunk.Kind == GenerateChunkKind.Usage)
                 {
                     promptTokens = chunk.PromptTokens;
+                    continue;
+                }
+                if (chunk.Kind == GenerateChunkKind.Stop)
+                {
+                    truncatedByMaxTokens = chunk.TruncatedByMaxTokens;
                     continue;
                 }
                 outputTokens++;
@@ -559,10 +574,13 @@ public static class AnthropicEndpoints
             catch (IOException) { /* response stream closed */ }
         }
 
-        // message_delta
+        // message_delta. Falls back to the engine's own Stop-chunk signal when the response was
+        // truncated mid-thought/text with no tool call in progress (issue #411 follow-up: was
+        // always "end_turn" before).
         var stopReason = hasToolCalls
             ? "tool_use"
-            : truncatedToolCall ? "max_tokens" : "end_turn";
+            : truncatedToolCall ? "max_tokens"
+            : truncatedByMaxTokens ? "max_tokens" : "end_turn";
         var msgDelta = new AMessageDeltaEvent("message_delta",
             new AMessageDelta(stopReason, null), new AUsage(promptTokens, outputTokens));
         await WriteAnthropicEvent(ctx.Response, "message_delta",

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -200,6 +200,7 @@ public static class OpenAiEndpoints
         int textTokens = 0;
         int reasoningTokens = 0;
         int promptTokens = 0;
+        bool truncatedByMaxTokens = false;
 
         try
         {
@@ -208,6 +209,10 @@ public static class OpenAiEndpoints
                 if (c.Kind == GenerateChunkKind.Usage)
                 {
                     promptTokens = c.PromptTokens;
+                }
+                else if (c.Kind == GenerateChunkKind.Stop)
+                {
+                    truncatedByMaxTokens = c.TruncatedByMaxTokens;
                 }
                 else if (c.Kind == GenerateChunkKind.Thinking)
                 {
@@ -278,6 +283,13 @@ public static class OpenAiEndpoints
             // Model hit max_tokens / EOS inside an unterminated tool call. The partial was
             // surfaced as content by Parse; report length so the client knows it was cut off
             // and does NOT receive a half-parsed call. Mirrors the streaming path.
+            finishReason = "length";
+        }
+        else if (truncatedByMaxTokens)
+        {
+            // No tool call in progress, but the engine's Stop chunk says the MaxNewTokens
+            // budget was exhausted rather than a natural stop token (issue #411 follow-up:
+            // this case previously fell through to the "stop" default below, unconditionally).
             finishReason = "length";
         }
 
@@ -405,6 +417,7 @@ public static class OpenAiEndpoints
         }
 
         bool truncatedToolCall = false;
+        bool truncatedByMaxTokens = false;
         try
         {
             await foreach (var c in ImageContent.Generate(engine, prompt, canonicalHistoryPrefix, images, sp, ctx.RequestAborted))
@@ -413,6 +426,11 @@ public static class OpenAiEndpoints
                 // text. The streaming response doesn't emit a usage object (OpenAI gates that
                 // behind stream_options.include_usage, unsupported here), so just skip it.
                 if (c.Kind == GenerateChunkKind.Usage) continue;
+                if (c.Kind == GenerateChunkKind.Stop)
+                {
+                    truncatedByMaxTokens = c.TruncatedByMaxTokens;
+                    continue;
+                }
                 tokenCount++;
                 if (c.Kind == GenerateChunkKind.Thinking)
                 {
@@ -469,10 +487,13 @@ public static class OpenAiEndpoints
             }
         }
 
-        // Final chunk with finish_reason
+        // Final chunk with finish_reason. Falls back to the engine's own Stop-chunk signal when
+        // the response was truncated mid-thought/text with no tool call in progress (issue #411
+        // follow-up: this case previously fell through to "stop" unconditionally).
         var finishReason = hasToolCalls
             ? "tool_calls"
-            : truncatedToolCall ? "length" : "stop";
+            : truncatedToolCall ? "length"
+            : truncatedByMaxTokens ? "length" : "stop";
         var finalChunk = new ChatCompletionChunk(
             requestId, "chat.completion.chunk", created, engine.ModelId,
             [new ChunkChoice(0, new ChunkDelta(null, null), finishReason)]);

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -263,7 +263,6 @@ public static class OpenAiEndpoints
         }
 
         OaiToolCall[]? toolCalls = null;
-        string finishReason = "stop";
         string? content = plainText;
         if (parsedCalls.Count > 0)
         {
@@ -273,25 +272,15 @@ public static class OpenAiEndpoints
                     Type: "function",
                     Function: new OaiToolCallFunction(c.Name, JinjaChatTemplate.SerializeToJson(c.Arguments))))
                 .ToArray();
-            finishReason = "tool_calls";
             // OpenAI returns content: null when a tool_calls array is present and there
             // was no accompanying text; an empty string would be a wire-shape mismatch.
             if (plainText.Length == 0) content = null;
         }
-        else if (truncatedCall)
-        {
-            // Model hit max_tokens / EOS inside an unterminated tool call. The partial was
-            // surfaced as content by Parse; report length so the client knows it was cut off
-            // and does NOT receive a half-parsed call. Mirrors the streaming path.
-            finishReason = "length";
-        }
-        else if (truncatedByMaxTokens)
-        {
-            // No tool call in progress, but the engine's Stop chunk says the MaxNewTokens
-            // budget was exhausted rather than a natural stop token (issue #411 follow-up:
-            // this case previously fell through to the "stop" default below, unconditionally).
-            finishReason = "length";
-        }
+        // truncatedCall: model hit max_tokens / EOS inside an unterminated tool call — the
+        // partial was surfaced as content by Parse, so report length instead of tool_calls.
+        // truncatedByMaxTokens: no tool call in progress, but the budget was exhausted on
+        // plain text/thinking. Mirrors the streaming path.
+        string finishReason = DetermineFinishReason(parsedCalls.Count > 0, truncatedCall, truncatedByMaxTokens);
 
         var message = new OaiAssistantMessage(
             "assistant",
@@ -487,13 +476,8 @@ public static class OpenAiEndpoints
             }
         }
 
-        // Final chunk with finish_reason. Falls back to the engine's own Stop-chunk signal when
-        // the response was truncated mid-thought/text with no tool call in progress (issue #411
-        // follow-up: this case previously fell through to "stop" unconditionally).
-        var finishReason = hasToolCalls
-            ? "tool_calls"
-            : truncatedToolCall ? "length"
-            : truncatedByMaxTokens ? "length" : "stop";
+        // Final chunk with finish_reason
+        var finishReason = DetermineFinishReason(hasToolCalls, truncatedToolCall, truncatedByMaxTokens);
         var finalChunk = new ChatCompletionChunk(
             requestId, "chat.completion.chunk", created, engine.ModelId,
             [new ChunkChoice(0, new ChunkDelta(null, null), finishReason)]);
@@ -679,6 +663,13 @@ public static class OpenAiEndpoints
         await response.WriteAsync($"data: {data}\n\n", response.HttpContext.RequestAborted);
         await response.Body.FlushAsync(response.HttpContext.RequestAborted);
     }
+
+    /// <summary>Shared priority order for the streaming and non-streaming handlers: a tool call
+    /// in progress always wins, then any form of budget truncation, else a natural stop.</summary>
+    private static string DetermineFinishReason(bool hasToolCalls, bool truncatedCall, bool truncatedByMaxTokens) =>
+        hasToolCalls ? "tool_calls"
+        : truncatedCall || truncatedByMaxTokens ? "length"
+        : "stop";
 }
 
 // ── Request / Response types ──────────────────────────────────────────────────

--- a/tests/SharpInference.Tests.Core/Ornith10ArchitectureTests.cs
+++ b/tests/SharpInference.Tests.Core/Ornith10ArchitectureTests.cs
@@ -51,8 +51,10 @@ public sealed class Ornith10ArchitectureTests
         Assert.Equal(LayerType.GatedDeltaNet, hp.LayerTypes[0]);
     }
 
-    // Ornith-1.0-9B: HF arch `qwen3_5` (dense) → GGUF arch `qwen35`. Recognized as a
-    // NEOX-RoPE dense transformer; not MoE, and not hybrid unless GDN tensors are present.
+    // Ornith-1.0-9B: HF arch `qwen3_5` → GGUF arch `qwen35`. Recognized as a NEOX-RoPE
+    // transformer; not MoE. Hybrid GDN activation depends solely on whether GDN tensors
+    // are present in the file (validated below) — this fixture omits them to pin the
+    // plain-dense fallback in isolation.
     [Fact]
     public void Ornith9BDense_IsRecognizedAsNeoxDense()
     {
@@ -77,8 +79,13 @@ public sealed class Ornith10ArchitectureTests
         Assert.Equal(48, hp.NumLayers);
     }
 
-    // If the 9B (or any dense qwen35) ships Gated-DeltaNet tensors, GgufModel.Open
-    // injects `_sharpi.is_hybrid_ssm` and the hybrid path activates automatically.
+    // If the 9B (or any qwen35) ships Gated-DeltaNet tensors, GgufModel.Open injects
+    // `_sharpi.is_hybrid_ssm` and the hybrid path activates automatically. This is NOT
+    // a hypothetical: validated end-to-end (issue #411) against the real bartowski
+    // Ornith-1.0-9B-Q4_K_M.gguf — it does carry GDN tensors, so the "dense" arch name
+    // is misleading; the shipped model actually takes this hybrid path (24 GDN + 8
+    // full-attention layers of 32, full_attention_interval=4), the same shape as the
+    // 35B/397B MoE variants minus the MoE FFN.
     [Fact]
     public void Ornith9BDense_ActivatesHybridWhenGdnTensorsProbed()
     {

--- a/tests/SharpInference.Tests.Core/ToolCallAdapterTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolCallAdapterTests.cs
@@ -17,6 +17,7 @@ public sealed class ToolCallAdapterTests
         Assert.IsType<QwenToolCallAdapter>(ToolCallAdapterRegistry.Get("qwen2"));
         Assert.IsType<QwenToolCallAdapter>(ToolCallAdapterRegistry.Get("qwen3"));
         Assert.IsType<QwenToolCallAdapter>(ToolCallAdapterRegistry.Get("qwen3moe"));
+        Assert.IsType<QwenToolCallAdapter>(ToolCallAdapterRegistry.Get("qwen35"));
         Assert.IsType<QwenToolCallAdapter>(ToolCallAdapterRegistry.Get("qwen35moe"));
     }
 

--- a/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/InferenceEngineChunkTests.cs
@@ -43,7 +43,7 @@ public sealed class InferenceEngineChunkTests
         // (issue #150) — ScriptedTokenizer.Encode returns a single token. The rest are Text.
         var usage = Assert.Single(chunks, c => c.Kind == GenerateChunkKind.Usage);
         Assert.Equal(1, usage.PromptTokens);
-        Assert.All(chunks.Where(c => c.Kind != GenerateChunkKind.Usage),
+        Assert.All(chunks.Where(c => c.Kind is not (GenerateChunkKind.Usage or GenerateChunkKind.Stop)),
             c => Assert.Equal(GenerateChunkKind.Text, c.Kind));
         var joined = string.Concat(chunks.Where(c => c.Kind == GenerateChunkKind.Text).Select(c => c.Text));
         Assert.Equal("Hi there", joined);

--- a/tests/SharpInference.Tests.Server/ServerTests.cs
+++ b/tests/SharpInference.Tests.Server/ServerTests.cs
@@ -439,6 +439,132 @@ public sealed class ServerTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal(3, doc.RootElement.GetProperty("usage").GetProperty("completion_tokens").GetInt32());
     }
 
+    // ── finish_reason / stop_reason on MaxNewTokens truncation (issue #411 follow-up) ─────────
+    // Regression coverage for a bug found while validating Ornith-1.0 through the server: a
+    // plain-text/thinking response cut off by the token budget with no tool call in progress
+    // used to always report finish_reason "stop" / stop_reason "end_turn" instead of "length" /
+    // "max_tokens". The engine now emits a GenerateChunkKind.Stop chunk carrying whether the
+    // budget was exhausted; FakeInferenceEngine.TruncatedByMaxTokens simulates it.
+
+    [Fact]
+    public async Task ChatCompletion_NonStreaming_TruncatedByMaxTokens_ReportsLengthFinishReason()
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
+                "test-model",
+                [(GenerateChunkKind.Text, "cut off mid-sen")])
+            { TruncatedByMaxTokens = true })));
+        var client = factory.CreateClient();
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Write an essay." } },
+            max_tokens = 5,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("length", doc.RootElement.GetProperty("choices")[0].GetProperty("finish_reason").GetString());
+    }
+
+    [Fact]
+    public async Task ChatCompletion_Streaming_TruncatedByMaxTokens_ReportsLengthFinishReason()
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
+                "test-model",
+                [(GenerateChunkKind.Text, "cut off mid-sen")])
+            { TruncatedByMaxTokens = true })));
+        var client = factory.CreateClient();
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Write an essay." } },
+            max_tokens = 5,
+            stream = true,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"finish_reason\":\"length\"", body);
+    }
+
+    [Fact]
+    public async Task Messages_NonStreaming_TruncatedByMaxTokens_ReportsMaxTokensStopReason()
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
+                "test-model",
+                [(GenerateChunkKind.Text, "cut off mid-sen")])
+            { TruncatedByMaxTokens = true })));
+        var client = factory.CreateClient();
+
+        var req = new
+        {
+            model = "test-model",
+            max_tokens = 5,
+            messages = new[] { new { role = "user", content = "Write an essay." } },
+        };
+        var response = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("max_tokens", doc.RootElement.GetProperty("stop_reason").GetString());
+    }
+
+    [Fact]
+    public async Task Messages_Streaming_TruncatedByMaxTokens_ReportsMaxTokensStopReason()
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
+                "test-model",
+                [(GenerateChunkKind.Text, "cut off mid-sen")])
+            { TruncatedByMaxTokens = true })));
+        var client = factory.CreateClient();
+
+        var req = new
+        {
+            model = "test-model",
+            max_tokens = 5,
+            messages = new[] { new { role = "user", content = "Write an essay." } },
+            stream = true,
+        };
+        var response = await client.PostAsJsonAsync("/v1/messages", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"stop_reason\":\"max_tokens\"", body);
+    }
+
+    [Fact]
+    public async Task ChatCompletion_NotTruncated_StillReportsStopFinishReason()
+    {
+        // Guards against a regression where the new Stop-chunk handling accidentally flips
+        // finish_reason to "length" for ordinary, non-truncated completions.
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(s => s.AddSingleton<IInferenceEngine>(new FakeInferenceEngine(
+                "test-model",
+                [(GenerateChunkKind.Text, "Hi"), (GenerateChunkKind.Text, "!")])
+            { TruncatedByMaxTokens = false })));
+        var client = factory.CreateClient();
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Hi" } },
+            max_tokens = 10,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("stop", doc.RootElement.GetProperty("choices")[0].GetProperty("finish_reason").GetString());
+    }
+
     [Fact]
     public async Task ChatCompletion_Streaming_TextOnly_NoReasoningContentDeltas()
     {
@@ -1389,6 +1515,14 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
     /// </summary>
     public TaskCompletionSource? Hold { get; init; }
 
+    /// <summary>
+    /// When set, a <see cref="GenerateChunkKind.Stop"/> chunk with <c>TruncatedByMaxTokens=true</c>
+    /// is emitted after the scripted output — mirroring the real engines' end-of-generation
+    /// signal so endpoint tests can assert <c>finish_reason</c>/<c>stop_reason</c> report
+    /// <c>"length"</c>/<c>"max_tokens"</c> when the budget was exhausted (issue #411 follow-up).
+    /// </summary>
+    public bool TruncatedByMaxTokens { get; init; }
+
     /// <summary>Signaled when a generation call has started (and, if <see cref="Hold"/> is set,
     /// is about to block) — so a test knows the first request is genuinely in flight.</summary>
     public readonly ManualResetEventSlim Entered = new();
@@ -1448,6 +1582,8 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
             await Task.Yield();
             yield return new GenerateChunk(kind, text);
         }
+        if (TruncatedByMaxTokens)
+            yield return new GenerateChunk(GenerateChunkKind.Stop, "", TruncatedByMaxTokens: true);
     }
 
     public async IAsyncEnumerable<GenerateChunk> GenerateImageChunksAsync(
@@ -1468,5 +1604,7 @@ internal sealed class FakeInferenceEngine : IInferenceEngine
             await Task.Yield();
             yield return new GenerateChunk(kind, text);
         }
+        if (TruncatedByMaxTokens)
+            yield return new GenerateChunk(GenerateChunkKind.Stop, "", TruncatedByMaxTokens: true);
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes discovered while validating Ornith-1.0 (#411) end-to-end on real weights:

**Ornith-1.0 validation (#411)**
- Verified `download-model.ps1`'s `ornith-9b`/`ornith-35b` presets against the live bartowski repos — both `Q4_K_M` quants are single files (sizes corrected: 9B 5.5 GB, 35B 19.9 GB); added `--fail` to the `curl.exe` download so a 404 doesn't silently save an HTML error page as a `.gguf`; added numeric `SizeGB` so the free-disk guard fires.
- **Key finding:** the real 9B GGUF ships Gated-DeltaNet tensors, so it takes the hybrid GDN+attention path (same shape as the 35B/397B MoE variants minus MoE FFN) — not the plain dense transformer the issue assumed. Corrected `CLAUDE.md` and test comments accordingly.
- Explicitly registered `qwen35` in `ToolCallAdapterRegistry` (previously fell through to the same default adapter; now documents the routing intent, covered by a test).
- End-to-end smoke-tested 9B on this laptop's 8GB RTX 4070 (`-g -1`, full CUDA offload): coherent output, correct EOS/stop, chat template loads, tool calls parse — both directly and through the server's OpenAI/Anthropic endpoints.

**Server bug fix, found while exercising the server host**
- A response truncated by hitting `max_tokens` mid-text/thinking (no tool call in progress) always reported `finish_reason: "stop"` (OpenAI) / `stop_reason: "end_turn"` (Anthropic) instead of `"length"`/`"max_tokens"` — reproduced live against Ornith-9B.
- Added a `GenerateChunkKind.Stop` chunk, emitted once at the end of generation by both `InferenceEngine` (main loop + MTP path) and `ContinuousBatchingEngine`, carrying whether the token budget was exhausted. Both server endpoints (streaming + non-streaming) now consume it.
- Ran `/code-review high` on this branch's diff before opening the PR; it caught and this PR fixes two real bugs the initial fix introduced/missed:
  - `ContinuousBatchingEngine`'s shutdown-drain path (engine `Dispose()` mid-generation) defaulted to reporting a natural stop for sequences that were actually cut off involuntarily.
  - A pre-existing, untouched test (`InferenceEngineChunkTests`) broke because it asserted every non-`Usage` chunk is `Text` — needed the same exclusion for the new `Stop` chunk.
  - Also extracted `DetermineStopReason`/`DetermineFinishReason` helpers to remove 4x duplicated priority-order logic across the streaming/non-streaming handlers (matches this codebase's existing shared-static-helper pattern for endpoint code).
- Two review findings were accepted as out-of-scope trade-offs rather than fixed: a pre-existing termination-timing asymmetry between the two engines' token classification (deeper architectural issue, not introduced by this fix), and a ~8-byte `GenerateChunk` struct-size increase (correctness-neutral, negligible next to per-token compute cost).

Remaining #411 work (35B end-to-end, needs a desktop with more VRAM/RAM) is tracked on the issue.

## Test plan
- [x] `dotnet build -c Release` — 0 warnings/errors (repo has `TreatWarningsAsErrors`)
- [x] `Tests.Core` (242 tests), `Tests.Server` (140 tests) — all pass
- [x] `Tests.ForwardPass` `InferenceEngineChunkTests` — passes after the fix (was failing before)
- [x] Live server smoke test against Ornith-1.0-9B: OpenAI + Anthropic chat completions, tool-calling, and the `max_tokens`-truncation fix all verified via curl against a running `SharpInference.Server.Host`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EWo1niax1g8A5E79RSALJ