### PR TITLE
feat(grammar): ordered-properties mode for JsonSchemaOutputConstraint (#425)

### DIFF
--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -230,6 +230,11 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [Description("File containing a JSON schema to constrain the entire response to (llama.cpp --json-schema-file/-jf; alias --jf since llama.cpp's single-dash -jf isn't representable: Spectre short options must be one character). Mutually exclusive with --json-schema.")]
         public string? JsonSchemaFile { get; init; }
 
+        [CommandOption("--json-schema-ordered")]
+        [Description("With --json-schema/--json-schema-file: require properties in declaration order (issue #425) -- optional properties may be skipped but never reordered. Lets a streaming consumer act on an early field before a later, larger one finishes.")]
+        [DefaultValue(false)]
+        public bool JsonSchemaOrdered { get; init; }
+
         // ── MoE expert-cache tuning (offloaded MoE models) ──
         // Good defaults are automatic: frequency-aware SLRU eviction, VRAM-sized cache,
         // and next-layer predictive prefetch are all ON without any flag. These knobs only
@@ -303,14 +308,16 @@ public sealed class RunCommand : Command<RunCommand.Settings>
     /// <summary>
     /// Builds a whole-turn <see cref="JsonSchemaOutputConstraint"/> (issue #423 follow-up) from
     /// <c>--json-schema</c> (inline) or <c>--json-schema-file</c>/<c>--jf</c> (file), or leaves
-    /// <paramref name="constraint"/> <c>null</c> when neither flag is given. Returns <c>false</c>
-    /// (with <paramref name="error"/> set) on mutual exclusivity, a missing/unreadable file,
-    /// malformed JSON, or a schema that can't be compiled to a constraint -- an explicit schema
-    /// request is a hard requirement, so failures are reported rather than silently ignored.
+    /// <paramref name="constraint"/> <c>null</c> when neither flag is given.
+    /// <paramref name="ordered"/> maps <c>--json-schema-ordered</c> (issue #425: properties in
+    /// declaration order). Returns <c>false</c> (with <paramref name="error"/> set) on mutual
+    /// exclusivity, a missing/unreadable file, malformed JSON, or a schema that can't be compiled
+    /// to a constraint -- an explicit schema request is a hard requirement, so failures are
+    /// reported rather than silently ignored.
     /// </summary>
     internal static bool TryLoadJsonSchemaConstraint(
         string? inlineSchema, string? schemaFilePath, GrammarVocabulary vocab,
-        out ITokenConstraint? constraint, out string? error)
+        out ITokenConstraint? constraint, out string? error, bool ordered = false)
     {
         constraint = null;
         error = null;
@@ -364,7 +371,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         try
         {
             var schemaObject = ToolSchema.FromOpenAiFunction("_", root).Arguments;
-            constraint = new JsonSchemaOutputConstraint(vocab, schemaObject);
+            constraint = new JsonSchemaOutputConstraint(vocab, schemaObject, ordered);
             return true;
         }
         catch (ArgumentException ex)
@@ -988,7 +995,8 @@ public sealed class RunCommand : Command<RunCommand.Settings>
 
         // ── JSON-Schema-constrained output (issue #423 follow-up) ─────────────────
         if (!TryLoadJsonSchemaConstraint(settings.JsonSchema, settings.JsonSchemaFile, grammarVocab,
-                out ITokenConstraint? jsonSchemaConstraint, out string? jsonSchemaError))
+                out ITokenConstraint? jsonSchemaConstraint, out string? jsonSchemaError,
+                ordered: settings.JsonSchemaOrdered))
         {
             AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(jsonSchemaError!)}");
             return 1;

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -353,6 +353,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         }
         else
         {
+            // An explicit ordered request without a schema is user error, not a no-op -- silently
+            // generating unconstrained output would violate the fail-loudly contract above.
+            if (ordered)
+            {
+                error = "--json-schema-ordered requires --json-schema or --json-schema-file/--jf.";
+                return false;
+            }
             return true;   // neither flag given -- no-op
         }
 

--- a/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/GemmaToolArgumentConstraint.cs
@@ -662,7 +662,15 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
 
             case OExpectCommaOrClose:
                 if (IsWs(b)) return Step.Consume;
-                if (b == (byte)',') { f.State = OExpectKey; return Step.Consume; }
+                if (b == (byte)',')
+                {
+                    // A ',' commits to another key — reject it when every declared key is already
+                    // emitted, else the machine livelocks in OExpectKey where only whitespace is
+                    // legal ('}' isn't accepted there and EOG is forbidden mid-call). Mirrors the
+                    // JSON walker's comma gate (issue #425 follow-through).
+                    if (!obj.HasNextKey(f.Emitted)) return Step.Reject;
+                    f.State = OExpectKey; return Step.Consume;
+                }
                 if (b == (byte)'}')
                 {
                     if ((f.Emitted & obj.RequiredMask) != obj.RequiredMask) return Step.Reject;
@@ -846,7 +854,7 @@ public sealed class GemmaToolArgumentConstraint : ITokenConstraint
                 return false;
             case OExpectCommaOrClose:
                 MarkWs(set);
-                set[','] = true;
+                if (obj.HasNextKey(f.Emitted)) set[','] = true;   // ',' commits to a key
                 if ((f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
                 return false;
             default:

--- a/src/SharpInference.Core/Grammar/JsonSchemaOutputConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonSchemaOutputConstraint.cs
@@ -27,11 +27,14 @@ public sealed class JsonSchemaOutputConstraint : ITokenConstraint
     /// declaring at least one property.
     /// </param>
     /// <param name="orderedProperties">
-    /// Ordered mode (issue #425): when <c>true</c>, every object in the schema tree must emit its
-    /// properties in declaration order — optional properties may be skipped, but a later property
-    /// can never precede an earlier one, and a required property is never skippable. Lets a
-    /// streaming consumer act on an early field (e.g. a short spoken <c>say</c>) before a later,
-    /// larger one (<c>show</c>) finishes. Default <c>false</c> preserves the any-order behavior.
+    /// Ordered mode (issue #425): when <c>true</c>, every typed object in the schema tree must emit
+    /// its properties in declaration order — optional properties may be skipped, but a later
+    /// property can never precede an earlier one, and a required property is never skippable. Lets
+    /// a streaming consumer act on an early field (e.g. a short spoken <c>say</c>) before a later,
+    /// larger one (<c>show</c>) finishes. Subtrees that degrade to a free value (open objects,
+    /// untyped arrays, past-depth-cap nesting — see <see cref="ToolSchemaCompiler"/>) remain
+    /// unordered like the rest of their content. Default <c>false</c> preserves the any-order
+    /// behavior.
     /// </param>
     /// <exception cref="ArgumentException">
     /// The schema could not be compiled to a constraint -- it isn't an object schema, declares no

--- a/src/SharpInference.Core/Grammar/JsonSchemaOutputConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonSchemaOutputConstraint.cs
@@ -26,21 +26,32 @@ public sealed class JsonSchemaOutputConstraint : ITokenConstraint
     /// for a raw JSON Schema <see cref="System.Text.Json.JsonElement"/>). Must be an object schema
     /// declaring at least one property.
     /// </param>
+    /// <param name="orderedProperties">
+    /// Ordered mode (issue #425): when <c>true</c>, every object in the schema tree must emit its
+    /// properties in declaration order — optional properties may be skipped, but a later property
+    /// can never precede an earlier one, and a required property is never skippable. Lets a
+    /// streaming consumer act on an early field (e.g. a short spoken <c>say</c>) before a later,
+    /// larger one (<c>show</c>) finishes. Default <c>false</c> preserves the any-order behavior.
+    /// </param>
     /// <exception cref="ArgumentException">
     /// The schema could not be compiled to a constraint -- it isn't an object schema, declares no
     /// properties, or uses only unsupported keywords.
     /// </exception>
-    public JsonSchemaOutputConstraint(GrammarVocabulary vocab, ToolSchemaObject schema)
+    public JsonSchemaOutputConstraint(GrammarVocabulary vocab, ToolSchemaObject schema, bool orderedProperties = false)
     {
         ArgumentNullException.ThrowIfNull(vocab);
         ArgumentNullException.ThrowIfNull(schema);
-        var compiled = ToolSchemaCompiler.TryCompileObject(schema)
+        var compiled = ToolSchemaCompiler.TryCompileObject(schema, orderedProperties)
             ?? throw new ArgumentException(
                 "schema could not be compiled to a constraint (must be an object schema with at " +
                 "least one declared property; unsupported keywords like $ref/oneOf/pattern are " +
                 "not constrained)", nameof(schema));
         _inner = JsonToolArgumentConstraint.ForWholeBody(vocab, compiled);
+        OrderedProperties = orderedProperties;
     }
+
+    /// <summary>Whether ordered-properties mode (issue #425) is active on this constraint.</summary>
+    public bool OrderedProperties { get; }
 
     public bool IsConstraining => _inner.IsConstraining;
     public ReadOnlySpan<float> Filter(ReadOnlySpan<float> logits) => _inner.Filter(logits);

--- a/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Text;
 
 namespace SharpInference.Core.Grammar;
@@ -299,6 +300,26 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
     }
 
     private static ulong AllBits(int n) => n >= 64 ? ulong.MaxValue : (1UL << n) - 1;
+
+    /// <summary>
+    /// Candidate mask for the next key at an object's key boundary. Unordered (default): every
+    /// not-yet-emitted key. Ordered (issue #425): keys must appear in declaration order, so the
+    /// window runs from just past the highest emitted index (emission is ascending, enforced by this
+    /// very mask) up to and INCLUDING the first required key — an optional key may be skipped, but
+    /// skipping a required key could never be repaired later and would dead-end at the close brace.
+    /// </summary>
+    private static ulong NextKeyCandidates(CompiledObject obj, ulong emitted)
+    {
+        if (!obj.Ordered) return AllBits(obj.Count) & ~emitted;
+        int next = 64 - BitOperations.LeadingZeroCount(emitted);    // highest emitted index + 1
+        ulong cand = 0;
+        for (int i = next; i < obj.Count; i++)
+        {
+            cand |= 1UL << i;
+            if ((obj.RequiredMask & (1UL << i)) != 0) break;
+        }
+        return cand;
+    }
 
     // ── Public lifecycle ──────────────────────────────────────────────────────
 
@@ -629,11 +650,10 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
                 }
                 if (b == (byte)'"')
                 {
-                    // Begin a key: candidates are every not-yet-emitted key.
-                    ulong cand = 0;
-                    for (int i = 0; i < obj.Count; i++)
-                        if ((f.Emitted & (1UL << i)) == 0) cand |= 1UL << i;
-                    if (cand == 0) return Step.Reject;     // all keys emitted; only '}' is legal
+                    // Begin a key: candidates are every not-yet-emitted key (unordered), or the
+                    // declaration-order window (ordered, issue #425).
+                    ulong cand = NextKeyCandidates(obj, f.Emitted);
+                    if (cand == 0) return Step.Reject;     // no key may appear here; only '}' is legal
                     f.Cand = cand; f.MatchLen = 0; f.State = OKeyContent;
                     return Step.Consume;
                 }
@@ -671,7 +691,14 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
 
             case OExpectCommaOrClose:
                 if (IsWs(b)) return Step.Consume;
-                if (b == (byte)',') { f.State = OExpectKey; return Step.Consume; }
+                if (b == (byte)',')
+                {
+                    // A ',' commits to another key — reject it when none can follow (all keys
+                    // emitted, or the ordered window is exhausted) so the machine can't be steered
+                    // into a dead OExpectKey state where only '}' was ever viable.
+                    if (NextKeyCandidates(obj, f.Emitted) == 0) return Step.Reject;
+                    f.State = OExpectKey; return Step.Consume;
+                }
                 if (b == (byte)'}')
                 {
                     if ((f.Emitted & obj.RequiredMask) != obj.RequiredMask) return Step.Reject;
@@ -984,9 +1011,9 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
             case OExpectKey:
                 MarkWs(set);
                 if (f.State == OExpectKeyOrClose && (f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
-                // A key opens with '"' whenever any key remains unemitted.
-                for (int i = 0; i < obj.Count; i++)
-                    if ((f.Emitted & (1UL << i)) == 0) { set['"'] = true; break; }
+                // A key opens with '"' whenever a candidate remains (any unemitted key, or the
+                // ordered declaration-order window — issue #425).
+                if (NextKeyCandidates(obj, f.Emitted) != 0) set['"'] = true;
                 break;
             case OKeyContent:
                 // Either a content byte continuing a candidate key, or '"' if a candidate is complete.
@@ -997,7 +1024,8 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
                 break;
             case OExpectColon: MarkWs(set); set[':'] = true; break;
             case OExpectCommaOrClose:
-                MarkWs(set); set[','] = true;
+                MarkWs(set);
+                if (NextKeyCandidates(obj, f.Emitted) != 0) set[','] = true;   // ',' commits to a key
                 if ((f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
                 break;
         }

--- a/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
+++ b/src/SharpInference.Core/Grammar/JsonToolArgumentConstraint.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using System.Text;
 
 namespace SharpInference.Core.Grammar;
@@ -300,26 +299,6 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
     }
 
     private static ulong AllBits(int n) => n >= 64 ? ulong.MaxValue : (1UL << n) - 1;
-
-    /// <summary>
-    /// Candidate mask for the next key at an object's key boundary. Unordered (default): every
-    /// not-yet-emitted key. Ordered (issue #425): keys must appear in declaration order, so the
-    /// window runs from just past the highest emitted index (emission is ascending, enforced by this
-    /// very mask) up to and INCLUDING the first required key — an optional key may be skipped, but
-    /// skipping a required key could never be repaired later and would dead-end at the close brace.
-    /// </summary>
-    private static ulong NextKeyCandidates(CompiledObject obj, ulong emitted)
-    {
-        if (!obj.Ordered) return AllBits(obj.Count) & ~emitted;
-        int next = 64 - BitOperations.LeadingZeroCount(emitted);    // highest emitted index + 1
-        ulong cand = 0;
-        for (int i = next; i < obj.Count; i++)
-        {
-            cand |= 1UL << i;
-            if ((obj.RequiredMask & (1UL << i)) != 0) break;
-        }
-        return cand;
-    }
 
     // ── Public lifecycle ──────────────────────────────────────────────────────
 
@@ -652,7 +631,7 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
                 {
                     // Begin a key: candidates are every not-yet-emitted key (unordered), or the
                     // declaration-order window (ordered, issue #425).
-                    ulong cand = NextKeyCandidates(obj, f.Emitted);
+                    ulong cand = obj.NextKeyCandidates(f.Emitted);
                     if (cand == 0) return Step.Reject;     // no key may appear here; only '}' is legal
                     f.Cand = cand; f.MatchLen = 0; f.State = OKeyContent;
                     return Step.Consume;
@@ -695,8 +674,8 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
                 {
                     // A ',' commits to another key — reject it when none can follow (all keys
                     // emitted, or the ordered window is exhausted) so the machine can't be steered
-                    // into a dead OExpectKey state where only '}' was ever viable.
-                    if (NextKeyCandidates(obj, f.Emitted) == 0) return Step.Reject;
+                    // into a whitespace-only OExpectKey livelock where only '}' was ever viable.
+                    if (!obj.HasNextKey(f.Emitted)) return Step.Reject;
                     f.State = OExpectKey; return Step.Consume;
                 }
                 if (b == (byte)'}')
@@ -1013,7 +992,7 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
                 if (f.State == OExpectKeyOrClose && (f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
                 // A key opens with '"' whenever a candidate remains (any unemitted key, or the
                 // ordered declaration-order window — issue #425).
-                if (NextKeyCandidates(obj, f.Emitted) != 0) set['"'] = true;
+                if (obj.HasNextKey(f.Emitted)) set['"'] = true;
                 break;
             case OKeyContent:
                 // Either a content byte continuing a candidate key, or '"' if a candidate is complete.
@@ -1025,7 +1004,7 @@ public sealed class JsonToolArgumentConstraint : ITokenConstraint
             case OExpectColon: MarkWs(set); set[':'] = true; break;
             case OExpectCommaOrClose:
                 MarkWs(set);
-                if (NextKeyCandidates(obj, f.Emitted) != 0) set[','] = true;   // ',' commits to a key
+                if (obj.HasNextKey(f.Emitted)) set[','] = true;   // ',' commits to a key
                 if ((f.Emitted & obj.RequiredMask) == obj.RequiredMask) set['}'] = true;
                 break;
         }

--- a/src/SharpInference.Core/Grammar/ToolSchemaCompiler.cs
+++ b/src/SharpInference.Core/Grammar/ToolSchemaCompiler.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace SharpInference.Core.Grammar;
 
 // ── Compiled schema ───────────────────────────────────────────────────────────
@@ -35,9 +37,45 @@ internal sealed class CompiledObject
     public required CompiledNode[] Values { get; init; }
     public required ulong RequiredMask { get; init; }
     /// <summary>Ordered mode (issue #425): keys must appear in declaration order — optional keys may
-    /// be skipped, but a later key can never precede an earlier one.</summary>
+    /// be skipped, but a later key can never precede an earlier one. Enforced by the JSON walker
+    /// (<see cref="JsonToolArgumentConstraint"/> / <see cref="JsonSchemaOutputConstraint"/>) via
+    /// <see cref="NextKeyCandidates"/>; the Gemma and Qwen-Coder walkers use their own key-candidate
+    /// scans and do not honor this flag.</summary>
     public bool Ordered { get; init; }
     public int Count => KeyBytes.Length;
+
+    /// <summary>
+    /// Candidate mask for the next key at a key boundary, given the emitted-keys mask. Unordered:
+    /// every not-yet-emitted key. Ordered (issue #425): keys must appear in declaration order, so
+    /// the window runs from just past the highest emitted index (emission is ascending, enforced by
+    /// this very mask) up to and INCLUDING the first required key — an optional key may be skipped,
+    /// but skipping a required key could never be repaired later and would dead-end at the close
+    /// brace.
+    /// </summary>
+    public ulong NextKeyCandidates(ulong emitted)
+    {
+        if (!Ordered) return AllBits(Count) & ~emitted;
+        ulong cand = 0;
+        for (int i = NextIndex(emitted); i < Count; i++)
+        {
+            cand |= 1UL << i;
+            if ((RequiredMask & (1UL << i)) != 0) break;
+        }
+        return cand;
+    }
+
+    /// <summary>O(1) "any key may still open here" check — <see cref="NextKeyCandidates"/> is
+    /// non-empty. Ordered: the window is non-empty iff any declared key lies past the highest
+    /// emitted one. Used on the per-simulated-byte hot path (the ',' gate), where building the full
+    /// window mask would be wasted work.</summary>
+    public bool HasNextKey(ulong emitted) =>
+        Ordered ? NextIndex(emitted) < Count : (AllBits(Count) & ~emitted) != 0;
+
+    /// <summary>Ordered mode: the lowest declaration index the next key may take — one past the
+    /// highest emitted key (0 when none emitted yet).</summary>
+    private static int NextIndex(ulong emitted) => 64 - BitOperations.LeadingZeroCount(emitted);
+
+    private static ulong AllBits(int n) => n >= 64 ? ulong.MaxValue : (1UL << n) - 1;
 }
 
 /// <summary>
@@ -70,11 +108,12 @@ internal static class ToolSchemaCompiler
     private static readonly byte[][] s_boolLiterals = [ToolSchema.Utf8("true"), ToolSchema.Utf8("false")];
     private static readonly byte[][] s_nullLiterals = [ToolSchema.Utf8("null")];
 
-    public static CompiledObject? TryCompileObject(ToolSchemaObject obj) => TryCompileObject(obj, ordered: false, 0);
-
-    /// <summary>Compiles with ordered-properties mode (issue #425): every object in the schema tree
-    /// requires its keys in declaration order (optional keys skippable, never reordered).</summary>
-    public static CompiledObject? TryCompileObject(ToolSchemaObject obj, bool ordered) => TryCompileObject(obj, ordered, 0);
+    /// <summary>Compiles an object schema, optionally in ordered-properties mode (issue #425):
+    /// every typed object in the schema tree then requires its keys in declaration order (see
+    /// <see cref="CompiledObject.Ordered"/>). Subtrees that degrade to <see cref="FreeValue"/>
+    /// (open/untyped/too-deep) are not order-enforced.</summary>
+    public static CompiledObject? TryCompileObject(ToolSchemaObject obj, bool ordered = false) =>
+        TryCompileObject(obj, ordered, 0);
 
     private static CompiledObject? TryCompileObject(ToolSchemaObject obj, bool ordered, int depth)
     {

--- a/src/SharpInference.Core/Grammar/ToolSchemaCompiler.cs
+++ b/src/SharpInference.Core/Grammar/ToolSchemaCompiler.cs
@@ -34,6 +34,9 @@ internal sealed class CompiledObject
     public required byte[][] KeyBytes { get; init; }
     public required CompiledNode[] Values { get; init; }
     public required ulong RequiredMask { get; init; }
+    /// <summary>Ordered mode (issue #425): keys must appear in declaration order — optional keys may
+    /// be skipped, but a later key can never precede an earlier one.</summary>
+    public bool Ordered { get; init; }
     public int Count => KeyBytes.Length;
 }
 
@@ -67,9 +70,13 @@ internal static class ToolSchemaCompiler
     private static readonly byte[][] s_boolLiterals = [ToolSchema.Utf8("true"), ToolSchema.Utf8("false")];
     private static readonly byte[][] s_nullLiterals = [ToolSchema.Utf8("null")];
 
-    public static CompiledObject? TryCompileObject(ToolSchemaObject obj) => TryCompileObject(obj, 0);
+    public static CompiledObject? TryCompileObject(ToolSchemaObject obj) => TryCompileObject(obj, ordered: false, 0);
 
-    private static CompiledObject? TryCompileObject(ToolSchemaObject obj, int depth)
+    /// <summary>Compiles with ordered-properties mode (issue #425): every object in the schema tree
+    /// requires its keys in declaration order (optional keys skippable, never reordered).</summary>
+    public static CompiledObject? TryCompileObject(ToolSchemaObject obj, bool ordered) => TryCompileObject(obj, ordered, 0);
+
+    private static CompiledObject? TryCompileObject(ToolSchemaObject obj, bool ordered, int depth)
     {
         if (depth >= MaxDepth || obj.Open || obj.Properties.Count is 0 or > 64) return null;
         var keys = new byte[obj.Properties.Count][];
@@ -82,16 +89,16 @@ internal static class ToolSchemaCompiler
             keys[i] = ToolSchema.Utf8(p.Name);
             // A loosely-typed value compiles to FreeValue (issue #378) rather than disqualifying the
             // tool — the key/required structure stays enforced, only the value is left free.
-            values[i] = CompileNode(p.Value, depth + 1);
+            values[i] = CompileNode(p.Value, ordered, depth + 1);
             if (p.Required) reqMask |= 1UL << i;
         }
-        return new CompiledObject { KeyBytes = keys, Values = values, RequiredMask = reqMask };
+        return new CompiledObject { KeyBytes = keys, Values = values, RequiredMask = reqMask, Ordered = ordered };
     }
 
     /// <summary>Compiles one value node, degrading any loosely-typed value (Any / untyped array /
     /// open or too-deep object) to <see cref="FreeValue"/> rather than null — so a partially-typed
     /// object still constrains its typed siblings (issue #378).</summary>
-    private static CompiledNode CompileNode(ToolSchemaNode node, int depth)
+    private static CompiledNode CompileNode(ToolSchemaNode node, bool ordered, int depth)
     {
         if (depth >= MaxDepth) return FreeValue;            // too deep to constrain → free
         switch (node.Kind)
@@ -120,11 +127,11 @@ internal static class ToolSchemaCompiler
             case JsonSchemaKind.Array:
                 // An untyped array (no item shape) is left free; a typed array constrains its items.
                 if (node.Items is null) return FreeValue;
-                return new CompiledNode { Kind = JsonSchemaKind.Array, Items = CompileNode(node.Items, depth + 1) };
+                return new CompiledNode { Kind = JsonSchemaKind.Array, Items = CompileNode(node.Items, ordered, depth + 1) };
 
             case JsonSchemaKind.Object:
                 // An open / too-deep nested object is left free; a typed nested object recurses.
-                var obj = node.Object is null ? null : TryCompileObject(node.Object, depth + 1);
+                var obj = node.Object is null ? null : TryCompileObject(node.Object, ordered, depth + 1);
                 return obj is null ? FreeValue : new CompiledNode { Kind = JsonSchemaKind.Object, Object = obj };
 
             default:

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -186,13 +186,17 @@ public static class OpenAiEndpoints
         // failures return 400 rather than silently generating unconstrained output.
         ITokenConstraint? jsonSchemaConstraint = null;
         JsonElement? requestedSchema = null;
+        bool schemaOrdered = false;     // json_schema.ordered / response_format.ordered (issue #425)
         if (req.ResponseFormat?.Type == "json_schema")
         {
             // Unlike "json_object" (below), a schema is REQUIRED here -- the client explicitly asked
             // for schema-constrained output, so a missing json_schema.schema is a client error, not a
             // silent no-op (issue #423 follow-up: an explicit schema request is a hard requirement).
             if (req.ResponseFormat.JsonSchema?.Schema is { } s)
+            {
                 requestedSchema = s;
+                schemaOrdered = req.ResponseFormat.JsonSchema.Ordered == true;
+            }
             else
             {
                 ctx.Response.StatusCode = 400;
@@ -209,6 +213,7 @@ public static class OpenAiEndpoints
             // llama.cpp's flat extension: an optional schema alongside the plain "valid JSON" request.
             // Absent here just means "valid JSON, no shape enforced" -- the pre-existing behavior.
             requestedSchema = req.ResponseFormat.Schema;
+            schemaOrdered = req.ResponseFormat.Ordered == true;
         }
         if (requestedSchema is { } schemaElement)
         {
@@ -225,7 +230,7 @@ public static class OpenAiEndpoints
             try
             {
                 var schemaObject = ToolSchema.FromOpenAiFunction("_", schemaElement).Arguments;
-                jsonSchemaConstraint = new JsonSchemaOutputConstraint(vocab, schemaObject);
+                jsonSchemaConstraint = new JsonSchemaOutputConstraint(vocab, schemaObject, schemaOrdered);
             }
             catch (ArgumentException ex)
             {
@@ -865,11 +870,12 @@ public sealed record ModelInfo(string Id, string Object, long Created, string Ow
 /// schema without the OpenAI envelope's <c>name</c>/<c>strict</c>. Either shape, when a schema is
 /// present, constrains the whole response via <see cref="SharpInference.Core.Grammar.JsonSchemaOutputConstraint"/>.
 /// </summary>
-public sealed record ResponseFormat(string? Type, JsonSchemaSpec? JsonSchema = null, JsonElement? Schema = null);
+public sealed record ResponseFormat(string? Type, JsonSchemaSpec? JsonSchema = null, JsonElement? Schema = null, bool? Ordered = null);
 
-/// <summary>OpenAI's <c>response_format.json_schema</c> envelope. Only <see cref="Schema"/> is
-/// consumed; <see cref="Name"/>/<see cref="Strict"/> round-trip but aren't validated (matching
-/// llama.cpp's own server behavior).</summary>
-public sealed record JsonSchemaSpec(string? Name, JsonElement? Schema, bool? Strict = null);
+/// <summary>OpenAI's <c>response_format.json_schema</c> envelope. Only <see cref="Schema"/> and
+/// <see cref="Ordered"/> (SharpInference extension, issue #425: require properties in declaration
+/// order) are consumed; <see cref="Name"/>/<see cref="Strict"/> round-trip but aren't validated
+/// (matching llama.cpp's own server behavior).</summary>
+public sealed record JsonSchemaSpec(string? Name, JsonElement? Schema, bool? Strict = null, bool? Ordered = null);
 
 public sealed record ErrorResponse(string Type, string Message);

--- a/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
+++ b/src/SharpInference.Server/Endpoints/OpenAiEndpoints.cs
@@ -186,17 +186,18 @@ public static class OpenAiEndpoints
         // failures return 400 rather than silently generating unconstrained output.
         ITokenConstraint? jsonSchemaConstraint = null;
         JsonElement? requestedSchema = null;
-        bool schemaOrdered = false;     // json_schema.ordered / response_format.ordered (issue #425)
+        // Ordered-properties opt-in (issue #425): honored wherever the client put it -- nested on
+        // the json_schema envelope or flat on response_format -- so the flag never silently no-ops
+        // based on which response_format shape carries it.
+        bool schemaOrdered = req.ResponseFormat?.Ordered == true
+                          || req.ResponseFormat?.JsonSchema?.Ordered == true;
         if (req.ResponseFormat?.Type == "json_schema")
         {
             // Unlike "json_object" (below), a schema is REQUIRED here -- the client explicitly asked
             // for schema-constrained output, so a missing json_schema.schema is a client error, not a
             // silent no-op (issue #423 follow-up: an explicit schema request is a hard requirement).
             if (req.ResponseFormat.JsonSchema?.Schema is { } s)
-            {
                 requestedSchema = s;
-                schemaOrdered = req.ResponseFormat.JsonSchema.Ordered == true;
-            }
             else
             {
                 ctx.Response.StatusCode = 400;
@@ -213,7 +214,6 @@ public static class OpenAiEndpoints
             // llama.cpp's flat extension: an optional schema alongside the plain "valid JSON" request.
             // Absent here just means "valid JSON, no shape enforced" -- the pre-existing behavior.
             requestedSchema = req.ResponseFormat.Schema;
-            schemaOrdered = req.ResponseFormat.Ordered == true;
         }
         if (requestedSchema is { } schemaElement)
         {

--- a/tests/SharpInference.Tests.Cli/JsonSchemaFlagsTests.cs
+++ b/tests/SharpInference.Tests.Cli/JsonSchemaFlagsTests.cs
@@ -117,6 +117,18 @@ public sealed class JsonSchemaFlagsTests
     }
 
     [Fact]
+    public void OrderedFlag_WithoutSchema_IsError()
+    {
+        // --json-schema-ordered alone must fail loudly, not silently generate unconstrained output.
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint(
+            null, null, Vocab, out var constraint, out var error, ordered: true);
+
+        Assert.False(ok);
+        Assert.Null(constraint);
+        Assert.Contains("--json-schema-ordered requires", error);
+    }
+
+    [Fact]
     public void SchemaFile_ValidObjectSchema_Succeeds()
     {
         string path = Path.GetTempFileName();

--- a/tests/SharpInference.Tests.Cli/JsonSchemaFlagsTests.cs
+++ b/tests/SharpInference.Tests.Cli/JsonSchemaFlagsTests.cs
@@ -99,6 +99,24 @@ public sealed class JsonSchemaFlagsTests
     }
 
     [Fact]
+    public void OrderedFlag_IsThreadedIntoConstraint()
+    {
+        // --json-schema-ordered (issue #425): declaration-order property emission, default off.
+        const string schema =
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""";
+
+        bool ok = RunCommand.TryLoadJsonSchemaConstraint(
+            schema, null, Vocab, out var constraint, out var error, ordered: true);
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.True(Assert.IsType<JsonSchemaOutputConstraint>(constraint).OrderedProperties);
+
+        ok = RunCommand.TryLoadJsonSchemaConstraint(schema, null, Vocab, out constraint, out error);
+        Assert.True(ok);
+        Assert.False(Assert.IsType<JsonSchemaOutputConstraint>(constraint).OrderedProperties);
+    }
+
+    [Fact]
     public void SchemaFile_ValidObjectSchema_Succeeds()
     {
         string path = Path.GetTempFileName();

--- a/tests/SharpInference.Tests.Core/JsonSchemaOutputConstraintTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonSchemaOutputConstraintTests.cs
@@ -205,22 +205,21 @@ public sealed class JsonSchemaOutputConstraintTests
     public void AllKeysEmitted_TrailingComma_IsMasked()
     {
         // Regression for the comma gate (applies to ordered AND unordered): once every declared key
-        // is emitted a ',' commits to a key that cannot exist, which previously reached a dead state
-        // (constraint gave up) instead of forcing '}'.
+        // is emitted a ',' commits to a key that cannot exist, which previously livelocked in a
+        // whitespace-only OExpectKey state instead of forcing '}'.
         var (c, tok, vocab) = Build(
             """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
 
         Feed(c, tok, "{\"answer\":\"hi\"");
         Assert.False(Allowed(c, vocab, tok.Char(',')));
+        Assert.False(Allowed(c, vocab, tok.Merged(",\"")));   // merged BPE comma+quote too
         Assert.True(Allowed(c, vocab, tok.Char('}')));
     }
 
     [Fact]
     public void OrderedProperties_Flag_IsExposed()
     {
-        var tok = new FakeJsonTokenizer();
-        var vocab = new GrammarVocabulary(tok);
-        Assert.False(new JsonSchemaOutputConstraint(vocab, Schema(SaySchemaJson)).OrderedProperties);
-        Assert.True(new JsonSchemaOutputConstraint(vocab, Schema(SaySchemaJson), orderedProperties: true).OrderedProperties);
+        Assert.False(((JsonSchemaOutputConstraint)Build(SaySchemaJson).c).OrderedProperties);
+        Assert.True(((JsonSchemaOutputConstraint)Build(SaySchemaJson, ordered: true).c).OrderedProperties);
     }
 }

--- a/tests/SharpInference.Tests.Core/JsonSchemaOutputConstraintTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonSchemaOutputConstraintTests.cs
@@ -17,11 +17,11 @@ public sealed class JsonSchemaOutputConstraintTests
         return ToolSchema.FromOpenAiFunction("_", doc.RootElement.Clone()).Arguments;
     }
 
-    private static (ITokenConstraint c, FakeJsonTokenizer tok, int vocab) Build(string schemaJson)
+    private static (ITokenConstraint c, FakeJsonTokenizer tok, int vocab) Build(string schemaJson, bool ordered = false)
     {
         var tok = new FakeJsonTokenizer();
         var vocab = new GrammarVocabulary(tok);
-        var c = new JsonSchemaOutputConstraint(vocab, Schema(schemaJson));
+        var c = new JsonSchemaOutputConstraint(vocab, Schema(schemaJson), ordered);
         return (c, tok, vocab.VocabSize);
     }
 
@@ -114,5 +114,113 @@ public sealed class JsonSchemaOutputConstraintTests
         c.Reset();
         Assert.True(c.IsConstraining);        // turn 2 must be constrained from token 1 too
         Assert.True(Allowed(c, vocab, tok.Char('{')));   // back to expecting a fresh object, not EOG-only
+    }
+
+    // ── Ordered-properties mode (issue #425) ─────────────────────────────────────
+    // The motivating schema: "say" is a short spoken line streamed to TTS, "show" a large markdown
+    // block -- ordered mode guarantees "say" streams FIRST so speech can start immediately.
+
+    private const string SaySchemaJson =
+        """{"type":"object","properties":{"say":{"type":"string"},"show":{"type":"string"}},"required":["say"]}""";
+
+    [Fact]
+    public void Ordered_FirstKey_MustBeFirstDeclared()
+    {
+        var (c, tok, vocab) = Build(SaySchemaJson, ordered: true);
+
+        Feed(c, tok, "{\"s");
+        Assert.True(Allowed(c, vocab, tok.Char('a')));    // "say" -- declared first
+        Assert.False(Allowed(c, vocab, tok.Char('h')));   // "show" may not precede "say"
+    }
+
+    [Fact]
+    public void Unordered_Default_AllowsAnyDeclarationOrder()
+    {
+        var (c, tok, vocab) = Build(SaySchemaJson);
+
+        Feed(c, tok, "{\"s");
+        Assert.True(Allowed(c, vocab, tok.Char('a')));    // "say"
+        Assert.True(Allowed(c, vocab, tok.Char('h')));    // "show" first stays legal by default
+    }
+
+    [Fact]
+    public void Ordered_InOrderObject_CompletesToEndOfGeneration()
+    {
+        var (c, tok, vocab) = Build(SaySchemaJson, ordered: true);
+
+        Feed(c, tok, "{\"say\":\"hi\",\"show\":\"# md\"}");
+        Assert.True(c.IsConstraining);                           // EOG-only terminal state
+        Assert.True(Allowed(c, vocab, FakeJsonTokenizer.Eos));
+    }
+
+    [Fact]
+    public void Ordered_OptionalKey_IsSkippable_ButNotReorderable()
+    {
+        // pre (optional) may be skipped, but once say (declared after it) is emitted there is no
+        // going back -- and nothing follows say, so ',' must be masked and '}' forced.
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"pre":{"type":"string"},"say":{"type":"string"}},"required":["say"]}""",
+            ordered: true);
+
+        Feed(c, tok, "{\"");
+        Assert.True(Allowed(c, vocab, tok.Char('p')));    // optional "pre" offered first...
+        Assert.True(Allowed(c, vocab, tok.Char('s')));    // ...but skipping straight to "say" is legal
+
+        Feed(c, tok, "say\":\"hi\"");
+        Assert.False(Allowed(c, vocab, tok.Char(',')));   // "pre" can no longer appear
+        Assert.True(Allowed(c, vocab, tok.Char('}')));
+    }
+
+    [Fact]
+    public void Ordered_RequiredKey_IsNotSkippable()
+    {
+        // The next-key window stops at the first required key: jumping from "say" to "show" would
+        // skip required "mid" with no way to repair, so 's' must be masked at the second key.
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"say":{"type":"string"},"mid":{"type":"string"},"show":{"type":"string"}},"required":["say","mid"]}""",
+            ordered: true);
+
+        Feed(c, tok, "{\"say\":\"x\",\"");
+        Assert.True(Allowed(c, vocab, tok.Char('m')));    // "mid" -- the required next key
+        Assert.False(Allowed(c, vocab, tok.Char('s')));   // "show" would skip required "mid"
+    }
+
+    [Fact]
+    public void Ordered_AppliesToNestedObjects()
+    {
+        var (c, tok, vocab) = Build(
+            """
+            {"type":"object","properties":{"outer":{"type":"object",
+             "properties":{"first":{"type":"string"},"second":{"type":"string"}},
+             "required":["first"]}},"required":["outer"]}
+            """,
+            ordered: true);
+
+        Feed(c, tok, "{\"outer\":{\"");
+        Assert.True(Allowed(c, vocab, tok.Char('f')));    // nested "first"
+        Assert.False(Allowed(c, vocab, tok.Char('s')));   // nested "second" may not lead
+    }
+
+    [Fact]
+    public void AllKeysEmitted_TrailingComma_IsMasked()
+    {
+        // Regression for the comma gate (applies to ordered AND unordered): once every declared key
+        // is emitted a ',' commits to a key that cannot exist, which previously reached a dead state
+        // (constraint gave up) instead of forcing '}'.
+        var (c, tok, vocab) = Build(
+            """{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}""");
+
+        Feed(c, tok, "{\"answer\":\"hi\"");
+        Assert.False(Allowed(c, vocab, tok.Char(',')));
+        Assert.True(Allowed(c, vocab, tok.Char('}')));
+    }
+
+    [Fact]
+    public void OrderedProperties_Flag_IsExposed()
+    {
+        var tok = new FakeJsonTokenizer();
+        var vocab = new GrammarVocabulary(tok);
+        Assert.False(new JsonSchemaOutputConstraint(vocab, Schema(SaySchemaJson)).OrderedProperties);
+        Assert.True(new JsonSchemaOutputConstraint(vocab, Schema(SaySchemaJson), orderedProperties: true).OrderedProperties);
     }
 }

--- a/tests/SharpInference.Tests.Core/JsonToolGrammarMockTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonToolGrammarMockTests.cs
@@ -110,7 +110,9 @@ public sealed class JsonToolGrammarMockTests
 
         Feed(c, tok, "Berlin\"");
         Assert.True(Allowed(c, vocab, tok.Char('}')));    // required satisfied → may close
-        Assert.True(Allowed(c, vocab, tok.Char(',')));
+        // Every declared key is emitted, so ',' would commit to a key that cannot exist — masked
+        // (issue #425's comma gate), where it previously dead-ended and disabled the constraint.
+        Assert.False(Allowed(c, vocab, tok.Char(',')));
 
         Feed(c, tok, "}");
         Assert.False(c.IsConstraining);                   // object closed → back to watching

--- a/tests/SharpInference.Tests.Core/JsonToolGrammarMockTests.cs
+++ b/tests/SharpInference.Tests.Core/JsonToolGrammarMockTests.cs
@@ -111,7 +111,8 @@ public sealed class JsonToolGrammarMockTests
         Feed(c, tok, "Berlin\"");
         Assert.True(Allowed(c, vocab, tok.Char('}')));    // required satisfied → may close
         // Every declared key is emitted, so ',' would commit to a key that cannot exist — masked
-        // (issue #425's comma gate), where it previously dead-ended and disabled the constraint.
+        // (issue #425's comma gate), where it previously livelocked in a whitespace-only
+        // OExpectKey state ('}' isn't legal there and EOG is forbidden mid-call).
         Assert.False(Allowed(c, vocab, tok.Char(',')));
 
         Feed(c, tok, "}");

--- a/tests/SharpInference.Tests.Core/ToolGrammarMockTests.cs
+++ b/tests/SharpInference.Tests.Core/ToolGrammarMockTests.cs
@@ -87,7 +87,9 @@ public sealed class ToolGrammarMockTests
         Feed(c, tok, "Berlin");
         c.Accept(FakeGemmaTokenizer.Quote);                 // close string
         Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char('}')));   // required satisfied
-        Assert.True(Allowed(c, vocab, FakeGemmaTokenizer.Char(',')));
+        // Every declared key is emitted, so ',' would commit to a key that cannot exist — masked
+        // (the comma gate), where it previously livelocked in a whitespace-only OExpectKey state.
+        Assert.False(Allowed(c, vocab, FakeGemmaTokenizer.Char(',')));
 
         c.Accept(FakeGemmaTokenizer.Char('}'));
         Assert.False(c.IsConstraining);                     // object closed → watching

--- a/tests/SharpInference.Tests.Server/JsonSchemaResponseFormatEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/JsonSchemaResponseFormatEndpointTests.cs
@@ -108,7 +108,55 @@ public sealed class JsonSchemaResponseFormatEndpointTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         Assert.NotNull(fake.LastSamplingParams);
-        Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
+        var constraint = Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
+        Assert.False(constraint.OrderedProperties);   // ordered mode (issue #425) is opt-in
+    }
+
+    [Fact]
+    public async Task JsonSchemaType_OrderedExtension_IsThreadedIntoConstraint()
+    {
+        // SharpInference extension (issue #425): json_schema.ordered:true requires properties in
+        // declaration order so a streaming client can rely on an early field arriving first.
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_schema", json_schema = new { name = "answer", schema = ValidSchema, ordered = true } },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        var constraint = Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
+        Assert.True(constraint.OrderedProperties);
+    }
+
+    [Fact]
+    public async Task JsonObjectType_FlatOrderedExtension_IsThreadedIntoConstraint()
+    {
+        // The flat llama.cpp-style shape gets the same opt-in: response_format.ordered:true.
+        var fake = new FakeInferenceEngine("test-model");
+        var client = CreateClient(fake, renderer: RendererWithVocab());
+
+        var req = new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "hi" } },
+            max_tokens = 10,
+            stream = false,
+            response_format = new { type = "json_object", schema = ValidSchema, ordered = true },
+        };
+        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(fake.LastSamplingParams);
+        var constraint = Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
+        Assert.True(constraint.OrderedProperties);
     }
 
     [Fact]

--- a/tests/SharpInference.Tests.Server/JsonSchemaResponseFormatEndpointTests.cs
+++ b/tests/SharpInference.Tests.Server/JsonSchemaResponseFormatEndpointTests.cs
@@ -112,11 +112,10 @@ public sealed class JsonSchemaResponseFormatEndpointTests
         Assert.False(constraint.OrderedProperties);   // ordered mode (issue #425) is opt-in
     }
 
-    [Fact]
-    public async Task JsonSchemaType_OrderedExtension_IsThreadedIntoConstraint()
+    /// <summary>POSTs a chat completion with <paramref name="responseFormat"/> and asserts the
+    /// engine received a <see cref="JsonSchemaOutputConstraint"/> with ordered mode ON.</summary>
+    private static async Task AssertOrderedConstraint(object responseFormat)
     {
-        // SharpInference extension (issue #425): json_schema.ordered:true requires properties in
-        // declaration order so a streaming client can rely on an early field arriving first.
         var fake = new FakeInferenceEngine("test-model");
         var client = CreateClient(fake, renderer: RendererWithVocab());
 
@@ -126,7 +125,7 @@ public sealed class JsonSchemaResponseFormatEndpointTests
             messages = new[] { new { role = "user", content = "hi" } },
             max_tokens = 10,
             stream = false,
-            response_format = new { type = "json_schema", json_schema = new { name = "answer", schema = ValidSchema, ordered = true } },
+            response_format = responseFormat,
         };
         var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -135,29 +134,23 @@ public sealed class JsonSchemaResponseFormatEndpointTests
         var constraint = Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
         Assert.True(constraint.OrderedProperties);
     }
+
+    // SharpInference extension (issue #425): ordered:true requires properties in declaration order
+    // so a streaming client can rely on an early field arriving first. The flag is honored wherever
+    // the client puts it -- nested on the json_schema envelope or flat on response_format -- for
+    // both response_format shapes.
 
     [Fact]
-    public async Task JsonObjectType_FlatOrderedExtension_IsThreadedIntoConstraint()
-    {
-        // The flat llama.cpp-style shape gets the same opt-in: response_format.ordered:true.
-        var fake = new FakeInferenceEngine("test-model");
-        var client = CreateClient(fake, renderer: RendererWithVocab());
+    public Task JsonSchemaType_NestedOrdered_IsThreadedIntoConstraint() =>
+        AssertOrderedConstraint(new { type = "json_schema", json_schema = new { name = "answer", schema = ValidSchema, ordered = true } });
 
-        var req = new
-        {
-            model = "test-model",
-            messages = new[] { new { role = "user", content = "hi" } },
-            max_tokens = 10,
-            stream = false,
-            response_format = new { type = "json_object", schema = ValidSchema, ordered = true },
-        };
-        var response = await client.PostAsJsonAsync("/v1/chat/completions", req);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    [Fact]
+    public Task JsonSchemaType_FlatOrdered_IsThreadedIntoConstraint() =>
+        AssertOrderedConstraint(new { type = "json_schema", ordered = true, json_schema = new { name = "answer", schema = ValidSchema } });
 
-        Assert.NotNull(fake.LastSamplingParams);
-        var constraint = Assert.IsType<JsonSchemaOutputConstraint>(fake.LastSamplingParams!.Constraint);
-        Assert.True(constraint.OrderedProperties);
-    }
+    [Fact]
+    public Task JsonObjectType_FlatOrdered_IsThreadedIntoConstraint() =>
+        AssertOrderedConstraint(new { type = "json_object", schema = ValidSchema, ordered = true });
 
     [Fact]
     public async Task JsonObjectType_WithFlatSchemaExtension_ConstraintIsJsonSchemaOutputConstraint()


### PR DESCRIPTION
## Summary

Implements #425: an **opt-in ordered mode** for `JsonSchemaOutputConstraint` where declared properties must appear in declaration order -- optional properties are skippable, but never reordered, and a required property is never skippable. This lets a streaming consumer act on an early field (the issue''s TTS `say` line) before a later, larger field (`show`) finishes streaming.

## How it works

- `ToolSchemaCompiler.TryCompileObject(obj, ordered)` stamps `CompiledObject.Ordered` recursively (typed nested objects are ordered too; FreeValue-degraded subtrees stay unordered, as documented).
- `CompiledObject.NextKeyCandidates(emitted)` computes next-key candidates on the shared compiled form: unordered keeps the existing every-unemitted-key bitmask; ordered narrows to the window from just past the highest emitted key **up to and including the first required key** -- so the mask itself makes skipping a required key impossible. `HasNextKey(emitted)` is the O(1) emptiness check for hot call sites.
- Ordered decoding is also cheaper, as the issue predicted: the candidate set is typically a single expected key.

### Comma gate (both modes, both walkers)

The review round upgraded this from "latent dead state" to a confirmed **fail-closed livelock**: at `OExpectCommaOrClose` a `,` was always legal even when no key could follow (all declared keys emitted). After sampling it, the machine sat in `OExpectKey` where the mask kept only whitespace legal (`}` is not accepted there, EOG is forbidden mid-object), so the dead-state escape never fired and generation burned whitespace tokens until the token limit. Now `,` is masked whenever the candidate window is empty, forcing `}`.

The multi-angle review found the **same livelock in `GemmaToolArgumentConstraint`** (the sibling walker over the same `CompiledObject`); the identical gate is applied there too, with its test pin flipped. `QwenCoderToolArgumentConstraint` already had the gate via `UnemittedMask`.

## Opt-in surfaces

| Surface | Opt-in |
|---|---|
| Library | `new JsonSchemaOutputConstraint(vocab, schema, orderedProperties: true)` |
| CLI | `--json-schema-ordered` (with `-j`/`--json-schema`/`--jf`; a hard error if no schema flag is given) |
| Server | `ordered: true` -- honored both nested on `json_schema` and flat on `response_format`, for both `json_schema` and `json_object` shapes (position-agnostic) |

Default behavior is unchanged (any-order), except the comma-gate livelock fix above.

## Review round (multi-agent, xhigh)

10 finder angles + adversarial verification over the diff. The automaton core survived all five correctness angles (mask/replay consistency incl. merged BPE tokens, ordered-window induction proving no reachable dead state, prefix-key resolution, LZCNT edge cases, free-value nesting, reset re-engagement). Findings applied:

- **fix**: Gemma comma-gate livelock (CONFIRMED by adversarial verifier with line-level trace)
- **fix**: server `ordered` was position-dependent (flat flag silently ignored for `type:"json_schema"`)
- **fix**: `--json-schema-ordered` without a schema flag silently no-oped
- **refactor**: `NextKeyCandidates`/`HasNextKey` hoisted onto `CompiledObject`; `TryCompileObject` overloads merged; O(1) emptiness on the per-simulated-byte comma gate
- **docs**: ordered coverage no longer overstated for FreeValue subtrees
- **refuted**: "comma gate removes a fail-open escape for extra tool args" -- the old path was the whitespace livelock, not a pass-through; the gate is a pure fix
- **skipped**: binary-compat of the ctor/record signature changes (0.x pre-release, ABI not pledged); design-doc `response_format` section drift (pre-existing, predates #423)

## Tests

Tests.Core 273 / Tests.Cli 60 / Tests.Server 154 all pass; solution builds clean under warnings-as-errors. New coverage: declaration-order masking (first key, required-not-skippable, optional-skip, nested objects, EOG completion), merged-token comma gate, Gemma comma gate, CLI ordered-without-schema error, server ordered wiring for all three flag placements.

## Out of scope

The issue''s lower-priority related asks -- `minLength`/non-empty required strings, and a top-level `toolcall | schema` alternation -- are intentionally not included, per the "happy to split out" note.

Closes #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EWo1niax1g8A5E79RSALJ