### PR TITLE
feat: caller-supplied whole-turn output constraint + JSON-schema structured output

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -200,6 +200,18 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [DefaultValue(false)]
         public bool ToolGrammar { get; init; }
 
+        // ── JSON-Schema-constrained output (issue #423 follow-up) ──
+        // Whole-turn structured output, the SharpInference analogue of OpenAI/llama.cpp's
+        // response_format:json_schema. Mirrors llama.cpp's own flag names (-j/--json-schema,
+        // --json-schema-file) where Spectre.Console.Cli can represent them.
+        [CommandOption("-j|--json-schema <SCHEMA>")]
+        [Description("JSON schema to constrain the entire response to (https://json-schema.org/), e.g. '{\"type\":\"object\",\"properties\":{...},\"required\":[...]}' (llama.cpp -j/--json-schema). Root must be an object schema declaring at least one property; unsupported keywords ($ref, oneOf/anyOf, pattern, minLength/maxLength, minimum/maximum) degrade to unconstrained. Mutually exclusive with --json-schema-file.")]
+        public string? JsonSchema { get; init; }
+
+        [CommandOption("--json-schema-file|--jf <PATH>")]
+        [Description("File containing a JSON schema to constrain the entire response to (llama.cpp --json-schema-file/-jf; alias --jf since llama.cpp's single-dash -jf isn't representable: Spectre short options must be one character). Mutually exclusive with --json-schema.")]
+        public string? JsonSchemaFile { get; init; }
+
         // ── MoE expert-cache tuning (offloaded MoE models) ──
         // Good defaults are automatic: frequency-aware SLRU eviction, VRAM-sized cache,
         // and next-layer predictive prefetch are all ON without any flag. These knobs only
@@ -268,6 +280,80 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
         error = null;
         return true;
+    }
+
+    /// <summary>
+    /// Builds a whole-turn <see cref="JsonSchemaOutputConstraint"/> (issue #423 follow-up) from
+    /// <c>--json-schema</c> (inline) or <c>--json-schema-file</c>/<c>--jf</c> (file), or leaves
+    /// <paramref name="constraint"/> <c>null</c> when neither flag is given. Returns <c>false</c>
+    /// (with <paramref name="error"/> set) on mutual exclusivity, a missing/unreadable file,
+    /// malformed JSON, or a schema that can't be compiled to a constraint -- an explicit schema
+    /// request is a hard requirement, so failures are reported rather than silently ignored.
+    /// </summary>
+    internal static bool TryLoadJsonSchemaConstraint(
+        string? inlineSchema, string? schemaFilePath, GrammarVocabulary vocab,
+        out ITokenConstraint? constraint, out string? error)
+    {
+        constraint = null;
+        error = null;
+
+        if (inlineSchema is { Length: > 0 } && schemaFilePath is { Length: > 0 })
+        {
+            error = "--json-schema and --json-schema-file/--jf are mutually exclusive; pass only one.";
+            return false;
+        }
+
+        string schemaText;
+        if (schemaFilePath is { Length: > 0 })
+        {
+            if (!File.Exists(schemaFilePath))
+            {
+                error = $"schema file not found: {schemaFilePath}";
+                return false;
+            }
+            try
+            {
+                schemaText = File.ReadAllText(schemaFilePath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                          or System.Security.SecurityException or NotSupportedException)
+            {
+                error = $"could not read --json-schema-file: {ex.Message}";
+                return false;
+            }
+        }
+        else if (inlineSchema is { Length: > 0 })
+        {
+            schemaText = inlineSchema;
+        }
+        else
+        {
+            return true;   // neither flag given -- no-op
+        }
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(schemaText);
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            error = $"could not parse JSON schema: {ex.Message}";
+            return false;
+        }
+
+        try
+        {
+            var schemaObject = ToolSchema.FromOpenAiFunction("_", root).Arguments;
+            constraint = new JsonSchemaOutputConstraint(vocab, schemaObject);
+            return true;
+        }
+        catch (ArgumentException ex)
+        {
+            error = $"--json-schema could not be compiled: {ex.Message}";
+            return false;
+        }
     }
 
     protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
@@ -831,6 +917,9 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         // --tools advertises OpenAI-format tool definitions to the model via its chat template;
         // --tool-grammar additionally constrains the argument bytes to the supplied JSON Schemas
         // (issue #374) for families with constraint support. Both are single-prompt features.
+        // Shared by --json-schema/--json-schema-file below (issue #423 follow-up) -- constructing
+        // this is free even when unused (the expensive per-token byte table builds lazily).
+        var grammarVocab = new GrammarVocabulary(tokenizer);
         List<ToolSchema>? toolSchemas = null;
         ITokenConstraint? toolConstraint = null;
         int[] toolBoundaryStops = [];
@@ -868,7 +957,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
             if (settings.ToolGrammar)
             {
-                toolConstraint = adapter.BuildArgumentConstraint(toolSchemas, new GrammarVocabulary(tokenizer));
+                toolConstraint = adapter.BuildArgumentConstraint(toolSchemas, grammarVocab);
                 AnsiConsole.MarkupLine(toolConstraint is not null
                     ? "[dim]Tool-call arguments are grammar-constrained (issue #374).[/]"
                     : $"[yellow]Warning:[/] --tool-grammar has no effect for arch '{s_arch}' (no constraint support, or no supplied tool is constrainable); arguments generate unconstrained.");
@@ -877,6 +966,23 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         else if (settings.ToolGrammar)
         {
             AnsiConsole.MarkupLine("[yellow]Warning:[/] --tool-grammar requires --tools (a schema to constrain against); ignoring.");
+        }
+
+        // ── JSON-Schema-constrained output (issue #423 follow-up) ─────────────────
+        if (!TryLoadJsonSchemaConstraint(settings.JsonSchema, settings.JsonSchemaFile, grammarVocab,
+                out ITokenConstraint? jsonSchemaConstraint, out string? jsonSchemaError))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(jsonSchemaError!)}");
+            return 1;
+        }
+        if (jsonSchemaConstraint is not null)
+        {
+            AnsiConsole.MarkupLine("[dim]Response is constrained to the supplied JSON schema.[/]");
+            if (toolConstraint is not null)
+                AnsiConsole.MarkupLine(
+                    "[yellow]Warning:[/] --json-schema/--json-schema-file combined with --tool-grammar likely " +
+                    "makes tool calls unreachable (the schema constrains the whole response from the first " +
+                    "token) — use one or the other.");
         }
 
         var sp = new SamplingParams
@@ -894,7 +1000,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             SpecDraftNMax = settings.SpecDraftNMax,
             SpecDraftNMin = settings.SpecDraftNMin,
             SpecDraftPMin = settings.SpecDraftPMin,
-            Constraint = toolConstraint,
+            Constraint = TokenConstraints.Combine(jsonSchemaConstraint, toolConstraint),
         };
         var rng = settings.Seed >= 0 ? new Random(settings.Seed) : new Random();
 
@@ -904,12 +1010,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         // offload hybrids fall back to normal generation: without a batched verify,
         // speculation costs k sequential target forwards per step and is never a win.
         bool specRequested = settings.DraftModelPath is not null || settings.DraftLookup;
-        if (specRequested && toolConstraint is not null)
+        if (specRequested && sp.Constraint is not null)
         {
-            // The constraint masks one token at a time against the running argument state; a
-            // multi-token speculative verify can't honor it. Drop speculation so the constraint
-            // actually applies (the standard decode path below reads sp.Constraint).
-            AnsiConsole.MarkupLine("[yellow]Warning:[/] --tool-grammar is not applied with speculative decoding (--draft-model/--draft-lookup); generating without speculation so the argument constraint takes effect.");
+            // Any active constraint (--tool-grammar and/or --json-schema/--json-schema-file, issue
+            // #423 follow-up) masks one token at a time against running grammar state; a multi-token
+            // speculative verify can't honor it. Drop speculation so the constraint actually applies
+            // (the standard decode path below reads sp.Constraint).
+            AnsiConsole.MarkupLine("[yellow]Warning:[/] --tool-grammar/--json-schema is not applied with speculative decoding (--draft-model/--draft-lookup); generating without speculation so the constraint takes effect.");
             specRequested = false;
         }
         if (specRequested)

--- a/src/SharpInference.Core/Grammar/AndTokenConstraint.cs
+++ b/src/SharpInference.Core/Grammar/AndTokenConstraint.cs
@@ -1,0 +1,97 @@
+namespace SharpInference.Core.Grammar;
+
+/// <summary>
+/// AND-composes a list of independent <see cref="ITokenConstraint"/>s, masking to the intersection
+/// of what each currently-constraining inner allows (issue #423) -- e.g. a caller-supplied whole-turn
+/// output grammar stacked with a tool-argument constraint once a tool call opens mid-turn.
+///
+/// <para>
+/// This is the opposite of <see cref="CompositeToolArgumentConstraint"/>, which OR-composes
+/// mutually-exclusive <em>alternative</em> sub-constraints (at most one is ever active at a time,
+/// e.g. a JSON-vs-XML tool-call wire format choice). <see cref="AndTokenConstraint"/> is for
+/// genuinely independent concerns that can be simultaneously active and must both be satisfied.
+/// </para>
+///
+/// <para>
+/// <see cref="Accept"/> and <see cref="Reset"/> always forward to every inner unconditionally --
+/// each needs to see every token to track its own state regardless of which inner (if any) is
+/// currently constraining. <see cref="Filter"/> only builds an intersection while 2+ inners are
+/// simultaneously constraining; with 0 or 1 constraining it behaves exactly like the
+/// zero-allocation single-constraint path every <see cref="ITokenConstraint"/> promises.
+/// </para>
+/// </summary>
+public sealed class AndTokenConstraint : ITokenConstraint
+{
+    private readonly ITokenConstraint[] _inner;
+    private float[]? _masked;
+
+    public AndTokenConstraint(IReadOnlyList<ITokenConstraint> inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        if (inner.Count < 2) throw new ArgumentException("at least two inner constraints are required", nameof(inner));
+        _inner = [.. inner];
+    }
+
+    public bool IsConstraining
+    {
+        get
+        {
+            foreach (var c in _inner) if (c.IsConstraining) return true;
+            return false;
+        }
+    }
+
+    public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+    {
+        // Count how many inners are currently constraining without allocating -- 0/1 take the
+        // zero-copy fast path every other constraint promises.
+        ITokenConstraint? sole = null;
+        int constrainingCount = 0;
+        foreach (var c in _inner)
+        {
+            if (!c.IsConstraining) continue;
+            sole = c;
+            if (++constrainingCount > 1) break;
+        }
+        if (constrainingCount == 0) return logits;
+        if (constrainingCount == 1) return sole!.Filter(logits);
+
+        // 2+ constraining simultaneously: intersect into our own scratch buffer.
+        var masked = _masked ??= new float[logits.Length];
+        if (masked.Length != logits.Length) return logits;   // vocab mismatch -- never wedge
+        logits.CopyTo(masked);
+
+        foreach (var c in _inner)
+        {
+            if (!c.IsConstraining) continue;
+            var view = c.Filter(logits);
+            // An inner that hit its own dead state returns the SAME span as `logits` (every
+            // ITokenConstraint's documented convention) -- skip it rather than contribute a no-op
+            // pass that would otherwise be indistinguishable from "everything is forbidden". A
+            // length mismatch (a misbehaving caller-supplied constraint, e.g. via
+            // SharpInferenceServerOptions.OutputConstraintFactory) is skipped the same way rather
+            // than indexed out of bounds -- never crash on a third-party constraint bug.
+            if (view == logits || view.Length != masked.Length) continue;
+            for (int i = 0; i < masked.Length; i++)
+                if (float.IsNegativeInfinity(view[i])) masked[i] = float.NegativeInfinity;
+        }
+
+        bool anyLegal = false;
+        for (int i = 0; i < masked.Length; i++)
+            if (!float.IsNegativeInfinity(masked[i])) { anyLegal = true; break; }
+
+        // Dead intersection (no legal token survives the AND): never wedge -- fall back unmasked,
+        // matching every other ITokenConstraint's dead-state contract.
+        return anyLegal ? masked : logits;
+    }
+
+    public void Accept(int token)
+    {
+        foreach (var c in _inner) c.Accept(token);
+    }
+
+    public void Reset()
+    {
+        foreach (var c in _inner) c.Reset();
+    }
+}

--- a/src/SharpInference.Core/Grammar/ITokenConstraint.cs
+++ b/src/SharpInference.Core/Grammar/ITokenConstraint.cs
@@ -35,7 +35,9 @@ public interface ITokenConstraint
     /// token. The returned span is owned by the constraint and reused across calls — sample from it
     /// immediately. Only valid to call when <see cref="IsConstraining"/> is true. If the grammar
     /// reaches a dead state (no legal token), returns <paramref name="logits"/> unchanged so
-    /// generation never wedges.
+    /// generation never wedges. "Unchanged" means literally returning the same span passed in (not
+    /// a value-equal copy) — composing constraints such as <see cref="AndTokenConstraint"/> rely on
+    /// reference equality to detect a dead-state punt without an O(vocab) comparison.
     /// </summary>
     ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits);
 

--- a/src/SharpInference.Core/Grammar/JsonSchemaOutputConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonSchemaOutputConstraint.cs
@@ -1,0 +1,49 @@
+namespace SharpInference.Core.Grammar;
+
+/// <summary>
+/// Whole-turn JSON-Schema output constraint (issue #423 follow-up): constrains the ENTIRE assistant
+/// response to a caller-supplied JSON Schema, with no tool-call envelope -- the SharpInference
+/// analogue of OpenAI/llama.cpp "structured output" (<c>response_format: json_schema</c>). Built on
+/// the same frame-stack matcher <see cref="JsonToolArgumentConstraint"/> uses for a tool call's
+/// argument object (issue #376), just engaged from the first token instead of after a preamble.
+///
+/// <para>
+/// Shares <see cref="JsonToolArgumentConstraint"/>'s known limitations (no <c>$ref</c>,
+/// <c>oneOf</c>/<c>anyOf</c>/<c>allOf</c>, <c>pattern</c>, <c>minLength</c>/<c>maxLength</c>,
+/// <c>minimum</c>/<c>maximum</c>, <c>minItems</c>/<c>maxItems</c>). Unlike that constraint's
+/// "silently degrade to unconstrained" philosophy for tool-calling (a best-effort nicety), an
+/// explicit schema-constrained request is a hard requirement -- the constructor throws when the
+/// schema can't be compiled, rather than silently generating unconstrained output.
+/// </para>
+/// </summary>
+public sealed class JsonSchemaOutputConstraint : ITokenConstraint
+{
+    private readonly JsonToolArgumentConstraint _inner;
+
+    /// <param name="vocab">Vocabulary view for the loaded model (issue #374).</param>
+    /// <param name="schema">
+    /// The schema's root object (e.g. <c>ToolSchema.FromOpenAiFunction("_", schemaElement).Arguments</c>
+    /// for a raw JSON Schema <see cref="System.Text.Json.JsonElement"/>). Must be an object schema
+    /// declaring at least one property.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// The schema could not be compiled to a constraint -- it isn't an object schema, declares no
+    /// properties, or uses only unsupported keywords.
+    /// </exception>
+    public JsonSchemaOutputConstraint(GrammarVocabulary vocab, ToolSchemaObject schema)
+    {
+        ArgumentNullException.ThrowIfNull(vocab);
+        ArgumentNullException.ThrowIfNull(schema);
+        var compiled = ToolSchemaCompiler.TryCompileObject(schema)
+            ?? throw new ArgumentException(
+                "schema could not be compiled to a constraint (must be an object schema with at " +
+                "least one declared property; unsupported keywords like $ref/oneOf/pattern are " +
+                "not constrained)", nameof(schema));
+        _inner = JsonToolArgumentConstraint.ForWholeBody(vocab, compiled);
+    }
+
+    public bool IsConstraining => _inner.IsConstraining;
+    public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits) => _inner.Filter(logits);
+    public void Accept(int token) => _inner.Accept(token);
+    public void Reset() => _inner.Reset();
+}

--- a/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
@@ -64,6 +64,16 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
     private readonly byte[][] _argsKeys;            // NameValueObject: "arguments"/"parameters" bytes
     private static readonly byte[] s_nameKey = Encoding.UTF8.GetBytes("name");
 
+    // Whole-body mode (issue #423 follow-up, JsonSchemaOutputConstraint): when set, there is no
+    // envelope/preamble at all -- the object is constrained from the very first token. Reset() must
+    // re-engage immediately rather than return to the watching-idle state (see Reset() below).
+    private readonly CompiledObject? _wholeBodyRoot;
+
+    // Whole-body mode only: set once the root object closes successfully. From here on Filter()
+    // forces EOG-only (no further content is legal) instead of returning to the tool-argument path's
+    // "watching" idle state -- "the ENTIRE response" means nothing may follow the object.
+    private bool _wholeBodyDone;
+
     // Watching / preamble state.
     private bool _armed;                            // saw the open marker, scanning the preamble
     private int _watchState;                        // preamble FSM state (W* constants)
@@ -128,16 +138,45 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
         }
     }
 
-    /// <summary>Whether this constraint can ever restrict anything (any tool was constrainable).</summary>
-    public bool HasConstrainableTools => _tools.Count > 0;
+    /// <summary>
+    /// Whole-body mode (issue #423 follow-up): constrains the ENTIRE output to
+    /// <paramref name="wholeBodyRoot"/> from the first token — no tool-call envelope, no preamble.
+    /// Used via <see cref="ForWholeBody"/> by <see cref="JsonSchemaOutputConstraint"/>.
+    /// </summary>
+    private JsonToolArgumentConstraint(GrammarVocabulary vocab, CompiledObject wholeBodyRoot)
+    {
+        ArgumentNullException.ThrowIfNull(vocab);
+        ArgumentNullException.ThrowIfNull(wholeBodyRoot);
+        _vocab = vocab;
+        _envelope = JsonToolEnvelope.NameValueObject;   // unused in this mode
+        _argsKeys = [];
+        _forbidden = new HashSet<int>(vocab.EogTokenIds);
+        _openMarkerId = 0;
+        _separatorId = -1;
+        _tools = new Dictionary<string, CompiledObject>(StringComparer.Ordinal);
+        _wholeBodyRoot = wholeBodyRoot;
+        Reset();
+    }
 
-    public bool IsConstraining => _depth > 0;
+    /// <summary>Builds a whole-body constraint (see the private ctor above) for <see cref="JsonSchemaOutputConstraint"/>.</summary>
+    internal static JsonToolArgumentConstraint ForWholeBody(GrammarVocabulary vocab, CompiledObject root) =>
+        new(vocab, root);
+
+    /// <summary>Whether this constraint can ever restrict anything (any tool was constrainable, or
+    /// whole-body mode is active).</summary>
+    public bool HasConstrainableTools => _tools.Count > 0 || _wholeBodyRoot is not null;
+
+    public bool IsConstraining => _depth > 0 || _wholeBodyDone;
 
     public void Reset()
     {
         _armed = false;
         _depth = 0;
+        _wholeBodyDone = false;
         ResetPreamble();
+        // Whole-body mode has no envelope to watch for -- re-engage immediately so the very first
+        // token of the (new) generation is already constrained, rather than going permanently inert.
+        if (_wholeBodyRoot is not null) PushObject(_wholeBodyRoot, OExpectOpenBrace);
     }
 
     private void ResetPreamble()
@@ -265,6 +304,12 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
 
     public void Accept(int token)
     {
+        if (_wholeBodyDone)
+        {
+            // Terminal state: Filter() only ever offered EOG ids here, so there's nothing further
+            // to track regardless of what was actually sampled.
+            return;
+        }
         if (IsConstraining)
         {
             bool ok = !_forbidden.Contains(token) && RunToken(token);
@@ -275,7 +320,14 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
                 WarnOnce("accept-divergence",
                     "a sampled token permitted by the mask was rejected by the grammar — constraint "
                     + "disabled for the rest of this call (possible Filter/Accept divergence).");
-            if (!ok || _depth == 0) { _depth = 0; _armed = false; ResetPreamble(); }
+            if (ok && _depth == 0 && _wholeBodyRoot is not null)
+            {
+                // Whole-body mode's root object closed successfully: force EOG-only for the rest of
+                // the turn instead of returning to the tool-argument path's "watching" idle state,
+                // which has no envelope to (re-)arm on in this mode anyway.
+                _wholeBodyDone = true;
+            }
+            else if (!ok || _depth == 0) { _depth = 0; _armed = false; ResetPreamble(); }
             return;
         }
 
@@ -335,6 +387,7 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
 
     public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
     {
+        if (_wholeBodyDone) return FilterEogOnly(logits);
         if (_depth == 0) return logits;
 
         var masked = _masked ??= new float[_vocab.VocabSize];
@@ -351,6 +404,26 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
             return logits;
         }
         return masked;
+    }
+
+    /// <summary>Whole-body mode's terminal state (after the root object closed): only an
+    /// end-of-generation token is legal, so nothing can follow the object. Reuses
+    /// <see cref="_forbidden"/> (the EOG id set) as the allow-list here, inverted from its normal
+    /// "never legal inside the object" meaning.</summary>
+    private ReadOnlySpan<float> FilterEogOnly(ReadOnlySpan<float> logits)
+    {
+        var masked = _masked ??= new float[_vocab.VocabSize];
+        if (masked.Length != logits.Length) return logits;     // vocab mismatch — never wedge
+        logits.CopyTo(masked);
+
+        bool anyEog = false;
+        for (int i = 0; i < masked.Length; i++)
+        {
+            if (_forbidden.Contains(i)) { anyEog = true; continue; }
+            masked[i] = float.NegativeInfinity;
+        }
+        // No EOG id in this vocabulary (shouldn't happen for a real tokenizer): never wedge.
+        return anyEog ? masked : logits;
     }
 
     /// <summary>Sets every forbidden token to -inf in <paramref name="buf"/>; returns the count kept.</summary>

--- a/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
@@ -414,13 +414,17 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
     {
         var masked = _masked ??= new float[_vocab.VocabSize];
         if (masked.Length != logits.Length) return logits;     // vocab mismatch — never wedge
-        logits.CopyTo(masked);
 
+        // _forbidden (the EOG id set) is tiny (typically 1-5 ids) against a vocab that can be
+        // 150k+ tokens -- fill once (vectorized) and sparsely restore just the EOG logits, instead
+        // of a HashSet.Contains check per vocab entry on this per-token hot path.
+        Array.Fill(masked, float.NegativeInfinity);
         bool anyEog = false;
-        for (int i = 0; i < masked.Length; i++)
+        foreach (int id in _forbidden)
         {
-            if (_forbidden.Contains(i)) { anyEog = true; continue; }
-            masked[i] = float.NegativeInfinity;
+            if ((uint)id >= (uint)masked.Length) continue;
+            masked[id] = logits[id];
+            anyEog = true;
         }
         // No EOG id in this vocabulary (shouldn't happen for a real tokenizer): never wedge.
         return anyEog ? masked : logits;

--- a/src/SharpInference.Core/Grammar/TokenConstraints.cs
+++ b/src/SharpInference.Core/Grammar/TokenConstraints.cs
@@ -1,0 +1,32 @@
+namespace SharpInference.Core.Grammar;
+
+/// <summary>
+/// Null-safe combinator for stacking independent <see cref="ITokenConstraint"/>s (issue #423) --
+/// e.g. a caller-supplied whole-turn output constraint alongside a tool-argument constraint that
+/// only becomes active once a tool call opens mid-turn. Prefer this over manually null-checking and
+/// constructing <see cref="AndTokenConstraint"/> at call sites.
+/// </summary>
+public static class TokenConstraints
+{
+    /// <summary>
+    /// Folds out nulls from <paramref name="constraints"/> and returns <c>null</c> (none left), the
+    /// sole survivor, or an <see cref="AndTokenConstraint"/> AND-composing every survivor. Also the
+    /// 2-arg case (e.g. <c>Combine(a, b)</c>) -- a params method accepts any fixed argument count,
+    /// so there's no need for a separate 2-arg overload.
+    /// </summary>
+    public static ITokenConstraint? Combine(params ITokenConstraint?[] constraints)
+    {
+        List<ITokenConstraint>? survivors = null;
+        foreach (var c in constraints)
+        {
+            if (c is null) continue;
+            (survivors ??= []).Add(c);
+        }
+        return survivors switch
+        {
+            null => null,
+            { Count: 1 } => survivors[0],
+            _ => new AndTokenConstraint(survivors),
+        };
+    }
+}

--- a/src/SharpInference.Server/ChatTemplate.cs
+++ b/src/SharpInference.Server/ChatTemplate.cs
@@ -117,6 +117,15 @@ public sealed class ChatTemplateRenderer
     /// </summary>
     private GrammarVocabulary? _grammarVocabulary;
 
+    /// <summary>
+    /// Public view of <see cref="_grammarVocabulary"/> (issue #423), so a host's
+    /// <see cref="SharpInferenceServerOptions.OutputConstraintFactory"/> can build a
+    /// vocabulary-aware whole-turn constraint the same way <see cref="BuildToolArgumentConstraint"/>
+    /// builds tool-argument constraints. Null until the model is loaded, or when a custom engine
+    /// factory supplied no vocabulary.
+    /// </summary>
+    public GrammarVocabulary? Grammar => _grammarVocabulary;
+
     /// <param name="architecture">Default architecture (used both for fallback and exposed via <see cref="Architecture"/>).</param>
     /// <param name="template">Optional compiled Jinja template; null means "use the hardcoded fallback".</param>
     public ChatTemplateRenderer(string architecture = "qwen2", JinjaChatTemplate? template = null)

--- a/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/AnthropicEndpoints.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpInference.Core;
+using SharpInference.Core.Grammar;
 using SharpInference.Engine;
 
 namespace SharpInference.Server.Endpoints;
@@ -160,12 +161,18 @@ public static class AnthropicEndpoints
 
         // Schema/grammar-constrained tool-argument decoding (issue #374): opt-in. Restricts the
         // sampler to tokens that keep the arguments schema-conformant in the model's native syntax.
+        ITokenConstraint? toolConstraint = null;
         if (req.Tools is { Length: > 0 } && ToolGrammarHelper.Enabled(opts))
         {
             var schemas = ToolGrammarHelper.ToSchemas(req.Tools.Select(t => (t.Name, t.InputSchema)));
-            if (chatTemplate.BuildToolArgumentConstraint(schemas) is { } constraint)
-                sp = sp with { Constraint = constraint };
+            toolConstraint = chatTemplate.BuildToolArgumentConstraint(schemas);
         }
+
+        // Caller-supplied whole-turn output constraint (issue #423): independent of tool schemas,
+        // AND-composed with the tool-argument constraint above rather than one overriding the other.
+        var outputConstraint = opts.OutputConstraintFactory?.Invoke(ctx.RequestServices);
+        if (TokenConstraints.Combine(outputConstraint, toolConstraint) is { } constraint)
+            sp = sp with { Constraint = constraint };
 
         var msgId = $"msg_{Guid.NewGuid():N}";
         var modelId = engine.ModelId;

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpInference.Core;
+using SharpInference.Core.Grammar;
 using SharpInference.Engine;
 
 namespace SharpInference.Server.Endpoints;
@@ -169,14 +170,80 @@ public static class OpenAiEndpoints
         // Schema/grammar-constrained tool-argument decoding (issue #374): opt-in, and skipped when
         // the client forces no tool use (tool_choice:"none"). Restricts the sampler to tokens that
         // keep the arguments schema-conformant in the model's native call syntax.
+        ITokenConstraint? toolConstraint = null;
         if (toolsActive && req.Tools is { Length: > 0 } && ToolGrammarHelper.Enabled(opts)
             && !IsToolChoiceNone(req.ToolChoice))
         {
             var schemas = ToolGrammarHelper.ToSchemas(
                 req.Tools.Select(t => (t.Function?.Name, t.Function?.Parameters)));
-            if (chatTemplate.BuildToolArgumentConstraint(schemas) is { } constraint)
-                sp = sp with { Constraint = constraint };
+            toolConstraint = chatTemplate.BuildToolArgumentConstraint(schemas);
         }
+
+        // Whole-turn JSON-Schema-constrained output (issue #423 follow-up): the SharpInference
+        // analogue of OpenAI/llama.cpp's response_format:json_schema (and llama.cpp's flat
+        // json_object.schema extension). An explicit schema request is a hard requirement, so
+        // failures return 400 rather than silently generating unconstrained output.
+        ITokenConstraint? jsonSchemaConstraint = null;
+        JsonElement? requestedSchema = null;
+        if (req.ResponseFormat?.Type == "json_schema")
+        {
+            // Unlike "json_object" (below), a schema is REQUIRED here -- the client explicitly asked
+            // for schema-constrained output, so a missing json_schema.schema is a client error, not a
+            // silent no-op (issue #423 follow-up: an explicit schema request is a hard requirement).
+            if (req.ResponseFormat.JsonSchema?.Schema is { } s)
+                requestedSchema = s;
+            else
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(
+                    JsonSerializer.Serialize(new ErrorResponse("invalid_request_error",
+                            "response_format.type is \"json_schema\" but no json_schema.schema was provided."),
+                        SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+                return;
+            }
+        }
+        else if (req.ResponseFormat?.Type == "json_object")
+        {
+            // llama.cpp's flat extension: an optional schema alongside the plain "valid JSON" request.
+            // Absent here just means "valid JSON, no shape enforced" -- the pre-existing behavior.
+            requestedSchema = req.ResponseFormat.Schema;
+        }
+        if (requestedSchema is { } schemaElement)
+        {
+            if (chatTemplate.Grammar is not { } vocab)
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(
+                    JsonSerializer.Serialize(new ErrorResponse("invalid_request_error",
+                            "response_format.json_schema requires a loaded model vocabulary, which isn't available for this engine."),
+                        SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+                return;
+            }
+            try
+            {
+                var schemaObject = ToolSchema.FromOpenAiFunction("_", schemaElement).Arguments;
+                jsonSchemaConstraint = new JsonSchemaOutputConstraint(vocab, schemaObject);
+            }
+            catch (ArgumentException ex)
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(
+                    JsonSerializer.Serialize(new ErrorResponse("invalid_request_error",
+                            $"response_format.json_schema could not be compiled: {ex.Message}"),
+                        SharpInferenceJsonContext.Default.ErrorResponse), ctx.RequestAborted);
+                return;
+            }
+        }
+
+        // Caller-supplied whole-turn output constraint (issue #423): independent of tool schemas,
+        // AND-composed with the tool-argument and json-schema constraints above rather than one
+        // overriding the others.
+        var outputConstraint = opts.OutputConstraintFactory?.Invoke(ctx.RequestServices);
+        if (TokenConstraints.Combine(outputConstraint, jsonSchemaConstraint, toolConstraint) is { } constraint)
+            sp = sp with { Constraint = constraint };
 
         var requestId = $"chatcmpl-{Guid.NewGuid():N}";
         long created = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -790,6 +857,18 @@ public sealed record OaiToolCallDelta(
 public sealed record ModelsResponse(string Object, ModelInfo[] Data);
 public sealed record ModelInfo(string Id, string Object, long Created, string OwnedBy);
 
-public sealed record ResponseFormat(string? Type);
+/// <summary>
+/// OpenAI <c>response_format</c> (issue #423 follow-up). <c>type:"json_schema"</c> follows OpenAI's
+/// own nested wire shape (<see cref="JsonSchema"/>.Schema); <c>type:"json_object"</c> additionally
+/// accepts a flat <see cref="Schema"/> (llama.cpp's <c>response_format.schema</c> extension) for a
+/// schema without the OpenAI envelope's <c>name</c>/<c>strict</c>. Either shape, when a schema is
+/// present, constrains the whole response via <see cref="SharpInference.Core.Grammar.JsonSchemaOutputConstraint"/>.
+/// </summary>
+public sealed record ResponseFormat(string? Type, JsonSchemaSpec? JsonSchema = null, JsonElement? Schema = null);
+
+/// <summary>OpenAI's <c>response_format.json_schema</c> envelope. Only <see cref="Schema"/> is
+/// consumed; <see cref="Name"/>/<see cref="Strict"/> round-trip but aren't validated (matching
+/// llama.cpp's own server behavior).</summary>
+public sealed record JsonSchemaSpec(string? Name, JsonElement? Schema, bool? Strict = null);
 
 public sealed record ErrorResponse(string Type, string Message);

--- a/src/SharpInference.Server/SharpInferenceJsonContext.cs
+++ b/src/SharpInference.Server/SharpInferenceJsonContext.cs
@@ -36,6 +36,7 @@ namespace SharpInference.Server;
 [JsonSerializable(typeof(ModelInfo[]))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(ResponseFormat))]
+[JsonSerializable(typeof(JsonSchemaSpec))]
 [JsonSerializable(typeof(AnthropicMessageRequest))]
 [JsonSerializable(typeof(AnthropicThinking))]
 [JsonSerializable(typeof(AnthropicTool))]

--- a/src/SharpInference.Server/SharpInferenceServerOptions.cs
+++ b/src/SharpInference.Server/SharpInferenceServerOptions.cs
@@ -1,3 +1,4 @@
+using SharpInference.Core.Grammar;
 using SharpInference.Engine;
 
 namespace SharpInference.Server;
@@ -48,6 +49,21 @@ public sealed class SharpInferenceServerOptions
     /// unconstrained decoding. Also turned on by the <c>SHARPI_TOOL_GRAMMAR=1</c> environment variable.
     /// </summary>
     public bool ToolGrammar { get; set; }
+
+    /// <summary>
+    /// Optional factory for a caller-supplied, whole-turn output constraint (issue #423) -- the
+    /// output-stream sibling of <see cref="ToolGrammar"/>'s argument-scoped constraint. Invoked once
+    /// per request (via <c>HttpContext.RequestServices</c>) by the chat endpoints; must return a
+    /// <b>fresh</b> instance each call (an <see cref="ITokenConstraint"/> is stateful and
+    /// single-request, the same contract <see cref="ChatTemplateRenderer.BuildToolArgumentConstraint"/>
+    /// already has), or <c>null</c> to leave the turn unconstrained. When a tool call is also active
+    /// and <see cref="ToolGrammar"/> is on, the two constraints are AND-composed (via
+    /// <see cref="TokenConstraints.Combine"/>) rather than one overriding the other. A host resolves
+    /// whatever it needs from the supplied <see cref="IServiceProvider"/> to build the constraint --
+    /// e.g. the loaded model's vocabulary via <see cref="ChatTemplateRenderer.Grammar"/>. <c>null</c>
+    /// (default) = no output-level constraint, byte-identical to the pre-#423 path.
+    /// </summary>
+    public Func<IServiceProvider, ITokenConstraint?>? OutputConstraintFactory { get; set; }
 
     // ── Model loading ────────────────────────────────────────────────────────
 

--- a/tests/SharpInference.Tests.Cli/JsonSchemaFlagsTests.cs
+++ b/tests/SharpInference.Tests.Cli/JsonSchemaFlagsTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using SharpInference.Cli;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Tests.Cli;
+
+/// <summary>
+/// Unit tests for <see cref="RunCommand.TryLoadJsonSchemaConstraint"/> -- the llama.cpp-style
+/// <c>-j/--json-schema</c> and <c>--json-schema-file/--jf</c> flags (issue #423 follow-up). Mirrors
+/// <see cref="CpuMoeFlagsTests"/>'s direct-call pattern. Deep grammar correctness is covered by
+/// <c>SharpInference.Tests.Core.JsonSchemaOutputConstraintTests</c>; these only test the CLI-level
+/// validation/wiring (mutual exclusivity, file loading, JSON parsing, schema compilation errors).
+/// </summary>
+public sealed class JsonSchemaFlagsTests
+{
+    /// <summary>Bare-minimum tokenizer -- these tests only exercise construction, never Accept/Filter.</summary>
+    private sealed class StubTokenizer : ITokenizer
+    {
+        public int VocabSize => 4;
+        public int BosTokenId => 0;
+        public int EosTokenId => 0;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => 0;
+        public bool AddBosToken => false;
+        public ImmutableArray<int> EogTokenIds => [0];
+        public IReadOnlyDictionary<string, int> SpecialTokens { get; } = new Dictionary<string, int>();
+        public byte[] DecodeBytes(int token) => [];
+        public IReadOnlyList<int> Encode(string text) => [];
+        public string Decode(IEnumerable<int> tokens) => "";
+    }
+
+    private static readonly GrammarVocabulary Vocab = new(new StubTokenizer());
+
+    [Fact]
+    public void NeitherFlag_IsNoOp()
+    {
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint(null, null, Vocab, out var constraint, out var error);
+
+        Assert.True(ok);
+        Assert.Null(constraint);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void BothFlags_IsError()
+    {
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint("{}", "somefile.json", Vocab, out var constraint, out var error);
+
+        Assert.False(ok);
+        Assert.Null(constraint);
+        Assert.Contains("mutually exclusive", error);
+    }
+
+    [Fact]
+    public void FileNotFound_IsError()
+    {
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint(
+            null, "definitely-does-not-exist.json", Vocab, out var constraint, out var error);
+
+        Assert.False(ok);
+        Assert.Null(constraint);
+        Assert.Contains("not found", error);
+    }
+
+    [Fact]
+    public void InlineSchema_MalformedJson_IsError()
+    {
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint("{not valid json", null, Vocab, out var constraint, out var error);
+
+        Assert.False(ok);
+        Assert.Null(constraint);
+        Assert.Contains("could not parse", error);
+    }
+
+    [Fact]
+    public void InlineSchema_UncompilableSchema_IsError()
+    {
+        // Not an object schema (bare string) -- compiles to null, reported as an error rather than
+        // silently generating unconstrained output.
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint(
+            """{"type":"string"}""", null, Vocab, out var constraint, out var error);
+
+        Assert.False(ok);
+        Assert.Null(constraint);
+        Assert.Contains("could not be compiled", error);
+    }
+
+    [Fact]
+    public void InlineSchema_ValidObjectSchema_Succeeds()
+    {
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""",
+            null, Vocab, out var constraint, out var error);
+
+        Assert.True(ok);
+        Assert.NotNull(constraint);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void SchemaFile_ValidObjectSchema_Succeeds()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path,
+                """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+            bool ok = RunCommand.TryLoadJsonSchemaConstraint(null, path, Vocab, out var constraint, out var error);
+
+            Assert.True(ok);
+            Assert.NotNull(constraint);
+            Assert.Null(error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/SharpInference.Tests.Core/AndTokenConstraintTests.cs
+++ b/tests/SharpInference.Tests.Core/AndTokenConstraintTests.cs
@@ -1,0 +1,233 @@
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Unit tests for <see cref="AndTokenConstraint"/> / <see cref="TokenConstraints.Combine"/> (issue
+/// #423) using small scripted mock constraints -- no vocabulary/tokenizer needed since these only
+/// exercise the AND-composition machinery itself, not any real grammar.
+/// </summary>
+public sealed class AndTokenConstraintTests
+{
+    private const int Vocab = 8;
+
+    /// <summary>
+    /// Constraining while <c>AcceptCount</c> is in [<paramref name="engageAfter"/>, +<paramref
+    /// name="forcedLen"/>); while constraining, forbids everything except <paramref name="allow"/>
+    /// (or, when <paramref name="alwaysDead"/>, forbids <paramref name="allow"/> too -- an always-dead
+    /// grammar state). Records Accept/Reset counts so forwarding can be asserted.
+    /// </summary>
+    private sealed class ScriptedConstraint(int engageAfter, int forcedLen, int allow, bool alwaysDead = false)
+        : ITokenConstraint
+    {
+        private float[]? _masked;
+        public int AcceptCount { get; private set; }
+        public int ResetCount { get; private set; }
+
+        public bool IsConstraining => AcceptCount >= engageAfter && AcceptCount < engageAfter + forcedLen;
+
+        public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+        {
+            var m = _masked ??= new float[logits.Length];
+            if (m.Length != logits.Length) return logits;
+            logits.CopyTo(m);
+
+            bool anyLegal = false;
+            for (int i = 0; i < m.Length; i++)
+            {
+                if (!alwaysDead && i == allow) { anyLegal = true; continue; }
+                m[i] = float.NegativeInfinity;
+            }
+            // Dead state (or alwaysDead): return the SAME span passed in, per ITokenConstraint's
+            // documented convention -- this is exactly what AndTokenConstraint's punt-detection relies on.
+            return anyLegal ? m : logits;
+        }
+
+        public void Accept(int token) => AcceptCount++;
+        public void Reset() { AcceptCount = 0; ResetCount++; }
+    }
+
+    private static bool Allowed(ReadOnlySpan<float> masked, int id) => !float.IsNegativeInfinity(masked[id]);
+    private static float[] FreshLogits() => new float[Vocab];   // all zeros = every token "allowed"
+
+    [Fact]
+    public void Combine_BothNull_ReturnsNull() => Assert.Null(TokenConstraints.Combine(null, null));
+
+    [Fact]
+    public void Combine_OneNull_ReturnsTheOther()
+    {
+        var a = new ScriptedConstraint(0, 1, allow: 0);
+        Assert.Same(a, TokenConstraints.Combine(a, null));
+        Assert.Same(a, TokenConstraints.Combine(null, a));
+    }
+
+    [Fact]
+    public void Combine_BothNonNull_ReturnsAndTokenConstraint()
+    {
+        var a = new ScriptedConstraint(0, 1, allow: 0);
+        var b = new ScriptedConstraint(0, 1, allow: 1);
+        Assert.IsType<AndTokenConstraint>(TokenConstraints.Combine(a, b));
+    }
+
+    // ── N-ary Combine(params ...) (issue #423 follow-up: 3-way server composition) ──────────────
+
+    [Fact]
+    public void CombineParams_Empty_ReturnsNull() => Assert.Null(TokenConstraints.Combine());
+
+    [Fact]
+    public void CombineParams_AllNull_ReturnsNull() =>
+        Assert.Null(TokenConstraints.Combine(null, null, null));
+
+    [Fact]
+    public void CombineParams_OneSurvivor_ReturnsItDirectly()
+    {
+        var a = new ScriptedConstraint(0, 1, allow: 0);
+        Assert.Same(a, TokenConstraints.Combine(null, a, null));
+    }
+
+    [Fact]
+    public void CombineParams_ThreeSurvivors_ReturnsAndTokenConstraint()
+    {
+        var a = new ScriptedConstraint(0, 1, allow: 0);
+        var b = new ScriptedConstraint(0, 1, allow: 1);
+        var c = new ScriptedConstraint(0, 1, allow: 2);
+        Assert.IsType<AndTokenConstraint>(TokenConstraints.Combine(a, null, b, c));
+    }
+
+    [Fact]
+    public void CombineParams_FourSurvivors_AllContributeToTheMask()
+    {
+        // Four inners simultaneously constraining, each allowing a distinct token -- only a token
+        // allowed by ALL FOUR survives; with no overlap, that's none (dead -> unmasked fallback).
+        var a = new ScriptedConstraint(0, 4, allow: 0);
+        var b = new ScriptedConstraint(0, 4, allow: 1);
+        var c = new ScriptedConstraint(0, 4, allow: 2);
+        var d = new ScriptedConstraint(0, 4, allow: 3);
+        var combined = TokenConstraints.Combine(a, b, c, d)!;
+
+        var masked = combined.Filter(new float[Vocab]);
+        for (int i = 0; i < Vocab; i++) Assert.False(float.IsNegativeInfinity(masked[i]));
+    }
+
+    [Fact]
+    public void Constructor_RequiresAtLeastTwoInner()
+    {
+        var a = new ScriptedConstraint(0, 1, allow: 0);
+        Assert.Throws<ArgumentException>(() => new AndTokenConstraint([a]));
+    }
+
+    [Fact]
+    public void IsConstraining_TrueWhenEitherInnerIsConstraining()
+    {
+        var a = new ScriptedConstraint(engageAfter: 0, forcedLen: 1, allow: 0);   // constrains only at AcceptCount==0
+        var b = new ScriptedConstraint(engageAfter: 5, forcedLen: 1, allow: 1);   // constrains only at AcceptCount==5
+        var combined = new AndTokenConstraint([a, b]);
+
+        Assert.True(combined.IsConstraining);      // a constraining, b not yet
+        for (int i = 0; i < 5; i++) combined.Accept(i);
+        Assert.True(combined.IsConstraining);      // a released, b now engaged
+    }
+
+    [Fact]
+    public void NonOverlappingWindows_DelegateDirectly()
+    {
+        // a constrains only at AcceptCount==0, b only at AcceptCount==5 -- never simultaneously active.
+        var a = new ScriptedConstraint(engageAfter: 0, forcedLen: 1, allow: 2);
+        var b = new ScriptedConstraint(engageAfter: 5, forcedLen: 1, allow: 3);
+        var combined = new AndTokenConstraint([a, b]);
+
+        var masked = combined.Filter(FreshLogits());
+        Assert.True(Allowed(masked, 2));
+        Assert.False(Allowed(masked, 3));
+
+        for (int i = 0; i < 5; i++) combined.Accept(i);
+
+        masked = combined.Filter(FreshLogits());
+        Assert.True(Allowed(masked, 3));
+        Assert.False(Allowed(masked, 2));
+    }
+
+    [Fact]
+    public void OverlappingWindows_EmptyIntersection_FallsBackUnmasked()
+    {
+        // Both active from the start, each allowing a different token -> intersection is empty ->
+        // never-wedge fallback returns every token legal, exactly like a single dead constraint would.
+        var a = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 2);
+        var b = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 3);
+        var combined = new AndTokenConstraint([a, b]);
+
+        var masked = combined.Filter(FreshLogits());
+        for (int i = 0; i < Vocab; i++) Assert.True(Allowed(masked, i));
+    }
+
+    [Fact]
+    public void OverlappingWindows_SharedAllowedToken_Survives()
+    {
+        var a = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 4);
+        var b = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 4);   // same allowed token
+        var combined = new AndTokenConstraint([a, b]);
+
+        var masked = combined.Filter(FreshLogits());
+        Assert.True(Allowed(masked, 4));
+        for (int i = 0; i < Vocab; i++)
+            if (i != 4) Assert.False(Allowed(masked, i));
+    }
+
+    /// <summary>Always constraining, but its Filter misbehaves: returns a freshly-allocated array
+    /// shorter than the input (neither the same reference as the input nor the same length) --
+    /// simulates a buggy caller-supplied constraint, e.g. one wired up via a host's
+    /// OutputConstraintFactory.</summary>
+    private sealed class WrongLengthConstraint : ITokenConstraint
+    {
+        public bool IsConstraining => true;
+        public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits) => new float[logits.Length / 2];
+        public void Accept(int token) { }
+        public void Reset() { }
+    }
+
+    [Fact]
+    public void MisbehavingInner_WrongFilterLength_IsSkipped_NeverCrashes()
+    {
+        var wrong = new WrongLengthConstraint();
+        var b = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 1);
+        var combined = new AndTokenConstraint([wrong, b]);
+
+        // Must not throw IndexOutOfRangeException -- the malformed inner is skipped, b's mask wins.
+        var masked = combined.Filter(FreshLogits());
+        Assert.True(Allowed(masked, 1));
+        Assert.False(Allowed(masked, 2));
+    }
+
+    [Fact]
+    public void DeadInnerDuringOverlap_IsSkipped_NotTreatedAsForbidAll()
+    {
+        // a is always-dead (its own grammar hit a dead state); b allows only token 1. a's punt must
+        // be skipped rather than contribute an all-forbidden pass, so b's mask alone should win.
+        var a = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 0, alwaysDead: true);
+        var b = new ScriptedConstraint(engageAfter: 0, forcedLen: 3, allow: 1);
+        var combined = new AndTokenConstraint([a, b]);
+
+        var masked = combined.Filter(FreshLogits());
+        Assert.True(Allowed(masked, 1));
+        Assert.False(Allowed(masked, 0));
+    }
+
+    [Fact]
+    public void Accept_And_Reset_AlwaysForwardToEveryInner()
+    {
+        var a = new ScriptedConstraint(engageAfter: 100, forcedLen: 1, allow: 0);   // never constrains
+        var b = new ScriptedConstraint(engageAfter: 0, forcedLen: 1, allow: 1);
+        var combined = new AndTokenConstraint([a, b]);
+
+        combined.Accept(0);
+        combined.Accept(1);
+        Assert.Equal(2, a.AcceptCount);
+        Assert.Equal(2, b.AcceptCount);
+
+        combined.Reset();
+        Assert.Equal(1, a.ResetCount);
+        Assert.Equal(1, b.ResetCount);
+        Assert.Equal(0, a.AcceptCount);
+        Assert.Equal(0, b.AcceptCount);
+    }
+}

--- a/tests/SharpInference.Tests.Core/JsonSchemaOutputConstraintTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonSchemaOutputConstraintTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using SharpInference.Core.Grammar;
+
+namespace SharpInference.Tests.Core;
+
+/// <summary>
+/// Model-independent tests for <see cref="JsonSchemaOutputConstraint"/> (issue #423 follow-up) using
+/// <see cref="FakeJsonTokenizer"/>, mirroring <see cref="JsonToolGrammarMockTests"/>'s pattern. Unlike
+/// the tool-argument constraint, there's no envelope/marker to arm on -- the constraint constrains
+/// the response from the very first token.
+/// </summary>
+public sealed class JsonSchemaOutputConstraintTests
+{
+    private static ToolSchemaObject Schema(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return ToolSchema.FromOpenAiFunction("_", doc.RootElement.Clone()).Arguments;
+    }
+
+    private static (ITokenConstraint c, FakeJsonTokenizer tok, int vocab) Build(string schemaJson)
+    {
+        var tok = new FakeJsonTokenizer();
+        var vocab = new GrammarVocabulary(tok);
+        var c = new JsonSchemaOutputConstraint(vocab, Schema(schemaJson));
+        return (c, tok, vocab.VocabSize);
+    }
+
+    private static void Feed(ITokenConstraint c, FakeJsonTokenizer tok, string text)
+    {
+        foreach (int id in tok.Encode(text)) c.Accept(id);
+    }
+
+    private static bool Allowed(ITokenConstraint c, int vocab, int tokenId)
+    {
+        Span<float> logits = new float[vocab];
+        var masked = c.Filter(logits);
+        return !float.IsNegativeInfinity(masked[tokenId]);
+    }
+
+    [Fact]
+    public void NonObjectSchema_Throws()
+    {
+        var vocab = new GrammarVocabulary(new FakeJsonTokenizer());
+        var ex = Assert.Throws<ArgumentException>(
+            () => new JsonSchemaOutputConstraint(vocab, Schema("""{"type":"string"}""")));
+        Assert.Contains("object schema", ex.Message);
+    }
+
+    [Fact]
+    public void EmptyObjectSchema_Throws()
+    {
+        var vocab = new GrammarVocabulary(new FakeJsonTokenizer());
+        Assert.Throws<ArgumentException>(
+            () => new JsonSchemaOutputConstraint(vocab, Schema("""{"type":"object"}""")));
+    }
+
+    [Fact]
+    public void ConstrainsFromTheFirstToken_NoAcceptNeeded()
+    {
+        var (c, _, _) = Build(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+        Assert.True(c.IsConstraining);
+    }
+
+    [Fact]
+    public void RequiredKey_CannotClose_UntilEmitted()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+
+        Feed(c, tok, "{");
+        Assert.False(Allowed(c, vocab, tok.Char('}')));   // required key missing
+        Assert.True(Allowed(c, vocab, tok.Char('"')));    // opens the "answer" key
+    }
+
+    [Fact]
+    public void OnlyDeclaredKeys_AreReachable()
+    {
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+
+        Feed(c, tok, "{\"");
+        Assert.True(Allowed(c, vocab, tok.Char('a')));    // 'a' starts "answer"
+        Assert.False(Allowed(c, vocab, tok.Char('x')));   // no key starts with 'x'
+    }
+
+    [Fact]
+    public void FullObject_Closes_ThenForcesEndOfGeneration()
+    {
+        // "Constrains the ENTIRE response" means nothing may follow the object -- once it closes,
+        // only an end-of-generation token is legal (forcing the model to stop), not free text.
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+
+        Feed(c, tok, "{\"answer\":\"hi\"}");
+        Assert.True(c.IsConstraining);                              // still constraining -- EOG-only now
+        Assert.True(Allowed(c, vocab, FakeJsonTokenizer.Eos));       // EOG is the one legal token
+        Assert.False(Allowed(c, vocab, tok.Char('x')));              // no further content is legal
+        Assert.False(Allowed(c, vocab, tok.Char('{')));              // not even a second object
+    }
+
+    [Fact]
+    public void Reset_ReEngagesImmediately_RegressionForMultiTurnReuse()
+    {
+        // Regression test: Reset() must re-engage the whole-body root immediately (not return to a
+        // watching-idle state that never arms, since there is no envelope marker to watch for).
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+
+        Feed(c, tok, "{\"answer\":\"hi\"}");
+        Assert.True(c.IsConstraining);       // done with turn 1 -- now forcing EOG-only
+        Assert.False(Allowed(c, vocab, tok.Char('{')));
+
+        c.Reset();
+        Assert.True(c.IsConstraining);        // turn 2 must be constrained from token 1 too
+        Assert.True(Allowed(c, vocab, tok.Char('{')));   // back to expecting a fresh object, not EOG-only
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/SayShowTagConstraintTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/SayShowTagConstraintTests.cs
@@ -1,0 +1,435 @@
+using System.Collections.Immutable;
+using System.Text;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Demo whole-turn output constraint (issue #423) implementing the grammar from the issue's own
+/// example: <c>output := ( text | "&lt;say&gt;" text "&lt;/say&gt;" | "&lt;show&gt;" text "&lt;/show&gt;" )*</c>.
+/// Free text passes through unconstrained; the instant a '&lt;' begins a marker it must complete to
+/// a valid open tag, and once open, the tag's content is free until the matching close tag is
+/// required. Operates on a byte-per-token vocabulary (token id == ASCII byte value) to keep the demo
+/// self-contained -- a real consumer's grammar would walk
+/// <see cref="GrammarVocabulary.TokenBytes"/> the way <c>GemmaToolArgumentConstraint</c> does for a
+/// multi-byte-token vocabulary, but that machinery isn't the point of this sample (issue #423
+/// explicitly leaves the output grammar itself to the consumer).
+/// </summary>
+public sealed class SayShowTagConstraint : ITokenConstraint
+{
+    private static readonly byte[] SayOpenTail = "say>"u8.ToArray();     // after the leading '<'
+    private static readonly byte[] ShowOpenTail = "show>"u8.ToArray();
+    private static readonly byte[] SayCloseTail = "/say>"u8.ToArray();   // after the leading '<'
+    private static readonly byte[] ShowCloseTail = "/show>"u8.ToArray();
+
+    private enum State { Outside, OpenMatch, Inside, CloseMatch }
+
+    private readonly int _vocab;
+    private float[]? _masked;
+
+    private State _state = State.Outside;
+    private int _matchLen;
+    private bool _sayCandidate;
+    private bool _showCandidate;
+    private bool _insideSay;
+
+    public SayShowTagConstraint(int vocabSize) => _vocab = vocabSize;
+
+    public bool IsConstraining => _state is State.OpenMatch or State.CloseMatch;
+
+    public void Reset()
+    {
+        _state = State.Outside;
+        _matchLen = 0;
+        _sayCandidate = false;
+        _showCandidate = false;
+        _insideSay = false;
+    }
+
+    public void Accept(int token)
+    {
+        var b = (byte)token;
+        switch (_state)
+        {
+            case State.Outside:
+                if (b == (byte)'<') { _state = State.OpenMatch; _matchLen = 0; _sayCandidate = true; _showCandidate = true; }
+                return;
+            case State.Inside:
+                if (b == (byte)'<') { _state = State.CloseMatch; _matchLen = 0; }
+                return;
+            case State.OpenMatch:
+                StepOpen(b);
+                return;
+            case State.CloseMatch:
+                StepClose(b);
+                return;
+        }
+    }
+
+    private void StepOpen(byte b)
+    {
+        if (_sayCandidate && (_matchLen >= SayOpenTail.Length || SayOpenTail[_matchLen] != b)) _sayCandidate = false;
+        if (_showCandidate && (_matchLen >= ShowOpenTail.Length || ShowOpenTail[_matchLen] != b)) _showCandidate = false;
+
+        if (!_sayCandidate && !_showCandidate) { Reset(); return; }   // a sampled token the mask should have forbidden
+
+        _matchLen++;
+        if (_sayCandidate && _matchLen == SayOpenTail.Length) { _state = State.Inside; _insideSay = true; return; }
+        if (_showCandidate && _matchLen == ShowOpenTail.Length) { _state = State.Inside; _insideSay = false; }
+    }
+
+    private void StepClose(byte b)
+    {
+        var tail = _insideSay ? SayCloseTail : ShowCloseTail;
+        if (_matchLen >= tail.Length || tail[_matchLen] != b) { Reset(); return; }   // ditto
+        _matchLen++;
+        if (_matchLen == tail.Length) _state = State.Outside;
+    }
+
+    public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+    {
+        if (logits.Length != _vocab) return logits;   // vocab mismatch -- never wedge
+
+        byte? b1 = null, b2 = null;
+        switch (_state)
+        {
+            case State.OpenMatch:
+                if (_sayCandidate && _matchLen < SayOpenTail.Length) b1 = SayOpenTail[_matchLen];
+                if (_showCandidate && _matchLen < ShowOpenTail.Length) b2 = ShowOpenTail[_matchLen];
+                break;
+            case State.CloseMatch:
+            {
+                var tail = _insideSay ? SayCloseTail : ShowCloseTail;
+                if (_matchLen < tail.Length) b1 = tail[_matchLen];
+                break;
+            }
+            default:
+                return logits;   // not constraining -- shouldn't be called, but never wedge regardless
+        }
+
+        if (b1 is null && b2 is null) return logits;   // dead state -- never wedge
+
+        var masked = _masked ??= new float[_vocab];
+        logits.CopyTo(masked);
+        bool any = false;
+        for (int i = 0; i < masked.Length; i++)
+        {
+            if ((byte)i == b1 || (byte)i == b2) { any = true; continue; }
+            masked[i] = float.NegativeInfinity;
+        }
+        return any ? masked : logits;
+    }
+}
+
+/// <summary>
+/// Tests for <see cref="SayShowTagConstraint"/> (issue #423 acceptance criterion 5): standalone
+/// grammar correctness, direct composition with another constraint via
+/// <see cref="TokenConstraints.Combine"/>, and a full run through a real
+/// <see cref="ContinuousBatchingEngine"/> -- mirroring <see cref="ContinuousBatchingConstraintTests"/>.
+/// </summary>
+public sealed class SayShowTagConstraintTests
+{
+    private const int Vocab = 128;
+    private static int Tok(char c) => c;
+
+    private static void Feed(ITokenConstraint c, string text)
+    {
+        foreach (char ch in text) c.Accept(Tok(ch));
+    }
+
+    private static bool Allowed(ITokenConstraint c, int tokenId)
+    {
+        Span<float> logits = new float[Vocab];
+        var masked = c.Filter(logits);
+        return !float.IsNegativeInfinity(masked[tokenId]);
+    }
+
+    // ── Standalone grammar correctness ─────────────────────────────────────────
+
+    [Fact]
+    public void FreeText_IsNeverConstraining()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "just some ordinary text, no tags here");
+        Assert.False(c.IsConstraining);
+    }
+
+    [Fact]
+    public void AfterAngleBracket_OnlyLegalTagStartByte_IsAllowed()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "hi<");
+        Assert.True(c.IsConstraining);
+        Assert.True(Allowed(c, Tok('s')));    // both "say" and "show" start with 's'
+        Assert.False(Allowed(c, Tok('x')));   // no valid tag starts with 'x'
+    }
+
+    [Fact]
+    public void AfterAngleS_BothSayAndShow_AreLegalContinuations()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "<s");
+        Assert.True(Allowed(c, Tok('a')));    // -> "say"
+        Assert.True(Allowed(c, Tok('h')));    // -> "show"
+        Assert.False(Allowed(c, Tok('x')));
+    }
+
+    [Fact]
+    public void OnceShowIsChosen_SayContinuation_IsNoLongerLegal()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "<sh");   // committed to "show" (say's 2nd byte would have been 'a', not 'h')
+        Assert.True(Allowed(c, Tok('o')));    // "show" continues
+        Assert.False(Allowed(c, Tok('a')));   // "say" is no longer reachable
+    }
+
+    [Fact]
+    public void InsideOpenTag_ContentIsFree()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "<say>anything at all");
+        Assert.False(c.IsConstraining);
+    }
+
+    [Fact]
+    public void ClosingTag_MustMatchTheOneThatOpened()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "<show>hi<");
+        Assert.True(c.IsConstraining);
+        Assert.True(Allowed(c, Tok('/')));
+        Feed(c, "/");
+        Assert.True(Allowed(c, Tok('s')));
+        Feed(c, "s");
+        Assert.True(Allowed(c, Tok('h')));    // "/show>" -- not "/say>"
+        Assert.False(Allowed(c, Tok('a')));
+    }
+
+    [Fact]
+    public void FullyClosedTag_ReturnsToFreeText()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "<say>hi</say>and more free text");
+        Assert.False(c.IsConstraining);
+    }
+
+    [Fact]
+    public void Reset_ReturnsToOutsideState()
+    {
+        var c = new SayShowTagConstraint(Vocab);
+        Feed(c, "<sa");
+        Assert.True(c.IsConstraining);
+        c.Reset();
+        Assert.False(c.IsConstraining);
+        Assert.True(Allowed(c, Tok('x')));    // back to fully free text
+    }
+
+    // ── Direct composition (no engine) ──────────────────────────────────────────
+
+    /// <summary>Always-constraining, single-allowed-byte mock -- stands in for an unrelated
+    /// constraint (e.g. a tool-argument constraint) simultaneously active with the tag grammar.</summary>
+    private sealed class SingleByteConstraint(int allowed) : ITokenConstraint
+    {
+        public bool IsConstraining => true;
+
+        public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+        {
+            var m = new float[logits.Length];
+            logits.CopyTo(m);
+            for (int i = 0; i < m.Length; i++)
+                if (i != allowed) m[i] = float.NegativeInfinity;
+            return m;
+        }
+
+        public void Accept(int token) { }
+        public void Reset() { }
+    }
+
+    [Fact]
+    public void ComposesWithAnotherConstraint_CanSteerWhichBranchTheGrammarTakes()
+    {
+        var tag = new SayShowTagConstraint(Vocab);
+        Feed(tag, "<s");   // matchLen=1: both 'a' (say) and 'h' (show) are legal per the tag grammar alone
+        Assert.True(Allowed(tag, Tok('a')));
+        Assert.True(Allowed(tag, Tok('h')));
+
+        // A second, independent constraint that only allows 'h' -- narrower than the tag grammar
+        // alone, so the combined mask must reflect BOTH restrictions, not just the tag grammar's.
+        var combined = TokenConstraints.Combine(tag, new SingleByteConstraint(Tok('h')))!;
+        var masked = combined.Filter(new float[Vocab]);
+        Assert.False(float.IsNegativeInfinity(masked[Tok('h')]));
+        Assert.True(float.IsNegativeInfinity(masked[Tok('a')]));
+
+        // Accepting the forced 'h' (through the combined constraint, which forwards to `tag` too)
+        // must update the tag grammar's own state: "show", not "say", is now the only reachable branch.
+        combined.Accept(Tok('h'));
+        Assert.True(Allowed(tag, Tok('o')));    // "show" continues
+        Assert.False(Allowed(tag, Tok('a')));   // "say" is no longer reachable
+    }
+
+    // ── Full run through a real ContinuousBatchingEngine ────────────────────────
+
+    /// <summary>Single-byte tokenizer: token id == ASCII byte (mirrors ContinuousBatchingConstraintTests;
+    /// duplicated locally since Tests.ForwardPass doesn't reference Tests.Core).</summary>
+    private sealed class CharTokenizer : ITokenizer
+    {
+        public int VocabSize => Vocab;
+        public int BosTokenId => 0;
+        public int EosTokenId => 0;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => 0;
+        public bool AddBosToken => false;
+        public ImmutableArray<int> EogTokenIds => [0];
+        public IReadOnlyDictionary<string, int> SpecialTokens { get; } =
+            new Dictionary<string, int>(StringComparer.Ordinal);
+
+        public byte[] DecodeBytes(int token) => token is > 0 and < Vocab ? [(byte)token] : [];
+
+        public IReadOnlyList<int> Encode(string text)
+        {
+            var ids = new int[text.Length];
+            for (int i = 0; i < text.Length; i++) ids[i] = text[i];
+            return ids;
+        }
+
+        public string Decode(IEnumerable<int> tokens)
+        {
+            var sb = new StringBuilder();
+            foreach (int t in tokens) sb.Append(Encoding.UTF8.GetString(DecodeBytes(t)));
+            return sb.ToString();
+        }
+    }
+
+    private sealed class FakeCache : ISequenceKvCache { public void Dispose() { } }
+
+    /// <summary>
+    /// Forward pass whose per-position preference is scripted by an explicit byte array (indexed by
+    /// an internal call counter), rather than always preferring one fixed token -- needed because
+    /// this constraint's grammar (unlike a schema constraint) reacts to WHERE in the stream a '&lt;'
+    /// appears, so the test has to say "the model wants to type THIS byte at THIS position" to prove
+    /// a deviation gets corrected. Single-sequence only (maxBatchSize:1): a per-sequence-aware script
+    /// would need to key the step counter by cache identity, which
+    /// <see cref="ContinuousBatchingConstraintTests"/> already covers generically with a uniform
+    /// (position-independent) preference, so a two-sequence variant isn't duplicated here.
+    /// </summary>
+    private sealed class ScriptedBytePreferenceForwardPass(byte[] preferred) : IBatchedForwardPass
+    {
+        public bool SnapKvEnabled => false;
+        public long KvBytesPerToken => 1;
+        public int MaxSeqLen => 8192;
+        public bool PrefillDequantCacheActive => false;
+        public bool SupportsBatchedGpuArgmax => true;
+
+        private int _step;
+
+        private float[] NextRow()
+        {
+            byte b = preferred[Math.Min(_step, preferred.Length - 1)];
+            _step++;
+            var r = new float[Vocab];
+            r[b] = 1f;
+            return r;
+        }
+
+        public ISequenceKvCache CreateCache() => new FakeCache();
+
+        public ReadOnlySpan<float> PrefillWithCache(IReadOnlyList<int> tokens, ISequenceKvCache cache, int startPos = 0)
+            => NextRow();
+
+        public float[]?[] PrefillPackedMulti(
+            ReadOnlyMemory<int>[] chunks, int[] startPos, ISequenceKvCache[] caches, bool[] wantLogits)
+        {
+            var outp = new float[]?[chunks.Length];
+            for (int i = 0; i < chunks.Length; i++) outp[i] = wantLogits[i] ? NextRow() : null;
+            return outp;
+        }
+
+        public float[][] BatchForwardMulti(int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        {
+            var outp = new float[tokens.Length][];
+            for (int i = 0; i < tokens.Length; i++) outp[i] = NextRow();
+            return outp;
+        }
+
+        public (int Token, float Logit)[] BatchForwardMultiArgmax(int[] tokens, int[] positions, ISequenceKvCache[] caches)
+        {
+            var outp = new (int, float)[tokens.Length];
+            for (int i = 0; i < tokens.Length; i++)
+            {
+                var row = NextRow();
+                outp[i] = (Array.IndexOf(row, 1f), 1f);
+            }
+            return outp;
+        }
+    }
+
+    /// <summary>Constraining only while AcceptCount is in [engageAfter, engageAfter+forcedLen); while
+    /// constraining, forbids every token except forcedByte. Stands in for an unrelated constraint
+    /// (e.g. a tool-argument constraint) simultaneously active with the tag grammar.</summary>
+    private sealed class FixedByteWindowConstraint(int engageAfter, int forcedLen, int forcedByte) : ITokenConstraint
+    {
+        private int _acceptCount;
+        public bool IsConstraining => _acceptCount >= engageAfter && _acceptCount < engageAfter + forcedLen;
+
+        public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits)
+        {
+            var m = new float[logits.Length];
+            logits.CopyTo(m);
+            for (int i = 0; i < m.Length; i++)
+                if (i != forcedByte) m[i] = float.NegativeInfinity;
+            return m;
+        }
+
+        public void Accept(int token) => _acceptCount++;
+        public void Reset() => _acceptCount = 0;
+    }
+
+    private static async Task<string> RunOne(ContinuousBatchingEngine engine, string prompt, SamplingParams sp)
+    {
+        var sb = new StringBuilder();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var s in engine.GenerateAsync(prompt, sp, cts.Token))
+            sb.Append(s);
+        return sb.ToString();
+    }
+
+    [Fact]
+    public async Task ComposedWithAnotherConstraint_ThroughRealEngine_ProducesValidBalancedTags()
+    {
+        // Scripted "model preference" per position: mostly an inert filler byte ('Z'), except where
+        // the trace needs a deliberate choice -- index 2 opens a tag, index 4 is the say/show
+        // divergence point (deliberately preferring 'a' / "say" to prove the second constraint's
+        // override below), index 10 opens the close tag. Every other forced-grammar position is
+        // overridden regardless of what's scripted here (only one legal byte survives at each), so
+        // 'Z' elsewhere is inert padding.
+        var preferred = new byte[24];
+        Array.Fill(preferred, (byte)'Z');
+        preferred[2] = (byte)'<';
+        preferred[4] = (byte)'a';
+        preferred[10] = (byte)'<';
+
+        var tag = new SayShowTagConstraint(Vocab);
+        // Stands in for an unrelated (e.g. tool-argument) constraint active only at the say/show
+        // divergence step, forcing 'h' -- narrower than the tag grammar's own {'a','h'} there.
+        var forceShow = new FixedByteWindowConstraint(engageAfter: 4, forcedLen: 1, forcedByte: Tok('h'));
+        var sp = new SamplingParams
+        {
+            Temperature = 0f,
+            MaxNewTokens = 17,
+            Constraint = TokenConstraints.Combine(tag, forceShow),
+        };
+
+        using var engine = new ContinuousBatchingEngine(
+            new ScriptedBytePreferenceForwardPass(preferred), new CharTokenizer(), "test", maxBatchSize: 1);
+
+        string text = await RunOne(engine, "prompt", sp);
+
+        // The model's own preference at the divergence point wanted "say" ('a'); the second
+        // constraint forced 'h' instead -- so the grammar committed to "show", and correctly
+        // required "/show>" (not "/say>") to close, despite every unforced byte being filler 'Z'.
+        Assert.Equal("ZZ<show>ZZ</show>", text);
+        Assert.False(tag.IsConstraining);   // ended back at the Outside/free state -- balanced
+    }
+}

--- a/tests/SharpInference.Tests.Server/JsonSchemaResponseFormatEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/JsonSchemaResponseFormatEndpointTests.cs
@@ -1,0 +1,265 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+using SharpInference.Engine;
+using SharpInference.Server;
+
+namespace SharpInference.Tests.Server;
+
+/// <summary>
+/// End-to-end wiring tests for <c>response_format.json_schema</c> / the llama.cpp-style flat
+/// <c>response_format.schema</c> extension (issue #423 follow-up), mirroring
+/// <see cref="OutputConstraintEndpointTests"/>'s <c>WebApplicationFactory</c> harness.
+/// <see cref="FakeInferenceEngine"/> serves a fixed canned script regardless of <c>sp.Constraint</c>,
+/// so these assert WIRING (the right constraint/error reaches
+/// <see cref="FakeInferenceEngine.LastSamplingParams"/> or the HTTP response) -- masking behavior
+/// itself is covered by <c>SharpInference.Tests.Core.JsonSchemaOutputConstraintTests</c>.
+/// </summary>
+public sealed class JsonSchemaResponseFormatEndpointTests
+{
+    /// <summary>Bare-minimum tokenizer. Whole-body mode needs no special/envelope token, only a
+    /// working <see cref="GrammarVocabulary"/> to construct against -- but the "AND-composed with
+    /// tool-grammar" test also needs Qwen's JSON tool-arg constraint to actually engage, which
+    /// requires <c>&lt;tool_call&gt;</c> to be registered as a special token (see
+    /// <c>JsonToolArgumentConstraint</c>'s constructor).</summary>
+    private sealed class MinimalTokenizer : ITokenizer
+    {
+        public int VocabSize => 8;
+        public int BosTokenId => 0;
+        public int EosTokenId => 0;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => 0;
+        public bool AddBosToken => false;
+        public ImmutableArray<int> EogTokenIds => [0];
+        public IReadOnlyDictionary<string, int> SpecialTokens { get; } =
+            new Dictionary<string, int>(StringComparer.Ordinal) { ["<tool_call>"] = 1 };
+        public byte[] DecodeBytes(int token) => [];
+        public IReadOnlyList<int> Encode(string text) => [];
+        public string Decode(IEnumerable<int> tokens) => "";
+    }
+
+    private static ChatTemplateRenderer RendererWithVocab()
+    {
+        var renderer = new ChatTemplateRenderer("qwen2");
+        renderer.Configure("qwen2", null, null, new GrammarVocabulary(new MinimalTokenizer()));
+        return renderer;
+    }
+
+    private static HttpClient CreateClient(
+        FakeInferenceEngine fake,
+        Action<SharpInferenceServerOptions>? configure = null,
+        ChatTemplateRenderer? renderer = null) =>
+        new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(b => b.ConfigureServices(s =>
+            {
+                if (configure is not null) s.Configure(configure);
+                if (renderer is not null) s.AddSingleton(renderer);
+                s.AddSingleton<IInferenceEngine>(fake);
+            }))
+            .CreateClient();
+
+    private static readonly object ValidSchema = new
+    {
+        type = "object",
+        properties = new { answer = new { type = "string" } },
+        required = new[] { "answer" },
+    };
+
+    [Fact]
+    public async Task NoResponseFormat_NoConstraint()
+    {
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.Null(fake.LastSamplingParams!.Constraint);
+    }
+
+    [Fact]
+    public async Task JsonSchemaType_ValidSchema_ConstraintIsJsonSchemaOutputConstraint()
+    {
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_schema", json_schema = new { name = "answer", schema = ValidSchema } },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
+    }
+
+    [Fact]
+    public async Task JsonObjectType_WithFlatSchemaExtension_ConstraintIsJsonSchemaOutputConstraint()
+    {
+        // llama.cpp's flat response_format.schema extension (no OpenAI json_schema envelope needed).
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_object", schema = ValidSchema },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
+    }
+
+    [Fact]
+    public async Task JsonSchemaType_UncompilableSchema_Returns400()
+    {
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_schema", json_schema = new { schema = new { type = "string" } } },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Contains("could not be compiled", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task JsonSchemaType_MissingSchema_Returns400()
+    {
+        // A missing json_schema.schema must be a client error, not a silent no-op (the client
+        // explicitly asked for type:"json_schema" -- proceeding unconstrained would violate the
+        // "explicit schema request is a hard requirement" contract).
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_schema" },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Contains("no json_schema.schema", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task JsonObjectType_NoSchema_IsNotAnError()
+    {
+        // Unlike "json_schema", "json_object" without a schema is the pre-existing lenient behavior
+        // (valid JSON, no shape enforced) -- must NOT become an error.
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_object" },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.Null(fake.LastSamplingParams!.Constraint);
+    }
+
+    [Fact]
+    public async Task JsonSchemaType_NoVocabularyAvailable_Returns400()
+    {
+        // No pinned renderer -- the default DI-constructed ChatTemplateRenderer never gets a
+        // GrammarVocabulary in these tests (no GGUF is loaded), so the request must fail loudly
+        // rather than silently generate unconstrained output.
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake);
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_schema", json_schema = new { schema = ValidSchema } },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Contains("vocabulary", doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task JsonSchemaType_AndToolGrammarActive_ConstraintIsAndComposed()
+    {
+        var fake = new FakeInferenceEngine("test-model", [
+            (GenerateChunkKind.Text, "<tool_call>"),
+            (GenerateChunkKind.Text, "{\"name\":\"get_weather\",\"arguments\":{\"city\":\"Paris\"}}"),
+            (GenerateChunkKind.Text, "</tool_call>"),
+        ]);
+        var client = CreateClient(fake, o => o.ToolGrammar = true, RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Weather?" } },
+            max_tokens = 50,
+            stream = false,
+            response_format = new { type = "json_schema", json_schema = new { schema = ValidSchema } },
+            tools = new[] { new
+            {
+                type = "function",
+                function = new
+                {
+                    name = "get_weather",
+                    description = "Get weather",
+                    parameters = new { type = "object", properties = new { city = new { type = "string" } } }
+                }
+            } }
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.IsType<AndTokenConstraint>(fake.LastSamplingParams!.Constraint);
+    }
+}

--- a/tests/SharpInference.Tests.Server/OutputConstraintEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/OutputConstraintEndpointTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SharpInference.Core;
+using SharpInference.Core.Grammar;
+using SharpInference.Engine;
+using SharpInference.Server;
+
+namespace SharpInference.Tests.Server;
+
+/// <summary>
+/// End-to-end wiring tests for the caller-supplied whole-turn output constraint
+/// (<see cref="SharpInferenceServerOptions.OutputConstraintFactory"/>, issue #423): confirms the
+/// factory's constraint reaches <c>SamplingParams.Constraint</c> through the real HTTP endpoints, and
+/// composes (AND) with the tool-argument constraint when both are active. <see cref="FakeInferenceEngine"/>
+/// serves a fixed canned script regardless of <c>sp.Constraint</c>, so these tests assert WIRING (the
+/// right constraint instance/type reaches <see cref="FakeInferenceEngine.LastSamplingParams"/>), not
+/// masked output -- masking behavior itself is covered by
+/// <c>SharpInference.Tests.ForwardPass.SayShowTagConstraintTests</c> and
+/// <c>SharpInference.Tests.Core.AndTokenConstraintTests</c>.
+/// </summary>
+public sealed class OutputConstraintEndpointTests
+{
+    /// <summary>Trivial never-constraining stub -- its TYPE is all these tests need to assert on.</summary>
+    private sealed class StubConstraint : ITokenConstraint
+    {
+        public bool IsConstraining => false;
+        public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits) => logits;
+        public void Accept(int token) { }
+        public void Reset() { }
+    }
+
+    /// <summary>
+    /// Bare-minimum tokenizer that only needs to make the Qwen JSON tool-argument constraint
+    /// constructible (registers <c>&lt;tool_call&gt;</c> as a special token, per
+    /// <c>JsonToolArgumentConstraint</c>'s constructor). These tests only assert wiring/composition
+    /// and never exercise <c>Filter</c>/<c>Accept</c>, so byte-level decode is unused.
+    /// </summary>
+    private sealed class MinimalToolTokenizer : ITokenizer
+    {
+        public int VocabSize => 8;
+        public int BosTokenId => 0;
+        public int EosTokenId => 0;
+        public int UnknownTokenId => 0;
+        public int PadTokenId => 0;
+        public bool AddBosToken => false;
+        public ImmutableArray<int> EogTokenIds => [0];
+        public IReadOnlyDictionary<string, int> SpecialTokens { get; } =
+            new Dictionary<string, int>(StringComparer.Ordinal) { ["<tool_call>"] = 1 };
+
+        public byte[] DecodeBytes(int token) => [];
+        public IReadOnlyList<int> Encode(string text) => [];
+        public string Decode(IEnumerable<int> tokens) => "";
+    }
+
+    private static HttpClient CreateClient(
+        FakeInferenceEngine fake,
+        Action<SharpInferenceServerOptions>? configure = null,
+        ChatTemplateRenderer? renderer = null) =>
+        new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(b => b.ConfigureServices(s =>
+            {
+                if (configure is not null) s.Configure(configure);
+                if (renderer is not null) s.AddSingleton(renderer);
+                s.AddSingleton<IInferenceEngine>(fake);
+            }))
+            .CreateClient();
+
+    [Fact]
+    public async Task NoFactory_NoTools_ConstraintStaysNull()
+    {
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake);
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.Null(fake.LastSamplingParams!.Constraint);
+    }
+
+    [Fact]
+    public async Task FactorySet_NoTools_ConstraintIsFactorysInstance()
+    {
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, o => o.OutputConstraintFactory = _ => new StubConstraint());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.IsType<StubConstraint>(fake.LastSamplingParams!.Constraint);
+    }
+
+    [Fact]
+    public async Task FactorySet_AndToolGrammarActive_ConstraintIsAndComposed()
+    {
+        // Pin a ChatTemplateRenderer with a real (non-null) GrammarVocabulary so
+        // BuildToolArgumentConstraint can actually engage -- the default DI-constructed renderer
+        // never gets a vocabulary in these tests (no GGUF is loaded).
+        var renderer = new ChatTemplateRenderer("qwen2");
+        renderer.Configure("qwen2", null, null, new GrammarVocabulary(new MinimalToolTokenizer()));
+
+        var fake = new FakeInferenceEngine("test-model", [
+            (GenerateChunkKind.Text, "<tool_call>"),
+            (GenerateChunkKind.Text, "{\"name\":\"get_weather\",\"arguments\":{\"city\":\"Paris\"}}"),
+            (GenerateChunkKind.Text, "</tool_call>"),
+        ]);
+        var client = CreateClient(fake,
+            o => { o.OutputConstraintFactory = _ => new StubConstraint(); o.ToolGrammar = true; },
+            renderer);
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Weather?" } },
+            max_tokens = 50,
+            stream = false,
+            tools = new[] { new
+            {
+                type = "function",
+                function = new
+                {
+                    name = "get_weather",
+                    description = "Get weather",
+                    parameters = new { type = "object", properties = new { city = new { type = "string" } } }
+                }
+            } }
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        Assert.IsType<AndTokenConstraint>(fake.LastSamplingParams!.Constraint);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #423. Adds a whole-turn `ITokenConstraint` mechanism that composes (AND) with the existing tool-argument constraint, plus a JSON-Schema-constrained "structured output" feature built on top of it for both the CLI and server.

- **Core**: `AndTokenConstraint` + `TokenConstraints.Combine` (N-ary null-safe composition), `SharpInferenceServerOptions.OutputConstraintFactory` (host-supplied per-request constraint), `JsonSchemaOutputConstraint` (whole-body JSON-Schema constraint, reusing `JsonToolArgumentConstraint`'s existing frame-stack matcher via a new additive "whole-body" mode instead of duplicating it).
- **CLI**: `-j/--json-schema <SCHEMA>` and `--json-schema-file/--jf <PATH>`, matching llama.cpp's own flag names (`-jf`'s single-dash 2-char form isn't representable in Spectre.Console.Cli, so it's a `--jf` double-dash alias, same precedent as the existing `--cpu-moe|--cmoe`).
- **Server**: `response_format.json_schema` (OpenAI's nested wire shape) and llama.cpp's flat `json_object.schema` extension, composed 3-way with the output-constraint factory and tool-argument constraint.

## Review fixes included

An 8-angle review surfaced and I fixed:
- CLI speculative-decoding gate only checked the tool constraint, missing the new json-schema constraint — could silently generate schema-violating output under `--draft-model`/`--draft-lookup`.
- `response_format.type:"json_schema"` with no schema silently no-op'd instead of erroring (now 400s).
- `AndTokenConstraint` could throw `IndexOutOfRangeException` on a misbehaving caller-supplied constraint (e.g. via `OutputConstraintFactory`) — now defensively skipped.
- Whole-body mode didn't actually constrain the *entire* response — trailing tokens after the JSON object closed were unconstrained. Now forces end-of-generation once the root object closes.
- Removed a redundant 2-arg `Combine` overload (the params overload already handles it).

Two lower-severity findings (altitude concern about bolting whole-body mode onto `JsonToolArgumentConstraint`; server lacking the CLI's operator warning for combining `--tool-grammar` + json-schema) were left as-is — documented in code comments / acceptable given existing precedent.

## Test plan
- [x] `dotnet build` — 0 warnings/errors (TreatWarningsAsErrors)
- [x] `dotnet test tests/SharpInference.Tests.Core` — 265 passed
- [x] `dotnet test tests/SharpInference.Tests.Cli` — 58 passed
- [x] `dotnet test tests/SharpInference.Tests.Server` — 151 passed
- [x] `dotnet test tests/SharpInference.Tests.ForwardPass --filter "ContinuousBatching|Constraint"` — 29 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EWo1niax1g8A5E79RSALJ