### PR TITLE
perf(cuda): DSpark draft round 27.8 -> 11.8 ms — on-device Markov heads + launch trims (#428 lever 1)

### DIFF
--- a/docs/dspark-plan.md
+++ b/docs/dspark-plan.md
@@ -77,11 +77,15 @@
 > per position, zero host syncs inside the chain) so only [B] tokens + [B]
 > confidences cross PCIe per round. Same prompt/settings as above: draft
 > 1971→836 ms over ~71 rounds; DSpark default 50.0→61.1 t/s, `min-confidence 0.8`
-> 46.5→58.0 t/s, plain 55–62 t/s (thermal window) — DSpark now sits at plain-decode
-> speed on 4B, still verify-bound (verify ≈ 47 ms/round at k≈7). Acceptance and
-> emitted tokens byte-identical to the host-heads path on the bench workload; the
-> new `CudaDSparkDraftModelTests` pin CUDA-vs-CPU proposal parity on the synthetic
-> head. Lever 2 (verify fixed cost) is now the whole remaining gap.
+> 46.5→58.0 t/s, plain 55–62 t/s (thermal window). With the draft flat at ~12 ms the
+> verify-length sweep now CROSSES plain on this 37%-acceptance content:
+> k=1 55.1 / k=2 64.7 / **k=3 67.9** / k=5 65.8 / k=7 59.9 t/s vs plain 61.5 —
+> `--dspark-verify-len 3` is a 1.10× win on the exact 4B pairing that lost 50-vs-64
+> pre-#428 (k=7, the block-size default, is the worst config on hard content; the
+> confidence trim at 0.8 only reaches 58.0 — a fixed short cap beats it here).
+> Acceptance and emitted tokens byte-identical to the host-heads path on the bench
+> workload; the new `CudaDSparkDraftModelTests` pin CUDA-vs-CPU proposal parity on
+> the synthetic head. Lever 2 (verify fixed cost) is the remaining upside.
 >
 > **#428 lever 2, MMQ half (2026-07-09): measured, and rejected on parity.** The
 > existing `SHARPI_BATCH_DECODE_MMQ=1` A/B (which force-routes the pinned

--- a/docs/dspark-plan.md
+++ b/docs/dspark-plan.md
@@ -63,6 +63,25 @@
 > tracked in issues #405–#409). Placement note: with `-c` unset the target's VRAM-fit KV
 > solve consumes the card and the planner correctly lands on `Cpu` — bound the context
 > to free headroom for the head.
+>
+> **#428 lever 1 (2026-07-09): the draft round is 11.8 ms, down from 27.8.** The
+> `SHARPI_DSPARK_TIMING=1` breakdown overturned the launch-bound theory: the old round
+> was ~1 ms launch enqueue + ~8.6 ms GPU + **~17.6 ms host Markov chain** — the
+> `DSparkHostHeads` GreedyBlock re-streams the 155 MB f32 `markov_w2` once per block
+> position (7×/round) at host DRAM bandwidth. Two changes:
+> (1) launch trims — one `AttentionBatchedRagged` launch/layer instead of the
+> per-query loop (35→5), beta=1 GemmEx residuals (no CopyDevice/AddInPlace), fused
+> q+k RoPE, shared f32→f16 activation converts; (2) the Markov re-bias, greedy
+> argmax chain, and confidence head moved on-device (fp16 `markov_w1`/`markov_w2`
+> resident, +156 MB VRAM at 4B-head shapes, gather→beta=1-GEMV→`llm_argmax_rows`
+> per position, zero host syncs inside the chain) so only [B] tokens + [B]
+> confidences cross PCIe per round. Same prompt/settings as above: draft
+> 1971→836 ms over ~71 rounds; DSpark default 50.0→61.1 t/s, `min-confidence 0.8`
+> 46.5→58.0 t/s, plain 55–62 t/s (thermal window) — DSpark now sits at plain-decode
+> speed on 4B, still verify-bound (verify ≈ 47 ms/round at k≈7). Acceptance and
+> emitted tokens byte-identical to the host-heads path on the bench workload; the
+> new `CudaDSparkDraftModelTests` pin CUDA-vs-CPU proposal parity on the synthetic
+> head. Lever 2 (verify fixed cost) is now the whole remaining gap.
 
 ## 1. Background
 

--- a/docs/dspark-plan.md
+++ b/docs/dspark-plan.md
@@ -82,6 +82,21 @@
 > emitted tokens byte-identical to the host-heads path on the bench workload; the
 > new `CudaDSparkDraftModelTests` pin CUDA-vs-CPU proposal parity on the synthetic
 > head. Lever 2 (verify fixed cost) is now the whole remaining gap.
+>
+> **#428 lever 2, MMQ half (2026-07-09): measured, and rejected on parity.** The
+> existing `SHARPI_BATCH_DECODE_MMQ=1` A/B (which force-routes the pinned
+> `allowDecodeMmq:false` verify onto the int8 decode-MMQ tile) gives verify
+> 3350→2233 ms and 60.5→**79.5 t/s** on the same 4B workload — but the 256-token
+> parity oracle FAILS: the output text diverges from plain greedy mid-sequence
+> (acceptance shifts 37%→31% along the changed trajectory). The MMQ verify logits
+> flip argmaxes on near-ties vs the per-token decode path, so the "argmax-stable"
+> property that holds for batched-vs-batched (#201/#206) does NOT extend to
+> batched-MMQ-vs-per-token — the `allowDecodeMmq:false` pin is load-bearing and
+> stays. The +19 t/s is only reachable as an explicit parity-relaxed opt-in (the
+> output is still self-consistent greedy under MMQ numerics), or via the other
+> lever-2 half: a CUDA-graph-captured k-token verify to cut the ~10.6 ms fixed
+> launch overhead of the un-graphed 36-layer batched trunk while staying on the
+> bit-exact WS matvecs.
 
 ## 1. Background
 

--- a/scripts/download-model.ps1
+++ b/scripts/download-model.ps1
@@ -3,7 +3,7 @@
     Downloads GGUF models for SharpInference development.
 .DESCRIPTION
     Downloads from HuggingFace to the models/ directory. Skips if already present.
-    Supports: smollm2, vibethinker, qwen3-8b, qwen3-4b, dspark-qwen3-4b, olmoe-1b-7b, llama31-70b, qwen3-coder-30b-a3b, qwen36-35b-a3b,
+    Supports: smollm2, vibethinker, qwen3-8b, qwen3-4b, dspark-qwen3-4b, dspark-qwen3-8b, olmoe-1b-7b, llama31-70b, qwen3-coder-30b-a3b, qwen36-35b-a3b,
               qwen36-27b-mtp, qwen36-27b-mtp-q5, qwen36-35b-a3b-mtp, carnice-35b-a3b-mtp,
               ornith-9b, ornith-35b,
               gemma4-12b-qat, gemma4-12b-q4km, gemma4-e4b-qat, gemma4-12b-agentic,
@@ -18,6 +18,7 @@
     .\download-model.ps1 -Model qwen3-8b                # Qwen3 8B (4.9 GB)
     .\download-model.ps1 -Model qwen3-4b                # Qwen3 4B Q4_K_M (~2.5 GB) — DSpark speculative-decoding target (PR #413)
     .\download-model.ps1 -Model dspark-qwen3-4b         # DSpark draft head for Qwen3-4B (2.8 GB BF16 safetensors + config.json)
+    .\download-model.ps1 -Model dspark-qwen3-8b         # DSpark draft head for Qwen3-8B (4.7 GB BF16 safetensors + config.json) — pairs with qwen3-8b (issue #428)
     .\download-model.ps1 -Model olmoe-1b-7b             # OLMoE 1B-7B Instruct Q4_K_M (~4.4 GB) — small MoE for kernel validation
     .\download-model.ps1 -Model llama31-70b             # Llama 3.1 70B (40.8 GB)
     .\download-model.ps1 -Model qwen3-coder-30b-a3b     # Qwen3-Coder 30B-A3B Q4_K_M (18.6 GB)
@@ -38,7 +39,7 @@
     .\download-model.ps1 -Model realesrgan-x4           # Real-ESRGAN x4plus upscaler (67 MB)
 #>
 param(
-    [ValidateSet("smollm2", "vibethinker", "vibethinker-q4", "qwen3-8b", "qwen3-0.6b", "qwen3-4b", "dspark-qwen3-4b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
+    [ValidateSet("smollm2", "vibethinker", "vibethinker-q4", "qwen3-8b", "qwen3-0.6b", "qwen3-4b", "dspark-qwen3-4b", "dspark-qwen3-8b", "olmoe-1b-7b", "llama31-70b", "qwen3-coder-30b-a3b", "qwen36-35b-a3b",
                  "qwen36-27b-mtp", "qwen36-27b-mtp-q5", "qwen36-35b-a3b-mtp", "carnice-35b-a3b-mtp",
                  "ornith-9b", "ornith-35b",
                  "gemma4-12b-qat", "gemma4-12b-q4km", "gemma4-e4b-qat", "gemma4-12b-agentic",
@@ -121,6 +122,22 @@ $Models = @{
         )
         Size  = "2.8 GB"
         Phase = "DSpark draft head (PR #413)"
+    }
+    # DSpark draft head for Qwen3-8B (issue #428 crossover validation): same DFlash
+    # block-7 layout as the 4B head (verified single model.safetensors + config.json
+    # on the hub), trained against Qwen/Qwen3-8B — pair with the `qwen3-8b` GGUF.
+    # Needs a 12 GB+ card for the GPU-draft placement next to the 8B target.
+    "dspark-qwen3-8b" = @{
+        Files = @(
+            "dspark_qwen3_8b_block7\model.safetensors",
+            "dspark_qwen3_8b_block7\config.json"
+        )
+        Urls  = @(
+            "https://huggingface.co/deepseek-ai/dspark_qwen3_8b_block7/resolve/main/model.safetensors",
+            "https://huggingface.co/deepseek-ai/dspark_qwen3_8b_block7/resolve/main/config.json"
+        )
+        Size  = "4.7 GB"
+        Phase = "DSpark draft head (issue #428)"
     }
     # Smallest MoE model that fits in 12 GB VRAM for full-offload kernel validation.
     # OLMoE arch (allenai) — 7B total params, 1B active, 64 experts × 8 active, softmax routing.

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -1606,6 +1606,14 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             (totalDecoded > generated ? $" ({generated} visible, {totalDecoded - generated} thinking)" : "") +
             $" | DSpark accept: {decoder.AcceptanceRate:P0} ({decoder.TotalDraftsAccepted}/{decoder.TotalDraftsEmitted}) | " +
             $"draft {decoder.DraftMs:F0}ms / verify {decoder.VerifyMs:F0}ms / commit {decoder.CommitMs:F0}ms[/]");
+        // Draft-internal breakdown for the #428 perf work: enqueue = launch-issue CPU
+        // time, gpu-wait = GPU execution + D2H collapsed into the per-block download
+        // sync, heads = host Markov/confidence chain.
+        if (Environment.GetEnvironmentVariable("SHARPI_DSPARK_TIMING") == "1"
+            && draft is CudaDSparkDraftModel cudaDraft)
+            AnsiConsole.MarkupLine(
+                $"[dim]DSpark draft breakdown: enqueue {decoder.DraftMs - cudaDraft.GpuWaitMs - cudaDraft.HostHeadsMs:F0}ms / " +
+                $"gpu-wait {cudaDraft.GpuWaitMs:F0}ms / heads {cudaDraft.HostHeadsMs:F0}ms[/]");
         return 0;
     }
 

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -274,6 +274,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _headNormQkBatchedKernel;
     private nint   _splitQgBatchedKernel;
     private nint   _ropeNeoxPartialBatchedKernel;
+    private nint   _ropeNeoxPartialBatchedQkKernel;
     private nint   _attentionKernel;
     // Gemma 4 (Phase 7): sliding-window attention, tanh-GELU FFN, final-logit
     // softcap. Kernel work only — forward-pass wiring lands in Phase 8.
@@ -2801,13 +2802,24 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     /// Dense batched GEMM against a RESIDENT fp16 weight with f32 device activations
     /// (DSpark GPU draft head, PR #413 Phase 4): converts the activations f32→f16 into
     /// internal scratch, then one <c>cublasGemmEx</c> f16×f16→f32 with fp32 accumulation.
-    /// <c>outputAll[nTok×rows] f32 = inputAll[nTok×cols] f32 × weightF16[rows×cols]ᵀ</c>,
-    /// all row-major. The weight skips <see cref="MatMulBatchedGemm"/>'s per-call dequant —
-    /// it is already fp16 in VRAM (via <see cref="UploadHalf"/>). NOT bit-exact vs the
-    /// f32 matvec path (activations rounded to fp16); draft-side use only, where numerics
-    /// affect acceptance rate, never emitted-token correctness.
+    /// <c>outputAll[nTok×rows] f32 = inputAll[nTok×cols] f32 × weightF16[rows×cols]ᵀ
+    /// + beta × outputAll</c>, all row-major. The weight skips
+    /// <see cref="MatMulBatchedGemm"/>'s per-call dequant — it is already fp16 in VRAM
+    /// (via <see cref="UploadHalf"/>). NOT bit-exact vs the f32 matvec path (activations
+    /// rounded to fp16); draft-side use only, where numerics affect acceptance rate,
+    /// never emitted-token correctness.
     /// </summary>
-    public void MatMulBatchedGemmF16W(Tensor outputAll, Tensor weightF16, Tensor inputAll, int nTok)
+    /// <param name="beta">GemmEx epilogue scale on the existing output: 0 (default)
+    /// overwrites, 1 accumulates — folding a residual add that would otherwise cost a
+    /// separate <see cref="AddInPlace"/> launch (issue #428).</param>
+    /// <param name="reuseConvertedInput">Skip the f32→f16 activation conversion and reuse
+    /// the internal scratch as-is. ONLY valid when the previous call to a
+    /// MatMulBatchedGemm* method converted the SAME <paramref name="inputAll"/> contents
+    /// at the same nTok×cols size (back-to-back projections of one normed block, e.g.
+    /// DSpark's q/k/v). The scratch is private to these methods; interleaved non-GEMM
+    /// launches don't disturb it.</param>
+    public void MatMulBatchedGemmF16W(Tensor outputAll, Tensor weightF16, Tensor inputAll, int nTok,
+                                      float beta = 0f, bool reuseConvertedInput = false)
     {
         EnsureImageKernels();
         if (!_imageKernelsAvailable)
@@ -2836,6 +2848,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         EnsureGemmAf16((nuint)((long)nTok * cols * 2L));
 
         // 1) Convert activations fp32 → fp16 (same kernel MatMulBatchedGemm uses).
+        //    Skipped when the caller certifies the scratch already holds this input
+        //    (reuseConvertedInput contract above); EnsureGemmAf16 was a no-op then —
+        //    the size matches the converting call by contract, so no realloc occurred.
+        if (!reuseConvertedInput)
         {
             nint ip = xPtr, op = _gemmAf16Buf;
             int n = nTok * cols;
@@ -2846,9 +2862,9 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(f32_to_f16) failed: {r}");
         }
 
-        // 2) GemmEx: C[nTok×rows] f32 = A[nTok×cols] f16 × B[rows×cols] f16ᵀ, fp32 accum.
+        // 2) GemmEx: C[nTok×rows] f32 = A[nTok×cols] f16 × B[rows×cols] f16ᵀ + beta·C, fp32 accum.
         {
-            float alpha = 1f, beta = 0f;
+            float alpha = 1f;
             int M = nTok, K = cols, N = rows;
             int status = CuBlasInterop.GemmEx(
                 _handle,
@@ -4188,6 +4204,40 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         uint grid = (uint)((totalPairs + 255) / 256);
         int r = NvrtcInterop.LaunchKernel(_ropeNeoxPartialBatchedKernel, grid, (uint)nTok, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rope_neox_partial_batched) failed: {r}");
+    }
+
+    /// <summary>
+    /// Fused q+k variant of <see cref="RoPEPartialBatched"/> (DSpark GPU draft, issue
+    /// #428): rotates <paramref name="q"/> (<c>[nTok × numQHeads × headDim]</c>) and
+    /// <paramref name="k"/> (<c>[nTok × numKvHeads × headDim]</c>) at position
+    /// basePosition + t in ONE launch. Per buffer bit-identical to the two separate
+    /// <see cref="RoPEPartialBatched"/> calls it replaces.
+    /// </summary>
+    public void RoPEPartialBatchedQk(Tensor q, Tensor k, int basePosition, int headDim,
+        int ropeDim, float ropeTheta, int numQHeads, int numKvHeads, int nTok, bool neox)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (!neox)
+            throw new ArgumentException("RoPEPartialBatchedQk currently supports only neox=true.", nameof(neox));
+        if (ropeDim <= 0 || (ropeDim & 1) != 0)
+            throw new ArgumentException("ropeDim must be a positive even number.", nameof(ropeDim));
+        if (ropeDim > headDim)
+            throw new ArgumentException("ropeDim must be <= headDim.", nameof(ropeDim));
+
+        int totalPairs = (numQHeads + numKvHeads) * (ropeDim / 2);
+        nint qPtr = GetDevPtr(q), kPtr = GetDevPtr(k);
+        int  pNQ = numQHeads, pNKV = numKvHeads, pHD = headDim, pRD = ropeDim, pPos = basePosition, pNT = nTok;
+        float pT = ropeTheta;
+        nint* args = stackalloc nint[9]
+        {
+            (nint)(&qPtr), (nint)(&kPtr),
+            (nint)(&pNQ), (nint)(&pNKV), (nint)(&pHD), (nint)(&pRD), (nint)(&pPos), (nint)(&pT), (nint)(&pNT)
+        };
+        uint grid = (uint)((totalPairs + 255) / 256);
+        int r = NvrtcInterop.LaunchKernel(_ropeNeoxPartialBatchedQkKernel, grid, (uint)nTok, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(rope_neox_partial_batched_qk) failed: {r}");
     }
 
     /// <summary>
@@ -6983,6 +7033,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _matvecQ40Dp4aSoaKernel, _dequantQ40F16SoaKernel,   // #124/#173
             _rmsNormBatchedKernel, _headNormBatchedKernel, _headNormQkKernel, _headNormQkBatchedKernel,
             _splitQgBatchedKernel, _ropeNeoxPartialBatchedKernel,
+            _ropeNeoxPartialBatchedQkKernel,   // #428
             _attentionKernel, _attentionBf16Kernel, _attentionSwaKernel, _attentionSwaBatchedKernel,
             _attentionSwaBf16Kernel, _attentionSwaBatchedBf16Kernel,
             _geluTanhMulKernel, _geluTanhMulStridedKernel, _softcapKernel,
@@ -7161,6 +7212,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _headNormQkBatchedKernel = GetKernelFunc("llm_head_norm_qk_batched");
         _splitQgBatchedKernel  = GetKernelFunc("llm_split_qg_batched");
         _ropeNeoxPartialBatchedKernel = GetKernelFunc("llm_rope_neox_partial_batched");
+        _ropeNeoxPartialBatchedQkKernel = GetKernelFunc("llm_rope_neox_partial_batched_qk");
         _ropeNeoxWithFactorsBatchedKernel = GetKernelFunc("llm_rope_neox_with_factors_batched");
         _attentionKernel       = GetKernelFunc("llm_attention");
         _attentionBf16Kernel   = GetKernelFunc("llm_attention_bf16");

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -275,6 +275,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _splitQgBatchedKernel;
     private nint   _ropeNeoxPartialBatchedKernel;
     private nint   _ropeNeoxPartialBatchedQkKernel;
+    private nint   _dsparkGatherW1Kernel;
+    private nint   _dsparkConfidenceKernel;
     private nint   _attentionKernel;
     // Gemma 4 (Phase 7): sliding-window attention, tanh-GELU FFN, final-logit
     // softcap. Kernel work only — forward-pass wiring lands in Phase 8.
@@ -4104,6 +4106,91 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         return result;
     }
 
+    /// <summary>
+    /// <see cref="ArgmaxRows"/>'s launch-only sibling (issue #428): the per-row
+    /// (index-bits, value) pairs land in the caller's device buffer
+    /// <paramref name="outIdxVal"/> (<c>rows*2</c> floats, llm_argmax_rows layout)
+    /// with NO download and NO sync — for on-stream consumers like the DSpark
+    /// device-side Markov chain, which reads the index back in a later kernel.
+    /// </summary>
+    public void ArgmaxRowsToDevice(Tensor logits, Tensor outIdxVal, int rows, int validLen, int rowStride)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (rows <= 0) return;
+        if (outIdxVal.ElementCount < (long)rows * 2)
+            throw new ArgumentException(
+                $"ArgmaxRowsToDevice: outIdxVal needs {rows}*2 floats, has {outIdxVal.ElementCount}.");
+
+        nint lPtr = GetDevPtr(logits);
+        nint outPtr = GetDevPtr(outIdxVal);
+        int pN = validLen;
+        int pStride = rowStride;
+        nint* args = stackalloc nint[4] { (nint)(&lPtr), (nint)(&pN), (nint)(&pStride), (nint)(&outPtr) };
+        int r = NvrtcInterop.LaunchKernel(_argmaxRowsKernel, (uint)rows, 1, 1, ArgmaxThreads, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(llm_argmax_rows) failed: {r}");
+    }
+
+    /// <summary>
+    /// DSpark device-side Markov chain, step <paramref name="step"/> (issue #428):
+    /// gathers <c>markov_w1[prev]</c> (fp16 <c>[vocab, rank]</c>) as f32 into
+    /// <paramref name="w1Row"/> (the bias GEMV's activation) and row
+    /// <paramref name="step"/> of <paramref name="w1RowsAll"/> (the confidence
+    /// feature tail). <c>prev</c> is the anchor token at step 0, else read
+    /// on-device from <paramref name="argmaxOut"/> (llm_argmax_rows layout,
+    /// index bits at <c>[(step-1)*2]</c>) — the chain never syncs to the host.
+    /// </summary>
+    public void DSparkGatherW1(Tensor w1F16, Tensor argmaxOut, int step, int anchorToken,
+        Tensor w1Row, Tensor w1RowsAll, int rank)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (w1F16.DType != DType.Float16)
+            throw new ArgumentException($"DSparkGatherW1 expects an fp16 w1 table, got {w1F16.DType}.", nameof(w1F16));
+
+        nint wPtr = GetDevPtr(w1F16), amPtr = GetDevPtr(argmaxOut);
+        nint rowPtr = GetDevPtr(w1Row), allPtr = GetDevPtr(w1RowsAll);
+        int pStep = step, pAnchor = anchorToken, pRank = rank;
+        nint* args = stackalloc nint[7]
+        {
+            (nint)(&wPtr), (nint)(&amPtr), (nint)(&pStep), (nint)(&pAnchor),
+            (nint)(&rowPtr), (nint)(&allPtr), (nint)(&pRank)
+        };
+        uint grid = (uint)((rank + 255) / 256);
+        int r = NvrtcInterop.LaunchKernel(_dsparkGatherW1Kernel, grid, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(llm_dspark_gather_w1) failed: {r}");
+    }
+
+    /// <summary>
+    /// DSpark confidence head over a whole block (issue #428), one launch:
+    /// <c>out[j] = sigmoid(confW · [hidden_j (‖ w1Rows[j])] + confB)</c>, matching
+    /// the host <c>DSparkHostHeads</c> feature layout exactly. When
+    /// <paramref name="withMarkov"/> is false the w1 tail is ignored (pass any
+    /// valid tensor for <paramref name="w1Rows"/>).
+    /// </summary>
+    public void DSparkConfidence(Tensor hidden, Tensor w1Rows, Tensor confW, float confB,
+        Tensor outConf, int embDim, int rank, bool withMarkov, int nRows)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (nRows <= 0) return;
+
+        nint hPtr = GetDevPtr(hidden), wrPtr = GetDevPtr(w1Rows);
+        nint cwPtr = GetDevPtr(confW), outPtr = GetDevPtr(outConf);
+        float pB = confB;
+        int pEmb = embDim, pRank = rank, pWith = withMarkov ? 1 : 0, pRows = nRows;
+        nint* args = stackalloc nint[9]
+        {
+            (nint)(&hPtr), (nint)(&wrPtr), (nint)(&cwPtr), (nint)(&pB), (nint)(&outPtr),
+            (nint)(&pEmb), (nint)(&pRank), (nint)(&pWith), (nint)(&pRows)
+        };
+        int r = NvrtcInterop.LaunchKernel(_dsparkConfidenceKernel, (uint)nRows, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(llm_dspark_confidence) failed: {r}");
+    }
+
     // IComputeBackend contract (#314): standalone in-place SiLU. The fused SwiGLU
     // path still prefers SiLuMul(gate, up); this delegates to the existing NVRTC
     // in-place kernel so the interface is honored uniformly across backends.
@@ -7033,7 +7120,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _matvecQ40Dp4aSoaKernel, _dequantQ40F16SoaKernel,   // #124/#173
             _rmsNormBatchedKernel, _headNormBatchedKernel, _headNormQkKernel, _headNormQkBatchedKernel,
             _splitQgBatchedKernel, _ropeNeoxPartialBatchedKernel,
-            _ropeNeoxPartialBatchedQkKernel,   // #428
+            _ropeNeoxPartialBatchedQkKernel, _dsparkGatherW1Kernel, _dsparkConfidenceKernel,   // #428
             _attentionKernel, _attentionBf16Kernel, _attentionSwaKernel, _attentionSwaBatchedKernel,
             _attentionSwaBf16Kernel, _attentionSwaBatchedBf16Kernel,
             _geluTanhMulKernel, _geluTanhMulStridedKernel, _softcapKernel,
@@ -7213,6 +7300,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _splitQgBatchedKernel  = GetKernelFunc("llm_split_qg_batched");
         _ropeNeoxPartialBatchedKernel = GetKernelFunc("llm_rope_neox_partial_batched");
         _ropeNeoxPartialBatchedQkKernel = GetKernelFunc("llm_rope_neox_partial_batched_qk");
+        _dsparkGatherW1Kernel = GetKernelFunc("llm_dspark_gather_w1");
+        _dsparkConfidenceKernel = GetKernelFunc("llm_dspark_confidence");
         _ropeNeoxWithFactorsBatchedKernel = GetKernelFunc("llm_rope_neox_with_factors_batched");
         _attentionKernel       = GetKernelFunc("llm_attention");
         _attentionBf16Kernel   = GetKernelFunc("llm_attention_bf16");

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -491,6 +491,67 @@ extern ""C"" __global__ void llm_argmax_rows(
     if (tid == 0) { ((int*)out)[row * 2] = sIdx[0]; ((float*)out)[row * 2 + 1] = sVal[0]; }
 }
 
+// ── DSpark device-side Markov/confidence heads (issue #428) ────────────────
+// The rank-r Markov chain is sequential per block position j: gather
+// markov_w1[prev_j] (prev_0 = anchor, else the argmax of position j-1), bias
+// the base logits row with markov_w2 @ w1row (a beta=1 GemmEx on the host
+// side), argmax the row. Keeping the whole chain on-stream removes the
+// [block × vocab] logits download AND the host-side 7× re-stream of the
+// [vocab × rank] markov_w2 — the dominant cost of the GPU draft round.
+
+// Gather markov_w1[prev] (fp16 [vocab, rank]) as f32 into `w1row` (the GEMV
+// activation) and `w1rows_all[step]` (the confidence head's per-position
+// feature tail). `prev` is read on-device from the argmax_rows output layout
+// (int index bits at out[(step-1)*2]) so the chain never syncs to the host.
+extern ""C"" __global__ void llm_dspark_gather_w1(
+    const unsigned short* __restrict__ w1_f16,   // [vocab, rank]
+    const void* __restrict__ argmax_out,         // [block*2] llm_argmax_rows layout
+    int step, int anchor_token,
+    float* __restrict__ w1row,                   // [rank]
+    float* __restrict__ w1rows_all,              // [block, rank]
+    int rank)
+{
+    int i = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    if (i >= rank) return;
+    int prev = (step == 0) ? anchor_token : ((const int*)argmax_out)[(step - 1) * 2];
+    float v = sharpi_fp16_to_fp32((unsigned int)w1_f16[(long long)prev * rank + i]);
+    w1row[i] = v;
+    w1rows_all[(long long)step * rank + i] = v;
+}
+
+// Confidence head over the whole block, one 256-thread block per position j:
+// out[j] = sigmoid(conf_w . [hidden_j (|| w1rows[j])] + conf_b). w1rows[j] is
+// the row the Markov chain gathered for position j (= markov_w1[prev_j]),
+// matching the host DSparkHostHeads feature exactly.
+extern ""C"" __global__ void llm_dspark_confidence(
+    const float* __restrict__ hidden,     // [block, emb_dim] final-normed
+    const float* __restrict__ w1rows,     // [block, rank]; unread when with_markov == 0
+    const float* __restrict__ conf_w,     // [emb_dim (+ rank)]
+    float conf_b,
+    float* __restrict__ out,              // [block]
+    int emb_dim, int rank, int with_markov, int n_rows)
+{
+    __shared__ float sdata[256];
+    int j = (int)blockIdx.x;
+    int tid = (int)threadIdx.x;
+    if (j >= n_rows) return;
+
+    float acc = 0.f;
+    for (int d = tid; d < emb_dim; d += (int)blockDim.x)
+        acc += conf_w[d] * hidden[(long long)j * emb_dim + d];
+    if (with_markov)
+        for (int r = tid; r < rank; r += (int)blockDim.x)
+            acc += conf_w[emb_dim + r] * w1rows[(long long)j * rank + r];
+    sdata[tid] = acc;
+    __syncthreads();
+    for (int s = (int)blockDim.x >> 1; s > 0; s >>= 1)
+    {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+    if (tid == 0) out[j] = 1.f / (1.f + __expf(-(sdata[0] + conf_b)));
+}
+
 // ── Softmax in place ───────────────────────────────────────────────────────
 // 1 block of 256 threads. 3-pass: max, exp+sum, normalize.
 extern ""C"" __global__ void llm_softmax(float* __restrict__ x, int n)

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -5913,6 +5913,52 @@ extern ""C"" __global__ void llm_rope_neox_partial_batched(
     x[b] = x0 * s + x1 * c;
 }
 
+// Fused q+k partial NEOX RoPE over N tokens (DSpark GPU draft, issue #428):
+// one launch rotates both the query rows (q, [n_tok × num_q_heads*head_dim])
+// and the key rows (k, [n_tok × num_kv_heads*head_dim]) at position
+// base_position + t. The pair space is the union of both buffers' pairs:
+// [0, q_pairs) hits q, the rest hits k. The per-pair rotation math is the
+// same as llm_rope_neox_partial_batched, so per buffer the result is
+// bit-identical to two separate launches.
+extern ""C"" __global__ void llm_rope_neox_partial_batched_qk(
+    float* __restrict__ q,
+    float* __restrict__ k,
+    int num_q_heads, int num_kv_heads, int head_dim, int rope_dim,
+    int base_position, float theta, int n_tok)
+{
+    int pair_idx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int rope_half_dim = rope_dim / 2;
+    int q_pairs = num_q_heads * rope_half_dim;
+    int total_pairs = (num_q_heads + num_kv_heads) * rope_half_dim;
+    int token = (int)blockIdx.y;
+    if (pair_idx >= total_pairs || token >= n_tok) return;
+
+    float* x;
+    int h, i, num_heads;
+    if (pair_idx < q_pairs) {
+        x = q; h = pair_idx / rope_half_dim; i = pair_idx % rope_half_dim;
+        num_heads = num_q_heads;
+    } else {
+        int p = pair_idx - q_pairs;
+        x = k; h = p / rope_half_dim; i = p % rope_half_dim;
+        num_heads = num_kv_heads;
+    }
+    int position = base_position + token;
+
+    float freq = 1.0f / powf(theta, 2.0f * (float)i / (float)rope_dim);
+    float angle = (float)position * freq;
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    long head_base = (long)token * (long)num_heads * (long)head_dim + (long)h * head_dim;
+    long a = head_base + i;
+    long b = head_base + i + rope_half_dim;
+    float x0 = x[a];
+    float x1 = x[b];
+    x[a] = x0 * c - x1 * s;
+    x[b] = x0 * s + x1 * c;
+}
+
 // ── TurboQuant rotate_query ────────────────────────────────────────────────
 // Applies the Walsh-Hadamard transform + per-layer sign flip to each query
 // head. One block per query head, head_dim threads per block.

--- a/src/SharpInference.Engine/CudaDSparkDraftModel.cs
+++ b/src/SharpInference.Engine/CudaDSparkDraftModel.cs
@@ -17,14 +17,22 @@ namespace SharpInference.Engine;
 /// fp32 activations/accumulation). Norm weights stay f32.</item>
 /// <item>Per-layer context K/V lives in device buffers, grown geometrically,
 /// with <see cref="DSparkConfig.BlockSize"/> slack rows at the tail: the block's
-/// own K/V is projected straight into rows [ctxLen, ctxLen+B), and the
-/// mask-free <see cref="CudaBackend.Attention"/> kernel over seqLen = ctxLen+B
-/// gives every block query bidirectional visibility of context + block —
-/// no crop, identical semantics to the CPU model's scratch-block attention.</item>
+/// own K/V is projected straight into rows [ctxLen, ctxLen+B), and ONE mask-free
+/// <see cref="CudaBackend.AttentionBatchedRagged"/> launch per layer (every
+/// query row aliased to this layer's cache, slot = ctxLen+B-1) gives every
+/// block query bidirectional visibility of context + block — bit-identical per
+/// (query, head) to the per-query <see cref="CudaBackend.Attention"/> loop it
+/// replaces (issue #428: 35 launches → 5), no crop, identical semantics to the
+/// CPU model's scratch-block attention.</item>
 /// <item>Base logits and final hiddens are downloaded once per block
-/// (~[B×vocab] + [B×embDim] floats) and the shared <see cref="DSparkHostHeads"/>
-/// applies the Markov re-bias, greedy chain, and confidence scoring on the
-/// host — the semi-autoregressive part is tiny and inherently sequential.</item>
+/// (~[B×vocab] + [B×embDim] floats, into pinned host buffers behind a single
+/// stream sync) and the shared <see cref="DSparkHostHeads"/> applies the Markov
+/// re-bias, greedy chain, and confidence scoring on the host — the
+/// semi-autoregressive part is tiny and inherently sequential.</item>
+/// <item>Launch-count trims (issue #428, the draft round is launch-bound on
+/// WDDM): residual adds ride the o/down GEMMs' beta=1 epilogue (no CopyDevice +
+/// AddInPlace pairs), q+k RoPE is one fused launch, and back-to-back projections
+/// of one normed block reuse the f32→f16 activation conversion.</item>
 /// </list>
 ///
 /// Draft-side numerics (fp16 GEMMs) affect acceptance rate only, never emitted
@@ -59,16 +67,23 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
     private readonly Tensor?[] _ctxK, _ctxV;
     private int _ctxCap;
     private int _ctxLen;
-    private Tensor? _attnScratch;              // [numHeads × _ctxCap] once cap > 4096
+    private Tensor? _attnScratch;              // [B × numHeads × _ctxCap] once cap > 4096
 
-    // Block scratch (fixed B rows).
-    private Tensor? _x, _resid, _norm;         // [B × embDim]
+    // Block scratch (fixed B rows). No residual buffer: x itself carries the
+    // residual — the o/down GEMMs accumulate onto it via beta=1 (issue #428).
+    private Tensor? _x, _norm;                 // [B × embDim]
     private Tensor? _q, _attnOut;              // [B × qDim]
     private Tensor? _gate, _up;                // [B × interm]
     private Tensor? _logitsDev;                // [B × vocab]
     private readonly float[] _xHost;           // [B × embDim] block input assembly
-    private readonly float[] _baseLogitsHost;  // [B × vocab]
-    private readonly float[] _blockHiddenHost; // [B × embDim]
+    // Pinned host landing zones for the per-block download pair — one async +
+    // one sync copy share a single StreamSynchronize (issue #49 pattern).
+    private nint _pinnedLogits;                // [B × vocab] floats
+    private nint _pinnedHidden;                // [B × embDim] floats
+    // One-launch ragged attention args: every block query attends this layer's
+    // ctx cache over the same [0, ctxLen+B) range (issue #428).
+    private readonly Tensor[] _raggedK, _raggedV;
+    private readonly int[] _raggedSlots;
 
     // AppendContext scratch, grown to the chunk size.
     private const int AppendChunkRows = 256;
@@ -82,6 +97,18 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
     public int TapDim => _tapDim;
     public int ContextLength => _ctxLen;
     public int MaxContext => _maxCtx;
+
+    private readonly System.Diagnostics.Stopwatch _phaseSw = new();
+
+    /// <summary>Milliseconds spent waiting on the per-block download pair — the
+    /// stream sync collapses the whole enqueued GPU pipeline into this window,
+    /// so it reads as "GPU execution + D2H transfer" per round (issue #428).</summary>
+    public double GpuWaitMs { get; private set; }
+
+    /// <summary>Milliseconds spent in the host-side Markov/confidence heads
+    /// (<see cref="DSparkHostHeads.GreedyBlock"/>) — the stage-C candidate
+    /// for on-device offload (issue #428).</summary>
+    public double HostHeadsMs { get; private set; }
 
     /// <summary>Layer ids to pass to <see cref="IForwardPass.EnableHiddenTaps"/> on the target.</summary>
     public int[] TargetLayerIds => _cfg.TargetLayerIds;
@@ -139,7 +166,6 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             }
 
             _x = AllocF32((long)_block * _embDim);
-            _resid = AllocF32((long)_block * _embDim);
             _norm = AllocF32((long)_block * _embDim);
             _q = AllocF32((long)_block * _qDim);
             _attnOut = AllocF32((long)_block * _qDim);
@@ -147,8 +173,15 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             _up = AllocF32((long)_block * _interm);
             _logitsDev = AllocF32((long)_block * _vocab);
             _xHost = new float[_block * _embDim];
-            _baseLogitsHost = new float[_block * _vocab];
-            _blockHiddenHost = new float[_block * _embDim];
+            _pinnedLogits = CudaBackend.AllocatePinnedHost((nuint)((long)_block * _vocab * sizeof(float)));
+            _pinnedHidden = CudaBackend.AllocatePinnedHost((nuint)((long)_block * _embDim * sizeof(float)));
+            if (_pinnedLogits == nint.Zero || _pinnedHidden == nint.Zero)
+                throw new InvalidOperationException(
+                    "cudaMallocHost failed for the DSpark block download buffers " +
+                    $"({(long)_block * _vocab * 4 + (long)_block * _embDim * 4} bytes pinned).");
+            _raggedK = new Tensor[_block];
+            _raggedV = new Tensor[_block];
+            _raggedSlots = new int[_block];
         }
         catch
         {
@@ -229,17 +262,23 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             _gpu.MatMulBatchedGemmF16W(fused, _fc!, tapsN, n);
             _gpu.RmsNormBatched(fused, fused, _hiddenNormW!, n, _embDim, _eps);
 
+            // All 2L projections below read the SAME normed `fused` rows: the first
+            // k GEMM converts them f32→f16 once, the rest reuse the scratch (#428).
+            bool converted = false;
             for (int l = 0; l < _cfg.NumLayers; l++)
             {
                 var kRows = _gpu.View(_ctxK[l]!, (long)startPos * _kvDim, (long)n * _kvDim);
                 var vRows = _gpu.View(_ctxV[l]!, (long)startPos * _kvDim, (long)n * _kvDim);
                 try
                 {
-                    _gpu.MatMulBatchedGemmF16W(kRows, _wk[l]!, fused, n);
+                    _gpu.MatMulBatchedGemmF16W(kRows, _wk[l]!, fused, n,
+                        reuseConvertedInput: converted);
+                    converted = true;
                     _gpu.HeadNormBatched(kRows, _kNormW[l]!, _numKvHeads, _headDim, n, _eps);
                     _gpu.RoPEPartialBatched(kRows, startPos, _headDim, _headDim,
                         _cfg.RopeTheta, _numKvHeads, n, neox: true);
-                    _gpu.MatMulBatchedGemmF16W(vRows, _wv[l]!, fused, n);
+                    _gpu.MatMulBatchedGemmF16W(vRows, _wv[l]!, fused, n,
+                        reuseConvertedInput: true);
                 }
                 finally
                 {
@@ -281,12 +320,20 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
         _gpu.UploadInto(_x!, _xHost);
 
         int seqLen = anchorPos + B;
+        // One-launch ragged attention args: every block query attends the same
+        // bidirectional [0, seqLen) range of this layer's ctx buffers (the ragged
+        // kernel attends [0, slots[j]+1) of caches[j]; aliasing all B rows to one
+        // cache with slot seqLen-1 is exactly the per-query Attention loop it
+        // replaces, bit-identical per (query, head)).
+        for (int j = 0; j < B; j++) _raggedSlots[j] = seqLen - 1;
+
         for (int l = 0; l < _cfg.NumLayers; l++)
         {
             // Attention. Block K/V is projected directly into the ctx buffers'
             // rows [anchorPos, anchorPos+B) — the next AppendContext at
             // startPos=anchorPos overwrites them, mirroring the reference crop.
-            _gpu.CopyDevice(_resid!, _x!);
+            // `_x` stays untouched below the norm and carries the residual: the
+            // o-projection accumulates onto it via beta=1 (no copy, no add).
             _gpu.RmsNormBatched(_norm!, _x!, _inNormW[l]!, B, _embDim, _eps);
             _gpu.MatMulBatchedGemmF16W(_q!, _wq[l]!, _norm!, B);
 
@@ -294,14 +341,12 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             var vRows = _gpu.View(_ctxV[l]!, (long)anchorPos * _kvDim, (long)B * _kvDim);
             try
             {
-                _gpu.MatMulBatchedGemmF16W(kRows, _wk[l]!, _norm!, B);
-                _gpu.MatMulBatchedGemmF16W(vRows, _wv[l]!, _norm!, B);
+                _gpu.MatMulBatchedGemmF16W(kRows, _wk[l]!, _norm!, B, reuseConvertedInput: true);
+                _gpu.MatMulBatchedGemmF16W(vRows, _wv[l]!, _norm!, B, reuseConvertedInput: true);
                 _gpu.HeadNormQkBatched(_q!, _qNormW[l]!, kRows, _kNormW[l]!,
                     _numHeads, _numKvHeads, _headDim, B, _eps);
-                _gpu.RoPEPartialBatched(_q!, anchorPos, _headDim, _headDim,
-                    _cfg.RopeTheta, _numHeads, B, neox: true);
-                _gpu.RoPEPartialBatched(kRows, anchorPos, _headDim, _headDim,
-                    _cfg.RopeTheta, _numKvHeads, B, neox: true);
+                _gpu.RoPEPartialBatchedQk(_q!, kRows, anchorPos, _headDim, _headDim,
+                    _cfg.RopeTheta, _numHeads, _numKvHeads, B, neox: true);
             }
             finally
             {
@@ -309,48 +354,38 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
                 _gpu.Free(vRows);
             }
 
-            // Bidirectional GQA: the kernel has no causal mask — every block query
-            // scans all seqLen = ctx+block keys.
-            for (int j = 0; j < B; j++)
-            {
-                var qRow = _gpu.View(_q!, (long)j * _qDim, _qDim);
-                var oRow = _gpu.View(_attnOut!, (long)j * _qDim, _qDim);
-                try
-                {
-                    _gpu.Attention(qRow, _ctxK[l]!, _ctxV[l]!, oRow, _attnScratch,
-                        _numHeads, _numKvHeads, _headDim, seqLen, _ctxCap);
-                }
-                finally
-                {
-                    _gpu.Free(qRow);
-                    _gpu.Free(oRow);
-                }
-            }
+            // Bidirectional GQA, one launch for all B queries (no causal mask —
+            // every block query scans all seqLen = ctx+block keys).
+            _raggedK.AsSpan().Fill(_ctxK[l]!);
+            _raggedV.AsSpan().Fill(_ctxV[l]!);
+            _gpu.AttentionBatchedRagged(_q!, _raggedK, _raggedV, _attnOut!, _attnScratch,
+                _numHeads, _numKvHeads, _headDim, _raggedSlots, _ctxCap);
 
-            _gpu.MatMulBatchedGemmF16W(_x!, _wo[l]!, _attnOut!, B);
-            _gpu.AddInPlace(_x!, _resid!);
+            _gpu.MatMulBatchedGemmF16W(_x!, _wo[l]!, _attnOut!, B, beta: 1f);
 
-            // FFN (SwiGLU).
-            _gpu.CopyDevice(_resid!, _x!);
+            // FFN (SwiGLU); `_x` again carries the residual through the down
+            // projection's beta=1, and gate/up share one activation conversion.
             _gpu.RmsNormBatched(_norm!, _x!, _ffnNormW[l]!, B, _embDim, _eps);
             _gpu.MatMulBatchedGemmF16W(_gate!, _wGate[l]!, _norm!, B);
-            _gpu.MatMulBatchedGemmF16W(_up!, _wUp[l]!, _norm!, B);
+            _gpu.MatMulBatchedGemmF16W(_up!, _wUp[l]!, _norm!, B, reuseConvertedInput: true);
             _gpu.SiLuMul(_gate!, _up!);
-            _gpu.MatMulBatchedGemmF16W(_x!, _wDown[l]!, _gate!, B);
-            _gpu.AddInPlace(_x!, _resid!);
+            _gpu.MatMulBatchedGemmF16W(_x!, _wDown[l]!, _gate!, B, beta: 1f);
         }
 
         _gpu.RmsNormBatched(_x!, _x!, _finalNormW!, B, _embDim, _eps);
         _gpu.MatMulBatchedGemmF16W(_logitsDev!, _lmHead!, _x!, B);
 
-        _gpu.Download(_logitsDev!, _baseLogitsHost);
-        _gpu.Download(_x!, _blockHiddenHost);
+        // One stream sync drains both copies: the async logits land before the
+        // sync hidden download's StreamSynchronize returns (issue #49 pattern).
+        _phaseSw.Restart();
+        _gpu.DownloadAsync(_logitsDev!, _pinnedLogits, B * _vocab);
+        _gpu.Download(_x!, _pinnedHidden, B * _embDim);
+        GpuWaitMs += _phaseSw.Elapsed.TotalMilliseconds;
 
-        fixed (float* logits = _baseLogitsHost)
-        fixed (float* hidden = _blockHiddenHost)
-        {
-            return _heads!.GreedyBlock(logits, hidden, anchorToken);
-        }
+        _phaseSw.Restart();
+        var proposal = _heads!.GreedyBlock((float*)_pinnedLogits, (float*)_pinnedHidden, anchorToken);
+        HostHeadsMs += _phaseSw.Elapsed.TotalMilliseconds;
+        return proposal;
     }
 
     public void TruncateContext(int length)
@@ -379,11 +414,12 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
         }
 
         // The attention kernel spills scores to scratch past 4096 keys; size it
-        // for the full capacity so seqLen can reach _ctxCap.
+        // for the full capacity so seqLen can reach _ctxCap. The one-launch ragged
+        // kernel spills per (query, head) — B × numHeads × cap floats (issue #428).
         if (newCap > 4096)
         {
             if (_attnScratch is { } old) _gpu.Free(old);
-            _attnScratch = AllocF32((long)_numHeads * newCap);
+            _attnScratch = AllocF32((long)_block * _numHeads * newCap);
         }
         _ctxCap = newCap;
 
@@ -470,10 +506,12 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
         FreeArr(_qNormW); FreeArr(_kNormW); FreeArr(_inNormW); FreeArr(_ffnNormW);
         FreeArr(_ctxK); FreeArr(_ctxV);
         FreeTensor(ref _attnScratch);
-        FreeTensor(ref _x); FreeTensor(ref _resid); FreeTensor(ref _norm);
+        FreeTensor(ref _x); FreeTensor(ref _norm);
         FreeTensor(ref _q); FreeTensor(ref _attnOut);
         FreeTensor(ref _gate); FreeTensor(ref _up); FreeTensor(ref _logitsDev);
         FreeTensor(ref _tapsDev); FreeTensor(ref _fusedDev);
+        CudaBackend.FreePinnedHost(_pinnedLogits); _pinnedLogits = nint.Zero;
+        CudaBackend.FreePinnedHost(_pinnedHidden); _pinnedHidden = nint.Zero;
 
         void FreeTensor(ref Tensor? t)
         {

--- a/src/SharpInference.Engine/CudaDSparkDraftModel.cs
+++ b/src/SharpInference.Engine/CudaDSparkDraftModel.cs
@@ -7,8 +7,8 @@ namespace SharpInference.Engine;
 /// <summary>
 /// CUDA implementation of the DSpark draft head (docs/dspark-plan.md Phase 4,
 /// PR #413). Same math as <see cref="DSparkDraftModel"/> — an EAGLE-3-style
-/// block drafter over fused target hidden-state taps — with the backbone on
-/// the GPU and the sequential heads on the host:
+/// block drafter over fused target hidden-state taps — fully resident on the
+/// GPU, sequential Markov/confidence heads included (issue #428):
 ///
 /// <list type="bullet">
 /// <item>Projections (fc, q/k/v/o, gate/up/down, lm_head) are resident fp16
@@ -24,15 +24,19 @@ namespace SharpInference.Engine;
 /// (query, head) to the per-query <see cref="CudaBackend.Attention"/> loop it
 /// replaces (issue #428: 35 launches → 5), no crop, identical semantics to the
 /// CPU model's scratch-block attention.</item>
-/// <item>Base logits and final hiddens are downloaded once per block
-/// (~[B×vocab] + [B×embDim] floats, into pinned host buffers behind a single
-/// stream sync) and the shared <see cref="DSparkHostHeads"/> applies the Markov
-/// re-bias, greedy chain, and confidence scoring on the host — the
-/// semi-autoregressive part is tiny and inherently sequential.</item>
-/// <item>Launch-count trims (issue #428, the draft round is launch-bound on
-/// WDDM): residual adds ride the o/down GEMMs' beta=1 epilogue (no CopyDevice +
-/// AddInPlace pairs), q+k RoPE is one fused launch, and back-to-back projections
-/// of one normed block reuse the f32→f16 activation conversion.</item>
+/// <item>The Markov re-bias, greedy chain, and confidence head run ON-DEVICE
+/// (issue #428): per position, a gather kernel pulls markov_w1[prev] (prev read
+/// on-stream from the previous position's argmax), one beta=1 GemmEx adds the
+/// markov_w2 bias into the logits row, and llm_argmax_rows picks the token —
+/// no host sync inside the chain. Measured host-side, the old
+/// <see cref="DSparkHostHeads"/> chain re-streamed the [vocab × rank] markov_w2
+/// 7× per round at ~17.6 ms — ~65% of the whole draft round; on-device the same
+/// traffic runs at HBM bandwidth and the [B×vocab] logits download disappears —
+/// only [B] tokens + [B] confidences cross PCIe, behind a single stream sync.</item>
+/// <item>Launch-count trims (issue #428): residual adds ride the o/down GEMMs'
+/// beta=1 epilogue (no CopyDevice + AddInPlace pairs), q+k RoPE is one fused
+/// launch, and back-to-back projections of one normed block reuse the f32→f16
+/// activation conversion.</item>
 /// </list>
 ///
 /// Draft-side numerics (fp16 GEMMs) affect acceptance rate only, never emitted
@@ -58,9 +62,20 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
     private Tensor? _hiddenNormW, _finalNormW;
     private readonly Tensor?[] _qNormW, _kNormW, _inNormW, _ffnNormW;
 
-    // Host-side pieces shared with the CPU model.
-    private DSparkHostHeads? _heads;
+    // Draft-only embedding table stays host-side (two rows gathered per block).
     private ushort* _embedBf16; private float* _embedF32;   // [vocab, embDim]
+
+    // Device-side Markov/confidence heads (issue #428; semantics mirror
+    // DSparkHostHeads exactly — see its GreedyBlock).
+    private readonly int _rank;
+    private readonly bool _confWithMarkov;
+    private Tensor? _markovW1F16, _markovW2F16;  // [vocab, rank] fp16
+    private Tensor? _confWDev;                   // [embDim (+ rank)] f32
+    private float _confB;
+    private Tensor? _w1RowDev;                   // [rank] — the bias GEMV activation
+    private Tensor? _w1RowsDev;                  // [B, rank] — confidence feature tails
+    private Tensor? _argmaxDev;                  // [B*2] llm_argmax_rows (idx bits, value)
+    private Tensor? _confDev;                    // [B]
 
     // Device context K/V per layer: [_ctxCap, kvDim] f32, filled to _ctxLen,
     // with _block slack rows at the tail for the in-place block K/V.
@@ -76,10 +91,10 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
     private Tensor? _gate, _up;                // [B × interm]
     private Tensor? _logitsDev;                // [B × vocab]
     private readonly float[] _xHost;           // [B × embDim] block input assembly
-    // Pinned host landing zones for the per-block download pair — one async +
+    // Pinned host landing zones for the per-block result pair — one async +
     // one sync copy share a single StreamSynchronize (issue #49 pattern).
-    private nint _pinnedLogits;                // [B × vocab] floats
-    private nint _pinnedHidden;                // [B × embDim] floats
+    private nint _pinnedArgmax;                // [B*2] floats (idx bits, value)
+    private nint _pinnedConf;                  // [B] floats
     // One-launch ragged attention args: every block query attends this layer's
     // ctx cache over the same [0, ctxLen+B) range (issue #428).
     private readonly Tensor[] _raggedK, _raggedV;
@@ -100,14 +115,16 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
 
     private readonly System.Diagnostics.Stopwatch _phaseSw = new();
 
-    /// <summary>Milliseconds spent waiting on the per-block download pair — the
-    /// stream sync collapses the whole enqueued GPU pipeline into this window,
-    /// so it reads as "GPU execution + D2H transfer" per round (issue #428).</summary>
+    /// <summary>Milliseconds spent waiting on the per-block result download —
+    /// the stream sync collapses the whole enqueued GPU pipeline (backbone +
+    /// device-side heads) into this window, so it reads as "GPU execution +
+    /// D2H transfer" per round (issue #428).</summary>
     public double GpuWaitMs { get; private set; }
 
-    /// <summary>Milliseconds spent in the host-side Markov/confidence heads
-    /// (<see cref="DSparkHostHeads.GreedyBlock"/>) — the stage-C candidate
-    /// for on-device offload (issue #428).</summary>
+    /// <summary>Milliseconds spent host-side after the download (proposal
+    /// assembly). The Markov/confidence chain itself runs on-device (issue
+    /// #428), so this should stay near zero — a regression here means the
+    /// heads fell back to the host somehow.</summary>
     public double HostHeadsMs { get; private set; }
 
     /// <summary>Layer ids to pass to <see cref="IForwardPass.EnableHiddenTaps"/> on the target.</summary>
@@ -148,7 +165,27 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             _finalNormW = UploadF32(weights, "norm.weight", [_embDim]);
             DSparkWeightLoading.LoadRowTable(weights, "embed_tokens.weight", [_vocab, _embDim],
                 out _embedBf16, out _embedF32);
-            _heads = new DSparkHostHeads(cfg, weights);
+
+            // Device-side Markov/confidence heads (issue #428): fp16 markov
+            // tables (BF16→FP16 exact for weight-range values, like the
+            // projections), f32 confidence projection. Loading mirrors
+            // DSparkHostHeads' names, shapes and optionality.
+            _rank = cfg.MarkovRank;
+            _confWithMarkov = cfg.ConfidenceHeadWithMarkov;
+            if (_rank > 0)
+            {
+                _markovW1F16 = UploadF16(weights, "markov_head.markov_w1.weight", [_vocab, _rank]);
+                _markovW2F16 = UploadF16(weights, "markov_head.markov_w2.weight", [_vocab, _rank]);
+            }
+            if (cfg.EnableConfidenceHead)
+            {
+                int confIn = _embDim + (_confWithMarkov ? _rank : 0);
+                _confWDev = UploadF32(weights, "confidence_head.proj.weight", [1, confIn]);
+                var b = weights.ReadF32("confidence_head.proj.bias");
+                if (b.Length != 1)
+                    throw new InvalidDataException("confidence_head.proj.bias must be a scalar.");
+                _confB = b[0];
+            }
 
             for (int l = 0; l < L; l++)
             {
@@ -173,12 +210,19 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             _up = AllocF32((long)_block * _interm);
             _logitsDev = AllocF32((long)_block * _vocab);
             _xHost = new float[_block * _embDim];
-            _pinnedLogits = CudaBackend.AllocatePinnedHost((nuint)((long)_block * _vocab * sizeof(float)));
-            _pinnedHidden = CudaBackend.AllocatePinnedHost((nuint)((long)_block * _embDim * sizeof(float)));
-            if (_pinnedLogits == nint.Zero || _pinnedHidden == nint.Zero)
+            if (_rank > 0)
+            {
+                _w1RowDev = AllocF32(_rank);    // exactly rank: the GEMV derives cols from it
+                _w1RowsDev = AllocF32((long)_block * _rank);
+            }
+            _argmaxDev = AllocF32((long)_block * 2);
+            _confDev = AllocF32(_block);
+            _pinnedArgmax = CudaBackend.AllocatePinnedHost((nuint)((long)_block * 2 * sizeof(float)));
+            _pinnedConf = CudaBackend.AllocatePinnedHost((nuint)((long)_block * sizeof(float)));
+            if (_pinnedArgmax == nint.Zero || _pinnedConf == nint.Zero)
                 throw new InvalidOperationException(
-                    "cudaMallocHost failed for the DSpark block download buffers " +
-                    $"({(long)_block * _vocab * 4 + (long)_block * _embDim * 4} bytes pinned).");
+                    "cudaMallocHost failed for the DSpark block result buffers " +
+                    $"({(long)_block * 3 * sizeof(float)} bytes pinned).");
             _raggedK = new Tensor[_block];
             _raggedV = new Tensor[_block];
             _raggedSlots = new int[_block];
@@ -192,8 +236,9 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
 
     /// <summary>
     /// Approximate VRAM-resident bytes of a loaded head at this config: fp16
-    /// projections + f32 norms (embeddings and the Markov/confidence heads stay
-    /// on the host). Context K/V and scratch grow separately.
+    /// projections + fp16 Markov tables (issue #428 device-side heads) + f32
+    /// norms/confidence proj (embeddings stay on the host). Context K/V and
+    /// scratch grow separately.
     /// </summary>
     public static long EstimateGpuResidentBytes(DSparkConfig cfg)
     {
@@ -204,8 +249,11 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
             + (long)cfg.IntermediateSize * embDim * 3;
         long f16Elems = embDim * (long)cfg.TapDim
             + (long)cfg.VocabSize * embDim
-            + perLayer * cfg.NumLayers;
+            + perLayer * cfg.NumLayers
+            + 2L * cfg.VocabSize * cfg.MarkovRank;   // markov_w1 + markov_w2 (#428)
         long f32Elems = (embDim * 2 + (cfg.HeadDim * 2 + embDim * 2) * (long)cfg.NumLayers);
+        if (cfg.EnableConfidenceHead)
+            f32Elems += embDim + (cfg.ConfidenceHeadWithMarkov ? cfg.MarkovRank : 0);
         return f16Elems * 2 + f32Elems * 4;
     }
 
@@ -375,17 +423,58 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
         _gpu.RmsNormBatched(_x!, _x!, _finalNormW!, B, _embDim, _eps);
         _gpu.MatMulBatchedGemmF16W(_logitsDev!, _lmHead!, _x!, B);
 
-        // One stream sync drains both copies: the async logits land before the
-        // sync hidden download's StreamSynchronize returns (issue #49 pattern).
+        // Device-side Markov chain (issue #428), semantics of
+        // DSparkHostHeads.GreedyBlock: per position j, gather markov_w1[prev]
+        // (prev = anchor at j=0, else position j-1's argmax, read on-stream),
+        // bias the logits row in place via a beta=1 GEMV against markov_w2,
+        // then argmax the row. No host sync anywhere in the chain.
+        if (_rank > 0)
+        {
+            for (int j = 0; j < B; j++)
+            {
+                _gpu.DSparkGatherW1(_markovW1F16!, _argmaxDev!, j, anchorToken,
+                    _w1RowDev!, _w1RowsDev!, _rank);
+                var logitsRow = _gpu.View(_logitsDev!, (long)j * _vocab, _vocab);
+                var amRow = _gpu.View(_argmaxDev!, (long)j * 2, 2);
+                try
+                {
+                    _gpu.MatMulBatchedGemmF16W(logitsRow, _markovW2F16!, _w1RowDev!, 1, beta: 1f);
+                    _gpu.ArgmaxRowsToDevice(logitsRow, amRow, 1, _vocab, _vocab);
+                }
+                finally
+                {
+                    _gpu.Free(logitsRow);
+                    _gpu.Free(amRow);
+                }
+            }
+        }
+        else
+        {
+            // No Markov head: the block's argmaxes are independent — one launch.
+            _gpu.ArgmaxRowsToDevice(_logitsDev!, _argmaxDev!, B, _vocab, _vocab);
+        }
+
+        bool hasConf = _confWDev is not null;
         _phaseSw.Restart();
-        _gpu.DownloadAsync(_logitsDev!, _pinnedLogits, B * _vocab);
-        _gpu.Download(_x!, _pinnedHidden, B * _embDim);
+        if (hasConf)
+        {
+            _gpu.DSparkConfidence(_x!, _w1RowsDev ?? _confDev!, _confWDev!, _confB, _confDev!,
+                _embDim, _rank, withMarkov: _confWithMarkov && _rank > 0, B);
+            _gpu.DownloadAsync(_confDev!, _pinnedConf, B);
+        }
+        // One sync drains the whole pipeline + both result copies (issue #49).
+        _gpu.Download(_argmaxDev!, _pinnedArgmax, B * 2);
         GpuWaitMs += _phaseSw.Elapsed.TotalMilliseconds;
 
         _phaseSw.Restart();
-        var proposal = _heads!.GreedyBlock((float*)_pinnedLogits, (float*)_pinnedHidden, anchorToken);
+        var tokens = new int[B];
+        var conf = new float[B];
+        int* am = (int*)_pinnedArgmax;
+        for (int j = 0; j < B; j++) tokens[j] = am[j * 2];
+        if (hasConf) new ReadOnlySpan<float>((float*)_pinnedConf, B).CopyTo(conf);
+        else Array.Fill(conf, 1f);
         HostHeadsMs += _phaseSw.Elapsed.TotalMilliseconds;
-        return proposal;
+        return new DSparkProposal(tokens, conf);
     }
 
     public void TruncateContext(int length)
@@ -487,7 +576,6 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
 
     private void FreeAll()
     {
-        _heads?.Dispose(); _heads = null;
         if (_embedBf16 != null)
         {
             System.Runtime.InteropServices.NativeMemory.Free(_embedBf16);
@@ -510,8 +598,11 @@ public sealed unsafe class CudaDSparkDraftModel : IDSparkDraft
         FreeTensor(ref _q); FreeTensor(ref _attnOut);
         FreeTensor(ref _gate); FreeTensor(ref _up); FreeTensor(ref _logitsDev);
         FreeTensor(ref _tapsDev); FreeTensor(ref _fusedDev);
-        CudaBackend.FreePinnedHost(_pinnedLogits); _pinnedLogits = nint.Zero;
-        CudaBackend.FreePinnedHost(_pinnedHidden); _pinnedHidden = nint.Zero;
+        FreeTensor(ref _markovW1F16); FreeTensor(ref _markovW2F16); FreeTensor(ref _confWDev);
+        FreeTensor(ref _w1RowDev); FreeTensor(ref _w1RowsDev);
+        FreeTensor(ref _argmaxDev); FreeTensor(ref _confDev);
+        CudaBackend.FreePinnedHost(_pinnedArgmax); _pinnedArgmax = nint.Zero;
+        CudaBackend.FreePinnedHost(_pinnedConf); _pinnedConf = nint.Zero;
 
         void FreeTensor(ref Tensor? t)
         {

--- a/tests/SharpInference.Tests.ForwardPass/CudaDSparkDraftModelTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaDSparkDraftModelTests.cs
@@ -1,0 +1,136 @@
+using SharpInference.Cuda;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Draft-level tests for <see cref="CudaDSparkDraftModel"/> on the same tiny
+/// synthetic checkpoint <see cref="DSparkDraftModelTests"/> validates the CPU
+/// model against (issue #428 — the launch-count optimizations need a guard
+/// tighter than the E2E suites, whose verify pass masks draft numerics).
+/// Silent-skips when CUDA is unavailable, mirroring CudaDSparkE2ETests.
+///
+/// Two kinds of assertions:
+/// <list type="bullet">
+/// <item>CUDA vs CPU proposals: exact token match + confidence tolerance. The
+/// CUDA backbone rounds activations to fp16 per GEMM, so this holds only while
+/// the synthetic head's argmax margins exceed that noise — it does today, and a
+/// draft-path change that flips it deserves a look either way.</item>
+/// <item>CUDA vs CUDA (incremental append / truncate-reappend vs fresh): exact
+/// equality — same launches over same values must reproduce bit-identical
+/// proposals, whatever the absolute numerics.</item>
+/// </list>
+/// </summary>
+public sealed class CudaDSparkDraftModelTests
+{
+    private const int TapDim = 16;   // mirrors DSparkDraftModelTests.TapDim
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); } catch { return null; }
+    }
+
+    [Fact]
+    public void ProposeBlock_MatchesCpuModel()
+    {
+        using var cuda = TryCreate();
+        if (cuda is null) return;
+
+        using var head = new DSparkDraftModelTests.SyntheticHead(withConfidence: true);
+        using var cpu = head.CreateModel();
+        using var gpu = head.CreateCudaModel(cuda);
+
+        const int ctx = 5;
+        var taps = DSparkDraftModelTests.MakeTaps(ctx, seed: 12345);
+        cpu.AppendContext(taps, 0, ctx);
+        gpu.AppendContext(taps, 0, ctx);
+        Assert.Equal(cpu.ContextLength, gpu.ContextLength);
+
+        var pCpu = cpu.ProposeBlock(anchorToken: 7, anchorPos: ctx);
+        var pGpu = gpu.ProposeBlock(anchorToken: 7, anchorPos: ctx);
+
+        Assert.Equal(pCpu.Tokens, pGpu.Tokens);
+        Assert.Equal(pCpu.Confidences.Length, pGpu.Confidences.Length);
+        for (int j = 0; j < pCpu.Confidences.Length; j++)
+            Assert.True(Math.Abs(pCpu.Confidences[j] - pGpu.Confidences[j]) <= 2e-2,
+                $"confidence[{j}]: cpu={pCpu.Confidences[j]}, gpu={pGpu.Confidences[j]}");
+    }
+
+    [Fact]
+    public void AppendContext_Incremental_EqualsBatch()
+    {
+        using var cuda = TryCreate();
+        if (cuda is null) return;
+
+        using var head = new DSparkDraftModelTests.SyntheticHead(withConfidence: true);
+        var taps = DSparkDraftModelTests.MakeTaps(5, seed: 777);
+
+        using var batch = head.CreateCudaModel(cuda);
+        batch.AppendContext(taps, 0, 5);
+
+        using var incremental = head.CreateCudaModel(cuda);
+        incremental.AppendContext(taps.AsSpan(0, 3 * TapDim), 0, 3);
+        incremental.AppendContext(taps.AsSpan(3 * TapDim), 3, 2);
+        Assert.Equal(5, incremental.ContextLength);
+
+        var pBatch = batch.ProposeBlock(anchorToken: 4, anchorPos: 5);
+        var pIncremental = incremental.ProposeBlock(anchorToken: 4, anchorPos: 5);
+
+        Assert.Equal(pBatch.Tokens, pIncremental.Tokens);
+        Assert.Equal(pBatch.Confidences, pIncremental.Confidences);
+    }
+
+    [Fact]
+    public void TruncateContext_Reappend_EqualsFresh()
+    {
+        using var cuda = TryCreate();
+        if (cuda is null) return;
+
+        using var head = new DSparkDraftModelTests.SyntheticHead(withConfidence: true);
+        var taps = DSparkDraftModelTests.MakeTaps(5, seed: 999);
+
+        using var fresh = head.CreateCudaModel(cuda);
+        fresh.AppendContext(taps, 0, 5);
+        var expected = fresh.ProposeBlock(anchorToken: 9, anchorPos: 5);
+
+        using var truncated = head.CreateCudaModel(cuda);
+        truncated.AppendContext(taps, 0, 5);
+        truncated.TruncateContext(3);
+        Assert.Equal(3, truncated.ContextLength);
+        truncated.AppendContext(taps.AsSpan(3 * TapDim), 3, 2);
+        var actual = truncated.ProposeBlock(anchorToken: 9, anchorPos: 5);
+
+        Assert.Equal(expected.Tokens, actual.Tokens);
+        Assert.Equal(expected.Confidences, actual.Confidences);
+    }
+
+    [Fact]
+    public void ConsecutiveProposals_AdvanceContext()
+    {
+        using var cuda = TryCreate();
+        if (cuda is null) return;
+
+        using var head = new DSparkDraftModelTests.SyntheticHead(withConfidence: true);
+        using var gpu = head.CreateCudaModel(cuda);
+
+        // Decoder-shaped round trip: propose → commit taps over the block rows
+        // the proposal projected its scratch K/V into → propose again. Verifies
+        // the in-place block K/V rows are correctly overwritten by AppendContext.
+        var taps = DSparkDraftModelTests.MakeTaps(6, seed: 4242);
+        gpu.AppendContext(taps.AsSpan(0, 4 * TapDim), 0, 4);
+        var p1 = gpu.ProposeBlock(anchorToken: 2, anchorPos: 4);
+        Assert.Equal(gpu.BlockSize, p1.Tokens.Length);
+
+        gpu.AppendContext(taps.AsSpan(4 * TapDim), 4, 2);
+        var p2 = gpu.ProposeBlock(anchorToken: 5, anchorPos: 6);
+        Assert.Equal(gpu.BlockSize, p2.Tokens.Length);
+
+        // Same state rebuilt fresh must reproduce the second proposal exactly.
+        using var fresh = head.CreateCudaModel(cuda);
+        fresh.AppendContext(taps, 0, 6);
+        var pFresh = fresh.ProposeBlock(anchorToken: 5, anchorPos: 6);
+        Assert.Equal(pFresh.Tokens, p2.Tokens);
+        Assert.Equal(pFresh.Confidences, p2.Confidences);
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/DSparkDraftModelTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/DSparkDraftModelTests.cs
@@ -171,7 +171,9 @@ public sealed class DSparkDraftModelTests
     /// xorshift stream, keeps them as the reference ground truth (BF16 tensors
     /// pre-rounded), and writes a temp .safetensors file the real loader reads.
     /// </summary>
-    private sealed class SyntheticHead : IDisposable
+    // Internal (not private): CudaDSparkDraftModelTests reuses the same synthetic
+    // checkpoint to compare the CUDA draft backbone against this CPU model.
+    internal sealed class SyntheticHead : IDisposable
     {
         public string FilePath { get; }
         public DSparkConfig Config { get; }
@@ -281,6 +283,12 @@ public sealed class DSparkDraftModelTests
             return new DSparkDraftModel(Config, st, maxContextLength);
         }
 
+        public CudaDSparkDraftModel CreateCudaModel(Cuda.CudaBackend gpu, int maxContextLength = MaxCtx)
+        {
+            using var st = SafetensorsLoader.Open(FilePath);
+            return new CudaDSparkDraftModel(Config, st, gpu, maxContextLength);
+        }
+
         public void Dispose()
         {
             try { File.Delete(FilePath); } catch (IOException) { }
@@ -373,7 +381,7 @@ public sealed class DSparkDraftModelTests
         return a;
     }
 
-    private static float[] MakeTaps(int count, uint seed)
+    internal static float[] MakeTaps(int count, uint seed)
     {
         var rng = new XorShift(seed);
         var taps = new float[count * TapDim];


### PR DESCRIPTION
## Summary

#428 lever 1: the DSpark GPU draft round drops **27.8 → 11.8 ms** on the 4070 Laptop (Qwen3-4B + `dspark_qwen3_4b_block7`, `-c 4096`). DSpark goes from 50.0 t/s (11 behind plain) to **67.9 t/s at `--dspark-verify-len 3` — a 1.10× win over plain decode (61.5 t/s)** on the exact pairing that previously lost. Stacked on #426 (base = `feat/dspark-phases-0-3`).

Three commits:

1. **Launch trims + timing instrumentation** — the per-(layer,query) `llm_attention` loop becomes one `AttentionBatchedRagged` launch per layer (35→5, bit-identical per (query, head) — every query row aliases the layer cache at slot `ctxLen+B-1` = the bidirectional `[0, ctx+B)` range); `MatMulBatchedGemmF16W` grows `beta` (GemmEx epilogue accumulate — the o/down projections fold their residual add, dropping the `CopyDevice`/`AddInPlace` pairs and the `_resid` buffer) and `reuseConvertedInput` (q/k/v, gate/up, and append k/v share one f32→f16 activation convert); new fused `llm_rope_neox_partial_batched_qk` kernel; the per-block downloads go to pinned buffers behind a single stream sync. New `SHARPI_DSPARK_TIMING=1` CLI breakdown (enqueue / gpu-wait / heads) of `DSparkDecoder.DraftMs`.

2. **Device-side Markov/argmax/confidence heads** — the breakdown from commit 1 showed the round was *not* launch-bound: ~17.6 of ~27.8 ms was `DSparkHostHeads.GreedyBlock` re-streaming the 155 MB f32 `markov_w2` once per block position on host DRAM, plus the 4.2 MB logits D2H feeding it. The whole sequential chain now runs on-stream: fp16 `markov_w1`/`markov_w2` resident (+156 MB at 4B-head shapes, counted in `EstimateGpuResidentBytes`), per position `llm_dspark_gather_w1` (prev token read on-device from the previous argmax slot — zero host syncs in the chain) → beta=1 GemmEx bias → `llm_argmax_rows` via the new launch-only `ArgmaxRowsToDevice`; one `llm_dspark_confidence` launch scores the block. Only `[B]` tokens + `[B]` confidences cross PCIe per round (84 bytes).

3. **Docs + 8B preset** — plan-doc status for lever 1 and the lever-2 MMQ oracle result (`SHARPI_BATCH_DECODE_MMQ=1` verify measures 79.5 t/s but the 256-token output diverges from plain greedy — the `allowDecodeMmq:false` pin is load-bearing and stays); `download-model.ps1 -Model dspark-qwen3-8b` preset for the desktop crossover bench.

## Measurements (same-session, interleaved)

| config | before | after |
|---|---|---|
| draft ms/round | 27.8 (enqueue ~1 + gpu ~8.6 + host heads ~17.6) | **11.8** (enqueue ~1.2 + gpu-wait ~10.6 + host 0) |
| DSpark default | 50.0 t/s (37% accept) | **60.5 t/s** (37%, byte-identical accept pattern) |
| DSpark `--dspark-min-confidence 0.8` | 46.5 t/s | **58.0 t/s** |
| DSpark `--dspark-verify-len 3` | 44.8 t/s | **67.9 t/s** |
| plain (graph-replayed) | 61.3–62.0 t/s | 61.4–61.7 t/s |

Full analysis + next levers posted on #428.

## Correctness

- Emitted tokens stay byte-identical to plain greedy — the E2E parity anchor is the target verify, untouched here; `CudaDSparkE2ETests`/`DSparkE2ETests` green with `TotalDraftsAccepted > 0`.
- New `CudaDSparkDraftModelTests` (4 tests) pin the draft backbone directly on the shared `SyntheticHead` checkpoint: exact CUDA-vs-CPU proposal parity (holds through the fp16 GEMMs and fp16 Markov tables) plus CUDA-vs-CUDA bit-equality for incremental append / truncate-reappend / consecutive blocks.
- Full `Tests.ForwardPass` suite: 955 tests run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EWo1niax1g8A5E79RSALJ
