### PR TITLE
KVarN variance-normalized KV-cache quantization: CPU + CUDA (#180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -455,3 +455,9 @@ prof/
 # Gemma 4 vision parity golden — large binary, regenerable via scripts/gemma4uv_ref.py (issue #250).
 # meta.json (the spec) stays tracked.
 tests/fixtures/gemma4uv/*.f32
+
+# KVarN P0 gate corpus + run outputs (issue #180) — fetched by scripts/kvarn-gate/get-wikitext2.ps1
+scripts/kvarn-gate/wiki.test.raw
+scripts/kvarn-gate/wikitext-2-raw-v1.zip
+scripts/kvarn-gate/.wikitext-extract/
+scripts/kvarn-gate/results/

--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ the IWHT defers to one call per kv-head. Combined K+V hot-path cost vs the prior
 End-to-end gain tracks the K+V share of token cost — small at short ctx, growing with length. Qwen3-8B CPU
 `--tq` decode drops only ~22% from 30→6050 ctx (12.0→9.4 t/s) — ~1.9× the per-block path at 6K.
 
+`--tq-mode kvarn` (issue #180) selects the KVarN quantizer instead of the Lloyd-Max codebooks: per-128-token-tile
+Hadamard rotation + dual-axis Sinkhorn variance normalization + asymmetric RTN — 4-bit keys / 2-bit values
+(≈4.75 + 2.75 bits/elt at `headDim` 128), calibration-free so any power-of-2 head dim quantizes. Runs on CPU
+(`-g 0`, head dim ≤ 1024) and on the full-CUDA-offload dense path (`-g -1`, head dim ≤ 256; the CUDA tiles are
+byte-compatible with the CPU compressor and the promotion cadence matches position-for-position). P0 accuracy
+gate (Qwen3-0.6B-Q8_0, wikitext-2, 3072 tokens): PPL 15.67 vs 15.47 fp32 (+1.3%). No SnapKV / Vulkan /
+partial-offload / MoE-on-GPU composition yet.
+
 ### Multi-Token Prediction (MTP)
 
 Models with native MTP heads (Qwen3.6-27B-MTP, Qwen3.5/3.6 A3B-MTP, DeepSeek V3/R1) get self-speculative

--- a/benchmarks/SharpInference.Bench/KVarNReadBench.cs
+++ b/benchmarks/SharpInference.Bench/KVarNReadBench.cs
@@ -1,0 +1,179 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using SharpInference.TurboQuant;
+
+namespace SharpInference.Bench;
+
+/// <summary>
+/// KVarN fused K-score micro-bench (issue #180 P1): scalar reference vs the
+/// AVX2 kernel inside <see cref="KVarNCompressor.KeyScores"/>, D=128, walking
+/// 64 compressed tiles per invocation (8192 positions — the decode depth where
+/// the compressed region dominates the token loop). OperationsPerInvoke is the
+/// tile count, so the reported time is ns/tile. The scalar path is forced via
+/// the internal <see cref="KVarNCompressor.ForceScalar"/> hook.
+/// </summary>
+[MemoryDiagnoser]
+[WarmupCount(3)]
+[IterationCount(5)]
+public unsafe class KVarNKeyScoreBench
+{
+    private const int Dim = 128;
+    private const int NumTiles = 64;
+
+    private KVarNCompressor _comp = null!;
+    private int _kTileBytes;
+    private byte* _kTiles;
+    private float* _rotatedQuery;
+    private float* _scores;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _comp = new KVarNCompressor(Dim);
+        _kTileBytes = _comp.KeyTileBytes;
+        _kTiles = (byte*)NativeMemory.AllocZeroed((nuint)((long)NumTiles * _kTileBytes));
+        _rotatedQuery = (float*)NativeMemory.AllocZeroed(Dim * sizeof(float));
+        _scores = (float*)NativeMemory.AllocZeroed((nuint)((long)NumTiles * KVarNCompressor.TileTokens * sizeof(float)));
+
+        var rng = new Random(42);
+        float[] tileData = new float[KVarNCompressor.TileTokens * Dim];
+        for (int tile = 0; tile < NumTiles; tile++)
+        {
+            for (int i = 0; i < tileData.Length; i++)
+                tileData[i] = (float)(rng.NextDouble() * 2 - 1);
+            _comp.CompressKeyTile(tileData, new Span<byte>(_kTiles + (long)tile * _kTileBytes, _kTileBytes));
+        }
+
+        float[] q = new float[Dim];
+        for (int i = 0; i < Dim; i++)
+            q[i] = (float)(rng.NextDouble() * 2 - 1);
+        _comp.RotateQuery(q, new Span<float>(_rotatedQuery, Dim));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        NativeMemory.Free(_kTiles);
+        NativeMemory.Free(_rotatedQuery);
+        NativeMemory.Free(_scores);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = NumTiles)]
+    public float Scalar()
+    {
+        KVarNCompressor.ForceScalar = true;
+        try
+        {
+            return RunAllTiles();
+        }
+        finally
+        {
+            KVarNCompressor.ForceScalar = false;
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = NumTiles)]
+    public float Avx2() => RunAllTiles();
+
+    private float RunAllTiles()
+    {
+        var query = new ReadOnlySpan<float>(_rotatedQuery, Dim);
+        for (int tile = 0; tile < NumTiles; tile++)
+        {
+            _comp.KeyScores(
+                new ReadOnlySpan<byte>(_kTiles + (long)tile * _kTileBytes, _kTileBytes),
+                query,
+                new Span<float>(_scores + (long)tile * KVarNCompressor.TileTokens, KVarNCompressor.TileTokens));
+        }
+        return _scores[0]; // defeat DCE
+    }
+}
+
+/// <summary>
+/// KVarN fused V-aggregate micro-bench: scalar vs AVX2 inside
+/// <see cref="KVarNCompressor.AggregateValues"/>, D=128 over 64 tiles.
+/// Reported time is ns/tile (OperationsPerInvoke = tile count).
+/// </summary>
+[MemoryDiagnoser]
+[WarmupCount(3)]
+[IterationCount(5)]
+public unsafe class KVarNVAggregateBench
+{
+    private const int Dim = 128;
+    private const int NumTiles = 64;
+
+    private KVarNCompressor _comp = null!;
+    private int _vTileBytes;
+    private byte* _vTiles;
+    private float* _weights;
+    private float* _acc;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _comp = new KVarNCompressor(Dim);
+        _vTileBytes = _comp.ValueTileBytes;
+        _vTiles = (byte*)NativeMemory.AllocZeroed((nuint)((long)NumTiles * _vTileBytes));
+        _weights = (float*)NativeMemory.AllocZeroed((nuint)((long)NumTiles * KVarNCompressor.TileTokens * sizeof(float)));
+        _acc = (float*)NativeMemory.AllocZeroed(Dim * sizeof(float));
+
+        var rng = new Random(43);
+        float[] tileData = new float[KVarNCompressor.TileTokens * Dim];
+        for (int tile = 0; tile < NumTiles; tile++)
+        {
+            for (int i = 0; i < tileData.Length; i++)
+                tileData[i] = (float)(rng.NextDouble() * 2 - 1);
+            _comp.CompressValueTile(tileData, new Span<byte>(_vTiles + (long)tile * _vTileBytes, _vTileBytes));
+        }
+
+        // Softmax-shaped positive weights (all nonzero: worst case for the kernels).
+        int total = NumTiles * KVarNCompressor.TileTokens;
+        double sum = 0;
+        for (int t = 0; t < total; t++)
+        {
+            _weights[t] = MathF.Exp((float)(rng.NextDouble() * 4 - 2));
+            sum += _weights[t];
+        }
+        for (int t = 0; t < total; t++)
+            _weights[t] = (float)(_weights[t] / sum);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        NativeMemory.Free(_vTiles);
+        NativeMemory.Free(_weights);
+        NativeMemory.Free(_acc);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = NumTiles)]
+    public float Scalar()
+    {
+        KVarNCompressor.ForceScalar = true;
+        try
+        {
+            return RunAllTiles();
+        }
+        finally
+        {
+            KVarNCompressor.ForceScalar = false;
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = NumTiles)]
+    public float Avx2() => RunAllTiles();
+
+    private float RunAllTiles()
+    {
+        var acc = new Span<float>(_acc, Dim);
+        acc.Clear();
+        for (int tile = 0; tile < NumTiles; tile++)
+        {
+            _comp.AggregateValues(
+                new ReadOnlySpan<byte>(_vTiles + (long)tile * _vTileBytes, _vTileBytes),
+                new ReadOnlySpan<float>(_weights + (long)tile * KVarNCompressor.TileTokens, KVarNCompressor.TileTokens),
+                acc);
+        }
+        return _acc[0]; // defeat DCE
+    }
+}

--- a/scripts/kvarn-gate/get-wikitext2.ps1
+++ b/scripts/kvarn-gate/get-wikitext2.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+Fetches the wikitext-2-raw-v1 TEST split for the KVarN P0 accuracy gate (issue #180).
+
+.DESCRIPTION
+Corpus choice note (kept here so gate runs are reproducible): the perplexity harness
+(`sharpi-cli perplexity`) is evaluated on the standard wikitext-2-raw test split
+(wiki.test.raw, ~1.2 MB, ~280k tokens under a BPE vocab) — the same corpus
+llama.cpp's perplexity tool is conventionally run on, so numbers are comparable
+across tools and stable across gate re-runs. The corpus itself is NOT committed
+(it is large and third-party); this script downloads the canonical zip from
+Stephen Merity's mirror (CC-BY-SA 3.0, the original wikitext distribution) and
+extracts only wiki.test.raw next to this script. The extracted file and zip are
+gitignored.
+
+Fallback: if the mirror is unreachable, build an eval text from stable repo prose
+instead, e.g.:
+  Get-Content docs/SharpInference-Design.md -Raw | Set-Content scripts/kvarn-gate/wiki.test.raw
+(and say so when reporting numbers — repo prose gives different absolute PPL).
+
+.EXAMPLE
+pwsh scripts/kvarn-gate/get-wikitext2.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$OutDir = $PSScriptRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$zipUrl  = 'https://wikitext.smerity.com/wikitext-2-raw-v1.zip'
+$zipPath = Join-Path $OutDir 'wikitext-2-raw-v1.zip'
+$outFile = Join-Path $OutDir 'wiki.test.raw'
+
+if (Test-Path $outFile) {
+    Write-Host "Already present: $outFile ($([math]::Round((Get-Item $outFile).Length / 1KB)) KB)"
+    return
+}
+
+Write-Host "Downloading $zipUrl ..."
+Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+
+$extractDir = Join-Path $OutDir '.wikitext-extract'
+if (Test-Path $extractDir) { Remove-Item -Recurse -Force $extractDir }
+Expand-Archive -Path $zipPath -DestinationPath $extractDir
+
+$src = Join-Path $extractDir 'wikitext-2-raw/wiki.test.raw'
+if (-not (Test-Path $src)) { throw "wiki.test.raw not found inside the archive (layout changed?)" }
+Copy-Item $src $outFile
+
+Remove-Item -Recurse -Force $extractDir
+Remove-Item -Force $zipPath
+
+Write-Host "Wrote $outFile ($([math]::Round((Get-Item $outFile).Length / 1KB)) KB)"

--- a/scripts/kvarn-gate/math-eval.ps1
+++ b/scripts/kvarn-gate/math-eval.ps1
@@ -1,0 +1,199 @@
+<#
+.SYNOPSIS
+KVarN P0 reasoning micro-eval (issue #180): 20 grade-school math word problems,
+run greedily through sharpi-cli per KV-cache config (fp32 / lloydmax / kvarn),
+scored by the LAST integer in the model output.
+
+.DESCRIPTION
+Each problem is prepended with a fixed ~600-token benign context passage so the
+KV cache grows well past the 256-token FP32 window — the math reasoning then
+happens over a COMPRESSED cache, which is exactly the regime KVarN's 2-bit V
+claim is about. The same prepend is used for all configs, so the only variable
+is the KV-cache quantizer.
+
+Runs are greedy (--temp 0, --repeat-penalty 1.0, --no-thinking) with generation
+capped at -NPredict tokens. Prompts are passed via a temp file (-f) to avoid
+shell quoting issues. Per-problem transcripts and a CSV go to -OutDir (gitignored).
+
+.EXAMPLE
+pwsh scripts/kvarn-gate/math-eval.ps1 -Model C:\models\Qwen3-0.6B-Q8_0.gguf
+pwsh scripts/kvarn-gate/math-eval.ps1 -Configs kvarn -NPredict 256
+#>
+[CmdletBinding()]
+param(
+    [string]$Model = 'C:\models\Qwen3-0.6B-Q8_0.gguf',
+    [ValidateSet('fp32', 'lloydmax', 'kvarn')]
+    [string[]]$Configs = @('fp32', 'lloydmax', 'kvarn'),
+    [string]$CliExe = (Join-Path $PSScriptRoot '..\..\src\SharpInference.Cli\bin\Release\net10.0\sharpi-cli.exe'),
+    [int]$NPredict = 256,
+    [string]$OutDir = (Join-Path $PSScriptRoot 'results')
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path $CliExe)) { throw "CLI not found at $CliExe — build first: dotnet build SharpInference.slnx -c Release" }
+if (-not (Test-Path $Model)) { throw "Model not found: $Model" }
+New-Item -ItemType Directory -Force $OutDir | Out-Null
+
+# ── Fixed ~600-token prepend (benign, irrelevant to the problems). Committed inline
+#    so every gate run uses byte-identical context. ~500 words ≈ 620-680 BPE tokens.
+$prepend = @'
+The following documentation describes the internal architecture of a general-purpose
+inference engine for large language models. The engine reads model files from disk
+using a memory-mapped parser, which means the operating system pages tensor data
+into physical memory only when a computation first touches it. This keeps startup
+fast even for very large models, because nothing is copied eagerly. After parsing,
+the engine builds a graph of the transformer: an embedding table, a stack of
+identical decoder layers, and a final projection back to the vocabulary. Each
+decoder layer contains a self-attention block and a feed-forward block, with
+normalization applied before each. The attention block projects the hidden state
+into query, key, and value vectors, applies a rotary position encoding to the
+queries and keys, and then computes a weighted average of the values, where the
+weights come from the scaled dot product of queries with all previous keys. The
+keys and values for every past position are kept in a cache so they are computed
+only once; during generation, each new token appends exactly one new key and one
+new value per layer. The feed-forward block expands the hidden state to a larger
+intermediate size, applies a gated activation, and projects back down. Weights are
+usually stored in a block-quantized format to save memory, and the compute kernels
+dequantize them on the fly inside the innermost loops. On processors with wide
+vector units, the engine uses hand-written SIMD kernels for the matrix-vector
+products that dominate decoding; on graphics hardware it dispatches compute
+shaders or library-provided matrix multiplies instead. Text enters the engine
+through a tokenizer, which splits the input into subword units drawn from a fixed
+vocabulary learned during training. Each unit maps to an integer identifier, and
+the sequence of identifiers is what the model actually consumes. During
+generation the engine repeatedly runs the forward pass for the most recent token,
+obtains a probability distribution over the vocabulary, and selects the next
+token according to the sampling settings. Greedy selection always takes the most
+probable token; temperature-based sampling flattens or sharpens the distribution
+before drawing from it. Generated identifiers are streamed back through the
+tokenizer's decoder, which reassembles them into readable text, taking care to
+buffer incomplete multi-byte characters until they are whole. A conversation
+layer sits above all of this and formats system, user, and assistant messages
+into the exact prompt layout the model was trained on, including any special
+markers that separate the speakers. When the context grows long, the engine can
+optionally compress the oldest cached keys and values into a smaller
+representation while keeping the most recent window at full precision, trading a
+small amount of fidelity for a large reduction in memory. Careful engineering of
+these caches, kernels, and buffers is what determines whether a model runs
+smoothly on a laptop or requires a server. The remainder of this document, which
+you may disregard, lists benchmark tables and tuning parameters for various
+hardware generations and does not affect the questions that follow.
+'@
+
+# ── 20 problems with unambiguous integer answers.
+$problems = @(
+    @{ Id = 'P01'; Q = 'Sara has 3 boxes of pencils. Each box holds 12 pencils. She gives 7 pencils to her friend. How many pencils does she have left?'; A = 29 },
+    @{ Id = 'P02'; Q = 'A farmer has 15 cows and buys 9 more. Then he sells 4 cows. How many cows does he have now?'; A = 20 },
+    @{ Id = 'P03'; Q = 'Tom reads 14 pages every day. How many pages does he read in one week (7 days)?'; A = 98 },
+    @{ Id = 'P04'; Q = 'A bus has 42 seats and 28 of them are taken. How many seats are empty?'; A = 14 },
+    @{ Id = 'P05'; Q = 'Lily saves 5 dollars each week for 8 weeks, then spends 13 dollars. How many dollars does she have left?'; A = 27 },
+    @{ Id = 'P06'; Q = 'There are 6 baskets with 9 apples in each basket. 11 of the apples are rotten. How many good apples are there?'; A = 43 },
+    @{ Id = 'P07'; Q = 'A classroom has 4 rows of 8 desks. 3 desks are broken. How many desks can be used?'; A = 29 },
+    @{ Id = 'P08'; Q = 'Jake had 50 marbles. He lost 12 and then won 5 more. How many marbles does he have now?'; A = 43 },
+    @{ Id = 'P09'; Q = 'A bakery bakes 120 rolls and sells them in bags of 6. How many bags do they fill?'; A = 20 },
+    @{ Id = 'P10'; Q = 'Mia is 9 years old. Her mother is 4 times as old as Mia. How many years older than Mia is her mother?'; A = 27 },
+    @{ Id = 'P11'; Q = 'A train travels 60 kilometers every hour. How far does it travel in 3 hours?'; A = 180 },
+    @{ Id = 'P12'; Q = 'Anna has 17 candies. Ben has 3 more candies than Anna. How many candies do they have together?'; A = 37 },
+    @{ Id = 'P13'; Q = 'A book has 96 pages. Emma reads 8 pages per day. How many days does she need to finish the book?'; A = 12 },
+    @{ Id = 'P14'; Q = 'There are 25 students in a class and each student needs 4 sheets of paper. How many sheets are needed in total?'; A = 100 },
+    @{ Id = 'P15'; Q = 'Pens cost 2 dollars each. Dan buys 7 pens and pays with a 20 dollar bill. How much change does he get?'; A = 6 },
+    @{ Id = 'P16'; Q = 'There are 18 birds in a tree. 7 fly away and then 5 new birds arrive. How many birds are in the tree now?'; A = 16 },
+    @{ Id = 'P17'; Q = 'Each pizza is cut into 8 slices. There are 3 pizzas and 5 slices get eaten. How many slices are left?'; A = 19 },
+    @{ Id = 'P18'; Q = 'Kate walks 2 kilometers to school and 2 kilometers back home each day. How many kilometers does she walk in 5 school days?'; A = 20 },
+    @{ Id = 'P19'; Q = 'A box holds 24 eggs. There are 5 full boxes and 9 eggs break. How many unbroken eggs are there?'; A = 111 },
+    @{ Id = 'P20'; Q = 'Sam has 4 packs of stickers with 10 stickers in each pack. He gives away half of all his stickers. How many stickers does he keep?'; A = 20 }
+)
+
+# Lines the CLI prints around the model output (status/perf); dropped before answer parsing
+# so numbers like "Decode: 47 tokens, 18.3 t/s" can never be mistaken for the answer.
+$noisePattern = '^(Loading model:|Backend:|TurboQuant:|Hardware:|Prefill: \d+ tokens,|Warning:|Note:|Gemma 4 defaults|\[ForwardPass\]|\[SharpInference\]|Model loaded in )'
+
+function Get-LastInteger([string[]]$lines) {
+    $text = ($lines | Where-Object { $_ -notmatch $noisePattern }) -join "`n"
+    $m = [regex]::Matches($text, '-?\d[\d,]*')
+    if ($m.Count -eq 0) { return $null }
+    return [long]($m[$m.Count - 1].Value -replace ',', '')
+}
+
+$allResults = @()
+$grandSw = [System.Diagnostics.Stopwatch]::StartNew()
+
+foreach ($config in $Configs) {
+    # @() wrap is load-bearing: switch unwraps a single-element array result to a
+    # scalar string, and splatting a scalar '--tq' to a native exe mangles the arg.
+    $tqArgs = @(switch ($config) {
+        'fp32'     { @() }
+        'lloydmax' { @('--tq') }
+        'kvarn'    { @('--tq', '--tq-mode', 'kvarn') }
+    })
+
+    $transcript = Join-Path $OutDir "math-eval-$config.txt"
+    "# math-eval config=$config model=$Model n-predict=$NPredict $(Get-Date -Format o)" | Set-Content $transcript
+
+    $correct = 0
+    $configSw = [System.Diagnostics.Stopwatch]::StartNew()
+    Write-Host "`n=== config: $config ===" -ForegroundColor Cyan
+
+    foreach ($p in $problems) {
+        $prompt = @"
+$prepend
+
+Ignore the documentation above; it is context filler. Solve this problem:
+$($p.Q)
+Think step by step briefly, then end your reply with the final answer as a plain integer on the last line.
+"@
+        $promptFile = Join-Path $OutDir 'prompt.tmp.txt'
+        Set-Content -Path $promptFile -Value $prompt -Encoding utf8 -NoNewline
+
+        $cliArgs = @('-m', $Model, '-f', $promptFile, '-g', '0',
+            '--temp', '0', '--repeat-penalty', '1.0', '--top-k', '0', '-n', "$NPredict",
+            '--no-thinking', '--no-display-prompt') + $tqArgs
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $output = & $CliExe @cliArgs 2>&1 | ForEach-Object { "$_" }
+        $sw.Stop()
+
+        $decodeLine = ($output | Where-Object { $_ -match 'Decode: (\d+) tokens' } | Select-Object -Last 1)
+        $decoded = if ($decodeLine -match 'Decode: (\d+) tokens') { [int]$Matches[1] } else { -1 }
+        # A failed invocation must abort the gate, not be scored as a model FAIL:
+        # error text often contains an integer, which last-integer parsing would
+        # happily read as an answer (this bit the first lloydmax run).
+        if ($LASTEXITCODE -ne 0 -or $decoded -lt 0) {
+            Add-Content $transcript "`n--- $($p.Id) INVALID: exit=$LASTEXITCODE decoded=$decoded ---"
+            Add-Content $transcript ($output -join "`n")
+            throw "CLI invocation invalid for $($p.Id) config=$config (exit=$LASTEXITCODE, no decode line); see $transcript"
+        }
+
+        $got = Get-LastInteger $output
+        $pass = ($null -ne $got) -and ($got -eq $p.A)
+        if ($pass) { $correct++ }
+        $hitCap = $decoded -ge $NPredict
+
+        $gotStr = if ($null -eq $got) { 'none' } else { "$got" }
+        $flag = if ($pass) { 'PASS' } else { 'FAIL' }
+        $capNote = if ($hitCap) { ' [hit-cap]' } else { '' }
+        Write-Host ("{0} expect={1,4} got={2,6} {3}{4} ({5:F1}s, {6} tok)" -f $p.Id, $p.A, $gotStr, $flag, $capNote, $sw.Elapsed.TotalSeconds, $decoded)
+
+        Add-Content $transcript "`n--- $($p.Id) expect=$($p.A) got=$gotStr $flag$capNote elapsed=$([math]::Round($sw.Elapsed.TotalSeconds,1))s ---"
+        Add-Content $transcript ($output -join "`n")
+
+        $allResults += [pscustomobject]@{
+            Config = $config; Problem = $p.Id; Expected = $p.A; Got = $gotStr
+            Pass = $pass; HitCap = $hitCap; Seconds = [math]::Round($sw.Elapsed.TotalSeconds, 1); DecodedTokens = $decoded
+        }
+    }
+
+    $configSw.Stop()
+    Write-Host ("config {0}: {1}/{2} correct  ({3:F1} min)" -f $config, $correct, $problems.Count, $configSw.Elapsed.TotalMinutes) -ForegroundColor Green
+}
+
+$csv = Join-Path $OutDir 'math-eval-results.csv'
+$allResults | Export-Csv -Path $csv -NoTypeInformation
+Write-Host "`nPer-problem results: $csv"
+Write-Host ("Total wall-clock: {0:F1} min" -f $grandSw.Elapsed.TotalMinutes)
+
+Write-Host "`nSummary:"
+$allResults | Group-Object Config | ForEach-Object {
+    $n = ($_.Group | Where-Object Pass).Count
+    Write-Host ("  {0,-9} {1,2}/{2}" -f $_.Name, $n, $_.Group.Count)
+}

--- a/src/SharpInference.Cli/PerplexityCommand.cs
+++ b/src/SharpInference.Cli/PerplexityCommand.cs
@@ -4,6 +4,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using SharpInference.Core;
 using SharpInference.Cpu;
+using SharpInference.Cuda;
 using SharpInference.Engine;
 
 namespace SharpInference.Cli;
@@ -62,7 +63,7 @@ public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
         public int TqWindow { get; init; }
 
         [CommandOption("--ngl|--n-gpu-layers|--gpu-layers|-g")]
-        [Description("Layers on GPU. Must be 0: the perplexity harness runs the CPU forward pass only (issue #180 P0).")]
+        [Description("Layers on GPU: 0 (default, CPU forward pass) or -1 (full CUDA offload via CudaForwardPass — issue #180 Task 5a). Partial offload is not supported.")]
         [DefaultValue(0)]
         public int NGpuLayers { get; init; }
     }
@@ -70,9 +71,11 @@ public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
     /// <summary>
     /// Validates the flag combination (no model needed) and resolves the quantizer.
     /// Mirrors the run command's --tq/--tq-mode rules: kvarn requires --tq, and the
-    /// whole harness is CPU-only so any -g != 0 is rejected outright. The window
-    /// floor is one compressed tile (128 for KVarN, 32 for Lloyd-Max FastScan) so
-    /// the cache constructor can't throw later with a less actionable message.
+    /// harness runs either the CPU forward pass (-g 0) or the full-CUDA-offload
+    /// CudaForwardPass (-g -1, issue #180 Task 5a) — any other -g is rejected
+    /// outright. The window floor is one compressed tile (128 for KVarN, 32 for
+    /// Lloyd-Max FastScan) so the cache constructor can't throw later with a less
+    /// actionable message.
     /// </summary>
     internal static bool TryValidateFlags(bool tq, string tqModeStr, int tqWindow, int nGpuLayers,
         out TqQuantizer quantizer, out string? error)
@@ -96,9 +99,9 @@ public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
             error = "--tq-mode kvarn requires --tq.";
             return false;
         }
-        if (nGpuLayers != 0)
+        if (nGpuLayers is not (0 or -1))
         {
-            error = "the perplexity harness runs the CPU forward pass only (issue #180 P0); use -g 0.";
+            error = "the perplexity harness runs either the CPU forward pass (-g 0) or full CUDA offload (-g -1); partial offload is not supported.";
             return false;
         }
         int minWindow = quantizer == TqQuantizer.KVarN ? 128 : 32;
@@ -193,7 +196,8 @@ public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
         var tokenizer = GgufTokenizer.FromGgufModel(model);
 
         // Same head-dim compatibility rules as the run command (issue #180): Lloyd-Max
-        // ships hardcoded codebooks for 128/256; KVarN accepts any power-of-2 in [8, 1024].
+        // ships hardcoded codebooks for 128/256; KVarN accepts any power-of-2 in
+        // [8, 1024] on CPU, [8, 256] on CUDA (the shared-memory WHT cap).
         if (settings.TurboQuant)
         {
             int headDim = hp.HeadDim;
@@ -204,12 +208,22 @@ public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
                     AnsiConsole.MarkupLine($"[red]Error:[/] --tq-mode kvarn requires a power-of-2 head dimension in [[8, 1024]]; this model has head dim {headDim}.");
                     return 1;
                 }
+                if (settings.NGpuLayers == -1 && headDim > 256)
+                {
+                    AnsiConsole.MarkupLine($"[red]Error:[/] --tq-mode kvarn on CUDA requires head dim ≤ 256 (shared-memory WHT cap); this model has head dim {headDim}. Use [yellow]-g 0[/].");
+                    return 1;
+                }
             }
             else if (headDim is not 128 and not 256)
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] TurboQuant requires head dimension 128 or 256; this model has head dim {headDim}.");
                 return 1;
             }
+        }
+        if (settings.NGpuLayers == -1 && settings.TurboQuant && quantizer == TqQuantizer.KVarN && hp.IsMoE)
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn on CUDA supports dense models only (issue #180 Task 5a); use [yellow]-g 0[/] for MoE.");
+            return 1;
         }
 
         // Raw-text tokenization (no chat template), like llama.cpp perplexity. BOS is
@@ -240,16 +254,59 @@ public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
             : quantizer == TqQuantizer.KVarN ? $"tq-kvarn-k4v2 (window={settings.TqWindow})"
             : $"tq-lloydmax-3bit (window={settings.TqWindow})";
 
-        using var cpuBackend = new CpuBackend();
-        using var fwd = new ForwardPass(model, cpuBackend, hp, maxContextLength: ctx);
-        if (settings.TurboQuant)
-        {
-            fwd.EnableTurboQuant(fp32WindowSize: settings.TqWindow, bits: 3, quantizer: quantizer);
-            if (settings.TqWindow >= n)
-                AnsiConsole.MarkupLine($"[yellow]Note:[/] --tq-window {settings.TqWindow} >= evaluated tokens ({n}); the cache never compresses, so this measures the FP32 path.");
-        }
+        if (settings.TurboQuant && settings.TqWindow >= n)
+            AnsiConsole.MarkupLine($"[yellow]Note:[/] --tq-window {settings.TqWindow} >= evaluated tokens ({n}); the cache never compresses, so this measures the FP32 path.");
 
-        AnsiConsole.MarkupLine($"[dim]Backend: [blue]CPU[/] | config: {Markup.Escape(config)} | evaluating {n} tokens[/]");
+        // Build the forward pass: CPU ForwardPass (-g 0) or the full-CUDA-offload
+        // CudaForwardPass (-g -1, issue #180 Task 5a). Both feed the same
+        // teacher-forced token-by-token Forward loop below, so with --tq every
+        // step exercises the compressed-read attention path exactly like decode.
+        CpuBackend? cpuBackend = null;
+        CudaBackend? cudaBackend = null;
+        IForwardPass fwd;
+        string backendLabel;
+        if (settings.NGpuLayers == -1)
+        {
+            if (!CudaBackend.IsAvailable())
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] -g -1 requires a CUDA device; none is available. Use [yellow]-g 0[/] for the CPU path.");
+                return 1;
+            }
+            if (hp.IsHybridSsm)
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] -g -1 perplexity uses CudaForwardPass, which does not cover hybrid GDN models; use [yellow]-g 0[/].");
+                return 1;
+            }
+            cudaBackend = CudaBackend.Create();
+            try
+            {
+                fwd = new CudaForwardPass(model, cudaBackend, hp, maxContextLength: ctx,
+                    enableTurboQuant: settings.TurboQuant, tqFp32Window: settings.TqWindow,
+                    tqQuantizer: quantizer);
+            }
+            catch
+            {
+                cudaBackend.Dispose();
+                throw;
+            }
+            backendLabel = $"[green]CUDA[/] ({cudaBackend.Name}, all {hp.NumLayers} layers)";
+        }
+        else
+        {
+            cpuBackend = new CpuBackend();
+            var cpuFwd = new ForwardPass(model, cpuBackend, hp, maxContextLength: ctx);
+            if (settings.TurboQuant)
+                cpuFwd.EnableTurboQuant(fp32WindowSize: settings.TqWindow, bits: 3, quantizer: quantizer);
+            fwd = cpuFwd;
+            backendLabel = "[blue]CPU[/]";
+        }
+        // Declared backend-first so `using` disposal (reverse order) tears down the
+        // forward pass before its backend.
+        using var _cpuDispose = cpuBackend;
+        using var _cudaDispose = cudaBackend;
+        using var _fwdDispose = (IDisposable)fwd;
+
+        AnsiConsole.MarkupLine($"[dim]Backend: {backendLabel} | config: {Markup.Escape(config)} | evaluating {n} tokens[/]");
 
         // Position buckets over the *target* position: [1, edge0) is context that always
         // fits the FP32 window, [edge0, edge1) early compressed region, [edge1, +) deep.

--- a/src/SharpInference.Cli/PerplexityCommand.cs
+++ b/src/SharpInference.Cli/PerplexityCommand.cs
@@ -1,0 +1,317 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Engine;
+
+namespace SharpInference.Cli;
+
+/// <summary>
+/// Teacher-forced perplexity evaluation over a text file — the llama.cpp
+/// <c>llama-perplexity</c> analogue and the KVarN P0 accuracy gate
+/// (issue #180, docs/kvarn-feasibility-research.md §6).
+///
+/// Method: tokenize the file (raw text path, BOS prepended when the model's
+/// <c>add_bos_token</c> asks for it), take the first <c>-c</c> tokens, and feed
+/// them one at a time through the CPU <see cref="ForwardPass"/> —
+/// <b>token-by-token <see cref="ForwardPass.Forward"/>, not batched Prefill</b>,
+/// so with <c>--tq</c> every step exercises the TurboQuant/KVarN compressed-read
+/// attention path exactly like decode does. After feeding token t we accumulate
+/// the negative log-likelihood of token t+1 under the full-vocab log-softmax
+/// (natural log, double accumulation). The first position is never scored.
+///
+/// Reported: token count, mean NLL, perplexity = exp(mean NLL), and mean NLL
+/// split by target-position buckets ([1, window) / [window, 1024) / [1024, +))
+/// so degradation in the compressed region is visible separately from the
+/// always-FP32 recent window.
+///
+/// Usage: sharpi-cli perplexity -m model.gguf -f corpus.txt -c 2048 [--tq [--tq-mode kvarn]]
+/// </summary>
+public sealed class PerplexityCommand : Command<PerplexityCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandOption("-m|--model")]
+        [Description("Path to GGUF model file")]
+        public string? ModelPath { get; init; }
+
+        [CommandOption("-f|--file")]
+        [Description("UTF-8 text file to evaluate (llama.cpp -f/--file). Tokenized raw (no chat template); the first -c tokens are scored.")]
+        public string? TextFile { get; init; }
+
+        [CommandOption("-c|--ctx-size")]
+        [Description("Number of tokens to evaluate (default: 2048). Clamped to the model context length and the corpus length.")]
+        [DefaultValue(2048)]
+        public int CtxSize { get; init; }
+
+        [CommandOption("--tq")]
+        [Description("Enable TurboQuant KV cache compression (same flag as the run command)")]
+        [DefaultValue(false)]
+        public bool TurboQuant { get; init; }
+
+        [CommandOption("--tq-mode")]
+        [Description("TurboQuant quantizer for --tq: lloydmax (default; 3-bit Lloyd-Max codebooks) or kvarn (issue #180: 4-bit K / 2-bit V, 128-token tiles; CPU only).")]
+        [DefaultValue("lloydmax")]
+        public string TqModeStr { get; init; } = "lloydmax";
+
+        [CommandOption("--tq-window")]
+        [Description("FP32 recent-token window before compression kicks in (default: 256; min 128 for kvarn — one full tile). Also sets the first position-bucket edge of the report, so pass the same value to the fp32 baseline for bucket-comparable numbers.")]
+        [DefaultValue(256)]
+        public int TqWindow { get; init; }
+
+        [CommandOption("--ngl|--n-gpu-layers|--gpu-layers|-g")]
+        [Description("Layers on GPU. Must be 0: the perplexity harness runs the CPU forward pass only (issue #180 P0).")]
+        [DefaultValue(0)]
+        public int NGpuLayers { get; init; }
+    }
+
+    /// <summary>
+    /// Validates the flag combination (no model needed) and resolves the quantizer.
+    /// Mirrors the run command's --tq/--tq-mode rules: kvarn requires --tq, and the
+    /// whole harness is CPU-only so any -g != 0 is rejected outright. The window
+    /// floor is one compressed tile (128 for KVarN, 32 for Lloyd-Max FastScan) so
+    /// the cache constructor can't throw later with a less actionable message.
+    /// </summary>
+    internal static bool TryValidateFlags(bool tq, string tqModeStr, int tqWindow, int nGpuLayers,
+        out TqQuantizer quantizer, out string? error)
+    {
+        quantizer = TqQuantizer.LloydMax;
+        switch (tqModeStr.Trim().ToLowerInvariant())
+        {
+            case "" or "lloydmax" or "lloyd-max":
+                quantizer = TqQuantizer.LloydMax;
+                break;
+            case "kvarn":
+                quantizer = TqQuantizer.KVarN;
+                break;
+            default:
+                error = $"Unknown --tq-mode value '{tqModeStr}'. Expected one of: lloydmax, kvarn.";
+                return false;
+        }
+
+        if (quantizer == TqQuantizer.KVarN && !tq)
+        {
+            error = "--tq-mode kvarn requires --tq.";
+            return false;
+        }
+        if (nGpuLayers != 0)
+        {
+            error = "the perplexity harness runs the CPU forward pass only (issue #180 P0); use -g 0.";
+            return false;
+        }
+        int minWindow = quantizer == TqQuantizer.KVarN ? 128 : 32;
+        if (tq && tqWindow < minWindow)
+        {
+            error = $"--tq-window must be >= {minWindow} for --tq-mode {(quantizer == TqQuantizer.KVarN ? "kvarn (one full 128-token tile)" : "lloydmax (one FastScan tile)")}; got {tqWindow}.";
+            return false;
+        }
+        if (tqWindow < 1)
+        {
+            error = $"--tq-window must be >= 1; got {tqWindow}.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>
+    /// NLL of <paramref name="target"/> under the full-vocab log-softmax of
+    /// <paramref name="logits"/>, in nats. Two passes (max, then sum-exp) with
+    /// double accumulation; returns a non-finite value if the logits contain
+    /// NaN/Inf so the caller can count anomalies instead of silently averaging them.
+    /// </summary>
+    internal static double NegativeLogLikelihood(ReadOnlySpan<float> logits, int target)
+    {
+        if ((uint)target >= (uint)logits.Length) return double.NaN;
+
+        double max = double.NegativeInfinity;
+        for (int i = 0; i < logits.Length; i++)
+            if (logits[i] > max) max = logits[i];   // NaN never compares greater — caught below
+
+        double sumExp = 0.0;
+        for (int i = 0; i < logits.Length; i++)
+            sumExp += Math.Exp(logits[i] - max);
+
+        // log-softmax: logit[target] - max - log(sum exp(logit - max))
+        return -(logits[target] - max - Math.Log(sumExp));
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        if (!TryValidateFlags(settings.TurboQuant, settings.TqModeStr, settings.TqWindow,
+                settings.NGpuLayers, out TqQuantizer quantizer, out string? flagError))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(flagError!)}");
+            return 1;
+        }
+        if (settings.TurboQuant && quantizer == TqQuantizer.KVarN && SnapKvConfig.FromEnvironment().Enabled)
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn does not compose with SnapKV eviction yet (issue #180 follow-up); unset [yellow]SHARPI_SNAPKV_BUDGET[/].");
+            return 1;
+        }
+
+        if (settings.TextFile is not { Length: > 0 } textFile)
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] No text file given. Use [yellow]-f <corpus.txt>[/]");
+            return 1;
+        }
+        if (!File.Exists(textFile))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] text file not found: {Markup.Escape(textFile)}");
+            return 1;
+        }
+        string text;
+        try
+        {
+            text = File.ReadAllText(textFile);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                      or System.Security.SecurityException or NotSupportedException)
+        {
+            AnsiConsole.MarkupLine($"[red]Error reading text file:[/] {Markup.Escape(ex.Message)}");
+            return 1;
+        }
+
+        var modelPath = settings.ModelPath;
+        if (modelPath is null || !File.Exists(modelPath))
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] No model file found. Use [yellow]-m <path>[/]");
+            return 1;
+        }
+        if (settings.CtxSize < 2)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] -c must be >= 2 (need at least one prediction); got {settings.CtxSize}.");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine($"[dim]Loading model:[/] {Markup.Escape(modelPath)}");
+        using var model = GgufModel.Open(modelPath);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var tokenizer = GgufTokenizer.FromGgufModel(model);
+
+        // Same head-dim compatibility rules as the run command (issue #180): Lloyd-Max
+        // ships hardcoded codebooks for 128/256; KVarN accepts any power-of-2 in [8, 1024].
+        if (settings.TurboQuant)
+        {
+            int headDim = hp.HeadDim;
+            if (quantizer == TqQuantizer.KVarN)
+            {
+                if ((headDim & (headDim - 1)) != 0 || headDim is < 8 or > 1024)
+                {
+                    AnsiConsole.MarkupLine($"[red]Error:[/] --tq-mode kvarn requires a power-of-2 head dimension in [[8, 1024]]; this model has head dim {headDim}.");
+                    return 1;
+                }
+            }
+            else if (headDim is not 128 and not 256)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] TurboQuant requires head dimension 128 or 256; this model has head dim {headDim}.");
+                return 1;
+            }
+        }
+
+        // Raw-text tokenization (no chat template), like llama.cpp perplexity. BOS is
+        // prepended for models whose metadata asks for it (add_bos_token=true), mirroring
+        // the run command's SHARPI_RAW_PROMPT path.
+        var tokens = tokenizer.Encode(text);
+        if (tokenizer.AddBosToken && tokenizer.BosTokenId >= 0
+            && (tokens.Count == 0 || tokens[0] != tokenizer.BosTokenId))
+        {
+            var withBos = new List<int>(tokens.Count + 1) { tokenizer.BosTokenId };
+            withBos.AddRange(tokens);
+            tokens = withBos;
+        }
+
+        int ctx = Math.Min(settings.CtxSize, hp.ContextLength);
+        if (ctx < settings.CtxSize)
+            AnsiConsole.MarkupLine($"[yellow]Note:[/] -c {settings.CtxSize} clamped to the model context length ({hp.ContextLength}).");
+        int n = Math.Min(tokens.Count, ctx);
+        if (n < 2)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] corpus tokenized to {tokens.Count} token(s); need at least 2.");
+            return 1;
+        }
+        if (tokens.Count < ctx)
+            AnsiConsole.MarkupLine($"[yellow]Note:[/] corpus has only {tokens.Count} tokens (< -c {ctx}); evaluating all of them.");
+
+        string config = !settings.TurboQuant ? "fp32"
+            : quantizer == TqQuantizer.KVarN ? $"tq-kvarn-k4v2 (window={settings.TqWindow})"
+            : $"tq-lloydmax-3bit (window={settings.TqWindow})";
+
+        using var cpuBackend = new CpuBackend();
+        using var fwd = new ForwardPass(model, cpuBackend, hp, maxContextLength: ctx);
+        if (settings.TurboQuant)
+        {
+            fwd.EnableTurboQuant(fp32WindowSize: settings.TqWindow, bits: 3, quantizer: quantizer);
+            if (settings.TqWindow >= n)
+                AnsiConsole.MarkupLine($"[yellow]Note:[/] --tq-window {settings.TqWindow} >= evaluated tokens ({n}); the cache never compresses, so this measures the FP32 path.");
+        }
+
+        AnsiConsole.MarkupLine($"[dim]Backend: [blue]CPU[/] | config: {Markup.Escape(config)} | evaluating {n} tokens[/]");
+
+        // Position buckets over the *target* position: [1, edge0) is context that always
+        // fits the FP32 window, [edge0, edge1) early compressed region, [edge1, +) deep.
+        int edge0 = settings.TqWindow;
+        int edge1 = Math.Max(1024, 2 * edge0);
+        Span<double> bucketNll = stackalloc double[3];
+        Span<int> bucketCount = stackalloc int[3];
+        double totalNll = 0.0;
+        int scored = 0, nonFinite = 0;
+
+        var sw = Stopwatch.StartNew();
+        for (int pos = 0; pos < n - 1; pos++)
+        {
+            cancellation.ThrowIfCancellationRequested();
+            var logits = fwd.Forward(tokens[pos], pos);
+            int targetPos = pos + 1;
+            double nll = NegativeLogLikelihood(logits, tokens[targetPos]);
+            if (!double.IsFinite(nll))
+            {
+                nonFinite++;
+            }
+            else
+            {
+                int b = targetPos < edge0 ? 0 : targetPos < edge1 ? 1 : 2;
+                bucketNll[b] += nll;
+                bucketCount[b]++;
+                totalNll += nll;
+                scored++;
+            }
+
+            if (targetPos % 256 == 0 && scored > 0)
+            {
+                double tps = targetPos / sw.Elapsed.TotalSeconds;
+                AnsiConsole.MarkupLine($"[dim]  pos {targetPos}/{n - 1}  running ppl {Math.Exp(totalNll / scored):F4}  ({tps:F1} tok/s)[/]");
+            }
+        }
+        double elapsedS = sw.Elapsed.TotalSeconds;
+
+        if (scored == 0)
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] no positions produced finite NLL — the forward pass emitted NaN/Inf logits throughout.");
+            return 1;
+        }
+
+        double meanNll = totalNll / scored;
+        Console.WriteLine();
+        Console.WriteLine($"perplexity: model={Path.GetFileName(modelPath)} file={Path.GetFileName(textFile)} config={config}");
+        Console.WriteLine($"tokens scored: {scored} (targets at positions 1..{n - 1}; first position skipped)");
+        Console.WriteLine($"mean NLL: {meanNll:F6}   perplexity: {Math.Exp(meanNll):F4}");
+        WriteBucket($"[1,{edge0})", bucketNll[0], bucketCount[0]);
+        WriteBucket($"[{edge0},{edge1})", bucketNll[1], bucketCount[1]);
+        WriteBucket($"[{edge1},+)", bucketNll[2], bucketCount[2]);
+        if (nonFinite > 0)
+            AnsiConsole.MarkupLine($"[red]non-finite NLL steps (excluded from the mean): {nonFinite}[/]");
+        Console.WriteLine($"elapsed: {elapsedS:F1}s ({(n - 1) / elapsedS:F2} tok/s)");
+        return 0;
+
+        static void WriteBucket(string range, double nllSum, int count)
+        {
+            Console.WriteLine(count == 0
+                ? $"bucket {range}: count=0"
+                : $"bucket {range}: count={count}  mean NLL={nllSum / count:F6}  ppl={Math.Exp(nllSum / count):F4}");
+        }
+    }
+}

--- a/src/SharpInference.Cli/Program.cs
+++ b/src/SharpInference.Cli/Program.cs
@@ -17,6 +17,8 @@ app.Configure(config =>
         .WithDescription("Print all GGUF metadata key/value pairs from a model file");
     config.AddCommand<ListTensorsCommand>("list-tensors")
         .WithDescription("Print the tensor index (name, dtype, shape, bytes) from a model file");
+    config.AddCommand<PerplexityCommand>("perplexity")
+        .WithDescription("Teacher-forced perplexity over a text file (llama.cpp llama-perplexity analogue; CPU only). Reports mean NLL, perplexity, and position-bucket NLLs — the TurboQuant/KVarN accuracy gate (issue #180).");
     config.AddCommand<ImageCommand>("image")
         .WithDescription("Generate an image from a text prompt using a native FLUX or Z-Image-Turbo diffusion pipeline (VAE + CLIP-L + T5-XXL + DiT GGUF). See 'sharpi-cli image --help' for required model paths.");
 });

--- a/src/SharpInference.Cli/README.md
+++ b/src/SharpInference.Cli/README.md
@@ -49,6 +49,7 @@ Flag names are intentionally compatible with `llama.cpp` / `llama-cli`.
 | `-g, --n-gpu-layers` | `0` | Layers on GPU (`0` = CPU only, `-1` = all) |
 | `-c, --ctx-size` | model default | Context / max sequence length |
 | `--tq` | off | TurboQuant KV cache compression (3-bit, ~5× VRAM reduction) |
+| `--tq-mode` | `lloydmax` | TurboQuant quantizer: `lloydmax` (3-bit codebooks) or `kvarn` (4-bit K / 2-bit V Sinkhorn RTN, 128-token tiles; CPU only, no SnapKV) |
 
 Run `sharpi-cli --help` for the full reference.
 

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -111,6 +111,13 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [DefaultValue(false)]
         public bool TurboQuant { get; init; }
 
+        [CommandOption("--tq-mode")]
+        [Description("TurboQuant quantizer for --tq: lloydmax (default; 3-bit Lloyd-Max codebooks) or kvarn " +
+            "(issue #180: Sinkhorn-normalized asymmetric RTN, 4-bit K / 2-bit V, 128-token tiles; " +
+            "CPU only (-g 0), any power-of-2 head dim, no SnapKV).")]
+        [DefaultValue("lloydmax")]
+        public string TqModeStr { get; init; } = "lloydmax";
+
         [CommandOption("--kv-type")]
         [Description("KV-cache element type for the CUDA backend: fp32 (default), bf16 (half the KV VRAM → ~2x context), or q8_0 (quarter → ~4x). Like llama.cpp --cache-type-k/v. Env: SHARPI_KV_DTYPE.")]
         public string? KvType { get; init; }
@@ -601,11 +608,57 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         Func<IReadOnlyList<int>, ReadOnlySpan<float>> prefill;
         Action resetCache;
 
-        // Validate TurboQuant head-dimension compatibility before any GPU allocation
+        // Resolve the TurboQuant quantizer (issue #180). KVarN is the CPU-only P0
+        // prototype: reject GPU offload and SnapKV up-front with actionable errors
+        // (ForwardPass.EnableTurboQuant re-checks the SnapKV combo as the config-time
+        // guard of last resort).
+        TqQuantizer tqQuantizer;
+        switch (settings.TqModeStr.Trim().ToLowerInvariant())
+        {
+            case "" or "lloydmax" or "lloyd-max":
+                tqQuantizer = TqQuantizer.LloydMax;
+                break;
+            case "kvarn":
+                tqQuantizer = TqQuantizer.KVarN;
+                break;
+            default:
+                AnsiConsole.MarkupLine($"[red]Error:[/] Unknown --tq-mode value '{Markup.Escape(settings.TqModeStr)}'. Expected one of: lloydmax, kvarn.");
+                return 1;
+        }
+        if (tqQuantizer == TqQuantizer.KVarN)
+        {
+            if (!settings.TurboQuant)
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn requires [yellow]--tq[/].");
+                return 1;
+            }
+            if (effNGpuLayers != 0)
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn runs on the CPU forward pass only (issue #180 P0); use [yellow]-g 0[/].");
+                return 1;
+            }
+            if (SnapKvConfig.FromEnvironment().Enabled)
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn does not compose with SnapKV eviction yet (issue #180 follow-up); unset [yellow]SHARPI_SNAPKV_BUDGET[/].");
+                return 1;
+            }
+        }
+
+        // Validate TurboQuant head-dimension compatibility before any GPU allocation.
+        // Lloyd-Max ships hardcoded codebooks for 128/256; KVarN is calibration-free
+        // and accepts any power-of-2 head dim in [8, 1024].
         if (settings.TurboQuant)
         {
             int headDim = hp.HeadDim;
-            if (headDim is not 128 and not 256)
+            if (tqQuantizer == TqQuantizer.KVarN)
+            {
+                if ((headDim & (headDim - 1)) != 0 || headDim is < 8 or > 1024)
+                {
+                    AnsiConsole.MarkupLine($"[red]Error:[/] --tq-mode kvarn requires a power-of-2 head dimension in [[8, 1024]]; this model has head dim {headDim}.");
+                    return 1;
+                }
+            }
+            else if (headDim is not 128 and not 256)
             {
                 AnsiConsole.MarkupLine($"[red]Error:[/] TurboQuant requires head dimension 128 or 256; this model has head dim {headDim}. Remove [yellow]--tq[/] to run without KV compression.");
                 return 1;
@@ -672,8 +725,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
             {
                 if (settings.TurboQuant)
                 {
-                    fwd!.EnableTurboQuant(fp32WindowSize: 256, bits: 3);
-                    AnsiConsole.MarkupLine("[dim]TurboQuant: [green]enabled[/] (3-bit, window=256)[/]");
+                    fwd!.EnableTurboQuant(fp32WindowSize: 256, bits: 3, quantizer: tqQuantizer);
+                    AnsiConsole.MarkupLine(tqQuantizer == TqQuantizer.KVarN
+                        ? "[dim]TurboQuant: [green]enabled[/] (KVarN K4V2, window=256)[/]"
+                        : "[dim]TurboQuant: [green]enabled[/] (3-bit, window=256)[/]");
                 }
                 forward = fwd!.Forward;
                 prefill = tokens => fwd.Prefill(tokens);

--- a/src/SharpInference.Cli/RunCommand.cs
+++ b/src/SharpInference.Cli/RunCommand.cs
@@ -114,7 +114,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         [CommandOption("--tq-mode")]
         [Description("TurboQuant quantizer for --tq: lloydmax (default; 3-bit Lloyd-Max codebooks) or kvarn " +
             "(issue #180: Sinkhorn-normalized asymmetric RTN, 4-bit K / 2-bit V, 128-token tiles; " +
-            "CPU only (-g 0), any power-of-2 head dim, no SnapKV).")]
+            "CPU (-g 0, any power-of-2 head dim ≤ 1024) or full-CUDA-offload dense (-g -1, head dim ≤ 256); no SnapKV).")]
         [DefaultValue("lloydmax")]
         public string TqModeStr { get; init; } = "lloydmax";
 
@@ -608,10 +608,11 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         Func<IReadOnlyList<int>, ReadOnlySpan<float>> prefill;
         Action resetCache;
 
-        // Resolve the TurboQuant quantizer (issue #180). KVarN is the CPU-only P0
-        // prototype: reject GPU offload and SnapKV up-front with actionable errors
-        // (ForwardPass.EnableTurboQuant re-checks the SnapKV combo as the config-time
-        // guard of last resort).
+        // Resolve the TurboQuant quantizer (issue #180). KVarN runs on the CPU forward
+        // pass (-g 0, P0) or on the full-CUDA-offload dense path (-g -1 / -g NumLayers,
+        // Task 5a); SnapKV, Vulkan, partial offload, and MoE-on-GPU are rejected
+        // up-front with actionable errors (ForwardPass.EnableTurboQuant and the
+        // CudaForwardPass constructor re-check as guards of last resort).
         TqQuantizer tqQuantizer;
         switch (settings.TqModeStr.Trim().ToLowerInvariant())
         {
@@ -632,21 +633,37 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn requires [yellow]--tq[/].");
                 return 1;
             }
-            if (effNGpuLayers != 0)
-            {
-                AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn runs on the CPU forward pass only (issue #180 P0); use [yellow]-g 0[/].");
-                return 1;
-            }
             if (SnapKvConfig.FromEnvironment().Enabled)
             {
                 AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn does not compose with SnapKV eviction yet (issue #180 follow-up); unset [yellow]SHARPI_SNAPKV_BUDGET[/].");
                 return 1;
             }
+            if (effNGpuLayers != 0)
+            {
+                // GPU KVarN is the CUDA full-offload dense path only (issue #180 Task 5a).
+                string kvarnBackend = (settings.Backend ?? "auto").Trim().ToLowerInvariant();
+                if (kvarnBackend == "vulkan")
+                {
+                    AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn is not supported on the Vulkan backend; use [yellow]--backend cuda -g -1[/] (full offload) or [yellow]-g 0[/] (CPU).");
+                    return 1;
+                }
+                if (!CudaBackend.IsAvailable())
+                {
+                    AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn with GPU offload requires a CUDA device (issue #180 Task 5a); use [yellow]-g 0[/] for the CPU path.");
+                    return 1;
+                }
+                if (hp.IsMoE)
+                {
+                    AnsiConsole.MarkupLine("[red]Error:[/] --tq-mode kvarn on CUDA supports dense models only (issue #180 Task 5a); use [yellow]-g 0[/] for MoE.");
+                    return 1;
+                }
+            }
         }
 
         // Validate TurboQuant head-dimension compatibility before any GPU allocation.
         // Lloyd-Max ships hardcoded codebooks for 128/256; KVarN is calibration-free
-        // and accepts any power-of-2 head dim in [8, 1024].
+        // and accepts any power-of-2 head dim in [8, 1024] on the CPU path, [8, 256]
+        // on CUDA (the shared-memory WHT cap — 512/1024 stay CPU-only for now).
         if (settings.TurboQuant)
         {
             int headDim = hp.HeadDim;
@@ -655,6 +672,11 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 if ((headDim & (headDim - 1)) != 0 || headDim is < 8 or > 1024)
                 {
                     AnsiConsole.MarkupLine($"[red]Error:[/] --tq-mode kvarn requires a power-of-2 head dimension in [[8, 1024]]; this model has head dim {headDim}.");
+                    return 1;
+                }
+                if (effNGpuLayers != 0 && headDim > 256)
+                {
+                    AnsiConsole.MarkupLine($"[red]Error:[/] --tq-mode kvarn on CUDA requires head dim ≤ 256 (shared-memory WHT cap); this model has head dim {headDim}. Use [yellow]-g 0[/] for the CPU path.");
                     return 1;
                 }
             }
@@ -694,8 +716,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                     // Auto: pick CUDA when available. CudaForwardPass handles full-offload
                     // (dense + MoE); CudaHybridForwardPass handles partial-offload (dense or
                     // MoE; routed experts stream through the CudaExpertSlotManager SLRU).
-                    // TQ on CUDA requires head_dim ∈ {128, 256}.
-                    bool tqHeadDimOk = hp.HeadDim is 128 or 256;
+                    // TQ on CUDA requires head_dim ∈ {128, 256}; KVarN pow2 in [8, 256]
+                    // (already validated above, so kvarn implies CUDA-compatible here).
+                    bool tqHeadDimOk = tqQuantizer == TqQuantizer.KVarN
+                        || hp.HeadDim is 128 or 256;
                     wantCuda = (!settings.TurboQuant || tqHeadDimOk)
                         && CudaBackend.IsAvailable();
                     break;
@@ -703,7 +727,8 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                     AnsiConsole.MarkupLine($"[red]Error:[/] Unknown --backend value '{settings.Backend}'. Expected one of: auto, vulkan, cuda.");
                     return 1;
             }
-            if (wantCuda && settings.TurboQuant && hp.HeadDim is not 128 and not 256)
+            if (wantCuda && settings.TurboQuant && tqQuantizer == TqQuantizer.LloydMax
+                && hp.HeadDim is not 128 and not 256)
             {
                 AnsiConsole.MarkupLine($"[yellow]Note:[/] --backend cuda TurboQuant requires head_dim ∈ {{128, 256}} (model head_dim={hp.HeadDim}); falling back to Vulkan.");
                 wantCuda = false;
@@ -836,6 +861,15 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 }
 
                 bool wantHybrid = (cudaGpuLayers > 0 && cudaGpuLayers < hp.NumLayers) || moeAutoNeedsHybrid;
+                if (wantHybrid && settings.TurboQuant && tqQuantizer == TqQuantizer.KVarN)
+                {
+                    // KVarN on GPU is the full-offload CudaForwardPass path only (issue
+                    // #180 Task 5a) — the hybrid pass has no KVarN ring/tile machinery.
+                    AnsiConsole.MarkupLine(
+                        $"[red]Error:[/] --tq-mode kvarn requires full CUDA offload, but only " +
+                        $"{cudaGpuLayers}/{hp.NumLayers} layers fit this GPU. Use [yellow]-g 0[/] for the CPU path.");
+                    return 1;
+                }
                 if (wantHybrid)
                 {
                     var hwProfile = HardwareProfile.Detect(cuda);
@@ -862,8 +896,10 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                     gpuBackend = null;
                     if (settings.TurboQuant)
                     {
-                        fwd!.EnableTurboQuant(fp32WindowSize: 256, bits: 3);
-                        AnsiConsole.MarkupLine("[dim]TurboQuant: [green]enabled[/] (3-bit, window=256)[/]");
+                        fwd!.EnableTurboQuant(fp32WindowSize: 256, bits: 3, quantizer: tqQuantizer);
+                        AnsiConsole.MarkupLine(tqQuantizer == TqQuantizer.KVarN
+                            ? "[dim]TurboQuant: [green]enabled[/] (KVarN K4V2, window=256)[/]"
+                            : "[dim]TurboQuant: [green]enabled[/] (3-bit, window=256)[/]");
                     }
                     forward = fwd!.Forward;
                     prefill = tokens => fwd.Prefill(tokens);
@@ -873,9 +909,11 @@ public sealed class RunCommand : Command<RunCommand.Settings>
                 else
                 {
                     var cfwd = new CudaForwardPass(model, cuda, hp, ctxSize,
-                        enableTurboQuant: settings.TurboQuant);
+                        enableTurboQuant: settings.TurboQuant, tqQuantizer: tqQuantizer);
                     if (settings.TurboQuant)
-                        AnsiConsole.MarkupLine($"[dim]TurboQuant: [green]enabled[/] (3-bit, context: {cfwd.MaxSeqLen})[/]");
+                        AnsiConsole.MarkupLine(tqQuantizer == TqQuantizer.KVarN
+                            ? $"[dim]TurboQuant: [green]enabled[/] (KVarN K4V2, window=256, context: {cfwd.MaxSeqLen})[/]"
+                            : $"[dim]TurboQuant: [green]enabled[/] (3-bit, context: {cfwd.MaxSeqLen})[/]");
                     gpuFwd = cfwd;
                     forward = cfwd.Forward;
                     prefill = tokens => cfwd.Prefill(tokens);

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -320,6 +320,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _tqRotateQueryKernel;
     private nint   _tqKvAppendKernel;
     private nint   _tqAttentionKernel;
+    // KVarN quantizer kernels (issue #180 Task 5a).
+    private nint   _kvarnRotateQueryKernel;
+    private nint   _kvarnCompressTileKernel;
+    private nint   _kvarnAttentionKernel;
 
     // qwen35moe Gated-DeltaNet (GDN) kernels.
     private nint   _siluInplaceKernel;
@@ -6057,6 +6061,118 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(tq_attention) failed: {r}");
     }
 
+    // ================================================================
+    //  KVarN KV-cache compression (issue #180 Task 5a)
+    // ================================================================
+
+    /// <summary>
+    /// Rotate query vectors for KVarN attention: the normalized Walsh-Hadamard
+    /// transform per query head, no sign flip (KVarN has none). Call once per
+    /// layer before <see cref="KvarnAttention"/>. head_dim must be a power of
+    /// two in [8, 256].
+    /// </summary>
+    public void KvarnRotateQuery(Tensor qInput, Tensor rotatedQ, int numHeads, int headDim)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        nint qP  = GetDevPtr(qInput);
+        nint rqP = GetDevPtr(rotatedQ);
+        int  pNH = numHeads, pHD = headDim;
+        nint* args = stackalloc nint[4]
+        {
+            (nint)(&qP), (nint)(&rqP), (nint)(&pNH), (nint)(&pHD)
+        };
+        int r = NvrtcInterop.LaunchKernel(_kvarnRotateQueryKernel,
+            (uint)numHeads, 1, 1, (uint)headDim, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kvarn_rotate_query) failed: {r}");
+    }
+
+    /// <summary>
+    /// Compress the oldest 128 rows of a layer's linear FP32 window (row 0 =
+    /// oldest) into one KVarN K tile + one V tile per kv-head, written at
+    /// <paramref name="tileIdx"/> in the packed tile stores (KVarNCompressor
+    /// byte layout, stride = tile bytes × numKvHeads per tile index).
+    /// <paramref name="work"/> must hold <c>numKvHeads × 2 × 128 × headDim</c>
+    /// floats of global scratch (the 128×headDim working tile exceeds the 48 KB
+    /// shared-memory ceiling, so normalization runs out of VRAM — promotion is
+    /// once per 128 decode steps per layer, so this is amortized).
+    /// </summary>
+    public void KvarnCompressTile(Tensor kWindow, Tensor vWindow, Tensor kTiles, Tensor vTiles,
+                                  Tensor work, int kvDim, int headDim, int tileIdx,
+                                  int numKvHeads, int kTileBytes, int vTileBytes,
+                                  int sinkhornIterations)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        nint kwP = GetDevPtr(kWindow);
+        nint vwP = GetDevPtr(vWindow);
+        nint ktP = GetDevPtr(kTiles);
+        nint vtP = GetDevPtr(vTiles);
+        nint wP  = GetDevPtr(work);
+        int  pKD = kvDim, pHD = headDim, pTI = tileIdx, pNKV = numKvHeads,
+             pKTB = kTileBytes, pVTB = vTileBytes, pSI = sinkhornIterations;
+        nint* args = stackalloc nint[12]
+        {
+            (nint)(&kwP), (nint)(&vwP), (nint)(&ktP), (nint)(&vtP), (nint)(&wP),
+            (nint)(&pKD), (nint)(&pHD), (nint)(&pTI), (nint)(&pNKV),
+            (nint)(&pKTB), (nint)(&pVTB), (nint)(&pSI)
+        };
+        // blockIdx.y: 0 = K tile, 1 = V tile; 128 threads cover the widest
+        // butterfly (head_dim 256 → 128 pairs) and one thread per token row.
+        int r = NvrtcInterop.LaunchKernel(_kvarnCompressTileKernel,
+            (uint)numKvHeads, 2, 1, 128, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kvarn_compress_tile) failed: {r}");
+    }
+
+    /// <summary>
+    /// Hybrid KVarN attention: scaled dot-product attention over the KVarN
+    /// compressed tiles plus the linear FP32 recent-window cache.
+    /// <paramref name="tqSeqLen"/> must be a whole multiple of 128 (the KVarN
+    /// cache invariant). Same scores-scratch contract as <see cref="TqAttention"/>:
+    /// ignored while <c>tqSeqLen + fp32SeqLen ≤ 4096</c>, required (sized
+    /// <c>numHeads × maxSeqLen</c>) above.
+    /// </summary>
+    public void KvarnAttention(Tensor q, Tensor rotatedQ, Tensor kTiles, Tensor vTiles,
+                               Tensor kCacheFp32, Tensor vCacheFp32, Tensor output,
+                               Tensor? scoresScratch,
+                               int numHeads, int numKvHeads, int headDim,
+                               int tqSeqLen, int fp32SeqLen, int maxSeqLen,
+                               int kTileBytes, int vTileBytes)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+
+        nint qP   = GetDevPtr(q);
+        nint rqP  = GetDevPtr(rotatedQ);
+        nint ktP  = GetDevPtr(kTiles);
+        nint vtP  = GetDevPtr(vTiles);
+        nint kfP  = GetDevPtr(kCacheFp32);
+        nint vfP  = GetDevPtr(vCacheFp32);
+        nint oP   = GetDevPtr(output);
+        nint ssP  = scoresScratch is { } sv ? GetDevPtr(sv) : nint.Zero;
+        int  pNH = numHeads, pNKV = numKvHeads, pHD = headDim,
+             pTQ = tqSeqLen, pFP = fp32SeqLen, pMSL = maxSeqLen,
+             pKTB = kTileBytes, pVTB = vTileBytes;
+        nint* args = stackalloc nint[16]
+        {
+            (nint)(&qP), (nint)(&rqP),
+            (nint)(&ktP), (nint)(&vtP),
+            (nint)(&kfP), (nint)(&vfP),
+            (nint)(&oP),  (nint)(&ssP),
+            (nint)(&pNH), (nint)(&pNKV), (nint)(&pHD),
+            (nint)(&pTQ), (nint)(&pFP),  (nint)(&pMSL),
+            (nint)(&pKTB), (nint)(&pVTB)
+        };
+        int r = NvrtcInterop.LaunchKernel(_kvarnAttentionKernel,
+            (uint)numHeads, 1, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kvarn_attention) failed: {r}");
+    }
+
     /// <summary>Look up one row from an F32 embedding table into <paramref name="output"/>.</summary>
     public void EmbedLookup(Tensor embTable, Tensor output, int tokenId, int embDim)
     {
@@ -7128,6 +7244,8 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _clearF32Kernel, _gatherRowsKernel, _scatterRowsKernel, _quantizeQ81Kernel,
             _scaleRowsKernel, _moeWeightedReduceKernel,
             _tqRotateQueryKernel, _tqKvAppendKernel, _tqAttentionKernel,
+            _kvarnRotateQueryKernel, _kvarnCompressTileKernel, _kvarnAttentionKernel,   // #180
+
             _siluInplaceKernel, _gdnConv1dDecodeKernel, _gdnL2NormPerHeadKernel,
             _gdnTileHeadsKernel, _gdnRecurrenceDecodeKernel,
             _gdnRecurrenceDecodeFastKernel, _gdnDecodeNormGateKernel,   // #404
@@ -7344,6 +7462,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _tqRotateQueryKernel = GetKernelFunc("llm_tq_rotate_query");
         _tqKvAppendKernel    = GetKernelFunc("llm_tq_kv_append");
         _tqAttentionKernel   = GetKernelFunc("llm_tq_attention");
+
+        // KVarN quantizer kernels (issue #180 Task 5a).
+        _kvarnRotateQueryKernel  = GetKernelFunc("llm_kvarn_rotate_query");
+        _kvarnCompressTileKernel = GetKernelFunc("llm_kvarn_compress_tile");
+        _kvarnAttentionKernel    = GetKernelFunc("llm_kvarn_attention");
 
         // qwen35moe GDN kernels.
         _siluInplaceKernel        = GetKernelFunc("llm_silu_inplace");

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -320,10 +320,11 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private nint   _tqRotateQueryKernel;
     private nint   _tqKvAppendKernel;
     private nint   _tqAttentionKernel;
-    // KVarN quantizer kernels (issue #180 Task 5a).
+    // KVarN quantizer kernels (issue #180 Task 5a; prefill twin Task 6).
     private nint   _kvarnRotateQueryKernel;
     private nint   _kvarnCompressTileKernel;
     private nint   _kvarnAttentionKernel;
+    private nint   _kvarnPrefillAttentionKernel;
 
     // qwen35moe Gated-DeltaNet (GDN) kernels.
     private nint   _siluInplaceKernel;
@@ -6234,6 +6235,65 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         }
     }
 
+    /// <summary>
+    /// Batched-query KVarN chunked-prefill attention (issue #180 Task 6): the
+    /// <paramref name="nTok"/> chunk queries (token-major <c>[nTok × numHeads·headDim]</c>,
+    /// already appended to the linear FP32 window at slots
+    /// <c>[fp32Base, fp32Base + nTok)</c>) each attend to ALL
+    /// <paramref name="tqSeqLen"/> compressed-tile positions plus the window slots
+    /// <c>[0, fp32Base + i]</c> (causal), via a streaming softmax — no score
+    /// storage, so there is no 4096-position cap. <paramref name="tqSeqLen"/> must
+    /// be a positive whole-tile multiple (the tqSeqLen == 0 chunk shape is the
+    /// plain flash prefill); <paramref name="headDim"/> a power of two ≤ 128 (the
+    /// kernel's shared-memory budget, which also pins the V codes to one
+    /// 128-channel group). Never captured — prefill runs outside CUDA graphs.
+    /// </summary>
+    public void KvarnAttentionPrefill(Tensor qAll, Tensor rotatedQAll, Tensor kTiles, Tensor vTiles,
+                                      Tensor kWindow, Tensor vWindow, Tensor outAll,
+                                      int numHeads, int numKvHeads, int headDim,
+                                      int tqSeqLen, int fp32Base, int nTok,
+                                      int kTileBytes, int vTileBytes)
+    {
+        EnsureImageKernels();
+        if (!_imageKernelsAvailable)
+            throw new NotSupportedException("NVRTC kernels are not available.");
+        if (headDim > 128 || (headDim & (headDim - 1)) != 0)
+            throw new NotSupportedException(
+                $"KvarnAttentionPrefill requires a power-of-2 head_dim ≤ 128 (shared-memory budget); got {headDim}.");
+        if (tqSeqLen <= 0 || (tqSeqLen & 127) != 0)
+            throw new ArgumentOutOfRangeException(nameof(tqSeqLen), tqSeqLen,
+                "tqSeqLen must be a positive multiple of 128 (use the flash prefill kernel while no tile exists).");
+        if (nTok <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nTok), nTok, "nTok must be > 0.");
+        if (fp32Base < 0)
+            throw new ArgumentOutOfRangeException(nameof(fp32Base), fp32Base, "fp32Base must be >= 0.");
+
+        nint qP  = GetDevPtr(qAll);
+        nint rqP = GetDevPtr(rotatedQAll);
+        nint ktP = GetDevPtr(kTiles);
+        nint vtP = GetDevPtr(vTiles);
+        nint kwP = GetDevPtr(kWindow);
+        nint vwP = GetDevPtr(vWindow);
+        nint oP  = GetDevPtr(outAll);
+        int  pNH = numHeads, pNKV = numKvHeads, pHD = headDim,
+             pTQ = tqSeqLen, pF0 = fp32Base, pN = nTok,
+             pKTB = kTileBytes, pVTB = vTileBytes;
+        nint* args = stackalloc nint[15]
+        {
+            (nint)(&qP), (nint)(&rqP),
+            (nint)(&ktP), (nint)(&vtP),
+            (nint)(&kwP), (nint)(&vwP),
+            (nint)(&oP),
+            (nint)(&pNH), (nint)(&pNKV), (nint)(&pHD),
+            (nint)(&pTQ), (nint)(&pF0), (nint)(&pN),
+            (nint)(&pKTB), (nint)(&pVTB)
+        };
+        uint gy = (uint)((nTok + 15) / 16);   // KPF_MQ = 16 queries per block
+        int r = NvrtcInterop.LaunchKernel(_kvarnPrefillAttentionKernel,
+            (uint)numHeads, gy, 1, 256, 1, 1, 0, _stream, args, null);
+        if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kvarn_prefill_attention) failed: {r}");
+    }
+
     /// <summary>Look up one row from an F32 embedding table into <paramref name="output"/>.</summary>
     public void EmbedLookup(Tensor embTable, Tensor output, int tokenId, int embDim)
     {
@@ -7306,6 +7366,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             _scaleRowsKernel, _moeWeightedReduceKernel,
             _tqRotateQueryKernel, _tqKvAppendKernel, _tqAttentionKernel,
             _kvarnRotateQueryKernel, _kvarnCompressTileKernel, _kvarnAttentionKernel,   // #180
+            _kvarnPrefillAttentionKernel,                                               // #180 Task 6
 
             _siluInplaceKernel, _gdnConv1dDecodeKernel, _gdnL2NormPerHeadKernel,
             _gdnTileHeadsKernel, _gdnRecurrenceDecodeKernel,
@@ -7528,6 +7589,7 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         _kvarnRotateQueryKernel  = GetKernelFunc("llm_kvarn_rotate_query");
         _kvarnCompressTileKernel = GetKernelFunc("llm_kvarn_compress_tile");
         _kvarnAttentionKernel    = GetKernelFunc("llm_kvarn_attention");
+        _kvarnPrefillAttentionKernel = GetKernelFunc("llm_kvarn_prefill_attention");
 
         // qwen35moe GDN kernels.
         _siluInplaceKernel        = GetKernelFunc("llm_silu_inplace");

--- a/src/SharpInference.Cuda/CudaBackend.cs
+++ b/src/SharpInference.Cuda/CudaBackend.cs
@@ -1154,8 +1154,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     private readonly List<GraphPosNode> _graphPosNodes = new();
     // Upper bound on a tracked kernel's arg count — sizes the reusable stackalloc cell/ptr
     // buffers in LaunchGraphForPosition and bounds the per-node snapshot in TrackPositionNode.
-    // The widest position-varying op (AttentionSwa) has 12 args; 16 leaves headroom.
-    private const int GraphMaxKernelArgs = 16;
+    // The widest position-varying op (llm_kvarn_attention) has 16 args; 20 leaves headroom.
+    // Exceeding this fails capture gracefully (session falls back to direct launches) but
+    // with no build-time signal — keep the widest-op note current when adding args.
+    private const int GraphMaxKernelArgs = 20;
 
     /// <summary>True while a graph capture is in progress on <see cref="Stream"/>.</summary>
     public bool GraphCapturing => _graphCapturing;
@@ -1180,7 +1182,16 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
     // no capture is open or the legacy single-graph (no-arg) capture is the one in flight.
     private int _capturingGraphId = int.MinValue;
 
-    private enum GraphPosKind { Position, PositionPlus1, SwaWindowStart, SwaWindowEnd }
+    // KvarnAppendSlot / KvarnFp32SeqLen / KvarnTqLen (issue #180 Task 5b): KVarN decode
+    // params that vary per token but are NOT pure functions of position — the linear FP32
+    // window count and the compressed length advance on the host (window count drops by a
+    // whole 128-token tile at each promotion). The engine publishes them per replay via
+    // SetGraphKvarnState; the kinds resolve against those fields in LaunchGraphNodes.
+    private enum GraphPosKind
+    {
+        Position, PositionPlus1, SwaWindowStart, SwaWindowEnd,
+        KvarnAppendSlot, KvarnFp32SeqLen, KvarnTqLen,
+    }
 
     // One captured kernel node whose params carry per-token-varying position scalars.
     private sealed class GraphPosNode
@@ -1190,6 +1201,31 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         public uint Gx, Gy, Gz, Bx, By, Bz, Sh;
         public nint[] ArgValues = [];                         // snapshot of every kernel-arg cell
         public (int Slot, GraphPosKind Kind, int Window)[] Updates = [];
+    }
+
+    // ── KVarN graph state (issue #180 Task 5b) ──
+    // While a KVarN decode region is being captured, the position-varying ops it shares
+    // with the plain path (KvAppend, Attention) must register their seqLen/slot args with
+    // the Kvarn* kinds above instead of Position/PositionPlus1 — the KVarN append slot is
+    // the window fill count, not the absolute position. The engine flips GraphKvarnTracking
+    // on around capture only; replay resolves the kinds from the SetGraphKvarnState values.
+    private bool _graphKvarnTrack;
+    private int _graphKvarnTqLen;
+    private int _graphKvarnFp32Count;
+
+    /// <summary>Register KVarN-tracked (window-relative) graph params during capture —
+    /// set true only while capturing a KVarN decode region (issue #180 Task 5b).</summary>
+    public bool GraphKvarnTracking { get => _graphKvarnTrack; set => _graphKvarnTrack = value; }
+
+    /// <summary>Publish the KVarN host state a graph replay should bake into its tracked
+    /// kernel-node params: <paramref name="tqLen"/> = compressed positions (whole tiles),
+    /// <paramref name="fp32Count"/> = window rows already appended (also this token's
+    /// append slot; the attention length is <c>fp32Count + 1</c>). Call before every
+    /// <see cref="LaunchGraphForPosition(int,int)"/> of a KVarN graph.</summary>
+    public void SetGraphKvarnState(int tqLen, int fp32Count)
+    {
+        _graphKvarnTqLen = tqLen;
+        _graphKvarnFp32Count = fp32Count;
     }
 
     // Pack a float's bit pattern into an arg cell (the kernel reads its low 4 bytes).
@@ -1381,11 +1417,14 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             foreach (var u in n.Updates)
                 cells[u.Slot] = u.Kind switch
                 {
-                    GraphPosKind.Position       => position,
-                    GraphPosKind.PositionPlus1  => position + 1,
-                    GraphPosKind.SwaWindowStart => Math.Max(0, position + 1 - u.Window),
-                    GraphPosKind.SwaWindowEnd   => position + 1,
-                    _                           => cells[u.Slot],
+                    GraphPosKind.Position        => position,
+                    GraphPosKind.PositionPlus1   => position + 1,
+                    GraphPosKind.SwaWindowStart  => Math.Max(0, position + 1 - u.Window),
+                    GraphPosKind.SwaWindowEnd    => position + 1,
+                    GraphPosKind.KvarnAppendSlot => _graphKvarnFp32Count,
+                    GraphPosKind.KvarnFp32SeqLen => _graphKvarnFp32Count + 1,
+                    GraphPosKind.KvarnTqLen      => _graphKvarnTqLen,
+                    _                            => cells[u.Slot],
                 };
             for (int i = 0; i < cnt; i++) ptrs[i] = (nint)(cells + i);
 
@@ -4530,7 +4569,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             Span<nint> av = stackalloc nint[7];
             av[0] = kPtr; av[1] = vPtr; av[2] = kcP; av[3] = vcP;
             av[4] = pKD; av[5] = pPos; av[6] = pMSL;
-            TrackPositionNode(_kvAppendKernel, grid, 1, 1, 256, 1, 1, 0, av, [(5, GraphPosKind.Position, 0)]);
+            // KVarN capture (issue #180 Task 5b): the append slot is the window fill
+            // count (host state), not the absolute position — track it as such.
+            TrackPositionNode(_kvAppendKernel, grid, 1, 1, 256, 1, 1, 0, av,
+                [(5, _graphKvarnTrack ? GraphPosKind.KvarnAppendSlot : GraphPosKind.Position, 0)]);
         }
     }
 
@@ -4575,9 +4617,10 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
             av[0] = qP; av[1] = kP; av[2] = vP; av[3] = oP; av[4] = ssP;
             av[5] = pNH; av[6] = pNKV; av[7] = pHD; av[8] = pSL; av[9] = pMSL;
             av[10] = GraphFloatBits(pScale);
-            // pSL = seqLen = position + 1 in the decode path.
+            // pSL = seqLen = position + 1 in the decode path; under a KVarN capture
+            // (issue #180 Task 5b) it is the window fill count + 1 instead.
             TrackPositionNode(_attentionKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, av,
-                [(8, GraphPosKind.PositionPlus1, 0)]);
+                [(8, _graphKvarnTrack ? GraphPosKind.KvarnFp32SeqLen : GraphPosKind.PositionPlus1, 0)]);
         }
     }
 
@@ -6171,6 +6214,24 @@ public sealed unsafe class CudaBackend : IComputeBackend, IImageOpsBackend, IDis
         int r = NvrtcInterop.LaunchKernel(_kvarnAttentionKernel,
             (uint)numHeads, 1, 1, 256, 1, 1, 0, _stream, args, null);
         if (r != 0) throw new InvalidOperationException($"cuLaunchKernel(kvarn_attention) failed: {r}");
+
+        // Steady-state KVarN graph capture (issue #180 Task 5b): tqSeqLen (arg 11) and
+        // fp32SeqLen (arg 12) advance on the host per token/promotion, so replay rewrites
+        // them from the SetGraphKvarnState values. Grid/shared are fixed; the shared-vs-
+        // scratch score choice is a runtime branch inside the kernel on those scalars, so
+        // a graph captured under 4096 total positions stays valid past it (the scratch
+        // pointer is pre-sized to max_seq_len at construction and baked at capture).
+        if (_graphCapturing)
+        {
+            Span<nint> av = stackalloc nint[16];
+            av[0] = qP;  av[1] = rqP; av[2] = ktP; av[3] = vtP;
+            av[4] = kfP; av[5] = vfP; av[6] = oP;  av[7] = ssP;
+            av[8] = pNH; av[9] = pNKV; av[10] = pHD;
+            av[11] = pTQ; av[12] = pFP; av[13] = pMSL;
+            av[14] = pKTB; av[15] = pVTB;
+            TrackPositionNode(_kvarnAttentionKernel, (uint)numHeads, 1, 1, 256, 1, 1, 0, av,
+                [(11, GraphPosKind.KvarnTqLen, 0), (12, GraphPosKind.KvarnFp32SeqLen, 0)]);
+        }
     }
 
     /// <summary>Look up one row from an F32 embedding table into <paramref name="output"/>.</summary>

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -6981,6 +6981,318 @@ extern ""C"" __global__ void llm_kvarn_attention(
     }
 }
 
+// ── KVarN chunked-prefill attention (issue #180 Task 6) ────────────────────
+// Batched-query twin of llm_kvarn_attention: a block handles KPF_MQ queries of
+// ONE head; grid = (num_heads, ceil(n_tok / KPF_MQ)). Each query at chunk-local
+// index i (absolute window slot f0 + i) attends
+//   • ALL tq_seq_len compressed-tile positions (every tile position is strictly
+//     older than the whole chunk — the driver promotes BEFORE appending), and
+//   • the linear FP32 window slots [0, f0 + i] (causal; the chunk's own rows
+//     were appended at slots [f0, f0 + n_tok) before this launch).
+//
+// Score/aggregation algebra is IDENTICAL to the per-token kernel — folded-q
+// K-scores over channel-major nibbles, unrotated-q window dots, V tiles
+// accumulated in the ROTATED domain with one deferred inverse WHT per query,
+// window V in the original domain — but the single stored-scores softmax is
+// replaced by a streaming (online) softmax so no per-position score storage is
+// needed at any depth:
+//   m, l       running max / exp-sum per query (shared across BOTH regions —
+//              this is the standard flash log-sum-exp combine, folded into one
+//              online stream instead of a two-pass region merge);
+//   racc[i,d]  rotated-domain tile-V partial, rescaled by exp(m_old − m_new);
+//   wacc[i,d]  original-domain window-V partial, rescaled the same way.
+// Because the WHT is linear, IWHT(Σ p·ṽ) = Σ p·IWHT(ṽ) = Σ p·v, so applying
+// the inverse transform ONCE to the tile-region partial and blending with the
+// (untransformed) window partial under the shared 1/l normalization gives the
+// same result as the per-token single-softmax kernel up to FP reassociation
+// (within the attention parity band, max(1e-3, 1e-2·|x|)).
+//
+// Layout contracts: q_all/rotq_all/out_all are token-major [n_tok × q_dim];
+// k/v_window are the LINEAR fp32 window [window × kv_dim], slot 0 = oldest.
+// head_dim: power of two ≤ 128 (shared budget: four MQ×128 f32 planes + an
+// 8 KB code stage ≈ 42 KB), which also keeps the V codes in ONE channel group
+// (ValueGroupSize = 128). tq_seq_len must be a positive whole-tile multiple —
+// the tq_seq_len == 0 chunk shape is served by the plain flash prefill kernel.
+#define KPF_MQ 16
+extern ""C"" __global__ void llm_kvarn_prefill_attention(
+    const float* __restrict__ q_all,
+    const float* __restrict__ rotq_all,
+    const unsigned int* __restrict__ k_tiles,
+    const unsigned int* __restrict__ v_tiles,
+    const float* __restrict__ k_window,
+    const float* __restrict__ v_window,
+    float* __restrict__ out_all,
+    int num_heads, int num_kv_heads, int head_dim,
+    int tq_seq_len, int f0, int n_tok,
+    int k_tile_bytes, int v_tile_bytes)
+{
+    const int T = 128;                        // tile tokens
+    __shared__ float s_q[KPF_MQ * 128];       // rotated q (tile phase) → raw q (window phase)
+    __shared__ float s_racc[KPF_MQ * 128];    // rotated-domain tile-V partials
+    __shared__ float s_wacc[KPF_MQ * 128];    // original-domain window-V partials
+    __shared__ float s_e[KPF_MQ * 128];       // per-block scores → exp values
+    __shared__ unsigned int s_codes[2048];    // staged K codes (D·T/2 B) / V codes (T·D/4 B)
+    __shared__ float s_hdrA[128];             // K: row_scale[T]   V: col_scale[D]
+    __shared__ float s_hdrB[128];             // K: chan_step[D]   V: tok_step[T]
+    __shared__ float s_hdrC[128];             // K: chan_min[D]    V: tok_min[T]
+    __shared__ float s_m[KPF_MQ], s_l[KPF_MQ], s_r[KPF_MQ], s_bias[KPF_MQ];
+
+    int h   = (int)blockIdx.x;
+    int qb  = (int)blockIdx.y;
+    int tid = (int)threadIdx.x;               // blockDim.x == 256
+    int q0g = qb * KPF_MQ;                    // first chunk-local query of this block
+    if (h >= num_heads || q0g >= n_tok) return;
+    int mq = n_tok - q0g; if (mq > KPF_MQ) mq = KPF_MQ;
+
+    int kv_head = h / (num_heads / num_kv_heads);
+    int kv_dim  = num_kv_heads * head_dim;
+    int q_dim   = num_heads * head_dim;
+    float scale = 1.0f / sqrtf((float)head_dim);
+    int num_tiles = tq_seq_len / T;
+
+    // Per-query sub-warp: 16 threads own query i = tid/16 (lane16 = tid%16), so
+    // the score/reduction shuffles stay inside one half-warp (width 16).
+    int i16 = tid >> 4;
+    int lane16 = tid & 15;
+
+    if (tid < KPF_MQ) { s_m[tid] = sharpi_neg_inf(); s_l[tid] = 0.0f; }
+    for (int idx = tid; idx < mq * head_dim; idx += 256) { s_racc[idx] = 0.0f; s_wacc[idx] = 0.0f; }
+    for (int idx = tid; idx < mq * head_dim; idx += 256) {
+        int i = idx / head_dim, d = idx - i * head_dim;
+        s_q[idx] = rotq_all[(long)(q0g + i) * (long)q_dim + (long)h * head_dim + d];
+    }
+    __syncthreads();
+
+    // ── Tile phase: K-scores + rotated-domain V aggregation, one tile at a time ──
+    for (int tile = 0; tile < num_tiles; tile++) {
+        // Stage the K tile: headers + channel-major nibble codes.
+        const float* kf32 = (const float*)((const unsigned char*)k_tiles
+            + ((long)tile * num_kv_heads + kv_head) * (long)k_tile_bytes);
+        for (int t = tid; t < T; t += 256) s_hdrA[t] = kf32[t];                       // row_scale
+        for (int c = tid; c < head_dim; c += 256) {
+            s_hdrB[c] = kf32[T + c];                                                  // chan_step
+            s_hdrC[c] = kf32[T + head_dim + c];                                       // chan_min
+        }
+        const unsigned int* kcodes_u = (const unsigned int*)(kf32 + T + 2 * head_dim);
+        int n_kcodes_u = head_dim * (T / 2) / 4;
+        for (int u = tid; u < n_kcodes_u; u += 256) s_codes[u] = kcodes_u[u];
+        __syncthreads();
+
+        // bias_i = Σ_c rotq_ic · chan_min_c (the KeyScores fold, per query).
+        {
+            float b = 0.0f;
+            if (i16 < mq)
+                for (int c = lane16; c < head_dim; c += 16)
+                    b += s_q[i16 * head_dim + c] * s_hdrC[c];
+            for (int off = 8; off > 0; off >>= 1)
+                b += __shfl_down_sync(0xffffffffu, b, off, 16);
+            if (lane16 == 0 && i16 < mq) s_bias[i16] = b;
+        }
+        __syncthreads();
+
+        // score_{i,t} = row_scale_t · (Σ_c rotq_ic·chan_step_c·code[c,t] + bias_i) · 1/√D
+        if (i16 < mq) {
+            const unsigned char* kcodes_b = (const unsigned char*)s_codes;
+            for (int t = lane16; t < T; t += 16) {
+                int tb = t >> 1;
+                bool hi = (t & 1) != 0;
+                float acc = 0.0f;
+                for (int c = 0; c < head_dim; c++) {
+                    unsigned int b = kcodes_b[c * (T / 2) + tb];
+                    unsigned int code = hi ? (b >> 4) : (b & 0xFu);
+                    acc += s_q[i16 * head_dim + c] * s_hdrB[c] * (float)code;
+                }
+                s_e[i16 * T + t] = s_hdrA[t] * (acc + s_bias[i16]) * scale;
+            }
+        }
+        __syncthreads();
+
+        // Online-softmax update over this tile's T scores. The sub-warp shuffles
+        // run UNCONDITIONALLY (inactive query groups carry neutral values): a
+        // full-mask shuffle inside an `i16 < mq` guard would be undefined when a
+        // tail chunk leaves a warp half-active (odd mq).
+        {
+            float mx = sharpi_neg_inf();
+            if (i16 < mq)
+                for (int t = lane16; t < T; t += 16) mx = fmaxf(mx, s_e[i16 * T + t]);
+            for (int off = 8; off > 0; off >>= 1)
+                mx = fmaxf(mx, __shfl_down_sync(0xffffffffu, mx, off, 16));
+            mx = __shfl_sync(0xffffffffu, mx, 0, 16);
+            float mnew = fmaxf(s_m[i16], mx);
+            float r = __expf(s_m[i16] - mnew);        // exp(-inf − finite) = 0 on the first tile
+            float sm = 0.0f;
+            if (i16 < mq) {
+                for (int t = lane16; t < T; t += 16) {
+                    float e = __expf(s_e[i16 * T + t] - mnew);
+                    s_e[i16 * T + t] = e;
+                    sm += e;
+                }
+            }
+            for (int off = 8; off > 0; off >>= 1)
+                sm += __shfl_down_sync(0xffffffffu, sm, off, 16);
+            if (lane16 == 0 && i16 < mq) {
+                s_l[i16] = s_l[i16] * r + sm;
+                s_m[i16] = mnew;
+                s_r[i16] = r;
+            }
+        }
+        __syncthreads();
+
+        // Rescale the tile-V partials (window partials are still zero here), then
+        // stage the V tile over the consumed K stage.
+        for (int idx = tid; idx < mq * head_dim; idx += 256)
+            s_racc[idx] *= s_r[idx / head_dim];
+        const float* vf32 = (const float*)((const unsigned char*)v_tiles
+            + ((long)tile * num_kv_heads + kv_head) * (long)v_tile_bytes);
+        for (int c = tid; c < head_dim; c += 256) s_hdrA[c] = vf32[c];                // col_scale
+        for (int t = tid; t < T; t += 256) {
+            s_hdrB[t] = vf32[head_dim + t];                                           // tok_step (G=1: D ≤ 128)
+            s_hdrC[t] = vf32[head_dim + T + t];                                       // tok_min
+        }
+        const unsigned int* vcodes_u = (const unsigned int*)(vf32 + head_dim + 2 * T);
+        int n_vcodes_u = T * (head_dim >> 2) / 4;
+        for (int u = tid; u < n_vcodes_u; u += 256) s_codes[u] = vcodes_u[u];
+        __syncthreads();
+
+        // vbias_i = Σ_t e_it · tok_min_t, then fold ws_it = e_it · tok_step_t in place.
+        {
+            float vb = 0.0f;
+            if (i16 < mq)
+                for (int t = lane16; t < T; t += 16) vb += s_e[i16 * T + t] * s_hdrC[t];
+            for (int off = 8; off > 0; off >>= 1)
+                vb += __shfl_down_sync(0xffffffffu, vb, off, 16);
+            if (lane16 == 0 && i16 < mq) s_bias[i16] = vb;
+        }
+        __syncthreads();
+        for (int idx = tid; idx < mq * T; idx += 256)
+            s_e[idx] *= s_hdrB[idx & (T - 1)];
+        __syncthreads();
+
+        // racc_{i,d} += col_scale_d · (Σ_t ws_it·code[t,d] + vbias_i)  (rotated domain).
+        {
+            const unsigned char* vcodes_b = (const unsigned char*)s_codes;
+            int bpt = head_dim >> 2;                  // V bytes per token row
+            for (int idx = tid; idx < mq * head_dim; idx += 256) {
+                int i = idx / head_dim, d = idx - i * head_dim;
+                int cb = d >> 2, sh = (d & 3) << 1;
+                float acc = 0.0f;
+                for (int t = 0; t < T; t++) {
+                    unsigned int b = vcodes_b[t * bpt + cb];
+                    acc += s_e[i * T + t] * (float)((b >> sh) & 0x3u);
+                }
+                s_racc[idx] += s_hdrA[d] * (acc + s_bias[i]);
+            }
+        }
+        __syncthreads();                              // headers/codes/s_e rewritten next tile
+    }
+
+    // ── Window phase: causal FP32 scores with the UNROTATED q ──
+    for (int idx = tid; idx < mq * head_dim; idx += 256) {
+        int i = idx / head_dim, d = idx - i * head_dim;
+        s_q[idx] = q_all[(long)(q0g + i) * (long)q_dim + (long)h * head_dim + d];
+    }
+    __syncthreads();
+
+    int w_total = f0 + n_tok;                         // valid window rows after the chunk append
+    for (int wb = 0; wb < w_total; wb += T) {
+        int wlen = w_total - wb; if (wlen > T) wlen = T;
+
+        if (i16 < mq) {
+            int lim = f0 + q0g + i16;                 // newest slot visible to this query (its own row)
+            for (int tl = lane16; tl < wlen; tl += 16) {
+                int slot = wb + tl;
+                float sc = sharpi_neg_inf();
+                if (slot <= lim) {
+                    const float* krow = k_window + (long)slot * (long)kv_dim + (long)kv_head * head_dim;
+                    float dot = 0.0f;
+                    for (int d = 0; d < head_dim; d++)
+                        dot += s_q[i16 * head_dim + d] * krow[d];
+                    sc = dot * scale;
+                }
+                s_e[i16 * T + tl] = sc;
+            }
+        }
+        __syncthreads();
+
+        // Same unconditional-shuffle structure as the tile-phase update (odd-mq
+        // tail chunks must not leave a warp half-active around a full-mask shuffle).
+        {
+            float mx = sharpi_neg_inf();
+            if (i16 < mq)
+                for (int tl = lane16; tl < wlen; tl += 16) mx = fmaxf(mx, s_e[i16 * T + tl]);
+            for (int off = 8; off > 0; off >>= 1)
+                mx = fmaxf(mx, __shfl_down_sync(0xffffffffu, mx, off, 16));
+            mx = __shfl_sync(0xffffffffu, mx, 0, 16);
+            float mnew = fmaxf(s_m[i16], mx);
+            // A fully-masked block leaves mnew == s_m (finite after the tile phase:
+            // tq_seq_len ≥ 128 by contract). Guard anyway so a stray −inf max can
+            // never poison the partials with exp(−inf − −inf) = NaN.
+            bool ok = mnew > sharpi_neg_inf();
+            float r = ok ? __expf(s_m[i16] - mnew) : 1.0f;
+            float sm = 0.0f;
+            if (i16 < mq) {
+                for (int tl = lane16; tl < wlen; tl += 16) {
+                    float e = ok ? __expf(s_e[i16 * T + tl] - mnew) : 0.0f;
+                    s_e[i16 * T + tl] = e;
+                    sm += e;
+                }
+            }
+            for (int off = 8; off > 0; off >>= 1)
+                sm += __shfl_down_sync(0xffffffffu, sm, off, 16);
+            if (lane16 == 0 && i16 < mq) {
+                s_l[i16] = s_l[i16] * r + sm;
+                s_m[i16] = mnew;
+                s_r[i16] = r;
+            }
+        }
+        __syncthreads();
+
+        // Rescale BOTH partials, then accumulate this block's window V rows.
+        for (int idx = tid; idx < mq * head_dim; idx += 256) {
+            float r = s_r[idx / head_dim];
+            s_racc[idx] *= r;
+            s_wacc[idx] *= r;
+        }
+        __syncthreads();
+        for (int idx = tid; idx < mq * head_dim; idx += 256) {
+            int i = idx / head_dim, d = idx - i * head_dim;
+            float acc = 0.0f;
+            for (int tl = 0; tl < wlen; tl++) {
+                float e = s_e[i * T + tl];                 // masked slots carry e = 0
+                acc += e * v_window[(long)(wb + tl) * (long)kv_dim + (long)kv_head * head_dim + d];
+            }
+            s_wacc[idx] += acc;
+        }
+        __syncthreads();
+    }
+
+    // ── One deferred inverse WHT per query row (in place, disjoint pairs per stage) ──
+    for (int s = head_dim >> 1; s >= 1; s >>= 1) {
+        for (int pair = tid; pair < mq * (head_dim >> 1); pair += 256) {
+            int i = pair / (head_dim >> 1);
+            int p = pair - i * (head_dim >> 1);
+            int pos_lo = i * head_dim + (p / s) * (s << 1) + (p % s);
+            int pos_hi = pos_lo + s;
+            float a = s_racc[pos_lo];
+            float b = s_racc[pos_hi];
+            s_racc[pos_lo] = a + b;
+            s_racc[pos_hi] = a - b;
+        }
+        __syncthreads();
+    }
+
+    // Blend: out = (IWHT(tile partial)·1/√D + window partial) / l.
+    float wht_scale = 1.0f / sqrtf((float)head_dim);
+    for (int idx = tid; idx < mq * head_dim; idx += 256) {
+        int i = idx / head_dim, d = idx - i * head_dim;
+        float l = s_l[i];
+        float inv = (l > 0.0f) ? (1.0f / l) : 0.0f;
+        out_all[(long)(q0g + i) * (long)q_dim + (long)h * head_dim + d]
+            = (s_racc[idx] * wht_scale + s_wacc[idx]) * inv;
+    }
+}
+#undef KPF_MQ
+
 // ── Scaled dot-product attention with GQA ─────────────────────────────────
 // One block per query head, 256 threads.
 //

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -6424,6 +6424,483 @@ extern ""C"" __global__ void llm_tq_attention(
     }
 }
 
+// ── KVarN rotate_query (issue #180) ────────────────────────────────────────
+// Normalized Walsh-Hadamard transform of each query head. Unlike the TQ
+// twin above there is NO per-layer sign flip (KVarN has no sign pattern —
+// Sinkhorn normalization replaces it as the outlier equalizer), and the
+// 1/sqrt(dim) scale is computed as 1.0f/sqrtf(dim) so it matches the CPU
+// WalshHadamard.Transform bit-for-bit (rsqrtf is only approximate).
+//
+// One block per query head, head_dim threads; head_dim must be a power of
+// two in [8, 256] (the shared-staging cap, same bound as llm_tq_rotate_query).
+extern ""C"" __global__ void llm_kvarn_rotate_query(
+    const float* __restrict__ q_input,
+    float* __restrict__ rotated_q,
+    int num_heads, int head_dim)
+{
+    __shared__ float sdata[256];
+
+    int h = (int)blockIdx.x;
+    int tid = (int)threadIdx.x;
+    if (h >= num_heads || tid >= head_dim) return;
+
+    int q_off = h * head_dim;
+    sdata[tid] = q_input[q_off + tid];
+    __syncthreads();
+
+    // WHT butterfly: dim/2 active threads per stage — the same pair
+    // enumeration as the CPU butterfly, so each stage is bit-identical.
+    for (int s = head_dim >> 1; s >= 1; s >>= 1) {
+        if (tid < (head_dim >> 1)) {
+            int pos_lo = (tid / s) * (s << 1) + (tid % s);
+            int pos_hi = pos_lo + s;
+            float a = sdata[pos_lo];
+            float b = sdata[pos_hi];
+            sdata[pos_lo] = a + b;
+            sdata[pos_hi] = a - b;
+        }
+        __syncthreads();
+    }
+
+    float scale = 1.0f / sqrtf((float)head_dim);
+    rotated_q[q_off + tid] = sdata[tid] * scale;
+}
+
+// ── KVarN tile compression (issue #180) ────────────────────────────────────
+// Compresses the OLDEST 128 rows of a layer's linear FP32 window (row 0 =
+// oldest — the host keeps the window shifted down, mirroring the CPU
+// TurboQuantKvCache) into one packed K tile (4-bit per-channel) and one
+// packed V tile (2-bit per-token, channel groups of 128) per kv-head.
+//
+// Clean-room mirror of KVarNCompressor.CompressKeyTile/CompressValueTile:
+//   1. normalized WHT per token row (K and V both),
+//   2. Sinkhorn dual-axis RMS normalization — columns first, rows last,
+//      log-space factor accumulation, 1e-12 epsilon guard,
+//   3. asymmetric RTN (K: per-channel min/step over the 128 tokens; V:
+//      per-token min/step per 128-channel group), round-to-nearest-EVEN
+//      (__float2int_rn == MathF.Round),
+//   4. scale folding: the quantized axis's Sinkhorn factor folds into the
+//      stored step/min; the other axis's factor is stored raw.
+//
+// Numerics contract: every op that feeds the RTN codes uses correctly-rounded
+// single-precision arithmetic (__fadd_rn/__fmul_rn block FMA contraction in
+// the sum-of-squares; '/', sqrtf are IEEE-correct under the default NVRTC
+// -prec-div/-prec-sqrt), so the packed CODES are bit-identical to the CPU
+// compressor. logf/expf may differ from MathF.Log/Exp in the last ulp, which
+// only perturbs the STORED scale floats (rowScale/colScale and the folded
+// step/min), never the codes.
+//
+// The 128×head_dim working tile (64 KB at D=128) exceeds the 48 KB shared
+// ceiling, so it lives in a global scratch buffer (`work`, one slice per
+// (kv_head, K/V) block); shared memory holds only one row (WHT) and the
+// per-axis log factors. Promotion runs once per 128 decode steps per layer,
+// so the extra global traffic is amortized — correctness first (Task 5a).
+//
+// Grid: (num_kv_heads, 2) — blockIdx.y 0 = K tile, 1 = V tile. Block: 128
+// threads (covers the widest butterfly at head_dim=256 and one thread per
+// token row). head_dim: power of two in [8, 256].
+extern ""C"" __global__ void llm_kvarn_compress_tile(
+    const float* __restrict__ k_window,   // [window × kv_dim] fp32, row 0 = oldest
+    const float* __restrict__ v_window,
+    unsigned int* __restrict__ k_tiles,   // packed K tiles, KVarNCompressor layout
+    unsigned int* __restrict__ v_tiles,   // packed V tiles
+    float* __restrict__ work,             // [num_kv_heads × 2 × 128 × head_dim] f32 scratch
+    int kv_dim, int head_dim, int tile_idx,
+    int num_kv_heads, int k_tile_bytes, int v_tile_bytes,
+    int sinkhorn_iters)
+{
+    const int T = 128;                    // KVarNCompressor.TileTokens
+    const float RMS_EPS = 1e-12f;
+    __shared__ float srow[256];           // one token row for the WHT butterfly
+    __shared__ float log_row[128];        // per-token Sinkhorn log factors → exp'd in place
+    __shared__ float log_col[256];        // per-channel Sinkhorn log factors → exp'd in place
+
+    int kv_head = (int)blockIdx.x;
+    int is_v = (int)blockIdx.y;
+    int tid = (int)threadIdx.x;           // blockDim.x == 128
+    if (kv_head >= num_kv_heads) return;
+
+    const float* window = (is_v != 0) ? v_window : k_window;
+    float* tile_f = work + (long)(kv_head * 2 + is_v) * (long)(T * head_dim);
+
+    int half_dim = head_dim >> 1;         // ≤ 128 == blockDim.x
+    float wht_scale = 1.0f / sqrtf((float)head_dim);
+
+    // 1. Gather + rotate each token row (row t of the tile = window row t).
+    for (int t = 0; t < T; t++) {
+        for (int c = tid; c < head_dim; c += 128)
+            srow[c] = window[(long)t * (long)kv_dim + (long)kv_head * head_dim + c];
+        __syncthreads();
+
+        for (int s = half_dim; s >= 1; s >>= 1) {
+            if (tid < half_dim) {
+                int pos_lo = (tid / s) * (s << 1) + (tid % s);
+                int pos_hi = pos_lo + s;
+                float a = srow[pos_lo];
+                float b = srow[pos_hi];
+                srow[pos_lo] = a + b;
+                srow[pos_hi] = a - b;
+            }
+            __syncthreads();
+        }
+
+        for (int c = tid; c < head_dim; c += 128)
+            tile_f[t * head_dim + c] = srow[c] * wht_scale;
+        __syncthreads();
+    }
+
+    // 2. Sinkhorn dual-axis RMS normalization (columns first, rows last).
+    for (int i = tid; i < T; i += 128) log_row[i] = 0.0f;
+    for (int i = tid; i < head_dim; i += 128) log_col[i] = 0.0f;
+    __syncthreads();
+
+    for (int iter = 0; iter < sinkhorn_iters; iter++) {
+        // Channels (columns) first — one thread per channel; the token loop
+        // runs t = 0..127 sequentially, matching the CPU accumulation order.
+        for (int c = tid; c < head_dim; c += 128) {
+            float sum_sq = 0.0f;
+            for (int t = 0; t < T; t++) {
+                float v = tile_f[t * head_dim + c];
+                sum_sq = __fadd_rn(sum_sq, __fmul_rn(v, v));   // no FMA contraction
+            }
+            float rms = sqrtf(sum_sq / (float)T);
+            if (rms > RMS_EPS) {
+                float inv = 1.0f / rms;
+                for (int t = 0; t < T; t++)
+                    tile_f[t * head_dim + c] *= inv;
+                log_col[c] += logf(rms);
+            }
+        }
+        __syncthreads();
+
+        // ... tokens (rows) last, so per-token RMS ends exactly at 1.
+        for (int t = tid; t < T; t += 128) {
+            float sum_sq = 0.0f;
+            for (int c = 0; c < head_dim; c++) {
+                float v = tile_f[t * head_dim + c];
+                sum_sq = __fadd_rn(sum_sq, __fmul_rn(v, v));
+            }
+            float rms = sqrtf(sum_sq / (float)head_dim);
+            if (rms > RMS_EPS) {
+                float inv = 1.0f / rms;
+                for (int c = 0; c < head_dim; c++)
+                    tile_f[t * head_dim + c] *= inv;
+                log_row[t] += logf(rms);
+            }
+        }
+        __syncthreads();
+    }
+
+    for (int i = tid; i < T; i += 128) log_row[i] = expf(log_row[i]);
+    for (int i = tid; i < head_dim; i += 128) log_col[i] = expf(log_col[i]);
+    __syncthreads();
+
+    // 3. Asymmetric RTN quantize + pack (KVarNCompressor packed layouts; both
+    //    tile strides are 4-byte multiples so the uint[] cache views stay
+    //    aligned; per-thread regions are disjoint, so plain byte stores).
+    if (is_v == 0) {
+        // K tile: [rowScale T×f32][chanStep D×f32][chanMin D×f32][codes D runs
+        // of T/2 bytes, channel-major, PackBits4: even token → low nibble].
+        long byte_off = ((long)tile_idx * num_kv_heads + kv_head) * (long)k_tile_bytes;
+        float* f32 = (float*)((unsigned char*)k_tiles + byte_off);
+        float* row_scale = f32;
+        float* chan_step = f32 + T;
+        float* chan_min  = f32 + T + head_dim;
+        unsigned char* codes = (unsigned char*)f32 + (T + 2 * head_dim) * 4;
+
+        for (int t = tid; t < T; t += 128) row_scale[t] = log_row[t];
+
+        for (int c = tid; c < head_dim; c += 128) {
+            float mn = 3.402823466e+38f, mx = -3.402823466e+38f;
+            for (int t = 0; t < T; t++) {
+                float v = tile_f[t * head_dim + c];
+                if (v < mn) mn = v;
+                if (v > mx) mx = v;
+            }
+            float step = (mx - mn) / 15.0f;
+            float inv_step = (step > 0.0f) ? (1.0f / step) : 0.0f;
+            chan_step[c] = log_col[c] * step;
+            chan_min[c]  = log_col[c] * mn;
+
+            unsigned char* run = codes + c * (T / 2);
+            for (int b = 0; b < T / 2; b++) {
+                int q0 = __float2int_rn((tile_f[(b * 2)     * head_dim + c] - mn) * inv_step);
+                int q1 = __float2int_rn((tile_f[(b * 2 + 1) * head_dim + c] - mn) * inv_step);
+                if (q0 < 0) q0 = 0; else if (q0 > 15) q0 = 15;
+                if (q1 < 0) q1 = 0; else if (q1 > 15) q1 = 15;
+                run[b] = (unsigned char)(q0 | (q1 << 4));
+            }
+        }
+    } else {
+        // V tile: [colScale D×f32][tokStep T·G×f32][tokMin T·G×f32][codes T
+        // runs of D/4 bytes, token-major, PackBits2: channel c → bits (c&3)·2].
+        int groups = (head_dim + 127) >> 7;   // ValueGroupSize = 128
+        long byte_off = ((long)tile_idx * num_kv_heads + kv_head) * (long)v_tile_bytes;
+        float* f32 = (float*)((unsigned char*)v_tiles + byte_off);
+        float* col_scale = f32;
+        float* tok_step  = f32 + head_dim;
+        float* tok_min   = f32 + head_dim + T * groups;
+        unsigned char* codes = (unsigned char*)f32 + (head_dim + 2 * T * groups) * 4;
+
+        for (int c = tid; c < head_dim; c += 128) col_scale[c] = log_col[c];
+
+        int bytes_per_token = head_dim >> 2;
+        for (int t = tid; t < T; t += 128) {
+            unsigned char* run = codes + t * bytes_per_token;
+            for (int g = 0; g < groups; g++) {
+                int c0 = g << 7;
+                int c1 = c0 + 128; if (c1 > head_dim) c1 = head_dim;
+
+                float mn = 3.402823466e+38f, mx = -3.402823466e+38f;
+                for (int c = c0; c < c1; c++) {
+                    float v = tile_f[t * head_dim + c];
+                    if (v < mn) mn = v;
+                    if (v > mx) mx = v;
+                }
+                float step = (mx - mn) / 3.0f;
+                float inv_step = (step > 0.0f) ? (1.0f / step) : 0.0f;
+                tok_step[t * groups + g] = log_row[t] * step;
+                tok_min[t * groups + g]  = log_row[t] * mn;
+
+                for (int b = (c0 >> 2); b < (c1 >> 2); b++) {
+                    int c = b << 2;
+                    int q0 = __float2int_rn((tile_f[t * head_dim + c    ] - mn) * inv_step);
+                    int q1 = __float2int_rn((tile_f[t * head_dim + c + 1] - mn) * inv_step);
+                    int q2 = __float2int_rn((tile_f[t * head_dim + c + 2] - mn) * inv_step);
+                    int q3 = __float2int_rn((tile_f[t * head_dim + c + 3] - mn) * inv_step);
+                    if (q0 < 0) q0 = 0; else if (q0 > 3) q0 = 3;
+                    if (q1 < 0) q1 = 0; else if (q1 > 3) q1 = 3;
+                    if (q2 < 0) q2 = 0; else if (q2 > 3) q2 = 3;
+                    if (q3 < 0) q3 = 0; else if (q3 > 3) q3 = 3;
+                    run[b] = (unsigned char)(q0 | (q1 << 2) | (q2 << 4) | (q3 << 6));
+                }
+            }
+        }
+    }
+}
+
+// ── KVarN attention (hybrid compressed tiles + FP32 window, issue #180) ────
+// One block per query head, 256 threads. Same 3-phase structure and score
+// storage strategy as llm_tq_attention (shared scores ≤ 4096 positions,
+// global scratch above), but reads KVarN packed tiles:
+//
+//   Phase 1a — per K tile, the per-channel factors fold into the rotated
+//     query ONCE (qfold_c = rotq_c·chanStep_c, bias = Σ_c rotq_c·chanMin_c —
+//     the KVarNCompressor.KeyScores algebra), then one thread per token walks
+//     that token's channel-major nibbles:
+//       score_t = rowScale_t · (Σ_c qfold_c·code[c,t] + bias) · 1/sqrt(D)
+//   Phase 1b — FP32 window scores with the UNROTATED q (the window holds
+//     original-domain rows; the window is linear, slot 0 = oldest).
+//   Phase 2  — one softmax over [0, tq_seq_len + fp32_seq_len).
+//   Phase 3  — V aggregation: compressed tiles accumulate in the ROTATED
+//     domain (all tiles share the rotation), ONE inverse WHT per head, then
+//     the FP32-window V contribution adds on top in the original domain —
+//     the KVarNCompressor class contract (deferred inverse, w/ws skip terms
+//     contribute exact zeros so no skip branches are needed for parity).
+//
+// tq_seq_len must be a whole-tile multiple (the KVarN cache invariant: the
+// window owns everything mod 128). head_dim: power of two in [8, 256].
+extern ""C"" __global__ void llm_kvarn_attention(
+    const float* __restrict__ q,
+    const float* __restrict__ rotated_q,
+    const unsigned int* __restrict__ k_tiles,
+    const unsigned int* __restrict__ v_tiles,
+    const float* __restrict__ k_cache_fp32,
+    const float* __restrict__ v_cache_fp32,
+    float* __restrict__ out,
+    float* __restrict__ scores_scratch,    // [num_heads × max_seq_len], null when total ≤ 4096
+    int num_heads, int num_kv_heads, int head_dim,
+    int tq_seq_len, int fp32_seq_len, int max_seq_len,
+    int k_tile_bytes, int v_tile_bytes)
+{
+    const int T = 128;                     // tile tokens
+    const int MAX_SHARED_SCORES = 4096;
+    __shared__ float shared_scores[MAX_SHARED_SCORES];
+    __shared__ float sdata[256];           // reductions + the deferred inverse WHT
+    __shared__ float qfold[256];           // per-tile folded query (rotq·chanStep)
+
+    int h = (int)blockIdx.x;
+    int tid = (int)threadIdx.x;
+    if (h >= num_heads) return;
+
+    int kv_head = h / (num_heads / num_kv_heads);
+    int kv_dim  = num_kv_heads * head_dim;
+    float scale = 1.0f / sqrtf((float)head_dim);
+    long q_off  = (long)h * (long)head_dim;
+    int total_seq = tq_seq_len + fp32_seq_len;
+    int num_tiles = tq_seq_len / T;
+
+    bool use_shared = (total_seq <= MAX_SHARED_SCORES);
+    float* head_scratch = scores_scratch + (long)h * (long)max_seq_len;
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Phase 1a: compressed-tile scores
+    // ────────────────────────────────────────────────────────────────────
+    for (int tile = 0; tile < num_tiles; tile++) {
+        const float* f32 = (const float*)((const unsigned char*)k_tiles
+            + ((long)tile * num_kv_heads + kv_head) * (long)k_tile_bytes);
+        const float* row_scale = f32;                       // [T]
+        const float* chan_step = f32 + T;                   // [D]
+        const float* chan_min  = f32 + T + head_dim;        // [D]
+        const unsigned char* codes = (const unsigned char*)f32 + (T + 2 * head_dim) * 4;
+
+        // Fold the per-channel factors into the query once per tile.
+        float partial_bias = 0.0f;
+        for (int c = tid; c < head_dim; c += 256) {
+            float rq = rotated_q[q_off + c];
+            qfold[c] = rq * chan_step[c];
+            partial_bias += rq * chan_min[c];
+        }
+        sdata[tid] = partial_bias;
+        __syncthreads();
+        for (unsigned int s = 128; s > 0; s >>= 1) {
+            if ((unsigned int)tid < s) sdata[tid] += sdata[tid + s];
+            __syncthreads();
+        }
+        float bias = sdata[0];
+        __syncthreads();
+
+        // One thread per token: walk the channel-major nibble runs.
+        for (int t = tid; t < T; t += 256) {
+            const unsigned char* col = codes + (t >> 1);
+            int shift = (t & 1) ? 4 : 0;
+            float acc = 0.0f;
+            for (int c = 0; c < head_dim; c++) {
+                int code = (col[c * (T / 2)] >> shift) & 0xF;
+                acc += qfold[c] * (float)code;
+            }
+            float score = row_scale[t] * (acc + bias) * scale;
+            int idx = tile * T + t;
+            if (use_shared) shared_scores[idx] = score;
+            else            head_scratch[idx]  = score;
+        }
+        __syncthreads();   // qfold/sdata are rewritten by the next tile
+    }
+
+    // 1b — FP32 recent window (unrotated q, linear slots).
+    for (int t = tid; t < fp32_seq_len; t += 256) {
+        float dot = 0.0f;
+        long k_off = (long)t * (long)kv_dim + (long)kv_head * (long)head_dim;
+        for (int d = 0; d < head_dim; d++)
+            dot += q[q_off + d] * k_cache_fp32[k_off + d];
+        float score = dot * scale;
+        if (use_shared) shared_scores[tq_seq_len + t] = score;
+        else            head_scratch[tq_seq_len + t]  = score;
+    }
+
+    if (use_shared) {
+        for (int t = total_seq + tid; t < MAX_SHARED_SCORES; t += 256)
+            shared_scores[t] = sharpi_neg_inf();
+    }
+    __syncthreads();
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Phase 2: in-place softmax over [0, total_seq)  (mirrors llm_tq_attention)
+    // ────────────────────────────────────────────────────────────────────
+    float local_max = sharpi_neg_inf();
+    for (int t = tid; t < total_seq; t += 256) {
+        float s = use_shared ? shared_scores[t] : head_scratch[t];
+        local_max = fmaxf(local_max, s);
+    }
+    sdata[tid] = local_max;
+    __syncthreads();
+    for (unsigned int s = 128; s > 0; s >>= 1) {
+        if ((unsigned int)tid < s) sdata[tid] = fmaxf(sdata[tid], sdata[tid + s]);
+        __syncthreads();
+    }
+    float max_val = sdata[0];
+    __syncthreads();
+
+    float local_sum = 0.0f;
+    for (int t = tid; t < total_seq; t += 256) {
+        float s = use_shared ? shared_scores[t] : head_scratch[t];
+        float e = __expf(s - max_val);
+        if (use_shared) shared_scores[t] = e;
+        else            head_scratch[t]  = e;
+        local_sum += e;
+    }
+    sdata[tid] = local_sum;
+    __syncthreads();
+    for (unsigned int s = 128; s > 0; s >>= 1) {
+        if ((unsigned int)tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+    float inv_sum = 1.0f / sdata[0];
+    __syncthreads();
+
+    for (int t = tid; t < total_seq; t += 256) {
+        if (use_shared) shared_scores[t] *= inv_sum;
+        else            head_scratch[t]  *= inv_sum;
+    }
+    __syncthreads();
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Phase 3: V aggregation
+    // ────────────────────────────────────────────────────────────────────
+
+    // 3a — compressed tiles, rotated domain. One thread per output channel.
+    float rot_acc = 0.0f;
+    if (tid < head_dim) {
+        int d = tid;
+        int groups = (head_dim + 127) >> 7;
+        int g = d >> 7;
+        int bytes_per_token = head_dim >> 2;
+        int code_shift = (d & 3) * 2;
+        int code_byte = d >> 2;
+
+        for (int tile = 0; tile < num_tiles; tile++) {
+            const float* f32 = (const float*)((const unsigned char*)v_tiles
+                + ((long)tile * num_kv_heads + kv_head) * (long)v_tile_bytes);
+            const float* col_scale = f32;                            // [D]
+            const float* tok_step  = f32 + head_dim;                 // [T·G]
+            const float* tok_min   = f32 + head_dim + T * groups;    // [T·G]
+            const unsigned char* codes = (const unsigned char*)f32 + (head_dim + 2 * T * groups) * 4;
+
+            // acc_c = Σ_t (w_t·tokStep_tg)·code[t,c]; the min term folds once
+            // per (token, group) — same algebra as AggregateValues.
+            float acc = 0.0f, group_bias = 0.0f;
+            for (int t = 0; t < T; t++) {
+                int idx = tile * T + t;
+                float w = use_shared ? shared_scores[idx] : head_scratch[idx];
+                group_bias += w * tok_min[t * groups + g];
+                float ws = w * tok_step[t * groups + g];
+                int code = (codes[t * bytes_per_token + code_byte] >> code_shift) & 0x3;
+                acc += ws * (float)code;
+            }
+            rot_acc += col_scale[d] * (acc + group_bias);
+        }
+    }
+    __syncthreads();   // phase-2 sdata reads are done; reuse it for the IWHT
+
+    // 3b — one deferred inverse WHT per head (the normalized WHT is an
+    // involution; the 1/sqrt(D) normalization is applied at readout below).
+    if (tid < head_dim) sdata[tid] = rot_acc;
+    __syncthreads();
+    for (int s = head_dim >> 1; s >= 1; s >>= 1) {
+        if (tid < (head_dim >> 1)) {
+            int pos_lo = (tid / s) * (s << 1) + (tid % s);
+            int pos_hi = pos_lo + s;
+            float a = sdata[pos_lo];
+            float b = sdata[pos_hi];
+            sdata[pos_lo] = a + b;
+            sdata[pos_hi] = a - b;
+        }
+        __syncthreads();
+    }
+    float wht_scale = 1.0f / sqrtf((float)head_dim);
+
+    // 3c — FP32-window V contribution (original domain) + output write.
+    for (int d = tid; d < head_dim; d += 256) {
+        float acc = (num_tiles > 0) ? sdata[d] * wht_scale : 0.0f;
+        for (int t = 0; t < fp32_seq_len; t++) {
+            float w = use_shared ? shared_scores[tq_seq_len + t] : head_scratch[tq_seq_len + t];
+            long v_off = (long)t * (long)kv_dim + (long)kv_head * (long)head_dim;
+            acc += w * v_cache_fp32[v_off + d];
+        }
+        out[q_off + d] = acc;
+    }
+}
+
 // ── Scaled dot-product attention with GQA ─────────────────────────────────
 // One block per query head, 256 threads.
 //

--- a/src/SharpInference.Cuda/CudaTextKernels.cs
+++ b/src/SharpInference.Cuda/CudaTextKernels.cs
@@ -6718,6 +6718,11 @@ extern ""C"" __global__ void llm_kvarn_attention(
     __shared__ float shared_scores[MAX_SHARED_SCORES];
     __shared__ float sdata[256];           // reductions + the deferred inverse WHT
     __shared__ float qfold[256];           // per-tile folded query (rotq·chanStep)
+    // Task 5b coalesced-walk scratch: phase 1a stages 8 per-warp token-partial rows
+    // (8 warps × T), phase 3a reuses the same pool as 256 × 4 channel-quad partials.
+    __shared__ float acc_pool[8 * 128];
+    __shared__ float ws_sh[256];           // 3a: per-tile w·tokStep, [groups × T]
+    __shared__ float vbias[2];             // 3a: per-group Σ_t w·tokMin (groups ≤ 2)
 
     int h = (int)blockIdx.x;
     int tid = (int)threadIdx.x;
@@ -6760,21 +6765,47 @@ extern ""C"" __global__ void llm_kvarn_attention(
         float bias = sdata[0];
         __syncthreads();
 
-        // One thread per token: walk the channel-major nibble runs.
-        for (int t = tid; t < T; t += 256) {
-            const unsigned char* col = codes + (t >> 1);
-            int shift = (t & 1) ? 4 : 0;
-            float acc = 0.0f;
-            for (int c = 0; c < head_dim; c++) {
-                int code = (col[c * (T / 2)] >> shift) & 0xF;
-                acc += qfold[c] * (float)code;
+        // Coalesced warp-per-channel walk (issue #180 Task 5b). The old layout —
+        // one thread per token striding T/2 bytes per channel — serialized
+        // head_dim dependent byte loads per thread with half the block idle.
+        // Now warp w covers channels {w, w+8, …}; within a channel, lane l
+        // reads the two consecutive code bytes for tokens 4l..4l+3 (a channel's
+        // whole 64-byte run = exactly 2 coalesced 32B sectors per warp) and
+        // accumulates qfold[c]·code into 4 per-token register partials. Tokens
+        // are owned exclusively by one lane within each warp, so the partials
+        // stage to the per-warp acc_pool row without atomics; a token's score
+        // then sums the 8 warp rows. FP reassociation vs the serial channel
+        // loop is within the attention parity band (max(1e-3, 1e-2·|x|)).
+        {
+            int warp = tid >> 5;
+            int lane = tid & 31;
+            float a0 = 0.0f, a1 = 0.0f, a2 = 0.0f, a3 = 0.0f;
+            for (int c = warp; c < head_dim; c += 8) {
+                float qf = qfold[c];
+                const unsigned char* run = codes + c * (T / 2) + lane * 2;
+                unsigned int b0 = run[0];
+                unsigned int b1 = run[1];
+                a0 += qf * (float)(b0 & 0xFu);   // even token → low nibble (PackBits4)
+                a1 += qf * (float)(b0 >> 4);
+                a2 += qf * (float)(b1 & 0xFu);
+                a3 += qf * (float)(b1 >> 4);
             }
+            float* accw = acc_pool + warp * T + lane * 4;
+            accw[0] = a0; accw[1] = a1; accw[2] = a2; accw[3] = a3;
+        }
+        __syncthreads();
+
+        for (int t = tid; t < T; t += 256) {
+            float acc = acc_pool[t]         + acc_pool[T + t]
+                      + acc_pool[2 * T + t] + acc_pool[3 * T + t]
+                      + acc_pool[4 * T + t] + acc_pool[5 * T + t]
+                      + acc_pool[6 * T + t] + acc_pool[7 * T + t];
             float score = row_scale[t] * (acc + bias) * scale;
             int idx = tile * T + t;
             if (use_shared) shared_scores[idx] = score;
             else            head_scratch[idx]  = score;
         }
-        __syncthreads();   // qfold/sdata are rewritten by the next tile
+        __syncthreads();   // qfold/sdata/acc_pool are rewritten by the next tile
     }
 
     // 1b — FP32 recent window (unrotated q, linear slots).
@@ -6838,15 +6869,27 @@ extern ""C"" __global__ void llm_kvarn_attention(
     //  Phase 3: V aggregation
     // ────────────────────────────────────────────────────────────────────
 
-    // 3a — compressed tiles, rotated domain. One thread per output channel.
+    // 3a — compressed tiles, rotated domain. Coalesced flat-index walk (issue
+    // #180 Task 5b): the old layout — one thread per channel walking all T
+    // token rows at a bytes_per_token stride, with 128+ threads idle — chained
+    // T·tiles dependent byte loads per thread. Now thread tid owns code byte
+    // (tid & (bpt−1)) of token rows t = tid/bpt, +256/bpt, …: every block pass
+    // reads 256 consecutive code bytes (fully coalesced), each thread keeps 4
+    // register partials for its lane-stable channel quad, and the per-(token,
+    // group) w·tokStep / w·tokMin factors — channel-invariant, previously
+    // re-read per channel — fold once per tile in shared. Per tile the quads
+    // reduce across token-strips and fold the per-tile col_scale + weighted-
+    // min bias into rot_acc: the same AggregateValues algebra, reassociated
+    // within the attention parity band. bpt = head_dim/4 ∈ {2,…,64} (pow2)
+    // always divides 256, so the byte/quad assignment is lane-stable.
     float rot_acc = 0.0f;
-    if (tid < head_dim) {
-        int d = tid;
+    {
         int groups = (head_dim + 127) >> 7;
-        int g = d >> 7;
         int bytes_per_token = head_dim >> 2;
-        int code_shift = (d & 3) * 2;
-        int code_byte = d >> 2;
+        int my_byte = tid & (bytes_per_token - 1);
+        int my_g = (my_byte << 2) >> 7;            // group of this thread's channel quad
+        int t_stride = 256 / bytes_per_token;
+        int t_first = tid / bytes_per_token;
 
         for (int tile = 0; tile < num_tiles; tile++) {
             const float* f32 = (const float*)((const unsigned char*)v_tiles
@@ -6856,18 +6899,55 @@ extern ""C"" __global__ void llm_kvarn_attention(
             const float* tok_min   = f32 + head_dim + T * groups;    // [T·G]
             const unsigned char* codes = (const unsigned char*)f32 + (head_dim + 2 * T * groups) * 4;
 
-            // acc_c = Σ_t (w_t·tokStep_tg)·code[t,c]; the min term folds once
-            // per (token, group) — same algebra as AggregateValues.
-            float acc = 0.0f, group_bias = 0.0f;
-            for (int t = 0; t < T; t++) {
-                int idx = tile * T + t;
-                float w = use_shared ? shared_scores[idx] : head_scratch[idx];
-                group_bias += w * tok_min[t * groups + g];
-                float ws = w * tok_step[t * groups + g];
-                int code = (codes[t * bytes_per_token + code_byte] >> code_shift) & 0x3;
-                acc += ws * (float)code;
+            // ws[g,t] = w_t·tokStep_tg once per tile (T·groups ≤ 256 entries).
+            for (int i = tid; i < T * groups; i += 256) {
+                int t = i & (T - 1);
+                int g = i >> 7;                    // i / T
+                float w = use_shared ? shared_scores[tile * T + t] : head_scratch[tile * T + t];
+                ws_sh[g * T + t] = w * tok_step[t * groups + g];
             }
-            rot_acc += col_scale[d] * (acc + group_bias);
+            // Per-group weighted-min bias Σ_t w_t·tokMin_tg (tree-reduced —
+            // reassociation is within the parity band).
+            for (int g = 0; g < groups; g++) {
+                float v = 0.0f;
+                for (int t = tid; t < T; t += 256) {
+                    float w = use_shared ? shared_scores[tile * T + t] : head_scratch[tile * T + t];
+                    v += w * tok_min[t * groups + g];
+                }
+                sdata[tid] = v;
+                __syncthreads();
+                for (unsigned int s = 128; s > 0; s >>= 1) {
+                    if ((unsigned int)tid < s) sdata[tid] += sdata[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) vbias[g] = sdata[0];
+                __syncthreads();
+            }
+
+            // acc_c = Σ_t ws[t]·code[t,c] over this thread's token strip.
+            float a0 = 0.0f, a1 = 0.0f, a2 = 0.0f, a3 = 0.0f;
+            for (int t = t_first; t < T; t += t_stride) {
+                float ws = ws_sh[my_g * T + t];
+                unsigned int b = codes[t * bytes_per_token + my_byte];
+                a0 += ws * (float)( b       & 0x3u);   // channel 4b+0 → bits 0..1 (PackBits2)
+                a1 += ws * (float)((b >> 2) & 0x3u);
+                a2 += ws * (float)((b >> 4) & 0x3u);
+                a3 += ws * (float)( b >> 6        );
+            }
+            float* accq = acc_pool + tid * 4;
+            accq[0] = a0; accq[1] = a1; accq[2] = a2; accq[3] = a3;
+            __syncthreads();
+
+            if (tid < head_dim) {
+                int d = tid;
+                int cb = d >> 2;                   // this channel's byte index
+                int j = d & 3;
+                float acc = 0.0f;
+                for (int k = cb; k < 256; k += bytes_per_token)
+                    acc += acc_pool[k * 4 + j];
+                rot_acc += col_scale[d] * (acc + vbias[d >> 7]);
+            }
+            __syncthreads();                       // ws_sh/acc_pool rewritten next tile
         }
     }
     __syncthreads();   // phase-2 sdata reads are done; reuse it for the IWHT

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -204,6 +204,15 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// </summary>
     public bool BatchedPrefillEnabled { get; set; }
     /// <summary>
+    /// Gates the issue-#180 Task 6 chunked batched KVarN prefill (tile-aligned chunks
+    /// through the batched trunk instead of the per-token Forward loop). Initialised from
+    /// <c>SHARPI_KVARN_BATCHED_PREFILL</c> (default on; <c>=0</c> reverts to the per-token
+    /// loop); settable so tests can A/B the chunked path against the per-token oracle on
+    /// the same model. Only consulted when the KVarN quantizer is active — also subject to
+    /// the master <see cref="BatchedPrefillEnabled"/> switch.
+    /// </summary>
+    public bool KvarnBatchedPrefillEnabled { get; set; }
+    /// <summary>
     /// Issue #162: window size (tokens) for chunked batched prefill of prompts longer
     /// than the non-flash 4096 cap. Each window is batched at its own startPos with flash
     /// attention streaming the prior KV, so the N-sized trunk scratch stays bounded to
@@ -397,6 +406,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     private int _bpCapacity;                 // current N the scratch is sized for (0 = none)
     private Tensor? _bpHidden, _bpResidual, _bpNorm;       // [N × embDim]
     private Tensor? _bpQ, _bpAttnOut;                      // [N × numHeads*maxHeadDim]
+    private Tensor? _bpRotQ;                               // [N × numHeads*maxHeadDim] KVarN rotated queries (#180 Task 6)
     private Tensor? _bpK, _bpV;                            // [N × numKvHeads*maxHeadDim]
     private Tensor? _bpFfnGate, _bpFfnUp;                  // [N × intermDim]
     private Tensor? _bpProjAll, _bpPleRowAll;             // [N × L*pleWidth]
@@ -658,6 +668,28 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// <summary>Test-only: number of FP32-window positions currently held.</summary>
     internal int TqFp32Count => _fp32Count;
 
+    /// <summary>
+    /// Test-only: download the first <paramref name="numTiles"/> packed KVarN K or V
+    /// tiles of one layer (tile-major, <c>numTiles × numKvHeads × tileBytes</c>) for
+    /// byte-level comparison between the chunked and per-token prefill paths (#180 Task 6).
+    /// </summary>
+    internal byte[] DownloadKvarnTileBytesForTest(int layer, bool valueTiles, int numTiles)
+    {
+        if (_gpuKvarnKTiles is null)
+            throw new InvalidOperationException("KVarN tile stores are not allocated (KVarN mode inactive).");
+        var store = valueTiles ? _gpuKvarnVTiles![layer] : _gpuKvarnKTiles[layer];
+        int stride = valueTiles ? _kvarnValueTileBytes : _kvarnKeyTileBytes;
+        long bytes = (long)numTiles * _numKvHeads * stride;   // strides are 4-byte multiples
+        var view = _gpu.View(store, 0, bytes / 4);
+        var floats = new float[bytes / 4];
+        _gpu.Download(view, floats);
+        _gpu.Synchronize();
+        _gpu.Free(view);
+        var result = new byte[bytes];
+        System.Runtime.InteropServices.MemoryMarshal.AsBytes(floats.AsSpan()).CopyTo(result);
+        return result;
+    }
+
     public CudaForwardPass(GgufModel model, CudaBackend gpu, ModelHyperparams hp,
         int maxContextLength = 0,
         bool enableTurboQuant = false, int tqFp32Window = 256, int tqBits = 3,
@@ -713,6 +745,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // bit-exact per-token loop (useful for A/B and parity debugging).
         BatchedPrefillEnabled =
             Environment.GetEnvironmentVariable("SHARPI_BATCHED_PREFILL") != "0";
+        // Chunked batched KVarN prefill (issue #180 Task 6) is on by default;
+        // SHARPI_KVARN_BATCHED_PREFILL=0 reverts KVarN prompts to the per-token loop.
+        KvarnBatchedPrefillEnabled =
+            Environment.GetEnvironmentVariable("SHARPI_KVARN_BATCHED_PREFILL") != "0";
         PrefillGemmEnabled =
             Environment.GetEnvironmentVariable("SHARPI_PREFILL_GEMM") != "0";
         // Issue #141 (MMQ): default on — the int8 tensor-core MMQ beats the
@@ -2809,6 +2845,20 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         if (_isGemma4Like)
             _gpu.EnsureQ81Scratch(Math.Max(_embDim, _intermDim));
 
+        // Chunked batched KVarN prefill (issue #180 Task 6): tile-aligned chunks through
+        // the batched trunk (batched QKV/FFN GEMMs + the streaming kvarn prefill-attention
+        // kernel) instead of the graph-replayed per-token loop (~20× on Qwen3-8B). The
+        // startPos check pins the driver's window/tile host state to the append position —
+        // it holds for fresh prefills and post-TruncateTo continuations (TruncateTo resyncs
+        // _fp32Count); anything else falls back to the per-token loop below.
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN && N >= 2
+            && startPos + N <= _maxSeqLen
+            && startPos == _tqCompressedLen + _fp32Count
+            && IsKvarnBatchedPrefillSupported())
+        {
+            return PrefillKvarnChunked(tokens, startPos);
+        }
+
         // SnapKV (issue #59) gating: only run eviction when this is a fresh
         // prefill (startPos==0), the effective budget is positive (env-set or
         // VRAM-scaled auto), the prompt is long enough that eviction would drop
@@ -2976,6 +3026,90 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         return BatchableWeight(_wOutput);
     }
 
+    /// <summary>
+    /// Whether the issue-#180 Task 6 chunked batched KVarN prefill can run this model.
+    /// The dense-trunk subset of <see cref="IsBatchedPrefillSupported"/> (that gate
+    /// hard-excludes TQ), narrowed further to what the KVarN chunk shapes need:
+    /// <list type="bullet">
+    ///   <item>plain dense trunk — no MoE, no Gemma-4 features (PLE/SWA/shared-KV/
+    ///         per-layer head_dim), no attention bias, NEOX RoPE, weighted-or-no QK-norm;</item>
+    ///   <item>head_dim 64 or 128 — the streaming prefill-attention kernel's shared-memory
+    ///         budget caps at 128 (which also pins V codes to one channel group), and the
+    ///         tqLen==0 chunks ride <see cref="CudaBackend.FlashAttentionPrefillTc2"/>
+    ///         (head_dim % 64); a KVarN model outside that (e.g. head_dim 256) falls back
+    ///         to the per-token loop;</item>
+    ///   <item>the Tc2 flash path enabled (pre-promotion chunks), fp32 KV (the KVarN
+    ///         constructor already rejects narrowed KV), and batchable trunk weights.</item>
+    /// </list>
+    /// </summary>
+    private bool IsKvarnBatchedPrefillSupported()
+    {
+        if (!BatchedPrefillEnabled || !KvarnBatchedPrefillEnabled) return false;
+        if (_isMoE || _isGemma4Like || _hasAttnBias || !_hp.IsNeoxRope) return false;
+        if (_hasQkNorm && _hp.UseL2QkNorm) return false;
+        if (_hp.SlidingWindowSize > 0 || _hp.LayerHeadDim is not null
+            || _hp.KvSourceLayer is not null || _hp.HasPerLayerTokenEmbd) return false;
+        if (_headDim is not (64 or 128)) return false;
+        if (!PrefillFlashTcEnabled || _forceFlashTc1) return false;
+        if (_kvDType != DType.Float32) return false;
+        for (int i = 0; i < _hp.NumLayers; i++)
+        {
+            if (_wv[i] is null) return false;
+            if (!BatchableWeight(_wq[i]) || !BatchableWeight(_wk[i]) || !BatchableWeight(_wv[i]) ||
+                !BatchableWeight(_wo[i]) ||
+                !BatchableWeight(_wGate[i]) || !BatchableWeight(_wUp[i]) ||
+                !BatchableWeight(_wDown[i]))
+                return false;
+        }
+        return BatchableWeight(_wOutput);
+    }
+
+    /// <summary>
+    /// Chunked batched KVarN prefill driver (issue #180 Task 6). Chunks are aligned to the
+    /// whole-tile promotion cadence so every query sees EXACTLY the same tile/window split
+    /// as the per-token loop, and every tile compresses EXACTLY the same 128 window rows:
+    /// <list type="number">
+    ///   <item>while the window is filling (tqLen == 0 for chunk positions &lt; window),
+    ///         one chunk of up to <c>window − fp32Count</c> tokens appends at slots
+    ///         [fp32Count, …) and attends causally within the window (flash);</item>
+    ///   <item>once <c>_fp32Count == window</c>, promote one tile on every layer (the same
+    ///         <see cref="PromoteKvarnTile"/> + host-counter advance the per-token Forward
+    ///         hoist performs — compress inputs are the identical window rows, so tiles are
+    ///         byte-identical given identical K/V), then run the next ≤128-token chunk.</item>
+    /// </list>
+    /// Steady-state chunks are exactly 128 tokens (window − (window − 128)). Each chunk
+    /// runs the standard batched trunk (<see cref="PrefillBatchedTrunk"/>); the KVarN
+    /// append/attention branch inside <see cref="GpuLayerBatchedTrunk"/> reads the stable
+    /// per-chunk <c>_fp32Count</c>/<c>_tqCompressedLen</c>. Direct launches only — decode's
+    /// lazily-captured CUDA graphs are untouched (they capture on the first Forward).
+    /// </summary>
+    private ReadOnlySpan<float> PrefillKvarnChunked(IReadOnlyList<int> tokens, int startPos)
+    {
+        int N = tokens.Count;
+        int[] all = tokens as int[] ?? System.Linq.Enumerable.ToArray(tokens);
+        int kvDimP = _numKvHeads * _headDim;
+        ReadOnlySpan<float> logits = default;
+        int done = 0;
+        while (done < N)
+        {
+            // Whole-tile promotion when the window is full — identical cadence to the
+            // per-token Forward hoist (Task 5b): the promotion runs BEFORE the append
+            // that would overflow, i.e. before chunk position tqLen + window.
+            if (_fp32Count >= _tqFp32Window)
+            {
+                for (int layer = 0; layer < _hp.NumLayers; layer++)
+                    PromoteKvarnTile(layer, kvDimP);
+                _tqCompressedLen += KVarNCompressor.TileTokens;
+                _fp32Count -= KVarNCompressor.TileTokens;
+            }
+            int len = Math.Min(N - done, _tqFp32Window - _fp32Count);
+            logits = PrefillBatchedTrunk(new ArraySegment<int>(all, done, len), startPos + done);
+            _fp32Count += len;
+            done += len;
+        }
+        return logits;
+    }
+
     private void GpuMatMulBatched(Tensor outAll, Tensor weights, Tensor inAll, int n)
     {
         if (s_prefillProfile) { _gpu.Synchronize(); _profMmSw.Restart(); }
@@ -3088,6 +3222,8 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         _bpNorm     = _gpu.Allocate(TensorShape.D1(emb));
         _bpQ        = _gpu.Allocate(TensorShape.D1((long)n * _numHeads * _maxHeadDim));
         _bpAttnOut  = _gpu.Allocate(TensorShape.D1((long)n * _numHeads * _maxHeadDim));
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN)
+            _bpRotQ = _gpu.Allocate(TensorShape.D1((long)n * _numHeads * _maxHeadDim));
         _bpK        = _gpu.Allocate(TensorShape.D1((long)n * _numKvHeads * _maxHeadDim));
         _bpV        = _gpu.Allocate(TensorShape.D1((long)n * _numKvHeads * _maxHeadDim));
         _bpFfnGate  = _gpu.Allocate(TensorShape.D1((long)n * _intermDim));
@@ -3115,11 +3251,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
     private void FreeBatchedTrunkScratch()
     {
-        foreach (var t in new[] { _bpHidden, _bpResidual, _bpNorm, _bpQ, _bpAttnOut,
+        foreach (var t in new[] { _bpHidden, _bpResidual, _bpNorm, _bpQ, _bpRotQ, _bpAttnOut,
                                   _bpK, _bpV, _bpFfnGate, _bpFfnUp,
                                   _bpProjAll, _bpPleRowAll, _bpPleGate, _bpPleY, _bpPleQuantDev })
             if (t is { } v) _gpu.Free(v);
-        _bpHidden = _bpResidual = _bpNorm = _bpQ = _bpAttnOut = _bpK = _bpV =
+        _bpHidden = _bpResidual = _bpNorm = _bpQ = _bpRotQ = _bpAttnOut = _bpK = _bpV =
             _bpFfnGate = _bpFfnUp = _bpProjAll = _bpPleRowAll = _bpPleGate = _bpPleY =
             _bpPleQuantDev = null;
         _bpPleRowHostAll = null;
@@ -3385,18 +3521,53 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             _gpu.HeadNormPureBatched(vAll, layerKv, layerHd, N, _hp.RmsNormEps);
         ApplyRopeBatched();
 
-        // Append-target ring (this layer's own KV) and attention-source ring (the effective
-        // layer's — same as `layer` unless shared-KV aliases it). SWA layers wrap a window-
-        // sized ring; everything else is full-context.
-        int appendCtx = isSwa && window > 0 ? SwaRingSize(_maxSeqLen, window) : _maxSeqLen;
-        int effLayerCtx = (_hp.IsSwaLayer is { } swaEff && swaEff[effLayer] && window > 0)
-            ? SwaRingSize(_maxSeqLen, window) : _maxSeqLen;
-        GpuPrefillAppendAttention(
-            qAll, kAll, vAll, attnAll,
-            kvShared ? null : _gpuKCache[layer], kvShared ? null : _gpuVCache[layer],
-            _gpuKCache[effLayer], _gpuVCache[effLayer],
-            _numHeads, layerKv, layerHd, startPos, N,
-            isSwa, window, appendCtx, effLayerCtx);
+        // KVarN chunked prefill (issue #180 Task 6): the fp32 cache is the LINEAR
+        // window (slot 0 = oldest, capacity _tqFp32Window), so the chunk's rows append
+        // at slots [_fp32Count, _fp32Count + N) — the driver guarantees no overflow and
+        // no promotion inside a chunk, so both counters are stable across the layer loop.
+        // Pre-promotion chunks (tqLen == 0: window slot == absolute position) take the
+        // plain streaming flash kernel with startPos remapped to the window slot base;
+        // steady-state chunks rotate the chunk queries (plain WHT — the per-token
+        // KvarnRotateQuery kernel, launched over N·numHeads head-rows) and run the
+        // streaming tile+window kernel. Everything is a direct launch (no graphs).
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN)
+        {
+            _gpu.KvAppendBatched(kAll, vAll, _gpuKCache[layer], _gpuVCache[layer],
+                kvDimL, _fp32Count, _tqFp32Window, N);
+            if (_tqCompressedLen == 0)
+            {
+                _gpu.FlashAttentionPrefillTc2(qAll, _gpuKCache[layer], _gpuVCache[layer], attnAll,
+                    _numHeads, layerKv, layerHd, _fp32Count, 0, _tqFp32Window, N,
+                    attnScale: _attnScale);
+            }
+            else
+            {
+                var rotAll = _gpu.View(_bpRotQ!, 0, (long)N * qDimL);
+                _gpu.KvarnRotateQuery(qAll, rotAll, _numHeads * N, layerHd);
+                _gpu.KvarnAttentionPrefill(qAll, rotAll,
+                    _gpuKvarnKTiles![layer], _gpuKvarnVTiles![layer],
+                    _gpuKCache[layer], _gpuVCache[layer], attnAll,
+                    _numHeads, layerKv, layerHd,
+                    _tqCompressedLen, _fp32Count, N,
+                    _kvarnKeyTileBytes, _kvarnValueTileBytes);
+                _gpu.Free(rotAll);
+            }
+        }
+        else
+        {
+            // Append-target ring (this layer's own KV) and attention-source ring (the effective
+            // layer's — same as `layer` unless shared-KV aliases it). SWA layers wrap a window-
+            // sized ring; everything else is full-context.
+            int appendCtx = isSwa && window > 0 ? SwaRingSize(_maxSeqLen, window) : _maxSeqLen;
+            int effLayerCtx = (_hp.IsSwaLayer is { } swaEff && swaEff[effLayer] && window > 0)
+                ? SwaRingSize(_maxSeqLen, window) : _maxSeqLen;
+            GpuPrefillAppendAttention(
+                qAll, kAll, vAll, attnAll,
+                kvShared ? null : _gpuKCache[layer], kvShared ? null : _gpuVCache[layer],
+                _gpuKCache[effLayer], _gpuVCache[effLayer],
+                _numHeads, layerKv, layerHd, startPos, N,
+                isSwa, window, appendCtx, effLayerCtx);
+        }
 
         GpuMatMulBatched(_bpHidden!, _wo[layer], attnAll, N);
         if (_wPostAttnNorm is not null)

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -550,6 +550,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
     // TurboQuant state (null/0 when disabled).
     private readonly bool _tqEnabled;
+    private readonly TqQuantizer _tqQuantizer;
     private readonly int _tqFp32Window;
     private readonly int _tqBits;
     private readonly int _tqBlockBytes;
@@ -561,6 +562,18 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     private Tensor? _rotatedQ;
     private Tensor? _evictK;
     private Tensor? _evictV;
+    // KVarN quantizer state (issue #180 Task 5a; only when _tqQuantizer == KVarN).
+    // In KVarN mode the per-layer _gpuKCache/_gpuVCache window is LINEAR (slot 0 =
+    // oldest, mirroring the CPU TurboQuantKvCache's shift-down window), not a ring:
+    // promotion compresses the oldest 128 rows into one packed K+V tile per kv-head
+    // and shifts the remainder down, so attention reads contiguous slots and the
+    // compress kernel reads a contiguous tile — no ring math anywhere.
+    private Tensor[]? _gpuKvarnKTiles;   // [layer] packed K tiles (uint[] view)
+    private Tensor[]? _gpuKvarnVTiles;   // [layer] packed V tiles
+    private Tensor? _kvarnWork;          // [numKvHeads × 2 × 128 × headDim] f32 compress scratch
+    private Tensor? _kvarnShiftScratch;  // [(window − 128) × kvDim] f32 window-shift bounce buffer
+    private int _kvarnKeyTileBytes;
+    private int _kvarnValueTileBytes;
     // Per-query-head softmax-scores scratch in VRAM, sized [numHeads × maxSeqLen].
     // Used by both the TQ and FP32 attention kernels when the live context exceeds
     // their shared-memory fast-path cap (4096 positions). Allocated only when
@@ -639,10 +652,17 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// </summary>
     internal int KvLength => _kvLength;
 
+    /// <summary>Test-only: TQ/KVarN compressed-region length (positions promoted so far).</summary>
+    internal int TqCompressedLength => _tqCompressedLen;
+
+    /// <summary>Test-only: number of FP32-window positions currently held.</summary>
+    internal int TqFp32Count => _fp32Count;
+
     public CudaForwardPass(GgufModel model, CudaBackend gpu, ModelHyperparams hp,
         int maxContextLength = 0,
         bool enableTurboQuant = false, int tqFp32Window = 256, int tqBits = 3,
-        bool? mmqSoa = null, bool preferBatchingOverAutoSnapKv = false)
+        bool? mmqSoa = null, bool preferBatchingOverAutoSnapKv = false,
+        TqQuantizer tqQuantizer = TqQuantizer.LloydMax)
     {
         _model = model;
         _gpu = gpu;
@@ -671,6 +691,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // !_isMoE at upload.
         _q6kSoa = Environment.GetEnvironmentVariable("SHARPI_Q6K_SOA") != "0";
         _tqEnabled = enableTurboQuant;
+        _tqQuantizer = tqQuantizer;
         _tqBits = enableTurboQuant ? tqBits : 0;
 
         _embDim = hp.EmbeddingDim;
@@ -720,17 +741,34 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 if (lhdMax[i] > _maxHeadDim) _maxHeadDim = lhdMax[i];
         _ropeThetaSwa = hp.RopeThetaSwa;
 
-        if (_tqEnabled && _headDim is not 128 and not 256)
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN)
+        {
+            // KVarN (issue #180): calibration-free, so any pow2 head_dim quantizes, but the
+            // CUDA WHT butterflies stage one row in 256 floats of shared memory — the same
+            // cap the TQ kernels have. Head dims 512/1024 stay CPU-only for now.
+            if (!System.Numerics.BitOperations.IsPow2(_headDim) || _headDim is < 8 or > 256)
+                throw new NotSupportedException(
+                    $"CUDA KVarN requires a power-of-2 head_dim in [8, 256] (shared-memory WHT cap; " +
+                    $"model head_dim={_headDim}). Larger head dims run on the CPU path (-g 0).");
+            // Dense-only for Task 5a: the MoE decode path is untested with the KVarN
+            // window/tile state machine — keep the exclusivity explicit rather than latent.
+            if (_isMoE)
+                throw new NotSupportedException(
+                    "CUDA KVarN supports dense models only (issue #180 Task 5a); use the CPU path for MoE.");
+        }
+        else if (_tqEnabled && _headDim is not 128 and not 256)
             throw new NotSupportedException(
                 $"CUDA TurboQuant requires head_dim ∈ {{128, 256}} (model head_dim={_headDim}).");
-        if (_tqEnabled && tqBits != 3)
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.LloydMax && tqBits != 3)
             throw new NotSupportedException(
                 $"CUDA TurboQuant only ships 3-bit kernels today (requested bits={tqBits}).");
 
         if (maxContextLength > 0)
             _maxSeqLen = Math.Min(maxContextLength, hp.ContextLength);
         else if (_tqEnabled)
-            _maxSeqLen = EstimateMaxContextTq(model, gpu, hp, tqFp32Window, tqBits);
+            _maxSeqLen = _tqQuantizer == TqQuantizer.KVarN
+                ? EstimateMaxContextKvarn(model, gpu, hp, tqFp32Window)
+                : EstimateMaxContextTq(model, gpu, hp, tqFp32Window, tqBits);
         else
             // Size the auto-context for the KV dtype the operator requested (#220): a bf16/q8_0
             // KV store fits 2×/4× the positions of fp32, but EstimateMaxContext previously priced
@@ -757,7 +795,22 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         if (_tqEnabled)
         {
             _tqFp32Window = Math.Min(tqFp32Window, _maxSeqLen);
-            _tqBlockBytes = TurboQuantOps.BlockSize(tqBits, _headDim);
+            if (_tqQuantizer == TqQuantizer.KVarN)
+            {
+                // KVarN compresses whole 128-token tiles straight out of the FP32
+                // window, so the window must hold at least one tile whenever a
+                // compressed region can exist (mirrors the TurboQuantKvCache guard).
+                if (_maxSeqLen > _tqFp32Window && _tqFp32Window < KVarNCompressor.TileTokens)
+                    throw new ArgumentException(
+                        $"KVarN requires an FP32 window of at least {KVarNCompressor.TileTokens} positions " +
+                        $"(one full tile) when the context ({_maxSeqLen}) exceeds the window; " +
+                        $"got tqFp32Window={_tqFp32Window}.", nameof(tqFp32Window));
+                _tqBlockBytes = 0; // Lloyd-Max per-block sizing is unused in KVarN mode
+            }
+            else
+            {
+                _tqBlockBytes = TurboQuantOps.BlockSize(tqBits, _headDim);
+            }
             // The TQ attention kernel uses a stored-scores fast path up to 4096 positions
             // and a triple-pass recompute path above that. No per-context allocation cap.
         }
@@ -942,7 +995,8 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         }
 
         string kvTag = _kvDType switch { DType.BFloat16 => " [KV bf16]", DType.Q8_0 => " [KV q8_0]", _ => "" };
-        Console.Error.WriteLine($"[CudaForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength}){(_tqEnabled ? " [TQ3]" : "")}{kvTag}");
+        string tqTag = !_tqEnabled ? "" : _tqQuantizer == TqQuantizer.KVarN ? " [KVarN K4V2]" : " [TQ3]";
+        Console.Error.WriteLine($"[CudaForwardPass] Context size: {_maxSeqLen} (model max: {hp.ContextLength}){tqTag}{kvTag}");
 
         bool vramTrace = Environment.GetEnvironmentVariable("SHARPI_TRACE_VRAM") == "1";
         void TraceVram(string label)
@@ -998,32 +1052,70 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 _gpuVCache[i] = gpu.Allocate(TensorShape.D1((long)_tqFp32Window * kvDim));
             }
 
-            // TQ-compressed storage for older positions, stored as uint[] (one block per
-            // (position, kv_head) at byte offset position*numKvHeads*blockBytes + ...).
             int maxTqPositions = Math.Max(0, _maxSeqLen - _tqFp32Window);
-            long tqBytesPerPos = (long)_numKvHeads * _tqBlockBytes;
-            long tqUintsPerLayer = (maxTqPositions * tqBytesPerPos + 3) / 4;
-            _gpuTqKCache = new Tensor[hp.NumLayers];
-            _gpuTqVCache = new Tensor[hp.NumLayers];
-            _gpuSignPatterns = new Tensor[hp.NumLayers];
-            for (int i = 0; i < hp.NumLayers; i++)
+            if (_tqQuantizer == TqQuantizer.KVarN)
             {
-                _gpuTqKCache[i] = gpu.Allocate(TensorShape.D1(tqUintsPerLayer));
-                _gpuTqVCache[i] = gpu.Allocate(TensorShape.D1(tqUintsPerLayer));
-                _gpuSignPatterns[i] = UploadTqSignPatterns(i);
+                // KVarN (issue #180): packed K4/V2 tile stores, one K + one V tile per
+                // (128 promoted positions, kv-head, layer). Byte layout matches
+                // KVarNCompressor exactly (tiles can be downloaded and verified with
+                // the CPU DecompressKey/ValueTile). Strides are 4-byte multiples so
+                // the uint[]-typed tensors stay aligned. No sign patterns, codebooks,
+                // boundaries, or per-row evict scratch — promotion is whole-tile.
+                _kvarnKeyTileBytes = KVarNCompressor.KeyTileSize(_headDim);
+                _kvarnValueTileBytes = KVarNCompressor.ValueTileSize(_headDim);
+                int maxTiles = (maxTqPositions + KVarNCompressor.TileTokens - 1) / KVarNCompressor.TileTokens;
+                if (maxTiles > 0)
+                {
+                    long kUintsPerLayer = (long)maxTiles * _numKvHeads * _kvarnKeyTileBytes / 4;
+                    long vUintsPerLayer = (long)maxTiles * _numKvHeads * _kvarnValueTileBytes / 4;
+                    _gpuKvarnKTiles = new Tensor[hp.NumLayers];
+                    _gpuKvarnVTiles = new Tensor[hp.NumLayers];
+                    for (int i = 0; i < hp.NumLayers; i++)
+                    {
+                        _gpuKvarnKTiles[i] = gpu.Allocate(TensorShape.D1(kUintsPerLayer));
+                        _gpuKvarnVTiles[i] = gpu.Allocate(TensorShape.D1(vUintsPerLayer));
+                    }
+                    // Compress-kernel working tile — 128×headDim floats per (kv-head, K/V)
+                    // block; lives in VRAM because a 128×128 f32 tile (64 KB) exceeds the
+                    // 48 KB shared-memory ceiling. Shared across layers (single stream).
+                    _kvarnWork = gpu.Allocate(TensorShape.D1(
+                        (long)_numKvHeads * 2 * KVarNCompressor.TileTokens * _headDim));
+                    // Window-shift bounce buffer: after promoting the oldest 128 rows the
+                    // remaining (window − 128) rows shift down; same-buffer overlapping
+                    // memcpy is UB when window > 256, so always bounce through scratch.
+                    int shiftRows = _tqFp32Window - KVarNCompressor.TileTokens;
+                    if (shiftRows > 0)
+                        _kvarnShiftScratch = gpu.Allocate(TensorShape.D1((long)shiftRows * kvDim));
+                }
+                _rotatedQ = gpu.Allocate(TensorShape.D1((long)_numHeads * _headDim));
             }
+            else
+            {
+                // TQ-compressed storage for older positions, stored as uint[] (one block per
+                // (position, kv_head) at byte offset position*numKvHeads*blockBytes + ...).
+                long tqBytesPerPos = (long)_numKvHeads * _tqBlockBytes;
+                long tqUintsPerLayer = (maxTqPositions * tqBytesPerPos + 3) / 4;
+                _gpuTqKCache = new Tensor[hp.NumLayers];
+                _gpuTqVCache = new Tensor[hp.NumLayers];
+                _gpuSignPatterns = new Tensor[hp.NumLayers];
+                for (int i = 0; i < hp.NumLayers; i++)
+                {
+                    _gpuTqKCache[i] = gpu.Allocate(TensorShape.D1(tqUintsPerLayer));
+                    _gpuTqVCache[i] = gpu.Allocate(TensorShape.D1(tqUintsPerLayer));
+                    _gpuSignPatterns[i] = UploadTqSignPatterns(i);
+                }
 
-            // Upload TQ constants to VRAM.
-            var centroids = TurboQuantCodebooks.GetCentroids(tqBits, _headDim).ToArray();
-            _gpuCodebook = gpu.Upload(centroids, TensorShape.D1(centroids.Length));
+                // Upload TQ constants to VRAM.
+                var centroids = TurboQuantCodebooks.GetCentroids(tqBits, _headDim).ToArray();
+                _gpuCodebook = gpu.Upload(centroids, TensorShape.D1(centroids.Length));
 
-            var boundaries = TurboQuantCodebooks.GetBoundaries(tqBits, _headDim).ToArray();
-            _gpuBoundaries = gpu.Upload(boundaries, TensorShape.D1(boundaries.Length));
+                var boundaries = TurboQuantCodebooks.GetBoundaries(tqBits, _headDim).ToArray();
+                _gpuBoundaries = gpu.Upload(boundaries, TensorShape.D1(boundaries.Length));
 
-            _rotatedQ = gpu.Allocate(TensorShape.D1((long)_numHeads * _headDim));
-            _evictK   = gpu.Allocate(TensorShape.D1((long)_numKvHeads * _headDim));
-            _evictV   = gpu.Allocate(TensorShape.D1((long)_numKvHeads * _headDim));
-
+                _rotatedQ = gpu.Allocate(TensorShape.D1((long)_numHeads * _headDim));
+                _evictK   = gpu.Allocate(TensorShape.D1((long)_numKvHeads * _headDim));
+                _evictV   = gpu.Allocate(TensorShape.D1((long)_numKvHeads * _headDim));
+            }
         }
         else
         {
@@ -1532,11 +1624,25 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // and TQ already bails graphs off anyway).
         if (_tqEnabled)
         {
-            if (_fp32Count >= _tqFp32Window)
-                _tqCompressedLen++;
-            _fp32WriteIdx = (_fp32WriteIdx + 1) % _tqFp32Window;
-            if (_fp32Count < _tqFp32Window)
+            if (_tqQuantizer == TqQuantizer.KVarN)
+            {
+                // Whole-tile promotion cadence (mirrors TurboQuantKvCache.Append):
+                // a full window promotes 128 positions, then the fresh row appends.
+                if (_fp32Count >= _tqFp32Window)
+                {
+                    _tqCompressedLen += KVarNCompressor.TileTokens;
+                    _fp32Count -= KVarNCompressor.TileTokens;
+                }
                 _fp32Count++;
+            }
+            else
+            {
+                if (_fp32Count >= _tqFp32Window)
+                    _tqCompressedLen++;
+                _fp32WriteIdx = (_fp32WriteIdx + 1) % _tqFp32Window;
+                if (_fp32Count < _tqFp32Window)
+                    _fp32Count++;
+            }
         }
 
         FinishLogits();
@@ -1613,7 +1719,52 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
             int kvDim = _numKvHeads * _headDim;
 
-            if (_tqEnabled)
+            if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN)
+            {
+                // KVarN (issue #180 Task 5a): the FP32 window is LINEAR (slot 0 =
+                // oldest), mirroring the CPU TurboQuantKvCache exactly, so CPU and
+                // CUDA agree position-for-position:
+                //   • window full → compress the oldest 128 rows into one packed
+                //     K+V tile per kv-head, shift the remainder down a whole tile;
+                //   • the fresh row appends at slot fp32Count (post-promotion);
+                //   • the TQ length only grows in 128-token steps.
+                // _fp32Count/_tqCompressedLen are shared host state advanced once
+                // per token AFTER the region (all layers see identical values).
+                bool promote = _fp32Count >= _tqFp32Window;
+                if (promote)
+                    PromoteKvarnTile(layer, kvDim);
+
+                int appendSlot = promote ? _fp32Count - KVarNCompressor.TileTokens : _fp32Count;
+                _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
+                    kvDim, appendSlot, _tqFp32Window);
+
+                int fp32SeqLen = appendSlot + 1;
+                int tqLen = promote ? _tqCompressedLen + KVarNCompressor.TileTokens : _tqCompressedLen;
+
+                if (tqLen == 0)
+                {
+                    // Pre-promotion fast path: everything is FP32 at its natural
+                    // slot, so the plain attention kernel reads the window directly.
+                    _gpu.Attention(_q, _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                        _attnScoresScratch,
+                        _numHeads, _numKvHeads, _headDim, fp32SeqLen, _tqFp32Window);
+                }
+                else
+                {
+                    // Rotate the query (plain WHT, no sign flip) for the fused
+                    // folded-scale tile scoring.
+                    _gpu.KvarnRotateQuery(_q, _rotatedQ!, _numHeads, _headDim);
+
+                    _gpu.KvarnAttention(_q, _rotatedQ!,
+                        _gpuKvarnKTiles![layer], _gpuKvarnVTiles![layer],
+                        _gpuKCache[layer], _gpuVCache[layer], _attnOut,
+                        _attnScoresScratch,
+                        _numHeads, _numKvHeads, _headDim,
+                        tqLen, fp32SeqLen, _maxSeqLen,
+                        _kvarnKeyTileBytes, _kvarnValueTileBytes);
+                }
+            }
+            else if (_tqEnabled)
             {
                 long rowBytes = (long)kvDim * sizeof(float);
 
@@ -1710,6 +1861,40 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
 
         _gpu.RmsNorm(_hidden, _hidden, _wOutputNorm, _hp.RmsNormEps);
         GpuMatMul(_logits, _wOutput, _hidden);
+    }
+
+    /// <summary>
+    /// KVarN whole-tile promotion (issue #180): compress the oldest 128 rows of
+    /// this layer's linear FP32 window into one packed K tile + one V tile per
+    /// kv-head at tile index <c>_tqCompressedLen / 128</c>, then shift the
+    /// remaining <c>window − 128</c> rows down a whole tile so slot 0 stays the
+    /// oldest position (the CPU TurboQuantKvCache window contract). The shift
+    /// bounces through <see cref="_kvarnShiftScratch"/> because a same-buffer
+    /// overlapping memcpy is undefined once window &gt; 256. All launches/copies
+    /// are stream-ordered, so the compress kernel reads the rows before the
+    /// shift overwrites them. Runs once per 128 decode steps per layer.
+    /// </summary>
+    private void PromoteKvarnTile(int layer, int kvDim)
+    {
+        int tileTokens = KVarNCompressor.TileTokens;
+        int tileIdx = _tqCompressedLen / tileTokens;
+        _gpu.KvarnCompressTile(_gpuKCache[layer], _gpuVCache[layer],
+            _gpuKvarnKTiles![layer], _gpuKvarnVTiles![layer], _kvarnWork!,
+            kvDim, _headDim, tileIdx, _numKvHeads,
+            _kvarnKeyTileBytes, _kvarnValueTileBytes,
+            KVarNCompressor.DefaultSinkhornIterations);
+
+        int shiftRows = _tqFp32Window - tileTokens;
+        if (shiftRows > 0)
+        {
+            long rowBytes = (long)kvDim * sizeof(float);
+            long shiftBytes = shiftRows * rowBytes;
+            long srcOff = tileTokens * rowBytes;
+            _gpu.CopyDeviceRegion(_kvarnShiftScratch!, 0, _gpuKCache[layer], srcOff, shiftBytes);
+            _gpu.CopyDeviceRegion(_gpuKCache[layer], 0, _kvarnShiftScratch!, 0, shiftBytes);
+            _gpu.CopyDeviceRegion(_kvarnShiftScratch!, 0, _gpuVCache[layer], srcOff, shiftBytes);
+            _gpu.CopyDeviceRegion(_gpuVCache[layer], 0, _kvarnShiftScratch!, 0, shiftBytes);
+        }
     }
 
     // CUDA-graph capture/replay for the non-Gemma dense decode region (#158, mirrors the
@@ -3572,6 +3757,11 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 $"TruncateTo({length}) cannot rewind into the TQ-compressed region " +
                 $"(tqCompressedLen={_tqCompressedLen}). Speculative decoding can only " +
                 "truncate inside the FP32 recent window.");
+        // KVarN's linear window makes an in-window rewind exact: slot == position −
+        // tqCompressedLen, so dropping the tail is just a count decrement (the ring-based
+        // Lloyd-Max mode has no equivalent resync — pre-existing behavior kept as-is).
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN)
+            _fp32Count = length - _tqCompressedLen;
         _kvLength = length;
         _kvCache.TruncateTo(length);
         // _kvEvictedCount is intentionally NOT reset here. TruncateTo only rewinds *decode*
@@ -5598,6 +5788,47 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         return Math.Clamp(maxTqPositions + fp32WindowSize, 512, hp.ContextLength);
     }
 
+    /// <summary>
+    /// Context-length estimator for the KVarN quantizer (issue #180 Task 5a): the FP32
+    /// window is fixed at <paramref name="fp32WindowSize"/> positions, the remainder live
+    /// in packed 128-token K4/V2 tiles (≈4.75 + 2.75 bits/element at head_dim 128 —
+    /// ~120 bytes K+V per token per kv-head vs 1024 for FP32 K+V, ≈8.5× in the
+    /// compressed region). Mirrors <see cref="EstimateMaxContextTq"/>'s VRAM
+    /// accounting with KVarN tile pricing.
+    /// </summary>
+    public static int EstimateMaxContextKvarn(GgufModel model, CudaBackend gpu, ModelHyperparams hp,
+        int fp32WindowSize = 256)
+    {
+        long vramBytes = (long)gpu.VramBytes;
+        if (vramBytes <= 0) vramBytes = 8L * 1024 * 1024 * 1024;
+
+        int headDim = hp.HeadDim;
+        long tileBytes = KVarNCompressor.KeyTileSize(headDim) + KVarNCompressor.ValueTileSize(headDim);
+
+        long weightBytes = 0;
+        foreach (var t in model.Tensors)
+            weightBytes += EstimateGpuTensorBytes(t);
+
+        long scratchBytes = (long)(hp.EmbeddingDim * 3 + hp.NumHeads * headDim
+            + hp.NumKvHeads * headDim * 2 + hp.NumHeads * headDim
+            + hp.IntermediateDim * 2 + hp.VocabSize) * sizeof(float);
+
+        long reserved = Math.Max(vramBytes / 3, 2L * 1024 * 1024 * 1024);
+        long available = vramBytes - weightBytes - scratchBytes - reserved;
+        if (available <= 0) available = 64L * 1024 * 1024;
+
+        long fp32Bytes = 2L * hp.NumLayers * hp.NumKvHeads * headDim * sizeof(float) * fp32WindowSize;
+        long bytesPerTile = (long)hp.NumLayers * hp.NumKvHeads * tileBytes; // one K + one V tile = 128 positions
+
+        long availableForTq = available - fp32Bytes;
+        if (availableForTq <= 0) availableForTq = 64L * 1024 * 1024;
+
+        long maxTiles = availableForTq / bytesPerTile;
+        long maxTqPositions = maxTiles * KVarNCompressor.TileTokens;
+        int total = (int)Math.Min(maxTqPositions + fp32WindowSize, int.MaxValue);
+        return Math.Clamp(total, 512, hp.ContextLength);
+    }
+
     private static long EstimateGpuTensorBytes(GgufTensorInfo tensor)
     {
         // Raw-upload dtypes (no CPU dequant): tensor lives on GPU at its native byte size,
@@ -5710,7 +5941,19 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         // per-sequence caches own — nothing to free there.
         if (_raggedAttnScores is { } ras) _gpu.Free(ras);
 
-        if (_tqEnabled)
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN)
+        {
+            if (_gpuKvarnKTiles is not null)
+                for (int i = 0; i < _hp.NumLayers; i++)
+                {
+                    _gpu.Free(_gpuKvarnKTiles[i]);
+                    _gpu.Free(_gpuKvarnVTiles![i]);
+                }
+            if (_kvarnWork is { } kw) _gpu.Free(kw);
+            if (_kvarnShiftScratch is { } ks) _gpu.Free(ks);
+            _gpu.Free(_rotatedQ!);
+        }
+        else if (_tqEnabled)
         {
             for (int i = 0; i < _hp.NumLayers; i++)
             {

--- a/src/SharpInference.Engine/CudaForwardPass.cs
+++ b/src/SharpInference.Engine/CudaForwardPass.cs
@@ -1610,29 +1610,44 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         else
             _gpu.EmbedLookup(_gpuEmbedding, _hidden, token, _embDim);
 
+        // KVarN whole-tile promotion (issue #180 Task 5b): hoisted OUT of the device
+        // region so the region keeps a static per-phase topology and can be captured
+        // into a CUDA graph. Once per 128 decode steps: compress + shift every layer's
+        // window with direct launches, then advance the shared host state so the region
+        // (graphed or direct) sees clean post-promotion values. All launches/copies are
+        // stream-ordered, so the region's work queues behind the promotion; numerically
+        // identical to the former in-region interleaving (each layer's promotion touches
+        // only that layer's window/tiles, which the region reads afterwards — same
+        // compress inputs, same tile index, same append slot / attention lengths).
+        if (_tqEnabled && _tqQuantizer == TqQuantizer.KVarN && _fp32Count >= _tqFp32Window)
+        {
+            int kvDimP = _numKvHeads * _headDim;
+            for (int layer = 0; layer < _hp.NumLayers; layer++)
+                PromoteKvarnTile(layer, kvDimP);
+            _tqCompressedLen += KVarNCompressor.TileTokens;
+            _fp32Count -= KVarNCompressor.TileTokens;
+        }
+
         // Transformer layers + final norm/output — static topology across tokens (only
-        // `position` varies), so optionally capture it once into a CUDA graph and replay
-        // per token to kill the ~1k-launch/token host overhead (#136/#158). The token-
-        // varying embedding ran above; the TQ ring-advance (host state) and logits
-        // download run after.
+        // `position` varies; KVarN adds three host-tracked scalars, see
+        // TryRunKvarnRegionViaGraph), so optionally capture it once into a CUDA graph
+        // and replay per token to kill the ~1k-launch/token host overhead (#136/#158).
+        // The token-varying embedding ran above; the TQ ring-advance (host state) and
+        // logits download run after.
         if (!TryRunDeviceRegionViaGraph(position))
             RunDeviceRegion(position);
 
         // After all layers have used the same FP32 indices for this token, advance the
         // TQ ring-buffer state (shared across layers). Pure host-state mutation for the
-        // NEXT token — kept outside the captured region (it would break static topology,
-        // and TQ already bails graphs off anyway).
+        // NEXT token — kept outside the captured region (it would break static topology;
+        // the Lloyd-Max ring path also still bails graphs off entirely).
         if (_tqEnabled)
         {
             if (_tqQuantizer == TqQuantizer.KVarN)
             {
-                // Whole-tile promotion cadence (mirrors TurboQuantKvCache.Append):
-                // a full window promotes 128 positions, then the fresh row appends.
-                if (_fp32Count >= _tqFp32Window)
-                {
-                    _tqCompressedLen += KVarNCompressor.TileTokens;
-                    _fp32Count -= KVarNCompressor.TileTokens;
-                }
+                // Whole-tile promotion (if due) already ran BEFORE the region (Task 5b
+                // hoist above, mirroring TurboQuantKvCache.Append's cadence); only the
+                // fresh row's append is left to count here.
                 _fp32Count++;
             }
             else
@@ -1724,24 +1739,21 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                 // KVarN (issue #180 Task 5a): the FP32 window is LINEAR (slot 0 =
                 // oldest), mirroring the CPU TurboQuantKvCache exactly, so CPU and
                 // CUDA agree position-for-position:
-                //   • window full → compress the oldest 128 rows into one packed
-                //     K+V tile per kv-head, shift the remainder down a whole tile;
-                //   • the fresh row appends at slot fp32Count (post-promotion);
+                //   • the fresh row appends at slot fp32Count;
                 //   • the TQ length only grows in 128-token steps.
-                // _fp32Count/_tqCompressedLen are shared host state advanced once
-                // per token AFTER the region (all layers see identical values).
-                bool promote = _fp32Count >= _tqFp32Window;
-                if (promote)
-                    PromoteKvarnTile(layer, kvDim);
-
-                int appendSlot = promote ? _fp32Count - KVarNCompressor.TileTokens : _fp32Count;
+                // Whole-tile promotion is hoisted into Forward (Task 5b) so this
+                // block is capture-clean: appendSlot / fp32SeqLen / tqLen are pure
+                // reads of post-promotion host state, registered as graph-tracked
+                // kernel params during capture (CudaBackend.GraphKvarnTracking).
+                // _fp32Count/_tqCompressedLen advance once per token AFTER the
+                // region (all layers see identical values).
+                int appendSlot = _fp32Count;
                 _gpu.KvAppend(_k, _v, _gpuKCache[layer], _gpuVCache[layer],
                     kvDim, appendSlot, _tqFp32Window);
 
                 int fp32SeqLen = appendSlot + 1;
-                int tqLen = promote ? _tqCompressedLen + KVarNCompressor.TileTokens : _tqCompressedLen;
 
-                if (tqLen == 0)
+                if (_tqCompressedLen == 0)
                 {
                     // Pre-promotion fast path: everything is FP32 at its natural
                     // slot, so the plain attention kernel reads the window directly.
@@ -1760,7 +1772,7 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
                         _gpuKCache[layer], _gpuVCache[layer], _attnOut,
                         _attnScoresScratch,
                         _numHeads, _numKvHeads, _headDim,
-                        tqLen, fp32SeqLen, _maxSeqLen,
+                        _tqCompressedLen, fp32SeqLen, _maxSeqLen,
                         _kvarnKeyTileBytes, _kvarnValueTileBytes);
                 }
             }
@@ -1872,7 +1884,10 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
     /// bounces through <see cref="_kvarnShiftScratch"/> because a same-buffer
     /// overlapping memcpy is undefined once window &gt; 256. All launches/copies
     /// are stream-ordered, so the compress kernel reads the rows before the
-    /// shift overwrites them. Runs once per 128 decode steps per layer.
+    /// shift overwrites them. Runs once per 128 decode steps per layer, called
+    /// from <see cref="Forward"/> BEFORE the device region (Task 5b) so the
+    /// region itself stays CUDA-graph-capturable — always direct launches,
+    /// never inside a capture.
     /// </summary>
     private void PromoteKvarnTile(int layer, int kvDim)
     {
@@ -1908,10 +1923,13 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             return false;
 
         // Graphs bake in the standard decode invariant (fixed topology, seqLen ==
-        // position+1, no host-varying device offsets). Three things break that and must
-        // bail to direct launches:
-        //  • TurboQuant — extra host-synced rotate/compress ops + a ring whose advance is
-        //    host state (the if/else attention branch also flips once a row evicts).
+        // position+1, no host-varying device offsets). Things that break that must
+        // bail to direct launches (or take a dedicated graph path):
+        //  • TurboQuant Lloyd-Max — extra host-synced rotate/compress ops + a ring whose
+        //    advance is host state (the if/else attention branch also flips once a row
+        //    evicts). KVarN (issue #180 Task 5b) instead dispatches to its own per-phase
+        //    graphs below: its promotion is hoisted out of the region and its three
+        //    host-varying scalars ride as tracked kernel params.
         //  • An actual SnapKV eviction — the cache is compacted, so cache-fill != absolute
         //    position. A configured-but-unevicted budget keeps _kvEvictedCount == 0 and is
         //    fine (the cache still fills sequentially).
@@ -1924,7 +1942,9 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
         //  • Active hidden-state taps (PR #413) — the per-layer tap Download both
         //    syncs mid-region (illegal during capture) and would need a
         //    position-varying memcpy destination a replayed graph can't retarget.
-        if (_tqEnabled || _kvEvictedCount > 0 || _snapKvCaptureSlot >= 0 || _isMoE
+        if (_tqEnabled)
+            return _tqQuantizer == TqQuantizer.KVarN && TryRunKvarnRegionViaGraph(position);
+        if (_kvEvictedCount > 0 || _snapKvCaptureSlot >= 0 || _isMoE
             || _taps is not null)
             return false;
 
@@ -1967,6 +1987,104 @@ public sealed unsafe class CudaForwardPass : IForwardPass, IBatchedForwardPass, 
             _gpu.AbortGraphCapture();
             _useCudaGraph = false;
             return false;
+        }
+    }
+
+    // Multi-graph ids for the two KVarN decode phases (issue #180 Task 5b). Negative so
+    // they can never collide with the per-layer ids the GDN-hybrid trunk capture uses.
+    // Internal (not private) so the CUDA KVarN tests can assert the graphs really engaged.
+    internal const int KvarnGraphPre = -101;     // _tqCompressedLen == 0: append + plain attention
+    internal const int KvarnGraphSteady = -102;  // _tqCompressedLen > 0: append + rotate + kvarn attention
+
+    // Instance-level capture latches (mirror _graphCaptured on the dense path): the backend's
+    // per-id graph store outlives this forward pass, so replay must be gated on THIS instance
+    // having captured the entry — a second instance sharing the backend would otherwise replay
+    // a graph whose baked device pointers belong to a disposed sibling.
+    private bool _kvarnPreGraphCaptured;
+    private bool _kvarnSteadyGraphCaptured;
+
+    // CUDA-graph capture/replay for the KVarN decode region (issue #180 Task 5b). The
+    // region has TWO static topologies keyed on the host `_tqCompressedLen == 0` branch:
+    //  • pre-promotion — byte-for-byte the plain fp32 path over the linear window
+    //    (append + plain attention), so it reuses the standard kernels;
+    //  • steady-state — append + rotate-query + hybrid KVarN attention.
+    // Each phase captures once into its own per-id graph and replays thereafter; the
+    // phase flip at the first promotion simply switches which graph replays (the pre
+    // graph stays valid for a post-ResetCache fresh sequence). Whole-tile promotion
+    // (compress + 4 D2D shifts per layer, once per 128 tokens) runs OUTSIDE the graph —
+    // Forward hoists it before this call — so the captured topology never changes.
+    //
+    // Three scalars vary per replay beyond `position` (RoPE): the append slot
+    // (= _fp32Count), the window attention length (= _fp32Count + 1), and the compressed
+    // length (_tqCompressedLen). They ride the same tracked-kernel-param mechanism as
+    // position (GraphKvarnTracking registers them during capture; SetGraphKvarnState
+    // publishes fresh values before every replay). The score-scratch question is moot:
+    // _attnScoresScratch is pre-sized to numHeads × maxSeqLen at construction whenever
+    // maxSeqLen > 4096, its pointer is baked at capture, and the shared-vs-scratch choice
+    // is a runtime branch inside the kernels on the tracked scalars — so one graph stays
+    // valid from capture through the deepest context.
+    //
+    // Returns true if the logits were produced via a graph; false → direct launches.
+    // Any capture/replay failure disables graphs for the session (mirrors the dense path).
+    private bool TryRunKvarnRegionViaGraph(int position)
+    {
+        if (!_useCudaGraph || !_gpu.GraphCaptureSupported)
+            return false;
+
+        // Defensive mirrors of the dense-path bails. All are structurally unreachable
+        // under KVarN today (SnapKV/MoE/taps/batching are rejected up front), but keep
+        // the invariants explicit so a future composition can't silently bake a bad graph.
+        if (_kvEvictedCount > 0 || _snapKvCaptureSlot >= 0 || _isMoE || _taps is not null)
+            return false;
+        if (!_activeSlotIsOwned)
+            return false;
+
+        bool steady = _tqCompressedLen > 0;
+        int graphId = steady ? KvarnGraphSteady : KvarnGraphPre;
+
+        // Publish this token's KVarN host state for the tracked-param rewrite (needed by
+        // both the replay below and the capture's own first launch).
+        _gpu.SetGraphKvarnState(_tqCompressedLen, _fp32Count);
+
+        if ((steady ? _kvarnSteadyGraphCaptured : _kvarnPreGraphCaptured)
+            && _gpu.GraphReadyFor(graphId))
+        {
+            try { _gpu.LaunchGraphForPosition(graphId, position); return true; }
+            catch
+            {
+                _useCudaGraph = false;
+                _kvarnPreGraphCaptured = _kvarnSteadyGraphCaptured = false;
+                return false;
+            }
+        }
+
+        // First token of this phase: pre-grow the Q4_K/Q8_0 dp4a Q8_1 input scratch to the
+        // widest decode matvec BEFORE capture (capture forbids cudaMalloc — mirrors the
+        // dense capture path).
+        _gpu.EnsureQ81Scratch(Math.Max(_embDim, _intermDim));
+
+        try
+        {
+            _gpu.GraphKvarnTracking = true;
+            if (!_gpu.TryBeginGraphCapture(graphId))
+                return false;
+            RunDeviceRegion(position);
+            if (!_gpu.TryEndGraphCaptureAndInstantiate(graphId))
+                return false;
+            _gpu.LaunchGraphForPosition(graphId, position);
+            if (steady) _kvarnSteadyGraphCaptured = true;
+            else _kvarnPreGraphCaptured = true;
+            return true;
+        }
+        catch
+        {
+            _gpu.AbortGraphCapture();
+            _useCudaGraph = false;
+            return false;
+        }
+        finally
+        {
+            _gpu.GraphKvarnTracking = false;
         }
     }
 

--- a/src/SharpInference.Engine/ForwardPass.cs
+++ b/src/SharpInference.Engine/ForwardPass.cs
@@ -622,13 +622,29 @@ public sealed unsafe class ForwardPass : IForwardPass, IBatchedForwardPass
 
     /// <summary>
     /// Enables TurboQuant KV cache compression. Must be called before any forward pass.
+    /// <paramref name="quantizer"/> selects the compressed-region codec: Lloyd-Max
+    /// FastScan (default, 3-4 bit; <paramref name="bits"/> applies) or KVarN
+    /// (issue #180: 4-bit K / 2-bit V in 128-token tiles; <paramref name="bits"/>
+    /// is ignored). KVarN does not compose with SnapKV eviction yet — the combo
+    /// is rejected here rather than corrupting the cache at Compact time.
+    /// KVarN also shrinks the guaranteed <see cref="TruncateTo"/> rewind depth to
+    /// <paramref name="fp32WindowSize"/> − 127 (whole-tile promotion): keep the
+    /// window well above the draft length when combining with speculative decoding.
     /// </summary>
-    public void EnableTurboQuant(int fp32WindowSize = 256, int bits = 3)
+    public void EnableTurboQuant(int fp32WindowSize = 256, int bits = 3,
+        TqQuantizer quantizer = TqQuantizer.LloydMax)
     {
+        if (quantizer == TqQuantizer.KVarN && _snapKvCfg.Enabled)
+            throw new NotSupportedException(
+                "SnapKV eviction (SHARPI_SNAPKV_BUDGET) is not yet supported with the KVarN quantizer " +
+                "(issue #180 follow-up: Compact-time re-quantization needs whole-tile re-assembly). " +
+                "Unset SHARPI_SNAPKV_BUDGET or use the default Lloyd-Max quantizer.");
+
         _tqKvCache = new TurboQuantKvCache(
             _hp.NumLayers, _ctxLen, _numKvHeads, _headDim,
             Math.Min(fp32WindowSize, _ctxLen), bits,
-            layerIndexBase: 0, totalLayerCountForSeeds: _hp.NumLayers);
+            layerIndexBase: 0, totalLayerCountForSeeds: _hp.NumLayers,
+            quantizer: quantizer);
         _rotatedQuery = Alloc(_numHeads * _headDim);
         _decompBuf = Alloc(_numHeads * _headDim);
     }
@@ -1919,14 +1935,17 @@ public sealed unsafe class ForwardPass : IForwardPass, IBatchedForwardPass
             float* headRotated = rotated + h * hd;
             float* headDecomp = decomp + h * hd;
 
-            var keyCompressor = tq.GetKeyCompressor(layer, kvHead);
-            keyCompressor.RotateQuery(
+            // Rotate the query into the compressed-domain basis (Lloyd-Max:
+            // per-head sign-flip + WHT; KVarN: plain WHT — issue #180).
+            tq.RotateQuery(layer, kvHead,
                 new ReadOnlySpan<float>(qHead, hd),
                 new Span<float>(headRotated, hd));
 
-            // K-scoring via FastScan (issue #34): tile-walks full 32-position
-            // tiles through an i8-LUT pshufb kernel and falls back to per-block
-            // DequantDot on the <32 staging tail.
+            // K-scoring over the compressed region. Lloyd-Max (issue #34):
+            // tile-walks full 32-position FastScan tiles through an i8-LUT
+            // pshufb kernel and falls back to per-block DequantDot on the <32
+            // staging tail. KVarN (issue #180): whole 128-token tiles via the
+            // fused KVarNCompressor.KeyScores (no staging tail exists).
             tq.ComputeKScores(layer, kvHead, headRotated, scale, headScores);
 
             // Phase 1b: FP32 window positions
@@ -1940,10 +1959,11 @@ public sealed unsafe class ForwardPass : IForwardPass, IBatchedForwardPass
 
             for (int d = 0; d < hd; d++) outHead[d] = 0;
 
-            // FastScan V-aggregation (issue #34 Phase 3): tile-walks the
-            // TQ-compressed positions with deferred sign-flip + IWHT, then
-            // the FP32-window loop below accumulates the recent positions
-            // on top in the original domain.
+            // V-aggregation over the compressed region: tiles accumulate in the
+            // rotated domain with ONE deferred inverse WHT per head (Lloyd-Max
+            // adds a sign-flip; KVarN uses UnrotateOutput), then the FP32-window
+            // loop below accumulates the recent positions on top in the
+            // original (un-rotated) domain — the domain contract both codecs share.
             tq.ComputeVAggregation(layer, kvHead, headScores, outHead);
 
             for (int t = fp32Start; t < seqLen; t++)

--- a/src/SharpInference.Engine/TurboQuantKvCache.cs
+++ b/src/SharpInference.Engine/TurboQuantKvCache.cs
@@ -5,9 +5,31 @@ using SharpInference.TurboQuant;
 namespace SharpInference.Engine;
 
 /// <summary>
-/// Hybrid FP32/TurboQuant KV cache: recent tokens in FP32, older tokens compressed to 3-4 bits.
+/// Selects the codec used for the compressed region of <see cref="TurboQuantKvCache"/>
+/// (issue #180: KVarN is built as a selectable quantizer inside the existing TurboQuant
+/// cache machinery, not a second cache type).
+/// </summary>
+public enum TqQuantizer
+{
+    /// <summary>
+    /// Lloyd-Max codebooks in FastScan tiles (3-4 bit, 32-position tiles with
+    /// per-block staging) — the shipping TurboQuant path.
+    /// </summary>
+    LloydMax = 0,
+
+    /// <summary>
+    /// KVarN (issue #180): Hadamard rotation + dual-axis Sinkhorn variance
+    /// normalization + asymmetric RTN — 4-bit keys / 2-bit values in whole
+    /// 128-token tiles assembled directly from the FP32 window.
+    /// </summary>
+    KVarN = 1,
+}
+
+/// <summary>
+/// Hybrid FP32/TurboQuant KV cache: recent tokens in FP32, older tokens compressed to 2-4 bits.
 /// The FP32 window provides full-precision attention for recently generated tokens.
-/// When tokens age out of the window, they are compressed to TQ format.
+/// When tokens age out of the window, they are compressed via the configured
+/// <see cref="TqQuantizer"/>: Lloyd-Max FastScan tiles (default) or KVarN 128-token tiles.
 /// </summary>
 public sealed unsafe class TurboQuantKvCache : IDisposable
 {
@@ -18,26 +40,41 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     private readonly int _kvDim;         // numKvHeads * headDim
     private readonly int _fp32WindowSize; // recent tokens in FP32
 
-    // Per-layer FP32 window (ring buffer)
+    // Per-layer FP32 window (linear shift-down buffer, slot 0 = oldest — not a ring)
     private readonly float*[] _fp32Keys;
     private readonly float*[] _fp32Values;
 
-    // Per-layer TQ compressed storage. Both keys and values live in FastScan
-    // tile layout (one tile = 32 positions, contiguous per kv-head) with the
-    // in-flight 0..31 positions staged in per-block format. K and V tiles use
-    // different internal layouts (K is dim-major, V is position-major — see
-    // FastScan.TileBytes / VTileBytes) but happen to be the same total bytes.
-    private readonly byte*[] _tqKeyTiles;      // [layer][numTiles * numKvHeads * _tileBytes]
-    private readonly byte*[] _tqKeyStaging;    // [layer][numKvHeads * TileSize * _tqBlockSize]
-    private readonly byte*[] _tqValueTiles;    // [layer][numTiles * numKvHeads * _vTileBytes]
-    private readonly byte*[] _tqValueStaging;  // [layer][numKvHeads * TileSize * _tqBlockSize]
-    private readonly KvCacheCompressor[][] _keyCompressors;   // [layer][kvHead]
-    private readonly KvCacheCompressor[][] _valueCompressors;
+    // Per-layer TQ compressed storage. In Lloyd-Max mode both keys and values
+    // live in FastScan tile layout (one tile = 32 positions, contiguous per
+    // kv-head) with the in-flight 0..31 positions staged in per-block format.
+    // K and V tiles use different internal layouts (K is dim-major, V is
+    // position-major — see FastScan.TileBytes / VTileBytes) but happen to be
+    // the same total bytes. In KVarN mode the same pointers hold KVarN 128-token
+    // tiles (strides KVarNCompressor.KeyTileBytes / ValueTileBytes); there is no
+    // staging — whole tiles are compressed straight out of the FP32 window, so
+    // the window owns everything mod 128 and the staging buffers stay null.
+    private readonly byte*[] _tqKeyTiles;      // [layer][numTiles * numKvHeads * _keyTileStride]
+    private readonly byte*[] _tqKeyStaging;    // [layer][numKvHeads * TileSize * _tqBlockSize] (Lloyd-Max only)
+    private readonly byte*[] _tqValueTiles;    // [layer][numTiles * numKvHeads * _valueTileStride]
+    private readonly byte*[] _tqValueStaging;  // [layer][numKvHeads * TileSize * _tqBlockSize] (Lloyd-Max only)
+    private readonly KvCacheCompressor[][]? _keyCompressors;   // [layer][kvHead] (Lloyd-Max only)
+    private readonly KvCacheCompressor[][]? _valueCompressors;
 
-    private readonly int _tqBlockSize;        // bytes per compressed block per KV head
-    private readonly int _tileBytes;          // FastScan.TileBytes(_headDim)  (K-layout)
-    private readonly int _vTileBytes;         // FastScan.VTileBytes(_headDim) (V-layout)
-    private readonly int _stagingBytesPerHead; // TileSize * _tqBlockSize
+    // KVarN mode (issue #180). One shared compressor: the write path (tile
+    // compression inside Append) is single-threaded, and the read methods
+    // (RotateQuery / KeyScores / AggregateValues) are stateless and safe to
+    // call from the per-head Parallel.For in TqAttention.
+    private readonly KVarNCompressor? _kvarn;
+    private readonly float[]? _kvarnGather;   // [TileTokens * headDim] per-head gather scratch (write path)
+
+    private readonly TqQuantizer _quantizer;
+    private readonly int _tileTokens;         // positions per compressed tile (32 FastScan / 128 KVarN)
+    private readonly int _keyTileStride;      // bytes per (tile, kv-head) K tile
+    private readonly int _valueTileStride;    // bytes per (tile, kv-head) V tile
+    private readonly int _tqBlockSize;        // bytes per compressed block per KV head (Lloyd-Max only)
+    private readonly int _tileBytes;          // FastScan.TileBytes(_headDim)  (K-layout, Lloyd-Max only)
+    private readonly int _vTileBytes;         // FastScan.VTileBytes(_headDim) (V-layout, Lloyd-Max only)
+    private readonly int _stagingBytesPerHead; // TileSize * _tqBlockSize (Lloyd-Max only)
     private readonly int _bits;
 
     private int _totalLength;    // total positions stored (TQ + FP32)
@@ -65,8 +102,15 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     public int TileBytes => _tileBytes;
     public int FastScanTileSize => SharpInference.TurboQuant.FastScan.TileSize;
 
+    /// <summary>The quantizer used for the compressed region.</summary>
+    public TqQuantizer Quantizer => _quantizer;
+
+    /// <summary>Positions per compressed tile (32 for Lloyd-Max FastScan, 128 for KVarN).</summary>
+    public int TileSizeTokens => _tileTokens;
+
     public TurboQuantKvCache(int numLayers, int maxSeqLen, int numKvHeads, int headDim,
-        int fp32WindowSize = 256, int bits = 3, int layerIndexBase = 0, int totalLayerCountForSeeds = 0)
+        int fp32WindowSize = 256, int bits = 3, int layerIndexBase = 0, int totalLayerCountForSeeds = 0,
+        TqQuantizer quantizer = TqQuantizer.LloydMax)
     {
         _numLayers = numLayers;
         _maxSeqLen = maxSeqLen;
@@ -75,10 +119,40 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         _kvDim = numKvHeads * headDim;
         _fp32WindowSize = fp32WindowSize;
         _bits = bits;
-        _tqBlockSize = TurboQuantOps.BlockSize(bits, headDim);
-        _tileBytes = SharpInference.TurboQuant.FastScan.TileBytes(headDim);
-        _vTileBytes = SharpInference.TurboQuant.FastScan.VTileBytes(headDim);
-        _stagingBytesPerHead = SharpInference.TurboQuant.FastScan.TileSize * _tqBlockSize;
+        _quantizer = quantizer;
+        if (quantizer == TqQuantizer.KVarN)
+        {
+            // KVarN (issue #180): whole 128-token tiles are compressed straight
+            // out of the FP32 window (the dual-axis Sinkhorn normalization needs
+            // the full tile assembled; partial tiles are rejected by design), so
+            // the window must be able to hold at least one tile whenever a
+            // compressed region can exist.
+            if (maxSeqLen > fp32WindowSize && fp32WindowSize < KVarNCompressor.TileTokens)
+                throw new ArgumentException(
+                    $"KVarN quantizer requires fp32WindowSize >= {KVarNCompressor.TileTokens} (one full tile) " +
+                    $"when maxSeqLen ({maxSeqLen}) exceeds the FP32 window; got fp32WindowSize={fp32WindowSize}.",
+                    nameof(fp32WindowSize));
+            _kvarn = new KVarNCompressor(headDim); // validates power-of-2 head dim in [8, 1024]
+            _kvarnGather = new float[KVarNCompressor.TileTokens * headDim];
+            _tileTokens = KVarNCompressor.TileTokens;
+            _keyTileStride = _kvarn.KeyTileBytes;
+            _valueTileStride = _kvarn.ValueTileBytes;
+            // Lloyd-Max per-block/FastScan sizing is unused in KVarN mode.
+            _tqBlockSize = 0;
+            _tileBytes = 0;
+            _vTileBytes = 0;
+            _stagingBytesPerHead = 0;
+        }
+        else
+        {
+            _tqBlockSize = TurboQuantOps.BlockSize(bits, headDim);
+            _tileBytes = SharpInference.TurboQuant.FastScan.TileBytes(headDim);
+            _vTileBytes = SharpInference.TurboQuant.FastScan.VTileBytes(headDim);
+            _stagingBytesPerHead = SharpInference.TurboQuant.FastScan.TileSize * _tqBlockSize;
+            _tileTokens = SharpInference.TurboQuant.FastScan.TileSize;
+            _keyTileStride = _tileBytes;
+            _valueTileStride = _vTileBytes;
+        }
         if (totalLayerCountForSeeds == 0)
             totalLayerCountForSeeds = numLayers;
         _layerTqLengths = new int[numLayers];
@@ -93,12 +167,17 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
             _fp32Values[i] = (float*)NativeMemory.AllocZeroed(fp32Bytes);
         }
 
-        // TQ compressed storage per layer: K and V each get tile + 32-slot
-        // per-block staging, with K and V tile layouts being transposes of
-        // each other (same total bytes per (tile, head)).
+        // TQ compressed storage per layer. Lloyd-Max: K and V each get tile +
+        // 32-slot per-block staging, with K and V tile layouts being transposes
+        // of each other (same total bytes per (tile, head)). KVarN: K4/V2 tiles
+        // only (no staging — whole tiles come out of the FP32 window). The
+        // ceil-divide tile count covers both promotion cadences: Lloyd-Max
+        // promotes one position at a time (max TQ length maxSeqLen − window),
+        // KVarN promotes 128 at a time (max TQ length maxSeqLen − window + 127,
+        // reached only in whole-tile steps — the same ceiling).
         int maxTqPositions = maxSeqLen - fp32WindowSize;
         if (maxTqPositions < 0) maxTqPositions = 0;
-        int maxTiles = (maxTqPositions + SharpInference.TurboQuant.FastScan.TileSize - 1) / SharpInference.TurboQuant.FastScan.TileSize;
+        int maxTiles = (maxTqPositions + _tileTokens - 1) / _tileTokens;
 
         _tqKeyTiles     = new byte*[numLayers];
         _tqKeyStaging   = new byte*[numLayers];
@@ -106,38 +185,45 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         _tqValueStaging = new byte*[numLayers];
         if (maxTqPositions > 0)
         {
-            var keyTileBytes   = (nuint)((long)maxTiles * numKvHeads * _tileBytes);
-            var valueTileBytes = (nuint)((long)maxTiles * numKvHeads * _vTileBytes);
+            var keyTileBytes   = (nuint)((long)maxTiles * numKvHeads * _keyTileStride);
+            var valueTileBytes = (nuint)((long)maxTiles * numKvHeads * _valueTileStride);
             var stageBytes     = (nuint)((long)numKvHeads * _stagingBytesPerHead);
             for (int i = 0; i < numLayers; i++)
             {
-                _tqKeyTiles[i]     = (byte*)NativeMemory.AllocZeroed(keyTileBytes);
-                _tqKeyStaging[i]   = (byte*)NativeMemory.AllocZeroed(stageBytes);
-                _tqValueTiles[i]   = (byte*)NativeMemory.AllocZeroed(valueTileBytes);
-                _tqValueStaging[i] = (byte*)NativeMemory.AllocZeroed(stageBytes);
+                _tqKeyTiles[i]   = (byte*)NativeMemory.AllocZeroed(keyTileBytes);
+                _tqValueTiles[i] = (byte*)NativeMemory.AllocZeroed(valueTileBytes);
+                if (quantizer == TqQuantizer.LloydMax)
+                {
+                    _tqKeyStaging[i]   = (byte*)NativeMemory.AllocZeroed(stageBytes);
+                    _tqValueStaging[i] = (byte*)NativeMemory.AllocZeroed(stageBytes);
+                }
             }
         }
 
-        // Create compressors per layer per KV head
-        _keyCompressors = new KvCacheCompressor[numLayers][];
-        _valueCompressors = new KvCacheCompressor[numLayers][];
-        for (int layer = 0; layer < numLayers; layer++)
+        // Create Lloyd-Max compressors per layer per KV head (KVarN needs no
+        // per-(layer, head) state — no codebooks, no sign-pattern seeds).
+        if (quantizer == TqQuantizer.LloydMax)
         {
-            _keyCompressors[layer] = new KvCacheCompressor[numKvHeads];
-            _valueCompressors[layer] = new KvCacheCompressor[numKvHeads];
-            for (int head = 0; head < numKvHeads; head++)
+            _keyCompressors = new KvCacheCompressor[numLayers][];
+            _valueCompressors = new KvCacheCompressor[numLayers][];
+            for (int layer = 0; layer < numLayers; layer++)
             {
-                int globalLayer = layer + layerIndexBase;
-                _keyCompressors[layer][head] = new KvCacheCompressor(bits, headDim, globalLayer * numKvHeads + head);
-                _valueCompressors[layer][head] = new KvCacheCompressor(bits, headDim, (globalLayer + totalLayerCountForSeeds) * numKvHeads + head);
+                _keyCompressors[layer] = new KvCacheCompressor[numKvHeads];
+                _valueCompressors[layer] = new KvCacheCompressor[numKvHeads];
+                for (int head = 0; head < numKvHeads; head++)
+                {
+                    int globalLayer = layer + layerIndexBase;
+                    _keyCompressors[layer][head] = new KvCacheCompressor(bits, headDim, globalLayer * numKvHeads + head);
+                    _valueCompressors[layer][head] = new KvCacheCompressor(bits, headDim, (globalLayer + totalLayerCountForSeeds) * numKvHeads + head);
+                }
             }
         }
     }
 
     public TurboQuantKvCache(ModelHyperparams hp, int fp32WindowSize = 256, int bits = 3,
-        int layerIndexBase = 0, int totalLayerCountForSeeds = 0)
+        int layerIndexBase = 0, int totalLayerCountForSeeds = 0, TqQuantizer quantizer = TqQuantizer.LloydMax)
         : this(hp.NumLayers, hp.ContextLength, hp.NumKvHeads, hp.HeadDim,
-               fp32WindowSize, bits, layerIndexBase, totalLayerCountForSeeds)
+               fp32WindowSize, bits, layerIndexBase, totalLayerCountForSeeds, quantizer)
     {
     }
 
@@ -153,10 +239,14 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
 
         int fp32Count = _totalLength - _layerTqLengths[layer];
 
-        // If FP32 window is full, compress the oldest FP32 entry
+        // If FP32 window is full, promote the oldest entries into the compressed
+        // region: one position (Lloyd-Max staging) or one whole tile (KVarN).
         if (fp32Count >= _fp32WindowSize)
         {
-            CompressOldestFp32(layer);
+            if (_quantizer == TqQuantizer.KVarN)
+                CompressOldestFp32TileKVarN(layer);
+            else
+                CompressOldestFp32(layer);
             fp32Count = _totalLength - _layerTqLengths[layer];
         }
 
@@ -201,13 +291,15 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     }
 
     /// <summary>
-    /// Pointer to a FastScan K-tile (32 positions × one kv-head). Tile index
-    /// is 0..NumKeyTiles(layer)-1; positions beyond <c>NumKeyTiles × 32</c> are
-    /// in the staging buffer and accessed via <see cref="KeyStagingBlockAt"/>.
+    /// Pointer to a compressed K-tile (<see cref="TileSizeTokens"/> positions ×
+    /// one kv-head): FastScan layout in Lloyd-Max mode, KVarN packed layout in
+    /// KVarN mode. Tile index is 0..NumKeyTiles(layer)-1; in Lloyd-Max mode
+    /// positions beyond <c>NumKeyTiles × 32</c> are in the staging buffer and
+    /// accessed via <see cref="KeyStagingBlockAt"/> (KVarN has no staging).
     /// </summary>
     public byte* KeyTileAt(int layer, int tileIdx, int kvHead)
     {
-        long byteOffset = ((long)tileIdx * _numKvHeads + kvHead) * _tileBytes;
+        long byteOffset = ((long)tileIdx * _numKvHeads + kvHead) * _keyTileStride;
         return _tqKeyTiles[layer] + byteOffset;
     }
 
@@ -221,18 +313,21 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         return _tqKeyStaging[layer] + byteOffset;
     }
 
-    /// <summary>Number of complete FastScan tiles for this layer's K cache.</summary>
+    /// <summary>Number of complete compressed tiles for this layer's K cache.</summary>
     public int NumKeyTiles(int layer) =>
-        _layerTqLengths[layer] / SharpInference.TurboQuant.FastScan.TileSize;
+        _layerTqLengths[layer] / _tileTokens;
 
-    /// <summary>Number of positions currently in the staging buffer (0..31).</summary>
+    /// <summary>
+    /// Number of positions currently in the staging buffer (0..31 in Lloyd-Max
+    /// mode; always 0 in KVarN mode — the TQ length only grows in whole tiles).
+    /// </summary>
     public int KeyStagingCount(int layer) =>
-        _layerTqLengths[layer] % SharpInference.TurboQuant.FastScan.TileSize;
+        _layerTqLengths[layer] % _tileTokens;
 
-    /// <summary>Pointer to a FastScan V-tile (32 positions × one kv-head).</summary>
+    /// <summary>Pointer to a compressed V-tile (<see cref="TileSizeTokens"/> positions × one kv-head).</summary>
     public byte* ValueTileAt(int layer, int tileIdx, int kvHead)
     {
-        long byteOffset = ((long)tileIdx * _numKvHeads + kvHead) * _vTileBytes;
+        long byteOffset = ((long)tileIdx * _numKvHeads + kvHead) * _valueTileStride;
         return _tqValueTiles[layer] + byteOffset;
     }
 
@@ -244,17 +339,39 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     }
 
     /// <summary>
-    /// Returns the key compressor for the given layer and KV head.
-    /// Used to rotate queries and compute fused dequant-dot.
+    /// Returns the Lloyd-Max key compressor for the given layer and KV head.
+    /// Used to rotate queries and compute fused dequant-dot. Unavailable in
+    /// KVarN mode — use <see cref="RotateQuery"/> / <see cref="ComputeKScores"/>.
     /// </summary>
     public KvCacheCompressor GetKeyCompressor(int layer, int kvHead) =>
-        _keyCompressors[layer][kvHead];
+        _keyCompressors is { } kc
+            ? kc[layer][kvHead]
+            : throw new InvalidOperationException(
+                "Lloyd-Max compressors are unavailable in KVarN quantizer mode; use RotateQuery/ComputeKScores/ComputeVAggregation.");
 
     /// <summary>
-    /// Returns the value compressor for the given layer and KV head.
+    /// Returns the Lloyd-Max value compressor for the given layer and KV head.
+    /// Unavailable in KVarN mode.
     /// </summary>
     public KvCacheCompressor GetValueCompressor(int layer, int kvHead) =>
-        _valueCompressors[layer][kvHead];
+        _valueCompressors is { } vc
+            ? vc[layer][kvHead]
+            : throw new InvalidOperationException(
+                "Lloyd-Max compressors are unavailable in KVarN quantizer mode; use RotateQuery/ComputeKScores/ComputeVAggregation.");
+
+    /// <summary>
+    /// Rotate a query vector into this cache's compressed-domain basis: plain
+    /// Walsh-Hadamard in KVarN mode, per-(layer, kv-head) sign-flip +
+    /// Walsh-Hadamard in Lloyd-Max mode. Call once per head per decode step;
+    /// the result feeds <see cref="ComputeKScores"/>. Thread-safe (stateless).
+    /// </summary>
+    public void RotateQuery(int layer, int kvHead, ReadOnlySpan<float> query, Span<float> rotatedQuery)
+    {
+        if (_quantizer == TqQuantizer.KVarN)
+            _kvarn!.RotateQuery(query, rotatedQuery);
+        else
+            _keyCompressors![layer][kvHead].RotateQuery(query, rotatedQuery);
+    }
 
     /// <summary>
     /// Sets the global position counter to <paramref name="length"/> without
@@ -278,6 +395,10 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     /// Truncates the cache to the given length, which must fall within the FP32 window
     /// (i.e., length >= TqLength). Positions in the compressed TQ region cannot be undone.
     /// Throws <see cref="NotSupportedException"/> if length would truncate into TQ-compressed data.
+    /// Note the guaranteed rewind depth differs by quantizer: Lloyd-Max promotes 32 positions
+    /// at a time (depth ≥ window − 31), KVarN promotes whole 128-token tiles (depth ≥
+    /// window − 127 — just 1 position at the minimum window of 128). Callers that rewind
+    /// (speculative decoding) must keep the window comfortably above their draft length.
     /// </summary>
     public void TruncateTo(int length)
     {
@@ -298,22 +419,23 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         int maxTqPositions = _maxSeqLen - _fp32WindowSize;
         if (maxTqPositions <= 0) return fp32Bytes;
 
-        int maxTiles = (maxTqPositions + SharpInference.TurboQuant.FastScan.TileSize - 1)
-                       / SharpInference.TurboQuant.FastScan.TileSize;
-        long keyTileBytes   = (long)_numLayers * maxTiles * _numKvHeads * _tileBytes;
-        long valueTileBytes = (long)_numLayers * maxTiles * _numKvHeads * _vTileBytes;
+        int maxTiles = (maxTqPositions + _tileTokens - 1) / _tileTokens;
+        long keyTileBytes   = (long)_numLayers * maxTiles * _numKvHeads * _keyTileStride;
+        long valueTileBytes = (long)_numLayers * maxTiles * _numKvHeads * _valueTileStride;
         long stageBytes     = (long)_numLayers * 2 * _numKvHeads * _stagingBytesPerHead;
         return fp32Bytes + keyTileBytes + valueTileBytes + stageBytes;
     }
 
     /// <summary>
     /// Compute K-scores (q·k for all TQ-compressed positions) for one
-    /// (layer, kv-head). Walks complete FastScan tiles via the i8 LUT kernel
-    /// and the staging tail via per-block <c>DequantDot</c>. Final score per
-    /// position is multiplied by <paramref name="attnScale"/>.
+    /// (layer, kv-head). Lloyd-Max: walks complete FastScan tiles via the i8
+    /// LUT kernel and the staging tail via per-block <c>DequantDot</c>. KVarN:
+    /// walks whole 128-token tiles via <see cref="KVarNCompressor.KeyScores"/>
+    /// (no staging tail exists). Final score per position is multiplied by
+    /// <paramref name="attnScale"/>.
     /// </summary>
     /// <param name="rotatedQuery">Pre-rotated query (caller invokes
-    /// <see cref="KvCacheCompressor.RotateQuery"/> once per head).</param>
+    /// <see cref="RotateQuery"/> once per head).</param>
     /// <param name="attnScale">Attention scale, typically 1/√headDim.</param>
     /// <param name="scoresOut">Output buffer, length ≥ <c>TqLength</c>.</param>
     public void ComputeKScores(
@@ -323,6 +445,12 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         float attnScale,
         float* scoresOut)
     {
+        if (_quantizer == TqQuantizer.KVarN)
+        {
+            ComputeKScoresKVarN(layer, kvHead, rotatedQuery, attnScale, scoresOut);
+            return;
+        }
+
         int hd = _headDim;
         int totalTq = _layerTqLengths[layer];
         int numFullTiles = totalTq / SharpInference.TurboQuant.FastScan.TileSize;
@@ -355,7 +483,7 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
 
         if (stagingCount > 0)
         {
-            var keyCompressor = _keyCompressors[layer][kvHead];
+            var keyCompressor = _keyCompressors![layer][kvHead];
             var rotatedQuerySpan = new ReadOnlySpan<float>(rotatedQuery, hd);
             int tailStart = numFullTiles * SharpInference.TurboQuant.FastScan.TileSize;
             for (int s = 0; s < stagingCount; s++)
@@ -366,6 +494,35 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
                     rotatedQuerySpan);
                 scoresOut[tailStart + s] = dot * attnScale;
             }
+        }
+    }
+
+    /// <summary>
+    /// KVarN K-scoring (issue #180): the compressed region always holds whole
+    /// 128-token tiles (the FP32 window owns everything mod 128), each scored
+    /// via the fused <see cref="KVarNCompressor.KeyScores"/> which folds the
+    /// per-channel Sinkhorn/RTN factors into the query once per tile.
+    /// </summary>
+    private void ComputeKScoresKVarN(
+        int layer,
+        int kvHead,
+        float* rotatedQuery,
+        float attnScale,
+        float* scoresOut)
+    {
+        int tileTokens = KVarNCompressor.TileTokens;
+        int numTiles = _layerTqLengths[layer] / tileTokens;
+        if (numTiles == 0) return;
+
+        var comp = _kvarn!;
+        var rotatedQuerySpan = new ReadOnlySpan<float>(rotatedQuery, _headDim);
+        for (int tileIdx = 0; tileIdx < numTiles; tileIdx++)
+        {
+            var tile = new ReadOnlySpan<byte>(KeyTileAt(layer, tileIdx, kvHead), _keyTileStride);
+            var scores = new Span<float>(scoresOut + (long)tileIdx * tileTokens, tileTokens);
+            comp.KeyScores(tile, rotatedQuerySpan, scores);
+            for (int t = 0; t < tileTokens; t++)
+                scores[t] *= attnScale;
         }
     }
 
@@ -383,6 +540,12 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         float* weights,
         float* outAcc)
     {
+        if (_quantizer == TqQuantizer.KVarN)
+        {
+            ComputeVAggregationKVarN(layer, kvHead, weights, outAcc);
+            return;
+        }
+
         int hd = _headDim;
         int totalTq = _layerTqLengths[layer];
         int numFullTiles = totalTq / SharpInference.TurboQuant.FastScan.TileSize;
@@ -451,12 +614,49 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
         // Phase 3: deferred sign-flip + inverse Walsh-Hadamard (once per head),
         // then fold into the caller's accumulator. Both operations are linear,
         // so they commute with the Σ_t accumulation above.
-        var signPattern = _valueCompressors[layer][kvHead].SignPattern;
+        var signPattern = _valueCompressors![layer][kvHead].SignPattern;
         for (int d = 0; d < hd; d++)
             rotatedAcc[d] *= signPattern[d];
 
         SharpInference.TurboQuant.WalshHadamard.Transform(rotatedAcc, rotatedAcc, hd);
 
+        for (int d = 0; d < hd; d++)
+            outAcc[d] += rotatedAcc[d];
+    }
+
+    /// <summary>
+    /// KVarN V-aggregation (issue #180): all tiles share the same channel
+    /// rotation, so they accumulate into one rotated-domain accumulator and the
+    /// inverse Walsh-Hadamard runs ONCE per head
+    /// (<see cref="KVarNCompressor.UnrotateOutput"/>) before folding into
+    /// <paramref name="outAcc"/>. The caller then adds the FP32-window V
+    /// contribution on top of <paramref name="outAcc"/> in the un-rotated
+    /// (original) domain — the same deferred-inverse contract the FastScan
+    /// path uses.
+    /// </summary>
+    private void ComputeVAggregationKVarN(
+        int layer,
+        int kvHead,
+        float* weights,
+        float* outAcc)
+    {
+        int hd = _headDim;
+        int tileTokens = KVarNCompressor.TileTokens;
+        int numTiles = _layerTqLengths[layer] / tileTokens;
+        if (numTiles == 0) return;
+
+        var comp = _kvarn!;
+        Span<float> rotatedAcc = stackalloc float[hd]; // hd ≤ 1024, validated by KVarNCompressor
+        rotatedAcc.Clear();
+
+        for (int tileIdx = 0; tileIdx < numTiles; tileIdx++)
+        {
+            var tile = new ReadOnlySpan<byte>(ValueTileAt(layer, tileIdx, kvHead), _valueTileStride);
+            var w = new ReadOnlySpan<float>(weights + (long)tileIdx * tileTokens, tileTokens);
+            comp.AggregateValues(tile, w, rotatedAcc);
+        }
+
+        comp.UnrotateOutput(rotatedAcc);
         for (int d = 0; d < hd; d++)
             outAcc[d] += rotatedAcc[d];
     }
@@ -481,8 +681,8 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
             var keyDest = new Span<byte>(_tqKeyStaging[layer]   + stagingOffset, _tqBlockSize);
             var valDest = new Span<byte>(_tqValueStaging[layer] + stagingOffset, _tqBlockSize);
 
-            _keyCompressors[layer][head].Compress(keySpan, keyDest);
-            _valueCompressors[layer][head].Compress(valSpan, valDest);
+            _keyCompressors![layer][head].Compress(keySpan, keyDest);
+            _valueCompressors![layer][head].Compress(valSpan, valDest);
         }
 
         _layerTqLengths[layer]++;
@@ -527,6 +727,55 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     }
 
     /// <summary>
+    /// KVarN promotion (issue #180): compress the oldest
+    /// <see cref="KVarNCompressor.TileTokens"/> FP32-window positions into one
+    /// K tile + one V tile per kv-head, then shift the window down by a whole
+    /// tile. Unlike the Lloyd-Max path there is no per-position staging — the
+    /// dual-axis Sinkhorn normalization needs the entire tile assembled before
+    /// it can quantize, so promotion is all-or-nothing per tile and the FP32
+    /// window always owns the trailing <c>totalLength mod 128</c> positions.
+    /// The constructor guarantees <c>fp32WindowSize >= TileTokens</c> whenever
+    /// a compressed region can exist, so a full window always contains a tile.
+    /// </summary>
+    private void CompressOldestFp32TileKVarN(int layer)
+    {
+        int tileTokens = KVarNCompressor.TileTokens;
+        var comp = _kvarn!;
+        int tileIdx = _layerTqLengths[layer] / tileTokens;
+        int fp32Count = _totalLength - _layerTqLengths[layer];
+        Span<float> gather = _kvarnGather.AsSpan();
+
+        // Per head: gather the oldest 128 window rows into a contiguous
+        // [token, channel] tile and compress. Write path is single-threaded
+        // (see the _kvarn field note), so the shared gather scratch is safe.
+        for (int head = 0; head < _numKvHeads; head++)
+        {
+            int headOffset = head * _headDim;
+
+            for (int t = 0; t < tileTokens; t++)
+                new ReadOnlySpan<float>(_fp32Keys[layer] + (long)t * _kvDim + headOffset, _headDim)
+                    .CopyTo(gather.Slice(t * _headDim, _headDim));
+            comp.CompressKeyTile(gather, new Span<byte>(KeyTileAt(layer, tileIdx, head), _keyTileStride));
+
+            for (int t = 0; t < tileTokens; t++)
+                new ReadOnlySpan<float>(_fp32Values[layer] + (long)t * _kvDim + headOffset, _headDim)
+                    .CopyTo(gather.Slice(t * _headDim, _headDim));
+            comp.CompressValueTile(gather, new Span<byte>(ValueTileAt(layer, tileIdx, head), _valueTileStride));
+        }
+
+        _layerTqLengths[layer] += tileTokens;
+
+        // Shift the remaining FP32 entries down by a whole tile.
+        int remaining = fp32Count - tileTokens;
+        if (remaining > 0)
+        {
+            long copyBytes = (long)remaining * _kvDim * sizeof(float);
+            Buffer.MemoryCopy(_fp32Keys[layer] + (long)tileTokens * _kvDim, _fp32Keys[layer], copyBytes, copyBytes);
+            Buffer.MemoryCopy(_fp32Values[layer] + (long)tileTokens * _kvDim, _fp32Values[layer], copyBytes, copyBytes);
+        }
+    }
+
+    /// <summary>
     /// SnapKV (issue #60) compaction for the TurboQuant cache: keep only the K/V
     /// positions listed in <paramref name="keep"/> (sorted ascending, all in
     /// <c>[0, N)</c>); discard the rest. After compaction the cache holds
@@ -550,6 +799,11 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     public void Compact(int[] keep, int N)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(TurboQuantKvCache));
+        if (_quantizer == TqQuantizer.KVarN)
+            throw new NotSupportedException(
+                "SnapKV compaction is not yet supported with the KVarN quantizer (issue #180 follow-up): " +
+                "re-quantizing survivors requires re-assembling whole 128-token tiles. " +
+                "Disable SnapKV (unset SHARPI_SNAPKV_BUDGET) or use the Lloyd-Max quantizer.");
         if (keep is null) throw new ArgumentNullException(nameof(keep));
         if (N != _totalLength)
             throw new ArgumentException(
@@ -708,8 +962,8 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
                                 var keyDst = new Span<byte>(tmpKeyStage   + stageOff, _tqBlockSize);
                                 var valDst = new Span<byte>(tmpValueStage + stageOff, _tqBlockSize);
 
-                                _keyCompressors[layer][head].Compress(keySrc, keyDst);
-                                _valueCompressors[layer][head].Compress(valSrc, valDst);
+                                _keyCompressors![layer][head].Compress(keySrc, keyDst);
+                                _valueCompressors![layer][head].Compress(valSrc, valDst);
                             }
 
                             // If we just completed a tile (slot 31 of tileSize),
@@ -847,7 +1101,7 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     {
         int tileSize = SharpInference.TurboQuant.FastScan.TileSize;
         int numFullTiles = _layerTqLengths[layer] / tileSize;
-        var compressor = _keyCompressors[layer][kvHead];
+        var compressor = _keyCompressors![layer][kvHead];
 
         if (position < numFullTiles * tileSize)
         {
@@ -872,7 +1126,7 @@ public sealed unsafe class TurboQuantKvCache : IDisposable
     {
         int tileSize = SharpInference.TurboQuant.FastScan.TileSize;
         int numFullTiles = _layerTqLengths[layer] / tileSize;
-        var compressor = _valueCompressors[layer][kvHead];
+        var compressor = _valueCompressors![layer][kvHead];
 
         if (position < numFullTiles * tileSize)
         {

--- a/src/SharpInference.TurboQuant/BitPacking.cs
+++ b/src/SharpInference.TurboQuant/BitPacking.cs
@@ -3,17 +3,45 @@ using System.Runtime.CompilerServices;
 namespace SharpInference.TurboQuant;
 
 /// <summary>
-/// 3-bit and 4-bit packing/unpacking for TurboQuant compressed KV cache.
+/// 2-bit, 3-bit and 4-bit packing/unpacking for TurboQuant/KVarN compressed KV cache.
+/// 128 2-bit values pack into 32 bytes (256 bits).
 /// 128 3-bit values pack into 48 bytes (384 bits).
 /// 128 4-bit values pack into 64 bytes (512 bits).
 /// </summary>
 public static class BitPacking
 {
+    /// <summary>Bytes needed for 128 packed 2-bit indices.</summary>
+    public const int PackedBytes2Bit = 32; // 128 * 2 / 8
+
     /// <summary>Bytes needed for 128 packed 3-bit indices.</summary>
     public const int PackedBytes3Bit = 48; // 128 * 3 / 8
 
     /// <summary>Bytes needed for 128 packed 4-bit indices.</summary>
     public const int PackedBytes4Bit = 64; // 128 * 4 / 8
+
+    /// <summary>
+    /// Pack a 2-bit index (0..3) at the given position into a byte buffer.
+    /// Position p maps to bits (p &amp; 3) * 2 of byte p / 4. The target field is
+    /// masked before writing, so no pre-clear of the buffer is required.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void PackBits2(Span<byte> buffer, int byteOffset, int position, int value)
+    {
+        int byteIdx = byteOffset + (position >> 2);
+        int bitShift = (position & 3) << 1;
+        buffer[byteIdx] = (byte)((buffer[byteIdx] & ~(0x3 << bitShift)) | ((value & 0x3) << bitShift));
+    }
+
+    /// <summary>
+    /// Unpack a 2-bit index (0..3) from the given position in a byte buffer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int UnpackBits2(ReadOnlySpan<byte> buffer, int byteOffset, int position)
+    {
+        int byteIdx = byteOffset + (position >> 2);
+        int bitShift = (position & 3) << 1;
+        return (buffer[byteIdx] >> bitShift) & 0x3;
+    }
 
     /// <summary>
     /// Pack a 3-bit index (0..7) at the given position into a byte buffer.

--- a/src/SharpInference.TurboQuant/KVarNCompressor.cs
+++ b/src/SharpInference.TurboQuant/KVarNCompressor.cs
@@ -1,0 +1,680 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace SharpInference.TurboQuant;
+
+/// <summary>
+/// KVarN KV-cache quantizer, preset <c>kvarn_k4v2_g128</c>: per-tile Hadamard
+/// rotation + dual-axis ("Sinkhorn") variance normalization + asymmetric
+/// round-to-nearest quantization. Keys are quantized to 4 bits per-channel,
+/// values to 2 bits per-token in channel groups of <see cref="ValueGroupSize"/>.
+/// Clean-room implementation from the algorithm description in
+/// docs/kvarn-feasibility-research.md (Müller et al., arXiv:2606.03458); no
+/// code was ported from the reference vLLM fork.
+///
+/// A tile is <see cref="TileTokens"/> = 128 consecutive token vectors of one
+/// kv-head, row-major [token, channel]. The whole tile must be assembled
+/// before compression because the dual-axis normalization needs both token
+/// and channel statistics — the same staging pattern TurboQuantKvCache
+/// already uses for its 32-position FastScan tiles.
+///
+/// Write pipeline (per tile):
+///  1. Walsh-Hadamard rotation of every token vector along the channel axis.
+///     The normalized WHT is orthonormal and self-inverse, so attention
+///     scores are preserved: (Hq)·(Hk) = q·k. Both K and V are rotated —
+///     see the V note below. Unlike TurboQuant no per-layer sign flip is
+///     applied: the Sinkhorn step below replaces it as the outlier equalizer,
+///     and skipping it keeps the rotation a pure involution.
+///  2. Sinkhorn variance normalization (<see cref="SinkhornNormalize"/>):
+///     alternate per-channel (column) and per-token (row) RMS normalization,
+///     accumulating the factors in log space. A few iterations drive both
+///     axes toward unit variance, so the fixed low-bit RTN grid no longer has
+///     to cover per-token or per-channel scale outliers (the error source
+///     KVarN identifies as the driver of long-decode drift).
+///  3. Asymmetric RTN: keys per-channel (min/step over the tile's 128 tokens,
+///     i.e. group size 128 along the token axis), values per-token in channel
+///     groups of 128 (clamped to headDim when headDim &lt; 128). Codes are
+///     unsigned (K: 0..15, V: 0..3); dequant is <c>min + step · code</c>.
+///  4. Scale folding: the Sinkhorn factor of the quantized axis is folded
+///     into the stored RTN affine (K: channel factor into step/min; V: token
+///     factor into step/min), so read paths apply exactly one leftover factor
+///     per element — rowScale_t for K, colScale_c for V:
+///       score_t = rowScale_t · Σ_c q'_c · (chanMin_c + chanStep_c · code)
+///       out'_c += colScale_c · Σ_t p_t · (tokMin_tg + tokStep_tg · code)
+///     For K the per-channel terms fold into the query once per tile
+///     (<see cref="KeyScores"/>), not once per token.
+///
+/// Why V is rotated too: V never meets a rotated query — it is aggregated by
+/// softmax weights — so rotation is not needed for score preservation. It is
+/// kept because (a) at 2 bits a per-token min/max grid is dominated by the
+/// token's largest-magnitude channels, and Sinkhorn's column factors are
+/// tile-wide: they equalize channel variance across the tile but cannot
+/// spread one token's energy concentration, while the Hadamard mixes each
+/// token's channels and tightens its range toward Gaussian; (b) aggregation
+/// is linear, so all tiles accumulate in the rotated domain and the inverse
+/// transform runs once per head per decode step
+/// (<see cref="UnrotateOutput"/>) — the same deferred-inverse pattern the
+/// FastScan V path uses; (c) it keeps the K and V write pipelines identical.
+/// The aggregate-parity and round-trip tests prove the un-rotation is exact.
+///
+/// Instances are not thread-safe for concurrent Compress* calls (they share
+/// per-instance scratch buffers, allocated once at construction). The read
+/// methods are stateless (stackalloc only) and safe to call concurrently.
+/// </summary>
+public sealed class KVarNCompressor
+{
+    /// <summary>Tokens per tile. Matches the paper's vLLM block size and the K quant group.</summary>
+    public const int TileTokens = 128;
+
+    /// <summary>Channel group size for per-token V quantization (clamped to headDim).</summary>
+    public const int ValueGroupSize = 128;
+
+    /// <summary>Key quantization bit width.</summary>
+    public const int KeyBits = 4;
+
+    /// <summary>Value quantization bit width.</summary>
+    public const int ValueBits = 2;
+
+    /// <summary>Default Sinkhorn iteration count (paper: ~3-5 suffice).</summary>
+    public const int DefaultSinkhornIterations = 4;
+
+    // Rows/columns whose RMS falls at or below this are left unscaled (their
+    // log factor contribution is 0), so all-zero rows/columns survive the
+    // normalization untouched and reconstruct exactly.
+    private const float RmsEpsilon = 1e-12f;
+
+    private readonly int _headDim;
+    private readonly int _valueGroups;
+    private readonly int _sinkhornIterations;
+
+    // Scratch reused across Compress* calls (write path only; see thread-safety note).
+    private readonly float[] _work;        // TileTokens × headDim rotated/normalized tile
+    private readonly float[] _axisScratch; // Sinkhorn factors of the folded-away axis
+
+    // ── Packed K tile layout (channel-major codes) ──────────────────────────
+    //
+    //   rowScale[T]  : T × f32 — per-token Sinkhorn factor (the only per-token
+    //                  multiply left on the score path)
+    //   chanStep[D]  : D × f32 — colScale_c · rtnStep_c (Sinkhorn channel
+    //                  factor folded into the RTN step)
+    //   chanMin[D]   : D × f32 — colScale_c · rtnMin_c (folded asymmetric
+    //                  zero-point, stored as a real-valued minimum)
+    //   codes        : D contiguous runs of T/2 bytes, channel-major. Run c
+    //                  holds channel c's 128 4-bit codes across the tile's
+    //                  tokens (token t in nibble t of the run: even t → low
+    //                  nibble of byte t/2, odd t → high nibble — the
+    //                  BitPacking.PackBits4 convention), so a tile-scores
+    //                  kernel walks each channel's codes sequentially while
+    //                  accumulating into scores[0..127] — the FastScan-style
+    //                  loop inversion a future SIMD kernel (P1) vectorizes
+    //                  along tokens.
+    //
+    //   dequant:  k̂'[t,c] = rowScale[t] · (chanMin[c] + chanStep[c] · code[c,t])
+    //
+    //   Total bytes = 4·T + 8·D + D·T/2. For T=128, D=128: 9728 bytes for
+    //   16384 elements → 4.75 effective bits/element (scales are f32 in this
+    //   P0 reference; f16 scales in P1 would shave ~0.7 bits).
+    private readonly int _kChanStepF32;  // f32 index of chanStep[]
+    private readonly int _kChanMinF32;   // f32 index of chanMin[]
+    private readonly int _kCodesOffset;  // byte offset of codes
+
+    // ── Packed V tile layout (token-major codes) ────────────────────────────
+    //
+    //   colScale[D]   : D × f32 — per-channel Sinkhorn factor (the only
+    //                   per-channel multiply left on the aggregate path)
+    //   tokStep[T·G]  : T·G × f32 — rowScale_t · rtnStep_tg folded, token-major
+    //                   (index t·G + g), G = ceil(D / ValueGroupSize)
+    //   tokMin[T·G]   : T·G × f32 — rowScale_t · rtnMin_tg folded
+    //   codes         : T contiguous runs of D/4 bytes, token-major. Run t
+    //                   holds token t's D 2-bit codes (channel c in bits
+    //                   (c&amp;3)·2 of byte c/4 — the BitPacking.PackBits2
+    //                   convention), so the V-aggregate walks token rows
+    //                   sequentially: outer loop over tokens, broadcast
+    //                   p_t · tokStep, inner run walk over channels.
+    //
+    //   dequant:  v̂'[t,c] = colScale[c] · (tokMin[t,g(c)] + tokStep[t,g(c)] · code[t,c])
+    //
+    //   Total bytes = 4·D + 8·T·G + T·D/4. For T=128, D=128 (G=1): 5632 bytes
+    //   for 16384 elements → 2.75 effective bits/element.
+    private readonly int _vTokStepF32;   // f32 index of tokStep[]
+    private readonly int _vTokMinF32;    // f32 index of tokMin[]
+    private readonly int _vCodesOffset;  // byte offset of codes
+
+    /// <summary>Head dimension (channels per token).</summary>
+    public int HeadDim => _headDim;
+
+    /// <summary>Bytes per compressed K tile (128 tokens × headDim, 4-bit).</summary>
+    public int KeyTileBytes { get; }
+
+    /// <summary>Bytes per compressed V tile (128 tokens × headDim, 2-bit).</summary>
+    public int ValueTileBytes { get; }
+
+    public KVarNCompressor(int headDim, int sinkhornIterations = DefaultSinkhornIterations)
+    {
+        ValidateHeadDim(headDim);
+        if (sinkhornIterations is < 1 or > 32)
+            throw new ArgumentOutOfRangeException(nameof(sinkhornIterations), "Sinkhorn iterations must be in [1, 32].");
+
+        _headDim = headDim;
+        _sinkhornIterations = sinkhornIterations;
+        _valueGroups = (headDim + ValueGroupSize - 1) / ValueGroupSize;
+
+        _kChanStepF32 = TileTokens;
+        _kChanMinF32 = TileTokens + headDim;
+        _kCodesOffset = (TileTokens + 2 * headDim) * sizeof(float);
+        KeyTileBytes = _kCodesOffset + headDim * (TileTokens / 2);
+
+        _vTokStepF32 = headDim;
+        _vTokMinF32 = headDim + TileTokens * _valueGroups;
+        _vCodesOffset = (headDim + 2 * TileTokens * _valueGroups) * sizeof(float);
+        ValueTileBytes = _vCodesOffset + TileTokens * (headDim / 4);
+
+        _work = new float[TileTokens * headDim];
+        _axisScratch = new float[Math.Max(TileTokens, headDim)];
+    }
+
+    /// <summary>Bytes per compressed K tile for the given head dimension.</summary>
+    public static int KeyTileSize(int headDim)
+    {
+        ValidateHeadDim(headDim);
+        return (TileTokens + 2 * headDim) * sizeof(float) + headDim * (TileTokens / 2);
+    }
+
+    /// <summary>Bytes per compressed V tile for the given head dimension.</summary>
+    public static int ValueTileSize(int headDim)
+    {
+        ValidateHeadDim(headDim);
+        int groups = (headDim + ValueGroupSize - 1) / ValueGroupSize;
+        return (headDim + 2 * TileTokens * groups) * sizeof(float) + TileTokens * (headDim / 4);
+    }
+
+    private static void ValidateHeadDim(int headDim)
+    {
+        if (!BitOperations.IsPow2(headDim) || headDim is < 8 or > 1024)
+            throw new ArgumentException("Head dimension must be a power of 2 in [8, 1024].", nameof(headDim));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Sinkhorn variance normalization
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Dual-axis variance normalization: alternately divides each channel
+    /// (column) and each token (row) of the tile by its RMS, accumulating the
+    /// factors in log space, so a few iterations drive both axes toward unit
+    /// variance. RMS (std about zero) is used rather than mean-centered std so
+    /// the normalization stays a pure per-row/per-column scaling — the only
+    /// form that folds back into dot products and weighted sums exactly.
+    /// Rows/columns with RMS ≤ epsilon (e.g. all-zero) are left unscaled.
+    ///
+    /// On return: original[t,c] == tile[t,c] · rowScaleOut[t] · colScaleOut[c]
+    /// (up to fp rounding). Columns are normalized first and rows last, so the
+    /// token axis — whose scale outliers drive decode drift — ends exactly
+    /// unit-RMS.
+    /// </summary>
+    /// <param name="tile">Row-major [tokens, dim] tile, normalized in place.</param>
+    /// <param name="tokens">Row count.</param>
+    /// <param name="dim">Column count.</param>
+    /// <param name="rowScaleOut">Receives the per-token factors (length ≥ tokens).</param>
+    /// <param name="colScaleOut">Receives the per-channel factors (length ≥ dim).</param>
+    /// <param name="iterations">Alternation count (~3-5 suffice).</param>
+    public static void SinkhornNormalize(
+        Span<float> tile,
+        int tokens,
+        int dim,
+        Span<float> rowScaleOut,
+        Span<float> colScaleOut,
+        int iterations)
+    {
+        if (tokens <= 0)
+            throw new ArgumentOutOfRangeException(nameof(tokens), "tokens must be positive.");
+        if (dim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(dim), "dim must be positive.");
+        if (tile.Length < tokens * dim)
+            throw new ArgumentException($"tile must hold {tokens}×{dim} floats.", nameof(tile));
+        if (rowScaleOut.Length < tokens)
+            throw new ArgumentException($"rowScaleOut must hold {tokens} floats.", nameof(rowScaleOut));
+        if (colScaleOut.Length < dim)
+            throw new ArgumentException($"colScaleOut must hold {dim} floats.", nameof(colScaleOut));
+        if (iterations < 1)
+            throw new ArgumentOutOfRangeException(nameof(iterations));
+
+        Span<float> logRow = rowScaleOut.Slice(0, tokens);
+        Span<float> logCol = colScaleOut.Slice(0, dim);
+        logRow.Clear();
+        logCol.Clear();
+
+        for (int iter = 0; iter < iterations; iter++)
+        {
+            // Channels (columns) first ...
+            for (int c = 0; c < dim; c++)
+            {
+                float sumSq = 0f;
+                for (int t = 0; t < tokens; t++)
+                {
+                    float v = tile[t * dim + c];
+                    sumSq += v * v;
+                }
+                float rms = MathF.Sqrt(sumSq / tokens);
+                if (rms <= RmsEpsilon)
+                    continue;
+                float inv = 1f / rms;
+                for (int t = 0; t < tokens; t++)
+                    tile[t * dim + c] *= inv;
+                logCol[c] += MathF.Log(rms);
+            }
+
+            // ... tokens (rows) last, so per-token RMS ends exactly at 1.
+            for (int t = 0; t < tokens; t++)
+            {
+                Span<float> row = tile.Slice(t * dim, dim);
+                float sumSq = 0f;
+                for (int c = 0; c < dim; c++)
+                    sumSq += row[c] * row[c];
+                float rms = MathF.Sqrt(sumSq / dim);
+                if (rms <= RmsEpsilon)
+                    continue;
+                float inv = 1f / rms;
+                for (int c = 0; c < dim; c++)
+                    row[c] *= inv;
+                logRow[t] += MathF.Log(rms);
+            }
+        }
+
+        // Log domain → linear scale factors.
+        for (int t = 0; t < tokens; t++)
+            logRow[t] = MathF.Exp(logRow[t]);
+        for (int c = 0; c < dim; c++)
+            logCol[c] = MathF.Exp(logCol[c]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Write path
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Compress one K tile: <see cref="TileTokens"/> key vectors (row-major
+    /// [token, channel]) into the packed 4-bit per-channel layout.
+    /// </summary>
+    /// <param name="keys">TileTokens × headDim floats, original (un-rotated) domain.</param>
+    /// <param name="tileOut">Destination, at least <see cref="KeyTileBytes"/> bytes.</param>
+    public void CompressKeyTile(ReadOnlySpan<float> keys, Span<byte> tileOut)
+    {
+        int d = _headDim;
+        if (keys.Length < TileTokens * d)
+            throw new ArgumentException($"keys must hold {TileTokens}×{d} floats.", nameof(keys));
+        if (tileOut.Length < KeyTileBytes)
+            throw new ArgumentException($"tileOut must be at least {KeyTileBytes} bytes.", nameof(tileOut));
+
+        Span<float> work = _work.AsSpan(0, TileTokens * d);
+        RotateRows(keys, work, d);
+
+        Span<float> f32 = MemoryMarshal.Cast<byte, float>(tileOut);
+        Span<float> rowScale = f32.Slice(0, TileTokens);            // stored raw
+        Span<float> colScale = _axisScratch.AsSpan(0, d);           // folded below
+        SinkhornNormalize(work, TileTokens, d, rowScale, colScale, _sinkhornIterations);
+
+        Span<float> chanStep = f32.Slice(_kChanStepF32, d);
+        Span<float> chanMin = f32.Slice(_kChanMinF32, d);
+        Span<byte> codes = tileOut.Slice(_kCodesOffset, d * (TileTokens / 2));
+
+        const int levels = (1 << KeyBits) - 1; // 15
+        for (int c = 0; c < d; c++)
+        {
+            float min = float.MaxValue, max = float.MinValue;
+            for (int t = 0; t < TileTokens; t++)
+            {
+                float v = work[t * d + c];
+                if (v < min) min = v;
+                if (v > max) max = v;
+            }
+
+            float step = (max - min) / levels;
+            float invStep = step > 0f ? 1f / step : 0f;
+            chanStep[c] = colScale[c] * step;
+            chanMin[c] = colScale[c] * min;
+
+            Span<byte> run = codes.Slice(c * (TileTokens / 2), TileTokens / 2);
+            for (int t = 0; t < TileTokens; t++)
+            {
+                int q = (int)MathF.Round((work[t * d + c] - min) * invStep);
+                if (q < 0) q = 0;
+                else if (q > levels) q = levels;
+                BitPacking.PackBits4(run, 0, t, q);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Compress one V tile: <see cref="TileTokens"/> value vectors (row-major
+    /// [token, channel]) into the packed 2-bit per-token layout.
+    /// </summary>
+    /// <param name="values">TileTokens × headDim floats, original (un-rotated) domain.</param>
+    /// <param name="tileOut">Destination, at least <see cref="ValueTileBytes"/> bytes.</param>
+    public void CompressValueTile(ReadOnlySpan<float> values, Span<byte> tileOut)
+    {
+        int d = _headDim;
+        if (values.Length < TileTokens * d)
+            throw new ArgumentException($"values must hold {TileTokens}×{d} floats.", nameof(values));
+        if (tileOut.Length < ValueTileBytes)
+            throw new ArgumentException($"tileOut must be at least {ValueTileBytes} bytes.", nameof(tileOut));
+
+        Span<float> work = _work.AsSpan(0, TileTokens * d);
+        RotateRows(values, work, d);
+
+        Span<float> f32 = MemoryMarshal.Cast<byte, float>(tileOut);
+        Span<float> colScale = f32.Slice(0, d);                     // stored raw
+        Span<float> rowScale = _axisScratch.AsSpan(0, TileTokens);  // folded below
+        SinkhornNormalize(work, TileTokens, d, rowScale, colScale, _sinkhornIterations);
+
+        int groups = _valueGroups;
+        Span<float> tokStep = f32.Slice(_vTokStepF32, TileTokens * groups);
+        Span<float> tokMin = f32.Slice(_vTokMinF32, TileTokens * groups);
+        Span<byte> codes = tileOut.Slice(_vCodesOffset, TileTokens * (d / 4));
+
+        const int levels = (1 << ValueBits) - 1; // 3
+        for (int t = 0; t < TileTokens; t++)
+        {
+            Span<float> row = work.Slice(t * d, d);
+            Span<byte> run = codes.Slice(t * (d / 4), d / 4);
+
+            for (int g = 0; g < groups; g++)
+            {
+                int c0 = g * ValueGroupSize;
+                int c1 = Math.Min(c0 + ValueGroupSize, d);
+
+                float min = float.MaxValue, max = float.MinValue;
+                for (int c = c0; c < c1; c++)
+                {
+                    float v = row[c];
+                    if (v < min) min = v;
+                    if (v > max) max = v;
+                }
+
+                float step = (max - min) / levels;
+                float invStep = step > 0f ? 1f / step : 0f;
+                tokStep[t * groups + g] = rowScale[t] * step;
+                tokMin[t * groups + g] = rowScale[t] * min;
+
+                for (int c = c0; c < c1; c++)
+                {
+                    int q = (int)MathF.Round((row[c] - min) * invStep);
+                    if (q < 0) q = 0;
+                    else if (q > levels) q = levels;
+                    BitPacking.PackBits2(run, 0, c, q);
+                }
+            }
+        }
+    }
+
+    /// <summary>Rotate each token row along the channel axis (normalized WHT).</summary>
+    private static void RotateRows(ReadOnlySpan<float> source, Span<float> dest, int dim)
+    {
+        for (int t = 0; t < TileTokens; t++)
+            WalshHadamard.Transform(source.Slice(t * dim, dim), dest.Slice(t * dim, dim), dim);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Read path
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Pre-rotate a query vector for use with <see cref="KeyScores"/> /
+    /// <see cref="DequantDot"/>. Call once per head, reuse across all tiles.
+    /// </summary>
+    public void RotateQuery(ReadOnlySpan<float> query, Span<float> rotatedQuery)
+    {
+        if (query.Length < _headDim)
+            throw new ArgumentException($"query must hold {_headDim} floats.", nameof(query));
+        if (rotatedQuery.Length < _headDim)
+            throw new ArgumentException($"rotatedQuery must hold {_headDim} floats.", nameof(rotatedQuery));
+        WalshHadamard.Transform(query, rotatedQuery, _headDim);
+    }
+
+    /// <summary>
+    /// Compute q·k̂ for every token in a K tile. The per-channel factors
+    /// (chanStep/chanMin, which already carry the Sinkhorn channel scale) are
+    /// folded into the query once for the whole tile; the code walk is
+    /// channel-major, matching the packed layout.
+    /// </summary>
+    /// <param name="tile">Compressed K tile.</param>
+    /// <param name="rotatedQuery">Pre-rotated query (<see cref="RotateQuery"/>).</param>
+    /// <param name="scoresOut">Receives <see cref="TileTokens"/> scores.</param>
+    public void KeyScores(ReadOnlySpan<byte> tile, ReadOnlySpan<float> rotatedQuery, Span<float> scoresOut)
+    {
+        int d = _headDim;
+        if (tile.Length < KeyTileBytes)
+            throw new ArgumentException($"tile must be at least {KeyTileBytes} bytes.", nameof(tile));
+        if (rotatedQuery.Length < d)
+            throw new ArgumentException($"rotatedQuery must hold {d} floats.", nameof(rotatedQuery));
+        if (scoresOut.Length < TileTokens)
+            throw new ArgumentException($"scoresOut must hold {TileTokens} floats.", nameof(scoresOut));
+
+        ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
+        ReadOnlySpan<float> rowScale = f32.Slice(0, TileTokens);
+        ReadOnlySpan<float> chanStep = f32.Slice(_kChanStepF32, d);
+        ReadOnlySpan<float> chanMin = f32.Slice(_kChanMinF32, d);
+        ReadOnlySpan<byte> codes = tile.Slice(_kCodesOffset, d * (TileTokens / 2));
+
+        // Fold per-channel factors into the query once per tile:
+        //   score_t = rowScale_t · (Σ_c q_c·chanMin_c  +  Σ_c (q_c·chanStep_c)·code[c,t])
+        Span<float> acc = stackalloc float[TileTokens];
+        acc.Clear();
+        float bias = 0f;
+
+        for (int c = 0; c < d; c++)
+        {
+            float q = rotatedQuery[c];
+            bias += q * chanMin[c];
+            float qw = q * chanStep[c];
+            if (qw == 0f)
+                continue;
+
+            ReadOnlySpan<byte> run = codes.Slice(c * (TileTokens / 2), TileTokens / 2);
+            for (int b = 0; b < TileTokens / 2; b++)
+            {
+                byte pair = run[b];
+                acc[b * 2] += qw * (pair & 0x0F);
+                acc[b * 2 + 1] += qw * ((pair >> 4) & 0x0F);
+            }
+        }
+
+        for (int t = 0; t < TileTokens; t++)
+            scoresOut[t] = rowScale[t] * (acc[t] + bias);
+    }
+
+    /// <summary>
+    /// Compute q·k̂ for a single token of a K tile. Equivalent to
+    /// dot(query, decompressed row); prefer <see cref="KeyScores"/> when
+    /// scoring the whole tile so the channel folding is amortized.
+    /// </summary>
+    public float DequantDot(ReadOnlySpan<byte> tile, ReadOnlySpan<float> rotatedQuery, int tokenIndex)
+    {
+        int d = _headDim;
+        if (tile.Length < KeyTileBytes)
+            throw new ArgumentException($"tile must be at least {KeyTileBytes} bytes.", nameof(tile));
+        if (rotatedQuery.Length < d)
+            throw new ArgumentException($"rotatedQuery must hold {d} floats.", nameof(rotatedQuery));
+        if ((uint)tokenIndex >= TileTokens)
+            throw new ArgumentOutOfRangeException(nameof(tokenIndex));
+
+        ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
+        ReadOnlySpan<float> chanStep = f32.Slice(_kChanStepF32, d);
+        ReadOnlySpan<float> chanMin = f32.Slice(_kChanMinF32, d);
+        ReadOnlySpan<byte> codes = tile.Slice(_kCodesOffset, d * (TileTokens / 2));
+
+        int byteInRun = tokenIndex >> 1;
+        bool high = (tokenIndex & 1) != 0;
+
+        float dot = 0f;
+        for (int c = 0; c < d; c++)
+        {
+            byte pair = codes[c * (TileTokens / 2) + byteInRun];
+            int code = high ? (pair >> 4) & 0x0F : pair & 0x0F;
+            dot += rotatedQuery[c] * (chanMin[c] + chanStep[c] * code);
+        }
+
+        return f32[tokenIndex] * dot; // rowScale[tokenIndex]
+    }
+
+    /// <summary>
+    /// Accumulate the softmax-weighted V aggregate for one tile into
+    /// <paramref name="rotatedAccInOut"/> (rotated domain). Tiles share the
+    /// same rotation, so fold any number of tiles into the same accumulator
+    /// and call <see cref="UnrotateOutput"/> once at the end. The per-token
+    /// factors (tokStep/tokMin, which already carry the Sinkhorn token scale)
+    /// are folded into the weight once per token; the code walk is
+    /// token-major, matching the packed layout.
+    /// </summary>
+    /// <param name="tile">Compressed V tile.</param>
+    /// <param name="weights">Softmax weights, one per tile token.</param>
+    /// <param name="rotatedAccInOut">Accumulator of headDim floats (rotated domain).</param>
+    public void AggregateValues(ReadOnlySpan<byte> tile, ReadOnlySpan<float> weights, Span<float> rotatedAccInOut)
+    {
+        int d = _headDim;
+        int groups = _valueGroups;
+        if (tile.Length < ValueTileBytes)
+            throw new ArgumentException($"tile must be at least {ValueTileBytes} bytes.", nameof(tile));
+        if (weights.Length < TileTokens)
+            throw new ArgumentException($"weights must hold {TileTokens} floats.", nameof(weights));
+        if (rotatedAccInOut.Length < d)
+            throw new ArgumentException($"rotatedAccInOut must hold {d} floats.", nameof(rotatedAccInOut));
+
+        ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
+        ReadOnlySpan<float> colScale = f32.Slice(0, d);
+        ReadOnlySpan<float> tokStep = f32.Slice(_vTokStepF32, TileTokens * groups);
+        ReadOnlySpan<float> tokMin = f32.Slice(_vTokMinF32, TileTokens * groups);
+        ReadOnlySpan<byte> codes = tile.Slice(_vCodesOffset, TileTokens * (d / 4));
+
+        //   out'_c += colScale_c · ( Σ_t w_t·tokMin_tg  +  Σ_t (w_t·tokStep_tg)·code[t,c] )
+        // The min term is constant per channel group, so it accumulates once
+        // per (token, group) instead of once per element.
+        Span<float> acc = stackalloc float[d];
+        acc.Clear();
+        Span<float> groupBias = stackalloc float[groups];
+        groupBias.Clear();
+
+        int bytesPerToken = d / 4;
+        for (int t = 0; t < TileTokens; t++)
+        {
+            float w = weights[t];
+            if (w == 0f)
+                continue;
+
+            ReadOnlySpan<byte> run = codes.Slice(t * bytesPerToken, bytesPerToken);
+            for (int g = 0; g < groups; g++)
+            {
+                groupBias[g] += w * tokMin[t * groups + g];
+                float ws = w * tokStep[t * groups + g];
+                if (ws == 0f)
+                    continue;
+
+                int b0 = (g * ValueGroupSize) >> 2;
+                int b1 = Math.Min((g + 1) * ValueGroupSize, d) >> 2;
+                for (int b = b0; b < b1; b++)
+                {
+                    byte quad = run[b];
+                    int c = b << 2;
+                    acc[c] += ws * (quad & 0x3);
+                    acc[c + 1] += ws * ((quad >> 2) & 0x3);
+                    acc[c + 2] += ws * ((quad >> 4) & 0x3);
+                    acc[c + 3] += ws * ((quad >> 6) & 0x3);
+                }
+            }
+        }
+
+        for (int c = 0; c < d; c++)
+            rotatedAccInOut[c] += colScale[c] * (acc[c] + groupBias[c / ValueGroupSize]);
+    }
+
+    /// <summary>
+    /// Undo the channel rotation on a V aggregate accumulated via
+    /// <see cref="AggregateValues"/>. Call once per head after all tiles have
+    /// been folded in (the normalized WHT is its own inverse).
+    /// </summary>
+    public void UnrotateOutput(Span<float> rotatedAcc)
+    {
+        if (rotatedAcc.Length < _headDim)
+            throw new ArgumentException($"rotatedAcc must hold {_headDim} floats.", nameof(rotatedAcc));
+        WalshHadamard.Transform(rotatedAcc.Slice(0, _headDim), rotatedAcc.Slice(0, _headDim), _headDim);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Debug / test path
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reconstruct a K tile to full precision (original, un-rotated domain).
+    /// Test/debug path — the hot path never materializes this.
+    /// </summary>
+    /// <param name="tile">Compressed K tile.</param>
+    /// <param name="keysOut">TileTokens × headDim floats, row-major.</param>
+    public void DecompressKeyTile(ReadOnlySpan<byte> tile, Span<float> keysOut)
+    {
+        int d = _headDim;
+        if (tile.Length < KeyTileBytes)
+            throw new ArgumentException($"tile must be at least {KeyTileBytes} bytes.", nameof(tile));
+        if (keysOut.Length < TileTokens * d)
+            throw new ArgumentException($"keysOut must hold {TileTokens}×{d} floats.", nameof(keysOut));
+
+        ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
+        ReadOnlySpan<float> rowScale = f32.Slice(0, TileTokens);
+        ReadOnlySpan<float> chanStep = f32.Slice(_kChanStepF32, d);
+        ReadOnlySpan<float> chanMin = f32.Slice(_kChanMinF32, d);
+        ReadOnlySpan<byte> codes = tile.Slice(_kCodesOffset, d * (TileTokens / 2));
+
+        for (int t = 0; t < TileTokens; t++)
+        {
+            Span<float> row = keysOut.Slice(t * d, d);
+            int byteInRun = t >> 1;
+            bool high = (t & 1) != 0;
+
+            for (int c = 0; c < d; c++)
+            {
+                byte pair = codes[c * (TileTokens / 2) + byteInRun];
+                int code = high ? (pair >> 4) & 0x0F : pair & 0x0F;
+                row[c] = rowScale[t] * (chanMin[c] + chanStep[c] * code);
+            }
+
+            WalshHadamard.Transform(row, row, d); // involution → inverse rotation
+        }
+    }
+
+    /// <summary>
+    /// Reconstruct a V tile to full precision (original, un-rotated domain).
+    /// Test/debug path — the hot path never materializes this.
+    /// </summary>
+    /// <param name="tile">Compressed V tile.</param>
+    /// <param name="valuesOut">TileTokens × headDim floats, row-major.</param>
+    public void DecompressValueTile(ReadOnlySpan<byte> tile, Span<float> valuesOut)
+    {
+        int d = _headDim;
+        int groups = _valueGroups;
+        if (tile.Length < ValueTileBytes)
+            throw new ArgumentException($"tile must be at least {ValueTileBytes} bytes.", nameof(tile));
+        if (valuesOut.Length < TileTokens * d)
+            throw new ArgumentException($"valuesOut must hold {TileTokens}×{d} floats.", nameof(valuesOut));
+
+        ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
+        ReadOnlySpan<float> colScale = f32.Slice(0, d);
+        ReadOnlySpan<float> tokStep = f32.Slice(_vTokStepF32, TileTokens * groups);
+        ReadOnlySpan<float> tokMin = f32.Slice(_vTokMinF32, TileTokens * groups);
+        ReadOnlySpan<byte> codes = tile.Slice(_vCodesOffset, TileTokens * (d / 4));
+
+        int bytesPerToken = d / 4;
+        for (int t = 0; t < TileTokens; t++)
+        {
+            Span<float> row = valuesOut.Slice(t * d, d);
+            ReadOnlySpan<byte> run = codes.Slice(t * bytesPerToken, bytesPerToken);
+
+            for (int c = 0; c < d; c++)
+            {
+                int g = c / ValueGroupSize;
+                int code = BitPacking.UnpackBits2(run, 0, c);
+                row[c] = colScale[c] * (tokMin[t * groups + g] + tokStep[t * groups + g] * code);
+            }
+
+            WalshHadamard.Transform(row, row, d);
+        }
+    }
+}

--- a/src/SharpInference.TurboQuant/KVarNCompressor.cs
+++ b/src/SharpInference.TurboQuant/KVarNCompressor.cs
@@ -1,5 +1,8 @@
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 namespace SharpInference.TurboQuant;
 
@@ -83,6 +86,16 @@ public sealed class KVarNCompressor
     // normalization untouched and reconstruct exactly.
     private const float RmsEpsilon = 1e-12f;
 
+    /// <summary>
+    /// Test hook: forces the scalar read kernels (<see cref="KeyScores"/> /
+    /// <see cref="AggregateValues"/>) even when AVX2 is available so the parity
+    /// suite and micro-benchmarks can compare both implementations on the same
+    /// hardware. Not intended for production use; both paths compute the same
+    /// algebra (the AVX2 path reassociates the floating-point accumulation and
+    /// contracts mul+add into FMA — one rounding instead of two).
+    /// </summary>
+    internal static bool ForceScalar;
+
     private readonly int _headDim;
     private readonly int _valueGroups;
     private readonly int _sinkhornIterations;
@@ -106,8 +119,8 @@ public sealed class KVarNCompressor
     //                  BitPacking.PackBits4 convention), so a tile-scores
     //                  kernel walks each channel's codes sequentially while
     //                  accumulating into scores[0..127] — the FastScan-style
-    //                  loop inversion a future SIMD kernel (P1) vectorizes
-    //                  along tokens.
+    //                  loop inversion <see cref="KeyScoresAvx2"/> vectorizes
+    //                  along tokens (P1).
     //
     //   dequant:  k̂'[t,c] = rowScale[t] · (chanMin[c] + chanStep[c] · code[c,t])
     //
@@ -435,7 +448,10 @@ public sealed class KVarNCompressor
     /// Compute q·k̂ for every token in a K tile. The per-channel factors
     /// (chanStep/chanMin, which already carry the Sinkhorn channel scale) are
     /// folded into the query once for the whole tile; the code walk is
-    /// channel-major, matching the packed layout.
+    /// channel-major, matching the packed layout. Dispatches to a fused AVX2
+    /// kernel when available (<see cref="KeyScoresAvx2"/>); the scalar path is
+    /// the reference implementation. The two paths differ only in
+    /// floating-point accumulation order.
     /// </summary>
     /// <param name="tile">Compressed K tile.</param>
     /// <param name="rotatedQuery">Pre-rotated query (<see cref="RotateQuery"/>).</param>
@@ -450,6 +466,15 @@ public sealed class KVarNCompressor
         if (scoresOut.Length < TileTokens)
             throw new ArgumentException($"scoresOut must hold {TileTokens} floats.", nameof(scoresOut));
 
+        if (Avx2.IsSupported && Fma.IsSupported && !ForceScalar)
+            KeyScoresAvx2(tile, rotatedQuery, scoresOut);
+        else
+            KeyScoresScalar(tile, rotatedQuery, scoresOut);
+    }
+
+    private void KeyScoresScalar(ReadOnlySpan<byte> tile, ReadOnlySpan<float> rotatedQuery, Span<float> scoresOut)
+    {
+        int d = _headDim;
         ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
         ReadOnlySpan<float> rowScale = f32.Slice(0, TileTokens);
         ReadOnlySpan<float> chanStep = f32.Slice(_kChanStepF32, d);
@@ -481,6 +506,93 @@ public sealed class KVarNCompressor
 
         for (int t = 0; t < TileTokens; t++)
             scoresOut[t] = rowScale[t] * (acc[t] + bias);
+    }
+
+    /// <summary>
+    /// AVX2 K-score kernel. Same algebra as <see cref="KeyScoresScalar"/> —
+    /// per-channel factors folded into the query, channel-major code walk —
+    /// but the 128 token scores are held in Vector256 accumulators, processed
+    /// in four chunks of 32 tokens so the working set (4 accumulators + unpack
+    /// temporaries) stays within the 16 YMM registers. Per channel and chunk:
+    /// one 16-byte load covers 32 nibbles (byte b = tokens 2b low / 2b+1 high,
+    /// the PackBits4 convention); low/high nibble extraction + byte interleave
+    /// (UnpackLow/High) restores token order, then vpmovzxbd + cvtdq2ps widens
+    /// to f32 for four FMAs against the broadcast folded query weight.
+    /// Numerics differ from scalar by FP reassociation + FMA contraction only.
+    /// </summary>
+    private unsafe void KeyScoresAvx2(ReadOnlySpan<byte> tile, ReadOnlySpan<float> rotatedQuery, Span<float> scoresOut)
+    {
+        int d = _headDim;
+        const int runBytes = TileTokens / 2;   // 64 code bytes per channel
+        const int chunkBytes = 16;             // bytes per chunk = 32 tokens
+
+        fixed (byte* tilePtr = tile)
+        fixed (float* qPtr = rotatedQuery)
+        fixed (float* scoresPtr = scoresOut)
+        {
+            float* f32 = (float*)tilePtr;
+            float* rowScale = f32;                 // [TileTokens]
+            float* chanStep = f32 + _kChanStepF32; // [d]
+            float* chanMin = f32 + _kChanMinF32;   // [d]
+            byte* codes = tilePtr + _kCodesOffset;
+
+            // bias = Σ_c q_c · chanMin_c — vectorized; d is a power of 2 ≥ 8,
+            // so the 8-lane loop has no tail.
+            var biasAcc = Vector256<float>.Zero;
+            for (int c = 0; c + 8 <= d; c += 8)
+                biasAcc = Fma.MultiplyAdd(Avx.LoadVector256(qPtr + c), Avx.LoadVector256(chanMin + c), biasAcc);
+            float bias = Vector256.Sum(biasAcc);
+
+            float* acc = stackalloc float[TileTokens];
+            var nibbleMask = Vector128.Create((byte)0x0F);
+
+            for (int chunk = 0; chunk < TileTokens / 32; chunk++)
+            {
+                byte* chunkCodes = codes + chunk * chunkBytes;
+                var a0 = Vector256<float>.Zero;
+                var a1 = Vector256<float>.Zero;
+                var a2 = Vector256<float>.Zero;
+                var a3 = Vector256<float>.Zero;
+
+                for (int c = 0; c < d; c++)
+                {
+                    float qw = qPtr[c] * chanStep[c];
+                    if (qw == 0f)
+                        continue;
+
+                    var pairs = Sse2.LoadVector128(chunkCodes + c * runBytes);
+                    var lo = Sse2.And(pairs, nibbleMask); // even tokens
+                    var hi = Sse2.And(                     // odd tokens
+                        Sse2.ShiftRightLogical(pairs.AsInt16(), 4).AsByte(),
+                        nibbleMask);
+                    var t01 = Sse2.UnpackLow(lo, hi);  // chunk tokens 0..15, in order
+                    var t23 = Sse2.UnpackHigh(lo, hi); // chunk tokens 16..31
+
+                    var qwv = Vector256.Create(qw);
+                    a0 = Fma.MultiplyAdd(Avx.ConvertToVector256Single(Avx2.ConvertToVector256Int32(t01)), qwv, a0);
+                    a1 = Fma.MultiplyAdd(Avx.ConvertToVector256Single(Avx2.ConvertToVector256Int32(
+                        Sse2.ShiftRightLogical128BitLane(t01, 8))), qwv, a1);
+                    a2 = Fma.MultiplyAdd(Avx.ConvertToVector256Single(Avx2.ConvertToVector256Int32(t23)), qwv, a2);
+                    a3 = Fma.MultiplyAdd(Avx.ConvertToVector256Single(Avx2.ConvertToVector256Int32(
+                        Sse2.ShiftRightLogical128BitLane(t23, 8))), qwv, a3);
+                }
+
+                int baseT = chunk * 32;
+                Avx.Store(acc + baseT, a0);
+                Avx.Store(acc + baseT + 8, a1);
+                Avx.Store(acc + baseT + 16, a2);
+                Avx.Store(acc + baseT + 24, a3);
+            }
+
+            // score_t = rowScale_t · (acc_t + bias)
+            var biasV = Vector256.Create(bias);
+            for (int t = 0; t < TileTokens; t += 8)
+            {
+                Avx.Store(scoresPtr + t, Avx.Multiply(
+                    Avx.LoadVector256(rowScale + t),
+                    Avx.Add(Avx.LoadVector256(acc + t), biasV)));
+            }
+        }
     }
 
     /// <summary>
@@ -532,7 +644,6 @@ public sealed class KVarNCompressor
     public void AggregateValues(ReadOnlySpan<byte> tile, ReadOnlySpan<float> weights, Span<float> rotatedAccInOut)
     {
         int d = _headDim;
-        int groups = _valueGroups;
         if (tile.Length < ValueTileBytes)
             throw new ArgumentException($"tile must be at least {ValueTileBytes} bytes.", nameof(tile));
         if (weights.Length < TileTokens)
@@ -540,6 +651,19 @@ public sealed class KVarNCompressor
         if (rotatedAccInOut.Length < d)
             throw new ArgumentException($"rotatedAccInOut must hold {d} floats.", nameof(rotatedAccInOut));
 
+        // The AVX2 kernel consumes 16 code bytes (64 channels) per step, so it
+        // needs every channel group to span a multiple of 64 channels — true
+        // for all shipping head dims (64/128/256); d ∈ {8,16,32} falls back.
+        if (Avx2.IsSupported && Fma.IsSupported && !ForceScalar && (d & 63) == 0)
+            AggregateValuesAvx2(tile, weights, rotatedAccInOut);
+        else
+            AggregateValuesScalar(tile, weights, rotatedAccInOut);
+    }
+
+    private void AggregateValuesScalar(ReadOnlySpan<byte> tile, ReadOnlySpan<float> weights, Span<float> rotatedAccInOut)
+    {
+        int d = _headDim;
+        int groups = _valueGroups;
         ReadOnlySpan<float> f32 = MemoryMarshal.Cast<byte, float>(tile);
         ReadOnlySpan<float> colScale = f32.Slice(0, d);
         ReadOnlySpan<float> tokStep = f32.Slice(_vTokStepF32, TileTokens * groups);
@@ -585,6 +709,116 @@ public sealed class KVarNCompressor
 
         for (int c = 0; c < d; c++)
             rotatedAccInOut[c] += colScale[c] * (acc[c] + groupBias[c / ValueGroupSize]);
+    }
+
+    /// <summary>
+    /// AVX2 V-aggregate kernel. Same algebra and skip semantics as
+    /// <see cref="AggregateValuesScalar"/> (w == 0 tokens and ws == 0 groups
+    /// are skipped; the group-min term accumulates once per token/group), but
+    /// the token-major code walk unpacks 16 bytes = 64 channels per step: four
+    /// crumb planes (bits 0-1/2-3/4-5/6-7, the PackBits2 convention) are
+    /// extracted with shift+mask, then a two-level byte/word interleave
+    /// (UnpackLow/High) restores channel order before vpmovzxbd + cvtdq2ps and
+    /// an FMA against the broadcast w·tokStep into the stack accumulator.
+    /// Requires d to be a multiple of 64 (see the dispatch in
+    /// <see cref="AggregateValues"/>). Numerics differ from scalar by FP
+    /// reassociation + FMA contraction only.
+    /// </summary>
+    private unsafe void AggregateValuesAvx2(ReadOnlySpan<byte> tile, ReadOnlySpan<float> weights, Span<float> rotatedAccInOut)
+    {
+        int d = _headDim;
+        int groups = _valueGroups;
+        int bytesPerToken = d / 4;
+
+        fixed (byte* tilePtr = tile)
+        fixed (float* wPtr = weights)
+        fixed (float* outPtr = rotatedAccInOut)
+        {
+            float* f32 = (float*)tilePtr;
+            float* colScale = f32;                // [d]
+            float* tokStep = f32 + _vTokStepF32;  // [T·G]
+            float* tokMin = f32 + _vTokMinF32;    // [T·G]
+            byte* codes = tilePtr + _vCodesOffset;
+
+            float* acc = stackalloc float[d];     // d ≤ 1024 (validated) → ≤ 4 KiB
+            new Span<float>(acc, d).Clear();
+            float* groupBias = stackalloc float[groups];
+            new Span<float>(groupBias, groups).Clear();
+
+            var crumbMask = Vector128.Create((byte)0x03);
+
+            for (int t = 0; t < TileTokens; t++)
+            {
+                float w = wPtr[t];
+                if (w == 0f)
+                    continue;
+
+                byte* run = codes + t * bytesPerToken;
+                for (int g = 0; g < groups; g++)
+                {
+                    groupBias[g] += w * tokMin[t * groups + g];
+                    float ws = w * tokStep[t * groups + g];
+                    if (ws == 0f)
+                        continue;
+
+                    var wsv = Vector256.Create(ws);
+                    int b0 = (g * ValueGroupSize) >> 2;
+                    int b1 = Math.Min((g + 1) * ValueGroupSize, d) >> 2;
+                    for (int b = b0; b < b1; b += 16)
+                    {
+                        // Byte j of the load holds channels 4j..4j+3 in crumbs.
+                        var quads = Sse2.LoadVector128(run + b);
+                        var c0 = Sse2.And(quads, crumbMask);
+                        var c1 = Sse2.And(Sse2.ShiftRightLogical(quads.AsInt16(), 2).AsByte(), crumbMask);
+                        var c2 = Sse2.And(Sse2.ShiftRightLogical(quads.AsInt16(), 4).AsByte(), crumbMask);
+                        var c3 = Sse2.And(Sse2.ShiftRightLogical(quads.AsInt16(), 6).AsByte(), crumbMask);
+
+                        // Byte interleave → channel pairs (4j, 4j+1) / (4j+2, 4j+3),
+                        // then word interleave → channels in order, 16 per vector.
+                        var p01Lo = Sse2.UnpackLow(c0, c1);
+                        var p23Lo = Sse2.UnpackLow(c2, c3);
+                        var p01Hi = Sse2.UnpackHigh(c0, c1);
+                        var p23Hi = Sse2.UnpackHigh(c2, c3);
+
+                        var q0 = Sse2.UnpackLow(p01Lo.AsInt16(), p23Lo.AsInt16()).AsByte();  // ch +0..15
+                        var q1 = Sse2.UnpackHigh(p01Lo.AsInt16(), p23Lo.AsInt16()).AsByte(); // ch +16..31
+                        var q2 = Sse2.UnpackLow(p01Hi.AsInt16(), p23Hi.AsInt16()).AsByte();  // ch +32..47
+                        var q3 = Sse2.UnpackHigh(p01Hi.AsInt16(), p23Hi.AsInt16()).AsByte(); // ch +48..63
+
+                        float* accBase = acc + (b << 2);
+                        FmaCodes16(accBase, q0, wsv);
+                        FmaCodes16(accBase + 16, q1, wsv);
+                        FmaCodes16(accBase + 32, q2, wsv);
+                        FmaCodes16(accBase + 48, q3, wsv);
+                    }
+                }
+            }
+
+            // out_c += colScale_c · (acc_c + groupBias_{c/G}) — the group index
+            // is constant across each 8-lane block because ValueGroupSize (128,
+            // clamped to d ≥ 64 here) is a multiple of 8.
+            for (int c = 0; c < d; c += 8)
+            {
+                var gb = Vector256.Create(groupBias[c / ValueGroupSize]);
+                var v = Avx.Add(Avx.LoadVector256(acc + c), gb);
+                var prev = Avx.LoadVector256(outPtr + c);
+                Avx.Store(outPtr + c, Fma.MultiplyAdd(Avx.LoadVector256(colScale + c), v, prev));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Widen 16 in-order code bytes to f32 and FMA them (× the broadcast
+    /// weight) into 16 consecutive accumulator floats.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void FmaCodes16(float* accBase, Vector128<byte> codes16, Vector256<float> wsv)
+    {
+        var lo = Avx.ConvertToVector256Single(Avx2.ConvertToVector256Int32(codes16));
+        var hi = Avx.ConvertToVector256Single(Avx2.ConvertToVector256Int32(
+            Sse2.ShiftRightLogical128BitLane(codes16, 8)));
+        Avx.Store(accBase, Fma.MultiplyAdd(lo, wsv, Avx.LoadVector256(accBase)));
+        Avx.Store(accBase + 8, Fma.MultiplyAdd(hi, wsv, Avx.LoadVector256(accBase + 8)));
     }
 
     /// <summary>

--- a/src/SharpInference.TurboQuant/SharpInference.TurboQuant.csproj
+++ b/src/SharpInference.TurboQuant/SharpInference.TurboQuant.csproj
@@ -8,4 +8,10 @@
     <ProjectReference Include="..\SharpInference.Core\SharpInference.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- KVarNCompressor.ForceScalar test/bench hook (AVX2-vs-scalar parity + micro-bench). -->
+    <InternalsVisibleTo Include="SharpInference.Tests.TurboQuant" />
+    <InternalsVisibleTo Include="SharpInference.Bench" />
+  </ItemGroup>
+
 </Project>

--- a/tests/SharpInference.Tests.Cli/PerplexityFlagsTests.cs
+++ b/tests/SharpInference.Tests.Cli/PerplexityFlagsTests.cs
@@ -1,0 +1,114 @@
+using SharpInference.Cli;
+using SharpInference.Engine;
+
+namespace SharpInference.Tests.Cli;
+
+/// <summary>
+/// Unit tests for <see cref="PerplexityCommand.TryValidateFlags"/> (the perplexity
+/// harness's --tq/--tq-mode/--tq-window/-g validation, issue #180 P0) and
+/// <see cref="PerplexityCommand.NegativeLogLikelihood"/> (the log-softmax NLL math).
+/// Same model-free pattern as <see cref="CpuMoeFlagsTests"/>: internal static helpers
+/// exercised directly.
+/// </summary>
+public sealed class PerplexityFlagsTests
+{
+    [Theory]
+    [InlineData(false, "lloydmax", 256, 0, TqQuantizer.LloydMax)]  // fp32 baseline (tq off, mode ignored)
+    [InlineData(true, "lloydmax", 256, 0, TqQuantizer.LloydMax)]
+    [InlineData(true, "lloyd-max", 256, 0, TqQuantizer.LloydMax)]
+    [InlineData(true, "", 256, 0, TqQuantizer.LloydMax)]
+    [InlineData(true, "kvarn", 256, 0, TqQuantizer.KVarN)]
+    [InlineData(true, "KVarN", 128, 0, TqQuantizer.KVarN)]         // case-insensitive; min window
+    [InlineData(true, "lloydmax", 32, 0, TqQuantizer.LloydMax)]    // Lloyd-Max min window (one FastScan tile)
+    public void ValidCombos_Resolve(bool tq, string mode, int window, int ngl, TqQuantizer expected)
+    {
+        bool ok = PerplexityCommand.TryValidateFlags(tq, mode, window, ngl, out var quantizer, out string? error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal(expected, quantizer);
+    }
+
+    [Fact]
+    public void Kvarn_WithoutTq_IsRejected()
+    {
+        bool ok = PerplexityCommand.TryValidateFlags(tq: false, "kvarn", 256, 0, out _, out string? error);
+
+        Assert.False(ok);
+        Assert.Contains("requires --tq", error);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    [InlineData(36)]
+    public void GpuLayers_NonZero_IsRejected(int ngl)
+    {
+        bool ok = PerplexityCommand.TryValidateFlags(tq: true, "kvarn", 256, ngl, out _, out string? error);
+
+        Assert.False(ok);
+        Assert.Contains("-g 0", error);
+    }
+
+    [Fact]
+    public void UnknownMode_IsRejected()
+    {
+        bool ok = PerplexityCommand.TryValidateFlags(tq: true, "fastscan", 256, 0, out _, out string? error);
+
+        Assert.False(ok);
+        Assert.Contains("fastscan", error);
+    }
+
+    [Theory]
+    [InlineData("kvarn", 127)]   // below one KVarN tile
+    [InlineData("lloydmax", 31)] // below one FastScan tile
+    public void Window_BelowTileFloor_IsRejected(string mode, int window)
+    {
+        bool ok = PerplexityCommand.TryValidateFlags(tq: true, mode, window, 0, out _, out string? error);
+
+        Assert.False(ok);
+        Assert.Contains("--tq-window", error);
+    }
+
+    [Fact]
+    public void Nll_UniformLogits_IsLogVocab()
+    {
+        float[] logits = new float[64];   // all zeros → uniform softmax → NLL = ln(64)
+        double nll = PerplexityCommand.NegativeLogLikelihood(logits, target: 17);
+
+        Assert.Equal(Math.Log(64), nll, precision: 10);
+    }
+
+    [Fact]
+    public void Nll_IsShiftInvariant_AndOrdersCorrectly()
+    {
+        float[] logits = [1.0f, 3.0f, 0.5f, -2.0f];
+        float[] shifted = [101.0f, 103.0f, 100.5f, 98.0f];
+
+        double a = PerplexityCommand.NegativeLogLikelihood(logits, 1);
+        double b = PerplexityCommand.NegativeLogLikelihood(shifted, 1);
+        Assert.Equal(a, b, precision: 6);
+
+        // The argmax token must be the cheapest (smallest NLL).
+        double argmaxNll = PerplexityCommand.NegativeLogLikelihood(logits, 1);
+        double otherNll = PerplexityCommand.NegativeLogLikelihood(logits, 3);
+        Assert.True(argmaxNll < otherNll);
+    }
+
+    [Fact]
+    public void Nll_NaNLogits_ReturnsNonFinite()
+    {
+        float[] logits = [0f, float.NaN, 1f];
+        double nll = PerplexityCommand.NegativeLogLikelihood(logits, 0);
+
+        Assert.False(double.IsFinite(nll));
+    }
+
+    [Fact]
+    public void Nll_TargetOutOfRange_ReturnsNaN()
+    {
+        double nll = PerplexityCommand.NegativeLogLikelihood([0f, 0f], target: 2);
+
+        Assert.True(double.IsNaN(nll));
+    }
+}

--- a/tests/SharpInference.Tests.Cli/PerplexityFlagsTests.cs
+++ b/tests/SharpInference.Tests.Cli/PerplexityFlagsTests.cs
@@ -20,6 +20,8 @@ public sealed class PerplexityFlagsTests
     [InlineData(true, "kvarn", 256, 0, TqQuantizer.KVarN)]
     [InlineData(true, "KVarN", 128, 0, TqQuantizer.KVarN)]         // case-insensitive; min window
     [InlineData(true, "lloydmax", 32, 0, TqQuantizer.LloydMax)]    // Lloyd-Max min window (one FastScan tile)
+    [InlineData(false, "lloydmax", 256, -1, TqQuantizer.LloydMax)] // full CUDA offload (Task 5a): fp32 baseline
+    [InlineData(true, "kvarn", 256, -1, TqQuantizer.KVarN)]        // full CUDA offload (Task 5a): kvarn gate
     public void ValidCombos_Resolve(bool tq, string mode, int window, int ngl, TqQuantizer expected)
     {
         bool ok = PerplexityCommand.TryValidateFlags(tq, mode, window, ngl, out var quantizer, out string? error);
@@ -39,11 +41,13 @@ public sealed class PerplexityFlagsTests
     }
 
     [Theory]
-    [InlineData(-1)]
     [InlineData(1)]
     [InlineData(36)]
-    public void GpuLayers_NonZero_IsRejected(int ngl)
+    [InlineData(-2)]
+    public void GpuLayers_Partial_IsRejected(int ngl)
     {
+        // 0 (CPU) and -1 (full CUDA offload, issue #180 Task 5a) are the only
+        // supported placements; anything partial is rejected.
         bool ok = PerplexityCommand.TryValidateFlags(tq: true, "kvarn", 256, ngl, out _, out string? error);
 
         Assert.False(ok);

--- a/tests/SharpInference.Tests.ForwardPass/CudaKvarnPrefillTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaKvarnPrefillTests.cs
@@ -1,0 +1,582 @@
+using System.Runtime.InteropServices;
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using SharpInference.TurboQuant;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Chunked batched KVarN prefill tests (issue #180 Task 6). Two levels:
+/// <list type="bullet">
+///   <item><b>Kernel</b> — <c>llm_kvarn_prefill_attention</c> (M chunk queries ×
+///         all tiles + causal fp32 window, streaming softmax) against the CPU
+///         <see cref="KVarNCompressor"/> oracle, per-dim max(1e-3, 1e-2·|x|) —
+///         the same band as the per-token KVarN attention tests.</item>
+///   <item><b>Integration</b> — <see cref="CudaForwardPass.Prefill"/> chunked vs
+///         per-token on a real model: identical promotion cadence, near-identical
+///         tiles (the RTN codes are byte-exact given identical inputs, but the
+///         chunked trunk computes K/V via batched MMQ GEMMs and flash attention,
+///         which are argmax-stable — not bit-identical — vs the per-token matvec
+///         path, so a small fraction of codes may shift by ±1 step), final-logit
+///         parity, and greedy-continuation agreement.</item>
+/// </list>
+/// Every test silently no-ops when CUDA (or the fixture model) is unavailable,
+/// matching <see cref="CudaKvarnTests"/>.
+/// </summary>
+public sealed unsafe class CudaKvarnPrefillTests(ITestOutputHelper output)
+{
+    private const int Tile = KVarNCompressor.TileTokens; // 128
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Kernel-level parity vs the CPU oracle
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(384, 128, 128, 2, 4, 128)]   // steady-state chunk: 3 tiles + window 128, M=128, GQA 2q/kv
+    [InlineData(256, 37, 44, 1, 2, 64)]      // tail chunk: odd f0, M=44 (last q-block has 12 queries), head_dim 64
+    [InlineData(256, 64, 45, 1, 2, 128)]     // ODD tail (last q-block mq=13): half-active warp around the sub-warp shuffles
+    [InlineData(4224, 128, 32, 1, 1, 128)]   // deep walk: 33 tiles, > 4096 total positions (no score-storage cap)
+    public void KvarnPrefillAttention_MatchesCpuOracle(
+        int tqLen, int f0, int m, int kvHeads, int qHeads, int headDim)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        Assert.Equal(0, tqLen % Tile);
+        int numTiles = tqLen / Tile;
+        int kvDim = kvHeads * headDim;
+        int qDim = qHeads * headDim;
+        int wTotal = f0 + m;                 // window rows after the chunk append
+        var comp = new KVarNCompressor(headDim);
+        int kStride = comp.KeyTileBytes;
+        int vStride = comp.ValueTileBytes;
+
+        var rng = new Random(20260711 + tqLen + headDim);
+        var keys = new float[tqLen + wTotal][];
+        var values = new float[tqLen + wTotal][];
+        for (int t = 0; t < tqLen + wTotal; t++)
+        {
+            keys[t] = Gaussian(kvDim, rng);
+            values[t] = Gaussian(kvDim, rng);
+        }
+
+        // CPU-compress the tq region into the packed tile layout (byte-compatible
+        // with the GPU store by KvarnCompressTile_MatchesCpu).
+        var kTileBytes = new byte[numTiles * kvHeads * kStride];
+        var vTileBytes = new byte[numTiles * kvHeads * vStride];
+        var gather = new float[Tile * headDim];
+        for (int tile = 0; tile < numTiles; tile++)
+        {
+            for (int head = 0; head < kvHeads; head++)
+            {
+                for (int t = 0; t < Tile; t++)
+                    keys[tile * Tile + t].AsSpan(head * headDim, headDim)
+                        .CopyTo(gather.AsSpan(t * headDim, headDim));
+                comp.CompressKeyTile(gather, kTileBytes.AsSpan((tile * kvHeads + head) * kStride, kStride));
+
+                for (int t = 0; t < Tile; t++)
+                    values[tile * Tile + t].AsSpan(head * headDim, headDim)
+                        .CopyTo(gather.AsSpan(t * headDim, headDim));
+                comp.CompressValueTile(gather, vTileBytes.AsSpan((tile * kvHeads + head) * vStride, vStride));
+            }
+        }
+
+        // Linear fp32 window (slot 0 = oldest): rows for positions tqLen .. tqLen+wTotal.
+        var kWindow = new float[wTotal * kvDim];
+        var vWindow = new float[wTotal * kvDim];
+        for (int t = 0; t < wTotal; t++)
+        {
+            keys[tqLen + t].CopyTo(kWindow.AsSpan(t * kvDim, kvDim));
+            values[tqLen + t].CopyTo(vWindow.AsSpan(t * kvDim, kvDim));
+        }
+
+        // Chunk queries, token-major [m × qDim].
+        var queries = Gaussian(m * qDim, rng);
+
+        var gpuKTiles = gpu.Upload(BytesToFloats(kTileBytes), TensorShape.D1(kTileBytes.Length / 4));
+        var gpuVTiles = gpu.Upload(BytesToFloats(vTileBytes), TensorShape.D1(vTileBytes.Length / 4));
+        var gpuKw = gpu.Upload(kWindow, TensorShape.D1(kWindow.Length));
+        var gpuVw = gpu.Upload(vWindow, TensorShape.D1(vWindow.Length));
+        var gpuQ = gpu.Upload(queries, TensorShape.D1(queries.Length));
+        var gpuRot = gpu.Allocate(TensorShape.D1(queries.Length));
+        var gpuOut = gpu.Allocate(TensorShape.D1(m * qDim));
+
+        // Batched rotation: the per-token WHT kernel launched over m·qHeads head-rows
+        // (rows are contiguous in the token-major layout) — same call the trunk makes.
+        gpu.KvarnRotateQuery(gpuQ, gpuRot, qHeads * m, headDim);
+        gpu.KvarnAttentionPrefill(gpuQ, gpuRot, gpuKTiles, gpuVTiles, gpuKw, gpuVw, gpuOut,
+            qHeads, kvHeads, headDim, tqLen, f0, m, kStride, vStride);
+        gpu.Synchronize();
+
+        var gpuResult = new float[m * qDim];
+        gpu.Download(gpuOut, gpuResult);
+        gpu.Synchronize();
+
+        // CPU oracle: per query i, ONE softmax over [tiles + window slots 0..f0+i]
+        // (RotateQuery → KeyScores per tile → window dots → softmax → AggregateValues
+        // rotated → UnrotateOutput → window V) — the per-token TqAttention pipeline.
+        int hpkg = qHeads / kvHeads;
+        float scale = 1f / MathF.Sqrt(headDim);
+        var rotated = new float[headDim];
+        var rotAcc = new float[headDim];
+        var expected = new float[m * qDim];
+        float worstCos = 1f;
+
+        for (int i = 0; i < m; i++)
+        {
+            int fp32Len = f0 + i + 1;
+            var scores = new float[tqLen + fp32Len];
+            for (int h = 0; h < qHeads; h++)
+            {
+                int kvHead = h / hpkg;
+                var qHead = queries.AsSpan(i * qDim + h * headDim, headDim);
+                comp.RotateQuery(qHead, rotated);
+
+                for (int tile = 0; tile < numTiles; tile++)
+                {
+                    comp.KeyScores(kTileBytes.AsSpan((tile * kvHeads + kvHead) * kStride, kStride),
+                        rotated, scores.AsSpan(tile * Tile, Tile));
+                    for (int t = 0; t < Tile; t++) scores[tile * Tile + t] *= scale;
+                }
+                for (int t = 0; t < fp32Len; t++)
+                {
+                    float dot = 0f;
+                    var kRow = keys[tqLen + t].AsSpan(kvHead * headDim, headDim);
+                    for (int d = 0; d < headDim; d++) dot += qHead[d] * kRow[d];
+                    scores[tqLen + t] = dot * scale;
+                }
+
+                Softmax(scores);
+
+                Array.Clear(rotAcc);
+                for (int tile = 0; tile < numTiles; tile++)
+                    comp.AggregateValues(vTileBytes.AsSpan((tile * kvHeads + kvHead) * vStride, vStride),
+                        scores.AsSpan(tile * Tile, Tile), rotAcc);
+                comp.UnrotateOutput(rotAcc);
+
+                var outHead = expected.AsSpan(i * qDim + h * headDim, headDim);
+                rotAcc.AsSpan(0, headDim).CopyTo(outHead);
+                for (int t = 0; t < fp32Len; t++)
+                {
+                    float w = scores[tqLen + t];
+                    var vRow = values[tqLen + t].AsSpan(kvHead * headDim, headDim);
+                    for (int d = 0; d < headDim; d++) outHead[d] += w * vRow[d];
+                }
+
+                float cos = Cosine(outHead, gpuResult.AsSpan(i * qDim + h * headDim, headDim));
+                if (cos < worstCos) worstCos = cos;
+            }
+        }
+
+        output.WriteLine($"tq={tqLen} f0={f0} m={m} kv={kvHeads} q={qHeads} d={headDim}: " +
+            $"worst per-(query,head) cosine vs CPU oracle {worstCos:F6}");
+        Assert.True(worstCos > 0.999f, $"KVarN prefill attention cosine too low: {worstCos:F4}");
+
+        for (int i = 0; i < expected.Length; i++)
+        {
+            float tol = MathF.Max(1e-3f, MathF.Abs(expected[i]) * 1e-2f);
+            Assert.True(MathF.Abs(gpuResult[i] - expected[i]) <= tol,
+                $"KVarN prefill attention mismatch at [{i}] (query {i / qDim}): " +
+                $"gpu={gpuResult[i]:G6} cpu={expected[i]:G6} tol={tol:E2}");
+        }
+
+        gpu.Free(gpuKTiles); gpu.Free(gpuVTiles);
+        gpu.Free(gpuKw); gpu.Free(gpuVw);
+        gpu.Free(gpuQ); gpu.Free(gpuRot); gpu.Free(gpuOut);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CudaForwardPass integration: chunked vs per-token prefill
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Full-path A/B on Qwen3-0.6B (window 256, prompt 640 → promotions at positions
+    /// 256/384/512 → 3 compressed tiles): the chunked driver must land the SAME
+    /// promotion cadence and tile position ranges as the per-token loop, produce
+    /// near-identical packed tiles (codes ±1 step under batched-GEMM/flash noise),
+    /// parity logits at the last prompt position, and the same greedy continuation.
+    /// </summary>
+    [Fact]
+    public void CudaForwardPass_KvarnChunkedPrefill_MatchesPerToken()
+    {
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int PromptLen = 640;
+        const int DecodeSteps = 20;
+        const int ExpectTq = 384;                 // 3 whole tiles (window 256: promotions at 256/384/512)
+
+        var (tilesK1, tilesV1, logits1, cont1, wasBatched1, layers1) =
+            RunPrefill(path, chunked: false, PromptLen, DecodeSteps, ExpectTq / Tile);
+        var (tilesK2, tilesV2, logits2, cont2, wasBatched2, layers2) =
+            RunPrefill(path, chunked: true, PromptLen, DecodeSteps, ExpectTq / Tile);
+
+        Assert.False(wasBatched1);
+        Assert.True(wasBatched2, "chunked KVarN prefill did not engage the batched trunk");
+        Assert.Equal(layers1, layers2);
+
+        // 1. Final-prompt-position logit parity (argmax + cosine). Position 639's
+        // attention reads all 3 tiles + the full window, so wrong tile contents or
+        // positions would blow this check grossly. The cosine band is calibrated to
+        // the known cross-path noise: per-token K/V flows through dp4a matvecs while
+        // the chunked trunk uses MMQ/flash, and each flipped 2-bit V code moves a
+        // dequantized value by ~2× the normalized row RMS.
+        int argmax1 = ArgMax(logits1), argmax2 = ArgMax(logits2);
+        float cos = Cosine(logits1, logits2);
+        float maxAbs = 0, atMax1 = 0, atMax2 = 0;
+        for (int i = 0; i < logits1.Length; i++)
+        {
+            float d = MathF.Abs(logits1[i] - logits2[i]);
+            if (d > maxAbs) { maxAbs = d; atMax1 = logits1[i]; atMax2 = logits2[i]; }
+        }
+        output.WriteLine($"final-position logits: argmax {argmax1} vs {argmax2}, cosine {cos:F6}, " +
+            $"max |Δ| {maxAbs:E3} (per-token {atMax1:G6} vs chunked {atMax2:G6})");
+
+        // 2. Greedy continuation (crosses the position-640 promotion on decode).
+        output.WriteLine($"greedy continuation (per-token): {string.Join(", ", cont1)}");
+        output.WriteLine($"greedy continuation (chunked):   {string.Join(", ", cont2)}");
+        int firstDiff = -1;
+        for (int i = 0; i < DecodeSteps; i++)
+            if (cont1[i] != cont2[i]) { firstDiff = i; break; }
+
+        Assert.Equal(argmax1, argmax2);
+        Assert.True(cos > 0.995f, $"final-position logit cosine too low: {cos:F6}");
+        Assert.True(firstDiff < 0,
+            $"greedy continuation diverged at decode step {firstDiff}: " +
+            $"per-token={cont1[Math.Max(firstDiff, 0)]} chunked={cont2[Math.Max(firstDiff, 0)]}");
+
+        // 3. Tile parity. Byte-identity is NOT attainable end-to-end: the per-token
+        // oracle computes K/V through dp4a matvecs (Q8_1-quantized activations,
+        // issue #142) while the chunked trunk uses the MMQ/flash batched kernels —
+        // both argmax-stable, neither bit-identical to the other (the same
+        // pre-existing property that makes fp32 batched prefill "argmax-stable,
+        // not bit-exact"). The compress kernel itself IS byte-exact given identical
+        // inputs (CudaKvarnTests.KvarnCompressTile_MatchesCpu), so these thresholds
+        // are calibrated to separate that K/V input noise — codes shift ±1-2 steps
+        // at quantization boundaries; the coarse 2-bit V steps (~2× the Sinkhorn-
+        // normalized row RMS) amplify each flip, so V rel-L2 runs tens of percent
+        // while K (4-bit) stays far tighter — from a chunk-schedule bug (wrong rows
+        // in a tile → ~94% uncorrelated codes with |Δ| up to 15, cosine ≈ 0).
+        var comp = new KVarNCompressor(GetHeadDim(path));
+        long codeTotal = 0, codeMismatch = 0; int maxDelta = 0;
+        float maxScaleRel = 0f;
+        double kMaxRelL2 = 0, kMinCos = 1, vMaxRelL2 = 0, vMinCos = 1;
+        var dec1 = new float[Tile * comp.HeadDim];
+        var dec2 = new float[Tile * comp.HeadDim];
+        for (int layer = 0; layer < layers1; layer++)
+        {
+            CompareTiles(tilesK1[layer], tilesK2[layer], comp.KeyTileBytes,
+                Tile + 2 * comp.HeadDim, bits: 4,
+                ref codeTotal, ref codeMismatch, ref maxDelta, ref maxScaleRel);
+            int groups = (comp.HeadDim + 127) / 128;
+            CompareTiles(tilesV1[layer], tilesV2[layer], comp.ValueTileBytes,
+                comp.HeadDim + 2 * Tile * groups, bits: 2,
+                ref codeTotal, ref codeMismatch, ref maxDelta, ref maxScaleRel);
+
+            for (int slot = 0; slot < tilesK1[layer].Length / comp.KeyTileBytes; slot++)
+            {
+                comp.DecompressKeyTile(tilesK1[layer].AsSpan(slot * comp.KeyTileBytes, comp.KeyTileBytes), dec1);
+                comp.DecompressKeyTile(tilesK2[layer].AsSpan(slot * comp.KeyTileBytes, comp.KeyTileBytes), dec2);
+                AccumulateTileError(dec1, dec2, ref kMaxRelL2, ref kMinCos);
+                comp.DecompressValueTile(tilesV1[layer].AsSpan(slot * comp.ValueTileBytes, comp.ValueTileBytes), dec1);
+                comp.DecompressValueTile(tilesV2[layer].AsSpan(slot * comp.ValueTileBytes, comp.ValueTileBytes), dec2);
+                AccumulateTileError(dec1, dec2, ref vMaxRelL2, ref vMinCos);
+            }
+        }
+        double mismatchFrac = codeTotal > 0 ? (double)codeMismatch / codeTotal : 0;
+        output.WriteLine($"tile codes: {codeMismatch}/{codeTotal} mismatched ({mismatchFrac:P4}), " +
+            $"max |Δcode| = {maxDelta}, max scale rel-diff = {maxScaleRel:E3}");
+        output.WriteLine($"decompressed K tiles: worst cosine {kMinCos:F6}, worst rel-L2 {kMaxRelL2:P3}");
+        output.WriteLine($"decompressed V tiles: worst cosine {vMinCos:F6}, worst rel-L2 {vMaxRelL2:P3}");
+        Assert.True(maxDelta <= 3,
+            $"tile code deltas up to {maxDelta} steps — beyond quantization-boundary noise (schedule bug?)");
+        Assert.True(mismatchFrac < 0.10,
+            $"tile code mismatch fraction {mismatchFrac:P3} ≥ 10% — beyond batched-GEMM noise (schedule bug?)");
+        Assert.True(kMinCos > 0.98,
+            $"decompressed K tile cosine {kMinCos:F4} ≤ 0.98 — tiles hold different content (schedule bug?)");
+        Assert.True(vMinCos > 0.85,
+            $"decompressed V tile cosine {vMinCos:F4} ≤ 0.85 — tiles hold different content (schedule bug?)");
+    }
+
+    /// <summary>
+    /// Tile byte-identity under re-chunking, and startPos-continuation composition
+    /// (the TruncateTo / multi-call shape). One shot prefills 640 tokens as chunks
+    /// [0,256)+[256,384)+[384,512)+[512,640); the split call (300 + 340 @300) turns
+    /// the second tile epoch into 44 + 84-token chunks. Tiles must depend ONLY on
+    /// the positions they cover — never on how those positions were batched — and
+    /// since both runs use the SAME kernels (per-query/per-row deterministic math,
+    /// no cross-path dp4a-vs-MMQ noise), the packed tiles must match BYTE-EXACTLY.
+    /// This is the strongest schedule check: any off-by-one in the promotion
+    /// cadence or append slots would shift a whole row into the wrong tile.
+    /// </summary>
+    [Fact]
+    public void CudaForwardPass_KvarnChunkedPrefill_SplitCall_MatchesSingleShot()
+    {
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int PromptLen = 640;
+        const int NumTiles = 3;
+        var tokens = MakeTokens(path, PromptLen);
+
+        using var gpu = TryCreate() ?? throw new InvalidOperationException("checked above");
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        int single;
+        var tilesK1 = new byte[hp.NumLayers][];
+        var tilesV1 = new byte[hp.NumLayers][];
+        using (var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 768,
+                   enableTurboQuant: true, tqFp32Window: 256, tqQuantizer: TqQuantizer.KVarN))
+        {
+            fwd.KvarnBatchedPrefillEnabled = true;
+            var logits = fwd.Prefill(tokens);
+            Assert.True(fwd.LastPrefillWasBatched);
+            single = ArgMax(logits);
+            for (int layer = 0; layer < hp.NumLayers; layer++)
+            {
+                tilesK1[layer] = fwd.DownloadKvarnTileBytesForTest(layer, valueTiles: false, NumTiles);
+                tilesV1[layer] = fwd.DownloadKvarnTileBytesForTest(layer, valueTiles: true, NumTiles);
+            }
+        }
+
+        using (var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 768,
+                   enableTurboQuant: true, tqFp32Window: 256, tqQuantizer: TqQuantizer.KVarN))
+        {
+            fwd.KvarnBatchedPrefillEnabled = true;
+            fwd.Prefill(tokens.Take(300).ToArray());
+            Assert.Equal(128, fwd.TqCompressedLength);   // promotion at position 256
+            Assert.Equal(172, fwd.TqFp32Count);
+            var logits = fwd.Prefill(tokens.Skip(300).ToArray(), startPos: 300);
+            Assert.True(fwd.LastPrefillWasBatched);
+            Assert.Equal(384, fwd.TqCompressedLength);
+            Assert.Equal(256, fwd.TqFp32Count);
+            Assert.Equal(single, ArgMax(logits));
+
+            long diffBytes = 0, totalBytes = 0;
+            for (int layer = 0; layer < hp.NumLayers; layer++)
+            {
+                var k2 = fwd.DownloadKvarnTileBytesForTest(layer, valueTiles: false, NumTiles);
+                var v2 = fwd.DownloadKvarnTileBytesForTest(layer, valueTiles: true, NumTiles);
+                for (int b = 0; b < k2.Length; b++) { totalBytes++; if (tilesK1[layer][b] != k2[b]) diffBytes++; }
+                for (int b = 0; b < v2.Length; b++) { totalBytes++; if (tilesV1[layer][b] != v2[b]) diffBytes++; }
+            }
+            output.WriteLine($"re-chunked tile bytes: {diffBytes}/{totalBytes} differ");
+            Assert.True(diffBytes == 0,
+                $"{diffBytes}/{totalBytes} tile bytes differ between chunk plans — tiles must depend " +
+                "only on the positions they cover, never on chunk boundaries (schedule bug).");
+        }
+    }
+
+    private (byte[][] TilesK, byte[][] TilesV, float[] Logits, int[] Continuation, bool WasBatched, int Layers)
+        RunPrefill(string modelPath, bool chunked, int promptLen, int decodeSteps, int numTiles)
+    {
+        using var gpu = TryCreate() ?? throw new InvalidOperationException("CUDA availability checked by caller");
+        using var model = GgufModel.Open(modelPath);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 768,
+            enableTurboQuant: true, tqFp32Window: 256, tqQuantizer: TqQuantizer.KVarN);
+        fwd.KvarnBatchedPrefillEnabled = chunked;
+
+        var tokens = MakeTokens(modelPath, promptLen);
+        var logits = fwd.Prefill(tokens).ToArray();
+        bool wasBatched = fwd.LastPrefillWasBatched;
+
+        // Promotion cadence must be IDENTICAL on both paths (window 256, prompt 640:
+        // promotions before appending positions 256/384/512 → tq 384, window full).
+        Assert.Equal(numTiles * Tile, fwd.TqCompressedLength);
+        Assert.Equal(promptLen - numTiles * Tile, fwd.TqFp32Count);
+
+        var tilesK = new byte[hp.NumLayers][];
+        var tilesV = new byte[hp.NumLayers][];
+        for (int layer = 0; layer < hp.NumLayers; layer++)
+        {
+            tilesK[layer] = fwd.DownloadKvarnTileBytesForTest(layer, valueTiles: false, numTiles);
+            tilesV[layer] = fwd.DownloadKvarnTileBytesForTest(layer, valueTiles: true, numTiles);
+        }
+
+        // Greedy continuation from the prefill logits (exercises the decode path on
+        // top of the prefilled cache, crossing the position-640 promotion).
+        var continuation = new int[decodeSteps];
+        int next = ArgMax(logits);
+        for (int step = 0; step < decodeSteps; step++)
+        {
+            continuation[step] = next;
+            next = ArgMax(fwd.Forward(next, promptLen + step));
+        }
+
+        return (tilesK, tilesV, logits, continuation, wasBatched, hp.NumLayers);
+    }
+
+    /// <summary>
+    /// Per-head packed-tile comparison: scale-header floats tracked as max relative
+    /// difference, code region nibble-by-nibble (K, 4-bit) / crumb-by-crumb (V, 2-bit)
+    /// accumulating mismatch count and max step delta into the caller's counters.
+    /// (No hard per-element assert here — the caller applies calibrated thresholds and
+    /// prints the aggregate stats, since the chunked trunk's MMQ/flash K/V inputs are
+    /// argmax-stable rather than bit-identical vs the per-token path.)
+    /// </summary>
+    private static void CompareTiles(byte[] a, byte[] b, int stride, int scaleFloats, int bits,
+        ref long codeTotal, ref long codeMismatch, ref int maxDelta, ref float maxScaleRel)
+    {
+        Assert.Equal(a.Length, b.Length);
+        int tiles = a.Length / stride;
+        for (int tile = 0; tile < tiles; tile++)
+        {
+            var ta = a.AsSpan(tile * stride, stride);
+            var tb = b.AsSpan(tile * stride, stride);
+
+            var fa = MemoryMarshal.Cast<byte, float>(ta.Slice(0, scaleFloats * 4));
+            var fb = MemoryMarshal.Cast<byte, float>(tb.Slice(0, scaleFloats * 4));
+            for (int i = 0; i < scaleFloats; i++)
+            {
+                float denom = MathF.Max(1e-3f, MathF.Abs(fa[i]));
+                float rel = MathF.Abs(fa[i] - fb[i]) / denom;
+                if (rel > maxScaleRel) maxScaleRel = rel;
+            }
+
+            int mask = (1 << bits) - 1;
+            int per = 8 / bits;
+            for (int byteIdx = scaleFloats * 4; byteIdx < stride; byteIdx++)
+            {
+                int ba = ta[byteIdx], bb = tb[byteIdx];
+                for (int k = 0; k < per; k++)
+                {
+                    int ca = (ba >> (k * bits)) & mask;
+                    int cb = (bb >> (k * bits)) & mask;
+                    codeTotal++;
+                    if (ca != cb)
+                    {
+                        codeMismatch++;
+                        int d = Math.Abs(ca - cb);
+                        if (d > maxDelta) maxDelta = d;
+                    }
+                }
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Relative L2 error and cosine between two decompressed tiles.</summary>
+    private static void AccumulateTileError(float[] a, float[] b, ref double maxRelL2, ref double minCos)
+    {
+        double diff2 = 0, ref2 = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            double d = (double)a[i] - b[i];
+            diff2 += d * d;
+            ref2 += (double)a[i] * a[i];
+        }
+        if (ref2 > 0)
+        {
+            double rel = Math.Sqrt(diff2 / ref2);
+            if (rel > maxRelL2) maxRelL2 = rel;
+        }
+        double cos = Cosine(a, b);
+        if (cos < minCos) minCos = cos;
+    }
+
+    private static int[] MakeTokens(string modelPath, int count)
+    {
+        using var model = GgufModel.Open(modelPath);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        var rng = new Random(6161);
+        var tokens = new int[count];
+        for (int i = 0; i < count; i++)
+            tokens[i] = rng.Next(0, Math.Min(hp.VocabSize, 32000));
+        return tokens;
+    }
+
+    private static int GetHeadDim(string modelPath)
+    {
+        using var model = GgufModel.Open(modelPath);
+        return ModelHyperparams.FromGgufMetadata(model.Metadata, model).HeadDim;
+    }
+
+    private static int ArgMax(ReadOnlySpan<float> logits)
+    {
+        int best = 0;
+        float bestVal = logits[0];
+        for (int i = 1; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+        return best;
+    }
+
+    private static void Softmax(Span<float> x)
+    {
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < x.Length; i++) if (x[i] > max) max = x[i];
+        double sum = 0;
+        for (int i = 0; i < x.Length; i++) { x[i] = MathF.Exp(x[i] - max); sum += x[i]; }
+        float inv = (float)(1.0 / sum);
+        for (int i = 0; i < x.Length; i++) x[i] *= inv;
+    }
+
+    private static float[] Gaussian(int n, Random rng)
+    {
+        var v = new float[n];
+        for (int i = 0; i < n; i++)
+        {
+            double u1 = 1.0 - rng.NextDouble();
+            double u2 = rng.NextDouble();
+            v[i] = (float)(Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2));
+        }
+        return v;
+    }
+
+    private static float[] BytesToFloats(byte[] bytes)
+    {
+        var floats = new float[bytes.Length / 4];
+        bytes.AsSpan().CopyTo(MemoryMarshal.AsBytes(floats.AsSpan()));
+        return floats;
+    }
+
+    private static float Cosine(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double dot = 0, na = 0, nb = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            na += (double)a[i] * a[i];
+            nb += (double)b[i] * b[i];
+        }
+        double denom = Math.Sqrt(na) * Math.Sqrt(nb);
+        return denom > 0 ? (float)(dot / denom) : 0f;
+    }
+
+    private static string? FindModelPath(string file = "Qwen3-0.6B-Q8_0.gguf")
+    {
+        string[] absolute =
+        {
+            $@"C:\models\{file}",
+            $@"E:\models\{file}",
+        };
+        foreach (var p in absolute)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var candidate = Path.Combine(dir, "models", file);
+            if (File.Exists(candidate)) return candidate;
+            var parent = Directory.GetParent(dir);
+            if (parent == null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/CudaKvarnTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaKvarnTests.cs
@@ -441,6 +441,105 @@ public sealed unsafe class CudaKvarnTests(ITestOutputHelper output)
             Assert.True(float.IsFinite(logits[i]), $"Non-finite logit at idx {i} after post-truncate decode");
     }
 
+    /// <summary>
+    /// Task 5b: graph-mode KVarN decode parity vs direct-launch decode. The same
+    /// 400-token stream runs through two forward passes — one with CUDA graphs forced
+    /// ON (captures the pre-promotion graph at pos 0 and the steady-state graph at the
+    /// first promotion), one forced OFF — crossing TWO promotion boundaries (window
+    /// 256 → promotions at positions 256 and 384), so replays exercise the tracked
+    /// appendSlot / fp32SeqLen / tqLen params across a tile-count change. A graph
+    /// replay issues the exact same kernel sequence with the same args as the direct
+    /// path, so logits are expected bit-identical; asserted to 1e-5 abs per element
+    /// with argmax equality at every step.
+    /// </summary>
+    [Fact]
+    public void CudaForwardPass_Kvarn_GraphDecode_MatchesDirectLaunch()
+    {
+        if (!CudaBackend.IsAvailable()) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        const int Steps = 400;
+        int[] checkpoints = [0, 255, 256, 257, 300, 383, 384, 385, 399];
+
+        // Sequential runs (dispose between) keep VRAM flat; each run gets a fresh
+        // backend so the graphs-off run can't accidentally see graphs-on state.
+        var (argmaxOn, snapsOn, graphsEngaged, captureSupported) = RunKvarnDecode(path, useGraphs: true, Steps, checkpoints);
+        var (argmaxOff, snapsOff, _, _) = RunKvarnDecode(path, useGraphs: false, Steps, checkpoints);
+
+        if (!graphsEngaged)
+        {
+            // A capture-time regression that only breaks the KVarN graphs (e.g. a new
+            // untrackable kernel arg) silently drops the whole 5b perf win — that must
+            // fail here, not soft-skip. Only a driver that refused capture outright
+            // (GraphCaptureSupported latched false during the run) downgrades this to
+            // a direct-vs-direct comparison.
+            Assert.False(captureSupported,
+                "KVarN graphs did not engage although the device supports graph capture — capture regression.");
+            output.WriteLine("CUDA graph capture unavailable on this device — parity trivially direct-vs-direct.");
+            return;
+        }
+
+        int argmaxMismatches = 0;
+        for (int pos = 0; pos < Steps; pos++)
+            if (argmaxOn[pos] != argmaxOff[pos]) argmaxMismatches++;
+        Assert.True(argmaxMismatches == 0,
+            $"{argmaxMismatches}/{Steps} argmax mismatches between graph and direct-launch KVarN decode.");
+
+        float maxDiff = 0f;
+        foreach (int pos in checkpoints)
+        {
+            var a = snapsOn[pos];
+            var b = snapsOff[pos];
+            for (int i = 0; i < a.Length; i++)
+            {
+                float d = MathF.Abs(a[i] - b[i]);
+                if (d > maxDiff) maxDiff = d;
+                Assert.True(d <= 1e-5f,
+                    $"Logit mismatch at pos {pos} idx {i}: graph={a[i]:G9} direct={b[i]:G9}");
+            }
+        }
+        output.WriteLine($"graph vs direct max |Δlogit| over {checkpoints.Length} checkpoints: {maxDiff:E2}");
+    }
+
+    private static (int[] Argmax, Dictionary<int, float[]> Snaps, bool GraphsEngaged, bool CaptureSupported) RunKvarnDecode(
+        string modelPath, bool useGraphs, int steps, int[] checkpoints)
+    {
+        using var gpu = TryCreate() ?? throw new InvalidOperationException("CUDA availability checked by caller");
+        using var model = GgufModel.Open(modelPath);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 640,
+            enableTurboQuant: true, tqFp32Window: 256, tqQuantizer: TqQuantizer.KVarN);
+        fwd.UseCudaGraph = useGraphs;
+
+        var rng = new Random(5150);
+        var argmax = new int[steps];
+        var snaps = new Dictionary<int, float[]>();
+        var checkpointSet = new HashSet<int>(checkpoints);
+
+        for (int pos = 0; pos < steps; pos++)
+        {
+            int token = rng.Next(0, Math.Min(hp.VocabSize, 32000));
+            var logits = fwd.Forward(token, pos);
+
+            int best = 0;
+            float bestVal = logits[0];
+            for (int i = 1; i < logits.Length; i++)
+                if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+            argmax[pos] = best;
+
+            if (checkpointSet.Contains(pos))
+                snaps[pos] = logits.ToArray();
+        }
+
+        // Both phase graphs must actually be resident after crossing a promotion —
+        // otherwise the "graphs on" run silently tested the direct path twice.
+        bool engaged = useGraphs
+            && gpu.GraphReadyFor(CudaForwardPass.KvarnGraphPre)
+            && gpu.GraphReadyFor(CudaForwardPass.KvarnGraphSteady);
+        return (argmax, snaps, engaged, gpu.GraphCaptureSupported);
+    }
+
     /// <summary>Construction-time guard parity with TQ: SnapKV and narrowed-KV combos throw.</summary>
     [Fact]
     public void CudaForwardPass_Kvarn_RejectsSnapKvAndNarrowedKv()

--- a/tests/SharpInference.Tests.ForwardPass/CudaKvarnTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/CudaKvarnTests.cs
@@ -1,0 +1,564 @@
+using System.Runtime.InteropServices;
+using SharpInference.Core;
+using SharpInference.Cuda;
+using SharpInference.Engine;
+using SharpInference.TurboQuant;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// CUDA KVarN kernel + decode-integration tests (issue #180 Task 5a). Each test
+/// silently no-ops when no CUDA device is available (same convention as
+/// <see cref="CudaTurboQuantTests"/>).
+///
+/// The CPU <see cref="KVarNCompressor"/> is the oracle throughout:
+/// <list type="bullet">
+///   <item>rotate-query parity is elementwise (abs 1e-4 — expected ~1e-7: both
+///         sides run the same butterfly with the same 1/sqrt(dim) scale);</item>
+///   <item>compress-tile parity is BYTE-EXACT on the packed RTN codes (the
+///         kernel uses correctly-rounded single ops + round-to-even, so codes
+///         depend only on ops that are bit-identical to the CPU compressor)
+///         and rel-1e-5 on the stored scale floats (logf/expf may differ from
+///         MathF.Log/Exp in the last ulp);</item>
+///   <item>attention parity vs the CPU KeyScores/AggregateValues/UnrotateOutput
+///         pipeline is per-dim max(1e-3, 1e-2·|expected|) — the same band the
+///         TQ CUDA tests use.</item>
+/// </list>
+/// </summary>
+public sealed unsafe class CudaKvarnTests(ITestOutputHelper output)
+{
+    private const int Tile = KVarNCompressor.TileTokens; // 128
+
+    private static CudaBackend? TryCreate()
+    {
+        if (!CudaBackend.IsAvailable()) return null;
+        try { return CudaBackend.Create(); }
+        catch { return null; }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rotate query
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(64, 4)]
+    [InlineData(128, 4)]
+    [InlineData(256, 2)]
+    public void KvarnRotateQuery_MatchesCpu(int headDim, int numHeads)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        var rng = new Random(4242 + headDim);
+        var query = new float[numHeads * headDim];
+        for (int i = 0; i < query.Length; i++) query[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var gpuQ = gpu.Upload(query, TensorShape.D1(query.Length));
+        var gpuRotated = gpu.Allocate(TensorShape.D1(query.Length));
+
+        gpu.KvarnRotateQuery(gpuQ, gpuRotated, numHeads, headDim);
+        gpu.Synchronize();
+
+        var gpuResult = new float[query.Length];
+        gpu.Download(gpuRotated, gpuResult);
+
+        var comp = new KVarNCompressor(headDim);
+        var expected = new float[query.Length];
+        for (int h = 0; h < numHeads; h++)
+            comp.RotateQuery(query.AsSpan(h * headDim, headDim), expected.AsSpan(h * headDim, headDim));
+
+        for (int i = 0; i < query.Length; i++)
+            Assert.True(MathF.Abs(gpuResult[i] - expected[i]) < 1e-4f,
+                $"KvarnRotateQuery mismatch at [{i}]: gpu={gpuResult[i]} cpu={expected[i]}");
+
+        gpu.Free(gpuQ); gpu.Free(gpuRotated);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Compress tile
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(64)]
+    [InlineData(128)]
+    [InlineData(256)]
+    public void KvarnCompressTile_MatchesCpu(int headDim)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        const int NumKvHeads = 2;
+        const int NumTiles = 2;   // exercises the tile-index output placement
+        const int WindowRows = 256;
+        int kvDim = NumKvHeads * headDim;
+        var comp = new KVarNCompressor(headDim);
+        int kStride = comp.KeyTileBytes;
+        int vStride = comp.ValueTileBytes;
+
+        var gpuKTiles = gpu.Allocate(TensorShape.D1((long)NumTiles * NumKvHeads * kStride / 4));
+        var gpuVTiles = gpu.Allocate(TensorShape.D1((long)NumTiles * NumKvHeads * vStride / 4));
+        var gpuWork = gpu.Allocate(TensorShape.D1((long)NumKvHeads * 2 * Tile * headDim));
+
+        var rng = new Random(20260710 + headDim);
+        var kWindows = new float[NumTiles][];
+        var vWindows = new float[NumTiles][];
+
+        // The kernel always compresses window rows [0, 128) into the given tile
+        // index (the host shifts the window between promotions), so each tile
+        // gets its own window upload.
+        for (int tile = 0; tile < NumTiles; tile++)
+        {
+            kWindows[tile] = Gaussian(WindowRows * kvDim, rng);
+            vWindows[tile] = Gaussian(WindowRows * kvDim, rng);
+            var gpuKw = gpu.Upload(kWindows[tile], TensorShape.D1(kWindows[tile].Length));
+            var gpuVw = gpu.Upload(vWindows[tile], TensorShape.D1(vWindows[tile].Length));
+            gpu.KvarnCompressTile(gpuKw, gpuVw, gpuKTiles, gpuVTiles, gpuWork,
+                kvDim, headDim, tile, NumKvHeads, kStride, vStride,
+                KVarNCompressor.DefaultSinkhornIterations);
+            gpu.Synchronize();
+            gpu.Free(gpuKw); gpu.Free(gpuVw);
+        }
+
+        byte[] gpuKBytes = DownloadBytes(gpu, gpuKTiles, NumTiles * NumKvHeads * kStride);
+        byte[] gpuVBytes = DownloadBytes(gpu, gpuVTiles, NumTiles * NumKvHeads * vStride);
+
+        int kScaleFloats = Tile + 2 * headDim;
+        int groups = (headDim + 127) / 128;
+        int vScaleFloats = headDim + 2 * Tile * groups;
+
+        var gather = new float[Tile * headDim];
+        var cpuTile = new byte[Math.Max(kStride, vStride)];
+        var gpuDec = new float[Tile * headDim];
+        var cpuDec = new float[Tile * headDim];
+
+        for (int tile = 0; tile < NumTiles; tile++)
+        {
+            for (int head = 0; head < NumKvHeads; head++)
+            {
+                // K tile.
+                GatherHead(kWindows[tile], gather, head, headDim, kvDim);
+                comp.CompressKeyTile(gather, cpuTile);
+                var gpuKTile = gpuKBytes.AsSpan((tile * NumKvHeads + head) * kStride, kStride);
+                AssertTileMatch(gpuKTile, cpuTile.AsSpan(0, kStride), kScaleFloats,
+                    $"K tile {tile} head {head} (headDim {headDim})");
+
+                comp.DecompressKeyTile(gpuKTile, gpuDec);
+                comp.DecompressKeyTile(cpuTile.AsSpan(0, kStride), cpuDec);
+                AssertDecompressedClose(gpuDec, cpuDec, $"K tile {tile} head {head}");
+
+                // V tile.
+                GatherHead(vWindows[tile], gather, head, headDim, kvDim);
+                comp.CompressValueTile(gather, cpuTile);
+                var gpuVTile = gpuVBytes.AsSpan((tile * NumKvHeads + head) * vStride, vStride);
+                AssertTileMatch(gpuVTile, cpuTile.AsSpan(0, vStride), vScaleFloats,
+                    $"V tile {tile} head {head} (headDim {headDim})");
+
+                comp.DecompressValueTile(gpuVTile, gpuDec);
+                comp.DecompressValueTile(cpuTile.AsSpan(0, vStride), cpuDec);
+                AssertDecompressedClose(gpuDec, cpuDec, $"V tile {tile} head {head}");
+            }
+        }
+
+        gpu.Free(gpuKTiles); gpu.Free(gpuVTiles); gpu.Free(gpuWork);
+    }
+
+    /// <summary>
+    /// Packed-tile comparison: stored scale floats (the header region) to rel
+    /// 1e-5 — logf/expf on the device can differ from MathF.Log/Exp by a ulp —
+    /// and the RTN code region BYTE-EXACT (codes depend only on correctly-rounded
+    /// ops that are bit-identical between the CPU and the kernel).
+    /// </summary>
+    private static void AssertTileMatch(ReadOnlySpan<byte> gpuTile, ReadOnlySpan<byte> cpuTile,
+        int scaleFloats, string what)
+    {
+        var gpuF = MemoryMarshal.Cast<byte, float>(gpuTile.Slice(0, scaleFloats * 4));
+        var cpuF = MemoryMarshal.Cast<byte, float>(cpuTile.Slice(0, scaleFloats * 4));
+        for (int i = 0; i < scaleFloats; i++)
+        {
+            float tol = MathF.Max(1e-6f, MathF.Abs(cpuF[i]) * 1e-5f);
+            Assert.True(MathF.Abs(gpuF[i] - cpuF[i]) <= tol,
+                $"{what}: scale float [{i}] mismatch: gpu={gpuF[i]:G9} cpu={cpuF[i]:G9} tol={tol:E2}");
+        }
+
+        int mismatches = 0;
+        int firstMismatch = -1;
+        for (int b = scaleFloats * 4; b < cpuTile.Length; b++)
+        {
+            if (gpuTile[b] != cpuTile[b])
+            {
+                if (firstMismatch < 0) firstMismatch = b;
+                mismatches++;
+            }
+        }
+        Assert.True(mismatches == 0,
+            $"{what}: {mismatches} code byte(s) differ (first at byte {firstMismatch}: " +
+            $"gpu=0x{(firstMismatch >= 0 ? gpuTile[firstMismatch] : 0):X2} " +
+            $"cpu=0x{(firstMismatch >= 0 ? cpuTile[firstMismatch] : 0):X2}). " +
+            "Codes must be bit-identical to the CPU compressor.");
+    }
+
+    private static void AssertDecompressedClose(float[] gpuDec, float[] cpuDec, string what)
+    {
+        for (int i = 0; i < cpuDec.Length; i++)
+        {
+            float tol = MathF.Max(1e-4f, MathF.Abs(cpuDec[i]) * 1e-4f);
+            Assert.True(MathF.Abs(gpuDec[i] - cpuDec[i]) <= tol,
+                $"{what}: decompressed [{i}] mismatch: gpu={gpuDec[i]:G9} cpu={cpuDec[i]:G9}");
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Attention
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(128, 97, 1, 1, 128)]    // one tile + partial window
+    [InlineData(256, 256, 2, 4, 128)]   // two tiles + full window, GQA 2 q heads / kv head
+    [InlineData(384, 130, 2, 2, 64)]    // three tiles, head_dim 64
+    public void KvarnAttention_MatchesCpuOracle(int tqLen, int fp32Len, int kvHeads, int qHeads, int headDim)
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        RunAttentionParity(gpu, tqLen, fp32Len, kvHeads, qHeads, headDim, useScratch: false,
+            seed: 991 + tqLen + headDim);
+    }
+
+    /// <summary>
+    /// Long-context branch: tq 4096 + window 64 = 4160 positions &gt; the 4096
+    /// shared-scores cap, so phase 1-3 run against the global scores scratch.
+    /// Same CPU oracle, same tolerance — a wrong scratch index, softmax, or V
+    /// walk shows up as a per-dim mismatch.
+    /// </summary>
+    [Fact]
+    public void KvarnAttention_ScratchPath_MatchesCpuOracle()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+
+        RunAttentionParity(gpu, tqLen: 4096, fp32Len: 64, kvHeads: 1, qHeads: 1, headDim: 128,
+            useScratch: true, seed: 777);
+    }
+
+    private void RunAttentionParity(CudaBackend gpu, int tqLen, int fp32Len,
+        int kvHeads, int qHeads, int headDim, bool useScratch, int seed)
+    {
+        Assert.Equal(0, tqLen % Tile);
+        int numTiles = tqLen / Tile;
+        int kvDim = kvHeads * headDim;
+        int totalSeq = tqLen + fp32Len;
+        var comp = new KVarNCompressor(headDim);
+        int kStride = comp.KeyTileBytes;
+        int vStride = comp.ValueTileBytes;
+
+        var rng = new Random(seed);
+        var keys = new float[totalSeq][];
+        var values = new float[totalSeq][];
+        for (int t = 0; t < totalSeq; t++)
+        {
+            keys[t] = Gaussian(kvDim, rng);
+            values[t] = Gaussian(kvDim, rng);
+        }
+
+        // CPU-compress the tq region into the packed tile layout the kernel reads
+        // (byte-compatible by construction — proven by KvarnCompressTile_MatchesCpu).
+        var kTileBytes = new byte[numTiles * kvHeads * kStride];
+        var vTileBytes = new byte[numTiles * kvHeads * vStride];
+        var gather = new float[Tile * headDim];
+        for (int tile = 0; tile < numTiles; tile++)
+        {
+            for (int head = 0; head < kvHeads; head++)
+            {
+                for (int t = 0; t < Tile; t++)
+                    keys[tile * Tile + t].AsSpan(head * headDim, headDim)
+                        .CopyTo(gather.AsSpan(t * headDim, headDim));
+                comp.CompressKeyTile(gather, kTileBytes.AsSpan((tile * kvHeads + head) * kStride, kStride));
+
+                for (int t = 0; t < Tile; t++)
+                    values[tile * Tile + t].AsSpan(head * headDim, headDim)
+                        .CopyTo(gather.AsSpan(t * headDim, headDim));
+                comp.CompressValueTile(gather, vTileBytes.AsSpan((tile * kvHeads + head) * vStride, vStride));
+            }
+        }
+
+        // FP32 window rows are the trailing positions, linear (slot 0 = oldest).
+        var kWindow = new float[fp32Len * kvDim];
+        var vWindow = new float[fp32Len * kvDim];
+        for (int t = 0; t < fp32Len; t++)
+        {
+            keys[tqLen + t].CopyTo(kWindow.AsSpan(t * kvDim, kvDim));
+            values[tqLen + t].CopyTo(vWindow.AsSpan(t * kvDim, kvDim));
+        }
+
+        var query = Gaussian(qHeads * headDim, rng);
+
+        var gpuKTiles = gpu.Upload(BytesToFloats(kTileBytes), TensorShape.D1(kTileBytes.Length / 4));
+        var gpuVTiles = gpu.Upload(BytesToFloats(vTileBytes), TensorShape.D1(vTileBytes.Length / 4));
+        var gpuKw = gpu.Upload(kWindow, TensorShape.D1(kWindow.Length));
+        var gpuVw = gpu.Upload(vWindow, TensorShape.D1(vWindow.Length));
+        var gpuQ = gpu.Upload(query, TensorShape.D1(query.Length));
+        var gpuRotated = gpu.Allocate(TensorShape.D1(query.Length));
+        var gpuOut = gpu.Allocate(TensorShape.D1(qHeads * headDim));
+        var scratch = useScratch ? gpu.Allocate(TensorShape.D1((long)qHeads * totalSeq)) : (Tensor?)null;
+
+        gpu.KvarnRotateQuery(gpuQ, gpuRotated, qHeads, headDim);
+        gpu.KvarnAttention(gpuQ, gpuRotated, gpuKTiles, gpuVTiles, gpuKw, gpuVw, gpuOut,
+            scratch, qHeads, kvHeads, headDim, tqLen, fp32Len, totalSeq, kStride, vStride);
+        gpu.Synchronize();
+
+        var gpuResult = new float[qHeads * headDim];
+        gpu.Download(gpuOut, gpuResult);
+
+        // CPU oracle: the exact pipeline ForwardPass.TqAttention drives in KVarN
+        // mode — RotateQuery → per-tile KeyScores (attn scale folded after) →
+        // FP32 window dots → softmax → per-tile AggregateValues (rotated domain)
+        // → one UnrotateOutput → FP32 window V accumulation.
+        var expected = new float[qHeads * headDim];
+        int hpkg = qHeads / kvHeads;
+        float scale = 1f / MathF.Sqrt(headDim);
+        var scores = new float[totalSeq];
+        var rotated = new float[headDim];
+        var rotAcc = new float[headDim];
+
+        for (int h = 0; h < qHeads; h++)
+        {
+            int kvHead = h / hpkg;
+            var qHead = query.AsSpan(h * headDim, headDim);
+            comp.RotateQuery(qHead, rotated);
+
+            for (int tile = 0; tile < numTiles; tile++)
+            {
+                comp.KeyScores(kTileBytes.AsSpan((tile * kvHeads + kvHead) * kStride, kStride),
+                    rotated, scores.AsSpan(tile * Tile, Tile));
+                for (int t = 0; t < Tile; t++) scores[tile * Tile + t] *= scale;
+            }
+            for (int t = 0; t < fp32Len; t++)
+            {
+                float dot = 0f;
+                var kRow = keys[tqLen + t].AsSpan(kvHead * headDim, headDim);
+                for (int d = 0; d < headDim; d++) dot += qHead[d] * kRow[d];
+                scores[tqLen + t] = dot * scale;
+            }
+
+            Softmax(scores);
+
+            Array.Clear(rotAcc);
+            for (int tile = 0; tile < numTiles; tile++)
+                comp.AggregateValues(vTileBytes.AsSpan((tile * kvHeads + kvHead) * vStride, vStride),
+                    scores.AsSpan(tile * Tile, Tile), rotAcc);
+            comp.UnrotateOutput(rotAcc);
+
+            var outHead = expected.AsSpan(h * headDim, headDim);
+            rotAcc.AsSpan(0, headDim).CopyTo(outHead);
+            for (int t = 0; t < fp32Len; t++)
+            {
+                float w = scores[tqLen + t];
+                var vRow = values[tqLen + t].AsSpan(kvHead * headDim, headDim);
+                for (int d = 0; d < headDim; d++) outHead[d] += w * vRow[d];
+            }
+        }
+
+        float cos = Cosine(expected, gpuResult);
+        output.WriteLine($"tq={tqLen} fp32={fp32Len} kv={kvHeads} q={qHeads} d={headDim} " +
+            $"scratch={useScratch}: cosine vs CPU oracle {cos:F6}");
+        Assert.True(cos > 0.999f, $"KVarN attention output cosine vs CPU oracle too low: {cos:F4}");
+
+        for (int i = 0; i < expected.Length; i++)
+        {
+            float tol = MathF.Max(1e-3f, MathF.Abs(expected[i]) * 1e-2f);
+            Assert.True(MathF.Abs(gpuResult[i] - expected[i]) <= tol,
+                $"KVarN attention mismatch at [{i}]: gpu={gpuResult[i]:G6} cpu={expected[i]:G6} tol={tol:E2}");
+        }
+
+        gpu.Free(gpuKTiles); gpu.Free(gpuVTiles);
+        gpu.Free(gpuKw); gpu.Free(gpuVw);
+        gpu.Free(gpuQ); gpu.Free(gpuRotated); gpu.Free(gpuOut);
+        if (scratch is { } s) gpu.Free(s);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CudaForwardPass integration (model-gated: skipped when neither CUDA nor
+    // the fixture model is present)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Whole-tile promotion cadence on the real decode path, mirroring the CPU
+    /// KVarNKvCacheTests: window 256 → the ring stays FP32 through position 255,
+    /// the append at position 256 promotes the first 128 positions, the append
+    /// at position 384 promotes the next 128 — the TQ length only ever grows in
+    /// 128-token steps and CPU/CUDA agree position-for-position. Also covers
+    /// TruncateTo semantics and the batching guard on the same instance.
+    /// </summary>
+    [Fact]
+    public void CudaForwardPass_Kvarn_PromotionCadence_And_Guards()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+        using var fwd = new CudaForwardPass(model, gpu, hp, maxContextLength: 640,
+            enableTurboQuant: true, tqFp32Window: 256, tqQuantizer: TqQuantizer.KVarN);
+
+        // Guards: KVarN inherits every TurboQuant exclusivity constraint.
+        Assert.False(fwd.SupportsContinuousBatching);
+        Assert.Throws<NotSupportedException>(() => fwd.CreateCache());
+        Assert.False(fwd.SupportsHiddenTaps);
+
+        int token = 100 % hp.VocabSize;
+        ReadOnlySpan<float> logits = default;
+        for (int pos = 0; pos < 400; pos++)
+        {
+            logits = fwd.Forward(token, pos);
+
+            // Promotion cadence (window 256): fp32Count reaches 256 at the append
+            // of position 256 → tq 0→128; again at position 384 → tq 128→256.
+            int expectedTq = pos < 256 ? 0 : pos < 384 ? 128 : 256;
+            Assert.Equal(expectedTq, fwd.TqCompressedLength);
+            Assert.Equal(pos + 1 - expectedTq, fwd.TqFp32Count);
+        }
+
+        for (int i = 0; i < logits.Length; i++)
+            Assert.True(float.IsFinite(logits[i]), $"Non-finite logit at idx {i} after 400 KVarN decode steps");
+
+        // TruncateTo: rewinding inside the FP32 window resyncs the linear window
+        // count; rewinding into the compressed region throws.
+        fwd.TruncateTo(300);
+        Assert.Equal(256, fwd.TqCompressedLength);
+        Assert.Equal(44, fwd.TqFp32Count);
+        Assert.Throws<NotSupportedException>(() => fwd.TruncateTo(200));
+
+        // Decode continues coherently after the rewind, keeping the cadence.
+        for (int pos = 300; pos < 340; pos++)
+        {
+            logits = fwd.Forward(token, pos);
+            Assert.Equal(256, fwd.TqCompressedLength);
+        }
+        for (int i = 0; i < logits.Length; i++)
+            Assert.True(float.IsFinite(logits[i]), $"Non-finite logit at idx {i} after post-truncate decode");
+    }
+
+    /// <summary>Construction-time guard parity with TQ: SnapKV and narrowed-KV combos throw.</summary>
+    [Fact]
+    public void CudaForwardPass_Kvarn_RejectsSnapKvAndNarrowedKv()
+    {
+        using var gpu = TryCreate();
+        if (gpu is null) return;
+        var path = FindModelPath();
+        if (path is null) return;
+
+        using var model = GgufModel.Open(path);
+        var hp = ModelHyperparams.FromGgufMetadata(model.Metadata, model);
+
+        var prevBudget = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        var prevDtype = Environment.GetEnvironmentVariable("SHARPI_KV_DTYPE");
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "256");
+            Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", null);
+            var ex = Assert.Throws<NotSupportedException>(() => new CudaForwardPass(
+                model, gpu, hp, maxContextLength: 640,
+                enableTurboQuant: true, tqQuantizer: TqQuantizer.KVarN));
+            Assert.Contains("SnapKV", ex.Message);
+
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", null);
+            Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", "bf16");
+            var ex2 = Assert.Throws<NotSupportedException>(() => new CudaForwardPass(
+                model, gpu, hp, maxContextLength: 640,
+                enableTurboQuant: true, tqQuantizer: TqQuantizer.KVarN));
+            Assert.Contains("TurboQuant", ex2.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevBudget);
+            Environment.SetEnvironmentVariable("SHARPI_KV_DTYPE", prevDtype);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static void GatherHead(float[] window, float[] gather, int head, int headDim, int kvDim)
+    {
+        for (int t = 0; t < Tile; t++)
+            window.AsSpan(t * kvDim + head * headDim, headDim)
+                .CopyTo(gather.AsSpan(t * headDim, headDim));
+    }
+
+    private static byte[] DownloadBytes(CudaBackend gpu, Tensor tensor, int byteCount)
+    {
+        var floats = new float[(byteCount + 3) / 4];
+        gpu.Download(tensor, floats);
+        var bytes = new byte[byteCount];
+        MemoryMarshal.AsBytes(floats.AsSpan()).Slice(0, byteCount).CopyTo(bytes);
+        return bytes;
+    }
+
+    private static float[] BytesToFloats(byte[] bytes)
+    {
+        var floats = new float[bytes.Length / 4];
+        bytes.AsSpan().CopyTo(MemoryMarshal.AsBytes(floats.AsSpan()));
+        return floats;
+    }
+
+    private static void Softmax(Span<float> x)
+    {
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < x.Length; i++) if (x[i] > max) max = x[i];
+        double sum = 0;
+        for (int i = 0; i < x.Length; i++) { x[i] = MathF.Exp(x[i] - max); sum += x[i]; }
+        float inv = (float)(1.0 / sum);
+        for (int i = 0; i < x.Length; i++) x[i] *= inv;
+    }
+
+    private static float[] Gaussian(int n, Random rng)
+    {
+        var v = new float[n];
+        for (int i = 0; i < n; i++)
+        {
+            double u1 = 1.0 - rng.NextDouble();
+            double u2 = rng.NextDouble();
+            v[i] = (float)(Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2));
+        }
+        return v;
+    }
+
+    private static float Cosine(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double dot = 0, na = 0, nb = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            na += (double)a[i] * a[i];
+            nb += (double)b[i] * b[i];
+        }
+        double denom = Math.Sqrt(na) * Math.Sqrt(nb);
+        return denom > 0 ? (float)(dot / denom) : 0f;
+    }
+
+    private static string? FindModelPath(string file = "Qwen3-0.6B-Q8_0.gguf")
+    {
+        string[] absolute =
+        {
+            $@"C:\models\{file}",
+            $@"E:\models\{file}",
+        };
+        foreach (var p in absolute)
+            if (File.Exists(p)) return p;
+
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var candidate = Path.Combine(dir, "models", file);
+            if (File.Exists(candidate)) return candidate;
+            var parent = Directory.GetParent(dir);
+            if (parent == null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+}

--- a/tests/SharpInference.Tests.ForwardPass/KVarNKvCacheTests.cs
+++ b/tests/SharpInference.Tests.ForwardPass/KVarNKvCacheTests.cs
@@ -1,0 +1,543 @@
+using SharpInference.Core;
+using SharpInference.Cpu;
+using SharpInference.Engine;
+using SharpInference.TurboQuant;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.ForwardPass;
+
+/// <summary>
+/// Tests for the KVarN quantizer mode of <see cref="TurboQuantKvCache"/>
+/// (issue #180 Task 2: KVarN wired into the TurboQuant cache + CPU TqAttention
+/// path as a selectable quantizer).
+///
+/// Covers:
+/// <list type="bullet">
+///   <item>End-to-end attention parity over a KVarN-mode cache vs (a) an exact
+///         reference computed on the decompressed tiles (wiring parity — tight
+///         bound) and (b) the FP32 truth (quantization quality — loose bound,
+///         numbers reported; KVarN V is 2-bit so ~0.5 relative error on Gaussian
+///         data is the expected codec floor, see KVarNCompressorTests).</item>
+///   <item>Cache mechanics: whole-tile promotion at the 128 boundary, Reset
+///         reuse, TruncateTo semantics, and config-time rejection of the
+///         unsupported combos (SnapKV, sub-tile FP32 window, non-pow2 head dim).</item>
+/// </list>
+/// </summary>
+public sealed class KVarNKvCacheTests(ITestOutputHelper output)
+{
+    private const int Tile = KVarNCompressor.TileTokens; // 128
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // End-to-end attention parity
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(100, 128, 1, 1)]   // shorter than window — all FP32, must be exact
+    [InlineData(129, 128, 1, 1)]   // exactly one compressed tile (+1 in the window)
+    [InlineData(256, 128, 1, 1)]   // one tile + a full FP32 window
+    [InlineData(700, 192, 2, 4)]   // several tiles + non-tile-aligned FP32 remainder, GQA (4 q / 2 kv)
+    public void Attention_KVarNCache_MatchesReferences(int seqLen, int window, int kvHeads, int qHeads)
+    {
+        const int headDim = 128;
+        var (cache, keys, values) = BuildKVarNCache(seqLen, window, kvHeads, headDim, seed: 913 + seqLen);
+        using var _ = cache;
+
+        var rng = new Random(4711);
+        float[] q = Gaussian(qHeads * headDim, rng);
+
+        float[] actual = CacheAttention(cache, q, qHeads);
+        float[] fp32Ref = ReferenceAttention(keys, values, q, qHeads, kvHeads, headDim);
+
+        int tqLen = cache.GetTqLength(0);
+        float relFp32 = RelL2(fp32Ref, actual);
+        float cosFp32 = Cosine(fp32Ref, actual);
+        output.WriteLine($"seqLen={seqLen} window={window} tq={tqLen} fp32={seqLen - tqLen} " +
+            $"kv={kvHeads} q={qHeads}: rel-L2 vs FP32 truth {relFp32:F4}, cosine {cosFp32:F4}");
+
+        if (tqLen == 0)
+        {
+            // No compressed positions: the whole path is plain FP32 math.
+            Assert.True(relFp32 < 1e-5f, $"All-FP32 case should be numerically exact, got rel-L2 {relFp32:E3}");
+            return;
+        }
+
+        Assert.Equal(0, tqLen % Tile); // KVarN invariant: whole tiles only
+
+        // Wiring parity: attention recomputed over the decompressed tiles + FP32
+        // window must match the fused cache path almost exactly (KeyScores and
+        // AggregateValues are proven against decompression in KVarNCompressorTests
+        // to <1e-4; softmax propagation keeps this in the 1e-3 band).
+        var (effKeys, effValues) = DecompressedKv(cache, keys, values);
+        float[] decompRef = ReferenceAttention(effKeys, effValues, q, qHeads, kvHeads, headDim);
+        float relWiring = RelL2(decompRef, actual);
+        output.WriteLine($"  rel-L2 vs decompressed reference (wiring parity): {relWiring:E3}");
+        Assert.True(relWiring < 5e-3f,
+            $"Cache attention deviates from the decompressed-tile reference: {relWiring:E3} — staging/promotion/aggregation wiring is broken.");
+
+        // Quality gate vs FP32 truth: dominated by the 2-bit V codec floor
+        // (~0.5 rel on Gaussian data per KVarNCompressorTests) plus a small
+        // softmax perturbation from the 4-bit K scores. Loose bound by design —
+        // the reported numbers above are the real deliverable.
+        Assert.True(relFp32 < 0.65f, $"KVarN attention error vs FP32 truth too high: {relFp32:F4}");
+        Assert.True(cosFp32 > 0.75f, $"KVarN attention cosine vs FP32 truth too low: {cosFp32:F4}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Cache mechanics
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Append_PromotesWholeTiles_AtWindowOverflow()
+    {
+        const int headDim = 64;
+        using var cache = new TurboQuantKvCache(
+            numLayers: 1, maxSeqLen: 512, numKvHeads: 1, headDim: headDim,
+            fp32WindowSize: 128, quantizer: TqQuantizer.KVarN);
+
+        var rng = new Random(7);
+        for (int pos = 0; pos < 300; pos++)
+        {
+            cache.Append(0, Gaussian(headDim, rng), Gaussian(headDim, rng));
+            cache.IncrementPosition();
+
+            // Promotion fires inside the Append that finds the window full:
+            // fp32Count reaches 128 at pos 128 (tq 0→128) and again at pos 256.
+            int expectedTq = pos < 128 ? 0 : pos < 256 ? 128 : 256;
+            Assert.Equal(expectedTq, cache.GetTqLength(0));
+            Assert.Equal(0, cache.GetTqLength(0) % Tile);
+            Assert.Equal(0, cache.KeyStagingCount(0));
+        }
+
+        Assert.Equal(300, cache.Length);
+        Assert.Equal(2, cache.NumKeyTiles(0));
+        Assert.Equal(256, cache.TqLength);
+        Assert.Equal(44, cache.Fp32Length);
+        Assert.Equal(Tile, cache.TileSizeTokens);
+        Assert.Equal(TqQuantizer.KVarN, cache.Quantizer);
+    }
+
+    [Fact]
+    public void Reset_AllowsReuse_WithCorrectPromotionAndFiniteAttention()
+    {
+        const int headDim = 128;
+        var (cache, _, _) = BuildKVarNCache(seqLen: 200, window: 128, kvHeads: 1, headDim: headDim, seed: 11);
+        using var _d = cache;
+        Assert.Equal(128, cache.GetTqLength(0));
+
+        cache.Reset();
+        Assert.Equal(0, cache.Length);
+        Assert.Equal(0, cache.GetTqLength(0));
+
+        // Refill after Reset: promotion cadence must be identical and the
+        // attention path must produce finite output from the reused buffers.
+        var rng = new Random(12);
+        for (int pos = 0; pos < 200; pos++)
+        {
+            cache.Append(0, Gaussian(headDim, rng), Gaussian(headDim, rng));
+            cache.IncrementPosition();
+        }
+        Assert.Equal(200, cache.Length);
+        Assert.Equal(128, cache.GetTqLength(0));
+
+        float[] outVec = CacheAttention(cache, Gaussian(headDim, rng), numQHeads: 1);
+        Assert.All(outVec, v => Assert.True(float.IsFinite(v)));
+    }
+
+    [Fact]
+    public void TruncateTo_WithinWindow_Ok_IntoCompressedRegion_Throws()
+    {
+        var (cache, _, _) = BuildKVarNCache(seqLen: 200, window: 128, kvHeads: 1, headDim: 128, seed: 21);
+        using var _d = cache;
+        Assert.Equal(128, cache.GetTqLength(0));
+
+        cache.TruncateTo(150); // within the FP32 window (tqLen=128 <= 150)
+        Assert.Equal(150, cache.Length);
+        Assert.Equal(128, cache.GetTqLength(0));
+
+        Assert.Throws<NotSupportedException>(() => cache.TruncateTo(100));
+
+        // Appends after a truncate keep the whole-tile promotion cadence.
+        var rng = new Random(22);
+        for (int pos = 150; pos < 260; pos++)
+        {
+            cache.Append(0, Gaussian(128, rng), Gaussian(128, rng));
+            cache.IncrementPosition();
+        }
+        Assert.Equal(260, cache.Length);
+        Assert.Equal(256, cache.GetTqLength(0)); // promoted again at total=256
+    }
+
+    [Fact]
+    public void Compact_Throws_InKVarNMode()
+    {
+        var (cache, _, _) = BuildKVarNCache(seqLen: 200, window: 128, kvHeads: 1, headDim: 128, seed: 31);
+        using var _d = cache;
+
+        int[] keep = new int[100];
+        for (int i = 0; i < keep.Length; i++) keep[i] = i * 2;
+
+        var ex = Assert.Throws<NotSupportedException>(() => cache.Compact(keep, 200));
+        Assert.Contains("KVarN", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_Rejects_WindowSmallerThanTile_WhenCompressedRegionPossible()
+    {
+        // A compressed region can exist (maxSeqLen > window) but the window can
+        // never assemble a full 128-token tile → reject at construction.
+        var ex = Assert.Throws<ArgumentException>(() => new TurboQuantKvCache(
+            numLayers: 1, maxSeqLen: 512, numKvHeads: 1, headDim: 128,
+            fp32WindowSize: 64, quantizer: TqQuantizer.KVarN));
+        Assert.Contains("128", ex.Message);
+
+        // No compressed region possible (maxSeqLen <= window) → any window is fine.
+        using var ok = new TurboQuantKvCache(
+            numLayers: 1, maxSeqLen: 64, numKvHeads: 1, headDim: 128,
+            fp32WindowSize: 64, quantizer: TqQuantizer.KVarN);
+        Assert.Equal(0, ok.Length);
+    }
+
+    [Fact]
+    public void Ctor_Rejects_NonPow2HeadDim()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new TurboQuantKvCache(
+            numLayers: 1, maxSeqLen: 512, numKvHeads: 1, headDim: 96,
+            fp32WindowSize: 128, quantizer: TqQuantizer.KVarN));
+        Assert.Contains("power of 2", ex.Message);
+    }
+
+    [Fact]
+    public void LloydMaxCompressorAccessors_Throw_InKVarNMode()
+    {
+        using var cache = new TurboQuantKvCache(
+            numLayers: 1, maxSeqLen: 512, numKvHeads: 1, headDim: 128,
+            fp32WindowSize: 128, quantizer: TqQuantizer.KVarN);
+
+        Assert.Throws<InvalidOperationException>(() => cache.GetKeyCompressor(0, 0));
+        Assert.Throws<InvalidOperationException>(() => cache.GetValueCompressor(0, 0));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ForwardPass-level integration (model-gated, skipped when the fixture
+    // model is absent — same convention as SnapKvTurboQuantTests)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ForwardPass_KVarN_WithSnapKvEnv_ThrowsAtEnable()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        var prevBudget = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", "256");
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+            using var backend = new CpuBackend();
+            using var fwd = new Engine.ForwardPass(model, backend, hp);
+
+            var ex = Assert.Throws<NotSupportedException>(() =>
+                fwd.EnableTurboQuant(fp32WindowSize: 128, bits: 3, quantizer: TqQuantizer.KVarN));
+            Assert.Contains("SnapKV", ex.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevBudget);
+        }
+    }
+
+    [Fact]
+    public void ForwardPass_KVarN_PrefillAndDecode_StaysCoherent()
+    {
+        var path = FindModelPath();
+        if (path is null) return;
+
+        var prevBudget = Environment.GetEnvironmentVariable("SHARPI_SNAPKV_BUDGET");
+        Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", null);
+        try
+        {
+            using var model = GgufModel.Open(path);
+            var hp = ModelHyperparams.FromGgufMetadata(model.Metadata);
+            using var backend = new CpuBackend();
+            using var fwd = new Engine.ForwardPass(model, backend, hp);
+            // Window 128 (the KVarN minimum) so a ~384-token prompt ends with
+            // two whole compressed tiles: promotions at totals 128 and 256.
+            fwd.EnableTurboQuant(fp32WindowSize: 128, bits: 3, quantizer: TqQuantizer.KVarN);
+
+            var tokenizer = GgufTokenizer.FromGgufModel(model);
+            var tokens = LongPrompt(tokenizer, approxTokenCount: 384);
+            var logits = fwd.Prefill(tokens).ToArray();
+
+            Assert.NotNull(fwd.TqCache);
+            Assert.Equal(TqQuantizer.KVarN, fwd.TqCache!.Quantizer);
+            Assert.Equal(0, fwd.TqCache.GetTqLength(0) % Tile);
+            Assert.True(fwd.TqCache.GetTqLength(0) >= 2 * Tile,
+                $"Expected >= 2 compressed tiles after a {tokens.Length}-token prefill, got tqLen={fwd.TqCache.GetTqLength(0)}.");
+
+            float min = float.MaxValue, max = float.MinValue;
+            for (int i = 0; i < logits.Length; i++)
+            {
+                Assert.True(float.IsFinite(logits[i]), $"Non-finite prefill logit at idx {i}: {logits[i]}");
+                if (logits[i] < min) min = logits[i];
+                if (logits[i] > max) max = logits[i];
+            }
+            Assert.True(max - min > 0.5f, $"Post-KVarN logit range collapsed to {min:F3}..{max:F3}.");
+
+            var produced = new List<int>(4);
+            for (int i = 0; i < 4; i++)
+            {
+                int next = Sampler.Greedy(logits);
+                produced.Add(next);
+                logits = fwd.Forward(next, tokens.Length + i).ToArray();
+                for (int k = 0; k < logits.Length; k++)
+                    Assert.True(float.IsFinite(logits[k]), $"Non-finite logit at decode step {i}, idx {k}");
+            }
+            int distinct = produced.Distinct().Count();
+            Assert.True(distinct >= 2,
+                $"Greedy decode under KVarN produced only {distinct} distinct token(s): [{string.Join(",", produced)}].");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPI_SNAPKV_BUDGET", prevBudget);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Builds a KVarN-mode cache with <paramref name="seqLen"/> random Gaussian K/V rows, stashing the originals.</summary>
+    private static (TurboQuantKvCache cache, float[][] keys, float[][] values) BuildKVarNCache(
+        int seqLen, int window, int kvHeads, int headDim, int seed)
+    {
+        var cache = new TurboQuantKvCache(
+            numLayers: 1, maxSeqLen: seqLen + Tile, numKvHeads: kvHeads, headDim: headDim,
+            fp32WindowSize: window, quantizer: TqQuantizer.KVarN);
+
+        var rng = new Random(seed);
+        int kvDim = kvHeads * headDim;
+        var keys = new float[seqLen][];
+        var values = new float[seqLen][];
+        for (int pos = 0; pos < seqLen; pos++)
+        {
+            keys[pos] = Gaussian(kvDim, rng);
+            values[pos] = Gaussian(kvDim, rng);
+            cache.Append(0, keys[pos], values[pos]);
+            cache.IncrementPosition();
+        }
+        return (cache, keys, values);
+    }
+
+    /// <summary>
+    /// Attention over the cache exactly as ForwardPass.TqAttention drives it:
+    /// per-head RotateQuery → ComputeKScores over the compressed region → FP32
+    /// dot products over the window → softmax → ComputeVAggregation (rotated
+    /// domain, one deferred un-rotation inside) → FP32-window V accumulation
+    /// in the original domain.
+    /// </summary>
+    private static unsafe float[] CacheAttention(TurboQuantKvCache cache, float[] q, int numQHeads)
+    {
+        int hd = cache.HeadDim;
+        int hpkg = numQHeads / cache.NumKvHeads;
+        int seqLen = cache.Length;
+        int tqLen = cache.GetTqLength(0);
+        float scale = 1f / MathF.Sqrt(hd);
+
+        var outBuf = new float[numQHeads * hd];
+        var scores = new float[seqLen];
+        var rotated = new float[hd];
+
+        for (int h = 0; h < numQHeads; h++)
+        {
+            int kvHead = h / hpkg;
+            var qHead = q.AsSpan(h * hd, hd);
+            cache.RotateQuery(0, kvHead, qHead, rotated);
+
+            fixed (float* rotPtr = rotated)
+            fixed (float* scoresPtr = scores)
+                cache.ComputeKScores(0, kvHead, rotPtr, scale, scoresPtr);
+
+            for (int t = tqLen; t < seqLen; t++)
+            {
+                float* kVec = cache.Fp32KeyAt(0, t) + kvHead * hd;
+                float dot = 0f;
+                for (int d = 0; d < hd; d++) dot += qHead[d] * kVec[d];
+                scores[t] = dot * scale;
+            }
+
+            Softmax(scores);
+
+            fixed (float* scoresPtr = scores)
+            fixed (float* outPtr = &outBuf[h * hd])
+                cache.ComputeVAggregation(0, kvHead, scoresPtr, outPtr);
+
+            for (int t = tqLen; t < seqLen; t++)
+            {
+                float* vVec = cache.Fp32ValueAt(0, t) + kvHead * hd;
+                float w = scores[t];
+                for (int d = 0; d < hd; d++)
+                    outBuf[h * hd + d] += w * vVec[d];
+            }
+        }
+        return outBuf;
+    }
+
+    /// <summary>Plain FP32 GQA attention over per-position K/V rows of kvDim floats.</summary>
+    private static float[] ReferenceAttention(
+        float[][] keys, float[][] values, float[] q, int numQHeads, int numKvHeads, int hd)
+    {
+        int hpkg = numQHeads / numKvHeads;
+        int seqLen = keys.Length;
+        float scale = 1f / MathF.Sqrt(hd);
+
+        var outBuf = new float[numQHeads * hd];
+        var scores = new float[seqLen];
+
+        for (int h = 0; h < numQHeads; h++)
+        {
+            int off = (h / hpkg) * hd;
+            for (int t = 0; t < seqLen; t++)
+            {
+                float dot = 0f;
+                for (int d = 0; d < hd; d++) dot += q[h * hd + d] * keys[t][off + d];
+                scores[t] = dot * scale;
+            }
+            Softmax(scores);
+            for (int t = 0; t < seqLen; t++)
+                for (int d = 0; d < hd; d++)
+                    outBuf[h * hd + d] += scores[t] * values[t][off + d];
+        }
+        return outBuf;
+    }
+
+    /// <summary>
+    /// Materializes the cache's effective K/V: compressed positions reconstructed
+    /// via KVarNCompressor.Decompress*Tile (read straight from the cache's tile
+    /// storage), FP32-window positions taken from the stashed originals (the
+    /// window stores exact copies).
+    /// </summary>
+    private static unsafe (float[][] keys, float[][] values) DecompressedKv(
+        TurboQuantKvCache cache, float[][] origKeys, float[][] origValues)
+    {
+        int hd = cache.HeadDim;
+        int kvHeads = cache.NumKvHeads;
+        int kvDim = kvHeads * hd;
+        int seqLen = cache.Length;
+        int tqLen = cache.GetTqLength(0);
+        var comp = new KVarNCompressor(hd);
+
+        var keys = new float[seqLen][];
+        var values = new float[seqLen][];
+        for (int t = 0; t < seqLen; t++)
+        {
+            keys[t] = new float[kvDim];
+            values[t] = new float[kvDim];
+        }
+
+        int numTiles = tqLen / Tile;
+        var decK = new float[Tile * hd];
+        var decV = new float[Tile * hd];
+        for (int tileIdx = 0; tileIdx < numTiles; tileIdx++)
+        {
+            for (int head = 0; head < kvHeads; head++)
+            {
+                comp.DecompressKeyTile(
+                    new ReadOnlySpan<byte>(cache.KeyTileAt(0, tileIdx, head), comp.KeyTileBytes), decK);
+                comp.DecompressValueTile(
+                    new ReadOnlySpan<byte>(cache.ValueTileAt(0, tileIdx, head), comp.ValueTileBytes), decV);
+                for (int t = 0; t < Tile; t++)
+                {
+                    Array.Copy(decK, t * hd, keys[tileIdx * Tile + t], head * hd, hd);
+                    Array.Copy(decV, t * hd, values[tileIdx * Tile + t], head * hd, hd);
+                }
+            }
+        }
+
+        for (int t = tqLen; t < seqLen; t++)
+        {
+            origKeys[t].CopyTo(keys[t], 0);
+            origValues[t].CopyTo(values[t], 0);
+        }
+        return (keys, values);
+    }
+
+    private static void Softmax(Span<float> x)
+    {
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < x.Length; i++) if (x[i] > max) max = x[i];
+        double sum = 0;
+        for (int i = 0; i < x.Length; i++) { x[i] = MathF.Exp(x[i] - max); sum += x[i]; }
+        float inv = (float)(1.0 / sum);
+        for (int i = 0; i < x.Length; i++) x[i] *= inv;
+    }
+
+    private static float[] Gaussian(int n, Random rng)
+    {
+        var v = new float[n];
+        for (int i = 0; i < n; i++)
+        {
+            // Box-Muller; 1 - NextDouble() avoids log(0).
+            double u1 = 1.0 - rng.NextDouble();
+            double u2 = rng.NextDouble();
+            v[i] = (float)(Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2));
+        }
+        return v;
+    }
+
+    private static float RelL2(ReadOnlySpan<float> reference, ReadOnlySpan<float> actual)
+    {
+        double errSq = 0, refSq = 0;
+        for (int i = 0; i < reference.Length; i++)
+        {
+            double e = actual[i] - reference[i];
+            errSq += e * e;
+            refSq += (double)reference[i] * reference[i];
+        }
+        return refSq > 0 ? (float)Math.Sqrt(errSq / refSq) : (float)Math.Sqrt(errSq);
+    }
+
+    private static float Cosine(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double dot = 0, na = 0, nb = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            na += (double)a[i] * a[i];
+            nb += (double)b[i] * b[i];
+        }
+        double denom = Math.Sqrt(na) * Math.Sqrt(nb);
+        return denom > 0 ? (float)(dot / denom) : 0f;
+    }
+
+    private static string? FindModelPath(string filename = "Qwen3-8B-Q4_K_M.gguf")
+    {
+        var dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 8; i++)
+        {
+            var candidate = Path.Combine(dir, "models", filename);
+            if (File.Exists(candidate)) return candidate;
+            var parent = Directory.GetParent(dir);
+            if (parent == null) break;
+            dir = parent.FullName;
+        }
+        return null;
+    }
+
+    private static int[] LongPrompt(GgufTokenizer tokenizer, int approxTokenCount)
+    {
+        const string seed =
+            "The quick brown fox jumps over the lazy dog. " +
+            "Sphinx of black quartz, judge my vow. " +
+            "Pack my box with five dozen liquor jugs. ";
+        var sb = new System.Text.StringBuilder();
+        while (true)
+        {
+            sb.Append(seed);
+            var attempt = tokenizer.Encode(sb.ToString());
+            if (attempt.Count >= approxTokenCount) return attempt.ToArray();
+            if (sb.Length > 100_000)
+                throw new InvalidOperationException("Tokenizer not packing enough tokens — unexpected.");
+        }
+    }
+}

--- a/tests/SharpInference.Tests.TurboQuant/KVarNCompressorTests.cs
+++ b/tests/SharpInference.Tests.TurboQuant/KVarNCompressorTests.cs
@@ -1,0 +1,641 @@
+using SharpInference.TurboQuant;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.TurboQuant;
+
+public sealed class KVarNCompressorTests(ITestOutputHelper output)
+{
+    private const int T = KVarNCompressor.TileTokens;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Layout / construction
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TileSizes_MatchLayoutFormula()
+    {
+        // K: 4·T + 8·D + D·T/2   V: 4·D + 8·T·G + T·D/4
+        Assert.Equal(4 * 128 + 8 * 128 + 128 * 64, KVarNCompressor.KeyTileSize(128));   // 9728
+        Assert.Equal(4 * 128 + 8 * 128 + 128 * 32, KVarNCompressor.ValueTileSize(128)); // 5632
+        Assert.Equal(4 * 128 + 8 * 64 + 64 * 64, KVarNCompressor.KeyTileSize(64));      // 5120
+        Assert.Equal(4 * 64 + 8 * 128 + 128 * 16, KVarNCompressor.ValueTileSize(64));   // 3328
+        Assert.Equal(4 * 256 + 8 * 128 * 2 + 128 * 64, KVarNCompressor.ValueTileSize(256)); // 11264
+
+        var c = new KVarNCompressor(128);
+        Assert.Equal(KVarNCompressor.KeyTileSize(128), c.KeyTileBytes);
+        Assert.Equal(KVarNCompressor.ValueTileSize(128), c.ValueTileBytes);
+    }
+
+    [Theory]
+    [InlineData(100)] // not a power of 2
+    [InlineData(4)]   // too small
+    [InlineData(2048)] // too large
+    public void InvalidHeadDim_Throws(int headDim)
+    {
+        Assert.Throws<ArgumentException>(() => new KVarNCompressor(headDim));
+        Assert.Throws<ArgumentException>(() => KVarNCompressor.KeyTileSize(headDim));
+    }
+
+    [Fact]
+    public void UndersizedBuffers_Throw()
+    {
+        var c = new KVarNCompressor(128);
+        var keys = new float[T * 128];
+        Assert.Throws<ArgumentException>(() => c.CompressKeyTile(keys, new byte[c.KeyTileBytes - 1]));
+        Assert.Throws<ArgumentException>(() => c.CompressValueTile(keys, new byte[c.ValueTileBytes - 1]));
+        Assert.Throws<ArgumentException>(() => c.CompressKeyTile(new float[T * 128 - 1], new byte[c.KeyTileBytes]));
+    }
+
+    [Fact]
+    public void BitPacking2_RoundTrip_AllValuesAndMixed()
+    {
+        byte[] buffer = new byte[BitPacking.PackedBytes2Bit];
+        for (int value = 0; value < 4; value++)
+        {
+            for (int pos = 0; pos < 128; pos++)
+                BitPacking.PackBits2(buffer, 0, pos, value);
+            for (int pos = 0; pos < 128; pos++)
+                Assert.Equal(value, BitPacking.UnpackBits2(buffer, 0, pos));
+        }
+
+        var rng = new Random(5);
+        int[] expected = new int[128];
+        for (int pos = 0; pos < 128; pos++)
+        {
+            expected[pos] = rng.Next(4);
+            BitPacking.PackBits2(buffer, 0, pos, expected[pos]);
+        }
+        for (int pos = 0; pos < 128; pos++)
+            Assert.Equal(expected[pos], BitPacking.UnpackBits2(buffer, 0, pos));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 1. Sinkhorn convergence
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sinkhorn_GaussianTile_RowAndColumnRmsNearUnit()
+    {
+        const int dim = 128;
+        float[] tile = GaussianMatrix(T, dim, seed: 42);
+        float[] original = (float[])tile.Clone();
+        float[] rowScale = new float[T];
+        float[] colScale = new float[dim];
+
+        KVarNCompressor.SinkhornNormalize(tile, T, dim, rowScale, colScale, iterations: 4);
+
+        (float rowLo, float rowHi, float colLo, float colHi) = AxisRmsRange(tile, T, dim);
+        output.WriteLine($"Gaussian tile after 4 iters: row RMS [{rowLo:F4}, {rowHi:F4}], col RMS [{colLo:F4}, {colHi:F4}]");
+
+        Assert.InRange(rowLo, 0.9f, 1.1f);
+        Assert.InRange(rowHi, 0.9f, 1.1f);
+        Assert.InRange(colLo, 0.9f, 1.1f);
+        Assert.InRange(colHi, 0.9f, 1.1f);
+
+        AssertScalesReconstruct(original, tile, rowScale, colScale, T, dim);
+    }
+
+    [Fact]
+    public void Sinkhorn_OutlierTile_RowAndColumnRmsNearUnit()
+    {
+        const int dim = 128;
+        float[] tile = GaussianMatrix(T, dim, seed: 7);
+
+        // Plant an outlier channel, an outlier token, and one huge lone element.
+        for (int t = 0; t < T; t++) tile[t * dim + 9] *= 100f;
+        for (int c = 0; c < dim; c++) tile[41 * dim + c] *= 100f;
+        tile[3 * dim + 5] = 1000f;
+
+        float[] original = (float[])tile.Clone();
+        float[] rowScale = new float[T];
+        float[] colScale = new float[dim];
+
+        KVarNCompressor.SinkhornNormalize(tile, T, dim, rowScale, colScale, iterations: 5);
+
+        (float rowLo, float rowHi, float colLo, float colHi) = AxisRmsRange(tile, T, dim);
+        output.WriteLine($"Outlier tile after 5 iters: row RMS [{rowLo:F4}, {rowHi:F4}], col RMS [{colLo:F4}, {colHi:F4}]");
+
+        Assert.InRange(rowLo, 0.9f, 1.1f);
+        Assert.InRange(rowHi, 0.9f, 1.1f);
+        Assert.InRange(colLo, 0.9f, 1.1f);
+        Assert.InRange(colHi, 0.9f, 1.1f);
+
+        AssertScalesReconstruct(original, tile, rowScale, colScale, T, dim);
+    }
+
+    [Fact]
+    public void Sinkhorn_AllZerosTile_LeavesScalesAtOne()
+    {
+        const int dim = 64;
+        float[] tile = new float[T * dim];
+        float[] rowScale = new float[T];
+        float[] colScale = new float[dim];
+
+        KVarNCompressor.SinkhornNormalize(tile, T, dim, rowScale, colScale, iterations: 4);
+
+        Assert.All(rowScale, s => Assert.Equal(1f, s));
+        Assert.All(colScale, s => Assert.Equal(1f, s));
+        Assert.All(tile, v => Assert.Equal(0f, v));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 2. Rotation preserves scores
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HadamardRotation_PreservesDotProducts()
+    {
+        const int dim = 128;
+        var compressor = new KVarNCompressor(dim);
+        var rng = new Random(11);
+
+        float maxErr = 0f;
+        for (int trial = 0; trial < 32; trial++)
+        {
+            float[] q = GaussianVector(dim, rng);
+            float[] k = GaussianVector(dim, rng);
+
+            float direct = Dot(q, k);
+
+            float[] qRot = new float[dim];
+            float[] kRot = new float[dim];
+            compressor.RotateQuery(q, qRot);
+            WalshHadamard.Transform(k, kRot, dim);
+
+            float rotated = Dot(qRot, kRot);
+            maxErr = MathF.Max(maxErr, MathF.Abs(rotated - direct));
+        }
+
+        output.WriteLine($"(HQ)·(HK) vs Q·K max abs error over 32 trials: {maxErr:E3}");
+        Assert.True(maxErr < 1e-3f, $"Rotation broke scores: max err {maxErr}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 3. Round-trip reconstruction error
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void KeyTile_RoundTrip_RelativeFrobeniusBounded()
+    {
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        float[] keys = GaussianMatrix(T, dim, seed: 21);
+
+        byte[] tile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, tile);
+
+        float[] decoded = new float[T * dim];
+        c.DecompressKeyTile(tile, decoded);
+
+        // Measured ~0.099 — consistent with the ~0.106σ theoretical RMS error of
+        // 4-bit min/max RTN over 128 Gaussian samples (step ≈ 5.6σ/15, err ≈ step/√12).
+        float relErr = RelativeFrobenius(keys, decoded);
+        output.WriteLine($"K 4-bit round-trip relative Frobenius error (Gaussian, D=128): {relErr:F4}");
+        Assert.True(relErr < 0.12f, $"K round-trip error too high: {relErr}");
+    }
+
+    [Fact]
+    public void ValueTile_RoundTrip_RelativeFrobeniusBounded()
+    {
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        float[] values = GaussianMatrix(T, dim, seed: 22);
+
+        byte[] tile = new byte[c.ValueTileBytes];
+        c.CompressValueTile(values, tile);
+
+        float[] decoded = new float[T * dim];
+        c.DecompressValueTile(tile, decoded);
+
+        // Measured ~0.50 — the expected floor for 2-bit min/max RTN on Gaussian data
+        // (step ≈ 5.6σ/3, err ≈ step/√12 ≈ 0.54σ; even optimal 2-bit Lloyd-Max is 0.34σ).
+        // The softmax-aggregate relative error is about the same (~0.46-0.51, see the
+        // aggregate test): heavy-tailed softmax weights give a small effective sample
+        // count, and the reference aggregate's own norm shrinks by the same averaging.
+        // Whether ~0.5 element-level V error is acceptable end-to-end is exactly what
+        // the P0 model-level accuracy gate must decide — these unit tests do not.
+        float relErr = RelativeFrobenius(values, decoded);
+        output.WriteLine($"V 2-bit round-trip relative Frobenius error (Gaussian, D=128): {relErr:F4}");
+        Assert.True(relErr < 0.55f, $"V round-trip error too high: {relErr}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 4. Attention-score fidelity vs the existing TurboQuant compressor
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void KeyScores_ErrorComparableToTurboQuant4Bit(bool plantOutliers)
+    {
+        const int dim = 128;
+        const int numQueries = 8;
+        var rng = new Random(31);
+
+        float[] keys = GaussianMatrix(T, dim, seed: 33);
+        if (plantOutliers)
+        {
+            // Token-scale outliers (KVarN's target failure mode) + a hot channel.
+            var orng = new Random(34);
+            for (int i = 0; i < 8; i++)
+            {
+                int t = orng.Next(T);
+                for (int c = 0; c < dim; c++) keys[t * dim + c] *= 20f;
+            }
+            for (int t = 0; t < T; t++) keys[t * dim + 3] *= 10f;
+        }
+
+        // KVarN tile.
+        var kvarn = new KVarNCompressor(dim);
+        byte[] kTile = new byte[kvarn.KeyTileBytes];
+        kvarn.CompressKeyTile(keys, kTile);
+
+        // Existing TurboQuant 4-bit, per-token blocks on the same data.
+        var tq = new KvCacheCompressor(4, dim, layerIndex: 0);
+        byte[] tqBlocks = new byte[T * tq.BlockSize];
+        for (int t = 0; t < T; t++)
+            tq.Compress(keys.AsSpan(t * dim, dim), tqBlocks.AsSpan(t * tq.BlockSize, tq.BlockSize));
+
+        double kvarnAbsErr = 0, tqAbsErr = 0;
+        int samples = 0;
+
+        float[] scores = new float[T];
+        float[] qRotKvarn = new float[dim];
+        float[] qRotTq = new float[dim];
+
+        for (int qi = 0; qi < numQueries; qi++)
+        {
+            float[] q = GaussianVector(dim, rng);
+            kvarn.RotateQuery(q, qRotKvarn);
+            tq.RotateQuery(q, qRotTq);
+            kvarn.KeyScores(kTile, qRotKvarn, scores);
+
+            for (int t = 0; t < T; t++)
+            {
+                double truth = DotDouble(q, keys.AsSpan(t * dim, dim));
+                kvarnAbsErr += Math.Abs(scores[t] - truth);
+                tqAbsErr += Math.Abs(tq.DequantDot(tqBlocks.AsSpan(t * tq.BlockSize, tq.BlockSize), qRotTq) - truth);
+                samples++;
+            }
+        }
+
+        double kvarnMean = kvarnAbsErr / samples;
+        double tqMean = tqAbsErr / samples;
+        output.WriteLine($"Mean |q·k̂ − q·k| ({(plantOutliers ? "outlier" : "Gaussian")} K tile, D=128, {samples} samples):");
+        output.WriteLine($"  KVarN K4 (RTN+Sinkhorn):    {kvarnMean:F4}");
+        output.WriteLine($"  TurboQuant 4-bit Lloyd-Max: {tqMean:F4}");
+        output.WriteLine($"  ratio KVarN/TQ:             {kvarnMean / tqMean:F3}");
+
+        // Measured ratios: 0.98 (Gaussian), 1.05 (outliers) — same ballpark by construction.
+        Assert.True(kvarnMean <= tqMean * 1.25,
+            $"KVarN score error {kvarnMean:F4} not in the same ballpark as TurboQuant {tqMean:F4}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 5. DequantDot == dot(query, Decompress(tile))
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DequantDot_MatchesDecompressedDot()
+    {
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(51);
+
+        float[] keys = GaussianMatrix(T, dim, seed: 52);
+        byte[] tile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, tile);
+
+        float[] decoded = new float[T * dim];
+        c.DecompressKeyTile(tile, decoded);
+
+        float[] scores = new float[T];
+        float[] qRot = new float[dim];
+        float maxErr = 0f, maxScoresErr = 0f;
+
+        for (int qi = 0; qi < 4; qi++)
+        {
+            float[] q = GaussianVector(dim, rng);
+            c.RotateQuery(q, qRot);
+            c.KeyScores(tile, qRot, scores);
+
+            for (int t = 0; t < T; t++)
+            {
+                float reference = Dot(q, decoded.AsSpan(t * dim, dim));
+                float fused = c.DequantDot(tile, qRot, t);
+                maxErr = MathF.Max(maxErr, MathF.Abs(fused - reference));
+                maxScoresErr = MathF.Max(maxScoresErr, MathF.Abs(scores[t] - reference));
+            }
+        }
+
+        output.WriteLine($"max |DequantDot − dot(q, decompressed)|: {maxErr:E3}");
+        output.WriteLine($"max |KeyScores  − dot(q, decompressed)|: {maxScoresErr:E3}");
+        Assert.True(maxErr < 1e-4f, $"DequantDot deviates from decompressed dot: {maxErr}");
+        Assert.True(maxScoresErr < 1e-4f, $"KeyScores deviates from decompressed dot: {maxScoresErr}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 6. V-aggregate parity
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(64)]
+    [InlineData(128)]
+    [InlineData(256)] // exercises the two-group (G=2) path
+    public void ValueAggregate_MatchesDecompressedAggregate(int dim)
+    {
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(61);
+
+        float[] values = GaussianMatrix(T, dim, seed: 62);
+        byte[] tile = new byte[c.ValueTileBytes];
+        c.CompressValueTile(values, tile);
+
+        float[] decoded = new float[T * dim];
+        c.DecompressValueTile(tile, decoded);
+
+        // Softmax weights from Gaussian logits.
+        float[] weights = SoftmaxWeights(T, rng);
+
+        // Compressed path: aggregate in rotated domain, un-rotate once.
+        float[] compressedAgg = new float[dim];
+        c.AggregateValues(tile, weights, compressedAgg);
+        c.UnrotateOutput(compressedAgg);
+
+        // Reference: weighted sum over the decompressed rows.
+        float[] referenceAgg = new float[dim];
+        for (int t = 0; t < T; t++)
+            for (int ch = 0; ch < dim; ch++)
+                referenceAgg[ch] += weights[t] * decoded[t * dim + ch];
+
+        // Informational: error of the compressed aggregate vs the fp32 truth.
+        float[] trueAgg = new float[dim];
+        for (int t = 0; t < T; t++)
+            for (int ch = 0; ch < dim; ch++)
+                trueAgg[ch] += weights[t] * values[t * dim + ch];
+
+        float maxParityErr = 0f;
+        for (int ch = 0; ch < dim; ch++)
+            maxParityErr = MathF.Max(maxParityErr, MathF.Abs(compressedAgg[ch] - referenceAgg[ch]));
+
+        output.WriteLine($"D={dim}: max |compressed-agg − decompressed-agg| = {maxParityErr:E3}");
+        output.WriteLine($"D={dim}: aggregate rel. error vs fp32 truth = {RelativeFrobenius(trueAgg, compressedAgg):F4}");
+        Assert.True(maxParityErr < 1e-4f, $"V-aggregate parity broken: {maxParityErr}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 7. Edge cases
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AllZerosTile_ReconstructsExactZero_AndScoresZero()
+    {
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        float[] zeros = new float[T * dim];
+
+        byte[] kTile = new byte[c.KeyTileBytes];
+        byte[] vTile = new byte[c.ValueTileBytes];
+        c.CompressKeyTile(zeros, kTile);
+        c.CompressValueTile(zeros, vTile);
+
+        float[] decoded = new float[T * dim];
+        c.DecompressKeyTile(kTile, decoded);
+        Assert.All(decoded, v => Assert.Equal(0f, v));
+        c.DecompressValueTile(vTile, decoded);
+        Assert.All(decoded, v => Assert.Equal(0f, v));
+
+        var rng = new Random(71);
+        float[] qRot = new float[dim];
+        c.RotateQuery(GaussianVector(dim, rng), qRot);
+
+        float[] scores = new float[T];
+        c.KeyScores(kTile, qRot, scores);
+        Assert.All(scores, s => Assert.Equal(0f, s));
+        Assert.Equal(0f, c.DequantDot(kTile, qRot, 17));
+
+        float[] agg = new float[dim];
+        c.AggregateValues(vTile, SoftmaxWeights(T, rng), agg);
+        c.UnrotateOutput(agg);
+        Assert.All(agg, v => Assert.Equal(0f, v));
+    }
+
+    [Fact]
+    public void ConstantToken_RoundTripsWithinTolerance()
+    {
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        float[] keys = GaussianMatrix(T, dim, seed: 72);
+        for (int ch = 0; ch < dim; ch++)
+            keys[19 * dim + ch] = 5f; // constant row → rotated row is a lone DC spike
+
+        byte[] tile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, tile);
+        float[] decoded = new float[T * dim];
+        c.DecompressKeyTile(tile, decoded);
+
+        // Measured: constant row ~0.018 (its rotated DC spike quantizes almost exactly);
+        // whole tile ~0.14 — slightly above plain Gaussian (~0.10) because the DC spike
+        // widens channel 0's per-channel RTN range for the other tokens.
+        float constErr = RelativeFrobenius(keys.AsSpan(19 * dim, dim), decoded.AsSpan(19 * dim, dim));
+        float wholeErr = RelativeFrobenius(keys, decoded);
+        output.WriteLine($"constant-token row rel. error: {constErr:F4}; whole tile: {wholeErr:F4}");
+        Assert.True(constErr < 0.05f, $"Constant token reconstructed poorly: {constErr}");
+        Assert.True(wholeErr < 0.18f, $"Tile with constant token reconstructed poorly: {wholeErr}");
+    }
+
+    [Fact]
+    public void SingleHugeOutlier_DoesNotDestroyOtherTokens()
+    {
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        float[] keys = GaussianMatrix(T, dim, seed: 73);
+        keys[17 * dim + 3] = 1e4f;
+
+        byte[] tile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, tile);
+        float[] decoded = new float[T * dim];
+        c.DecompressKeyTile(tile, decoded);
+
+        float maxOtherRowErr = 0f;
+        for (int t = 0; t < T; t++)
+        {
+            if (t == 17) continue;
+            maxOtherRowErr = MathF.Max(maxOtherRowErr,
+                RelativeFrobenius(keys.AsSpan(t * dim, dim), decoded.AsSpan(t * dim, dim)));
+        }
+        float outlierRowErr = RelativeFrobenius(keys.AsSpan(17 * dim, dim), decoded.AsSpan(17 * dim, dim));
+        output.WriteLine($"1e4 outlier at [17,3]: outlier row rel. err {outlierRowErr:F4}, worst other row {maxOtherRowErr:F4}");
+
+        // Measured: outlier row ~0.096, worst other row ~0.111 — the Sinkhorn row/col
+        // factors absorb the spike, so neither the outlier token nor its neighbors degrade.
+        Assert.True(maxOtherRowErr < 0.15f, $"Outlier bled into other tokens: {maxOtherRowErr}");
+        Assert.True(outlierRowErr < 0.15f, $"Outlier row itself reconstructed poorly: {outlierRowErr}");
+    }
+
+    [Theory]
+    [InlineData(64)]
+    [InlineData(256)]
+    public void OtherHeadDims_RoundTripAndDotParity(int dim)
+    {
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(74);
+
+        float[] keys = GaussianMatrix(T, dim, seed: 75);
+        byte[] kTile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, kTile);
+
+        float[] decoded = new float[T * dim];
+        c.DecompressKeyTile(kTile, decoded);
+        float kErr = RelativeFrobenius(keys, decoded);
+        output.WriteLine($"D={dim}: K round-trip rel. Frobenius {kErr:F4}");
+        Assert.True(kErr < 0.12f, $"K round-trip error too high at D={dim}: {kErr}");
+
+        float[] q = GaussianVector(dim, rng);
+        float[] qRot = new float[dim];
+        c.RotateQuery(q, qRot);
+        float[] scores = new float[T];
+        c.KeyScores(kTile, qRot, scores);
+
+        float maxErr = 0f;
+        for (int t = 0; t < T; t++)
+        {
+            float reference = Dot(q, decoded.AsSpan(t * dim, dim));
+            maxErr = MathF.Max(maxErr, MathF.Abs(scores[t] - reference));
+            maxErr = MathF.Max(maxErr, MathF.Abs(c.DequantDot(kTile, qRot, t) - reference));
+        }
+        output.WriteLine($"D={dim}: max score parity error {maxErr:E3}");
+        Assert.True(maxErr < 2e-4f, $"Score parity broken at D={dim}: {maxErr}");
+
+        float[] values = GaussianMatrix(T, dim, seed: 76);
+        byte[] vTile = new byte[c.ValueTileBytes];
+        c.CompressValueTile(values, vTile);
+        c.DecompressValueTile(vTile, decoded);
+        float vErr = RelativeFrobenius(values, decoded);
+        output.WriteLine($"D={dim}: V round-trip rel. Frobenius {vErr:F4}");
+        Assert.True(vErr < 0.55f, $"V round-trip error too high at D={dim}: {vErr}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static float[] GaussianMatrix(int rows, int cols, int seed)
+    {
+        var rng = new Random(seed);
+        float[] m = new float[rows * cols];
+        for (int i = 0; i < m.Length; i++)
+            m[i] = NextGaussian(rng);
+        return m;
+    }
+
+    private static float[] GaussianVector(int dim, Random rng)
+    {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++)
+            v[i] = NextGaussian(rng);
+        return v;
+    }
+
+    private static float NextGaussian(Random rng)
+    {
+        // Box-Muller; 1 - NextDouble() avoids log(0).
+        double u1 = 1.0 - rng.NextDouble();
+        double u2 = rng.NextDouble();
+        return (float)(Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2));
+    }
+
+    private static float[] SoftmaxWeights(int count, Random rng)
+    {
+        float[] w = new float[count];
+        double sum = 0;
+        for (int i = 0; i < count; i++)
+        {
+            w[i] = MathF.Exp(NextGaussian(rng));
+            sum += w[i];
+        }
+        for (int i = 0; i < count; i++)
+            w[i] = (float)(w[i] / sum);
+        return w;
+    }
+
+    private static float Dot(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        float sum = 0f;
+        for (int i = 0; i < a.Length; i++)
+            sum += a[i] * b[i];
+        return sum;
+    }
+
+    private static double DotDouble(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double sum = 0;
+        for (int i = 0; i < a.Length; i++)
+            sum += (double)a[i] * b[i];
+        return sum;
+    }
+
+    private static float RelativeFrobenius(ReadOnlySpan<float> reference, ReadOnlySpan<float> actual)
+    {
+        double errSq = 0, refSq = 0;
+        for (int i = 0; i < reference.Length; i++)
+        {
+            double e = actual[i] - reference[i];
+            errSq += e * e;
+            refSq += (double)reference[i] * reference[i];
+        }
+        return refSq > 0 ? (float)Math.Sqrt(errSq / refSq) : (float)Math.Sqrt(errSq);
+    }
+
+    private static (float rowLo, float rowHi, float colLo, float colHi) AxisRmsRange(
+        ReadOnlySpan<float> tile, int rows, int cols)
+    {
+        float rowLo = float.MaxValue, rowHi = float.MinValue;
+        for (int t = 0; t < rows; t++)
+        {
+            double sumSq = 0;
+            for (int c = 0; c < cols; c++)
+            {
+                float v = tile[t * cols + c];
+                sumSq += (double)v * v;
+            }
+            float rms = (float)Math.Sqrt(sumSq / cols);
+            rowLo = MathF.Min(rowLo, rms);
+            rowHi = MathF.Max(rowHi, rms);
+        }
+
+        float colLo = float.MaxValue, colHi = float.MinValue;
+        for (int c = 0; c < cols; c++)
+        {
+            double sumSq = 0;
+            for (int t = 0; t < rows; t++)
+            {
+                float v = tile[t * cols + c];
+                sumSq += (double)v * v;
+            }
+            float rms = (float)Math.Sqrt(sumSq / rows);
+            colLo = MathF.Min(colLo, rms);
+            colHi = MathF.Max(colHi, rms);
+        }
+
+        return (rowLo, rowHi, colLo, colHi);
+    }
+
+    private static void AssertScalesReconstruct(
+        ReadOnlySpan<float> original, ReadOnlySpan<float> normalized,
+        ReadOnlySpan<float> rowScale, ReadOnlySpan<float> colScale,
+        int rows, int cols)
+    {
+        for (int t = 0; t < rows; t++)
+        {
+            for (int c = 0; c < cols; c++)
+            {
+                float reconstructed = normalized[t * cols + c] * rowScale[t] * colScale[c];
+                float expected = original[t * cols + c];
+                float tolerance = 1e-3f * MathF.Max(1f, MathF.Abs(expected));
+                Assert.True(MathF.Abs(reconstructed - expected) <= tolerance,
+                    $"Scale reconstruction failed at [{t},{c}]: {reconstructed} vs {expected}");
+            }
+        }
+    }
+}

--- a/tests/SharpInference.Tests.TurboQuant/KVarNSimdParityTests.cs
+++ b/tests/SharpInference.Tests.TurboQuant/KVarNSimdParityTests.cs
@@ -1,0 +1,249 @@
+using SharpInference.TurboQuant;
+using Xunit.Abstractions;
+
+namespace SharpInference.Tests.TurboQuant;
+
+/// <summary>
+/// AVX2-vs-scalar parity for the fused KVarN read kernels (issue #180 P1).
+/// The AVX2 kernels compute the same algebra as the scalar reference but
+/// reassociate the floating-point accumulation (chunked Vector256 lanes vs a
+/// sequential channel/token walk), so parity is asserted relative to the
+/// tile's max |result| rather than element-exact. The scalar path is forced
+/// via <see cref="KVarNCompressor.ForceScalar"/>; on hardware without AVX2
+/// both invocations take the scalar path and the comparison is vacuous (but
+/// still runs).
+/// </summary>
+public sealed class KVarNSimdParityTests(ITestOutputHelper output)
+{
+    private const int T = KVarNCompressor.TileTokens;
+    private const float RelTolerance = 1e-5f;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // KeyScores
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(8, false)]
+    [InlineData(64, false)]
+    [InlineData(128, false)]
+    [InlineData(128, true)] // token/channel outliers — the KVarN target regime
+    [InlineData(256, false)]
+    [InlineData(512, false)] // upper vectorized dims stay covered
+    public void KeyScores_Avx2MatchesScalar(int dim, bool plantOutliers)
+    {
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(dim * 1000 + (plantOutliers ? 1 : 0));
+
+        float[] keys = GaussianMatrix(T, dim, rng);
+        if (plantOutliers)
+        {
+            for (int ch = 0; ch < dim; ch++) keys[41 * dim + ch] *= 100f;
+            for (int t = 0; t < T; t++) keys[t * dim + 9] *= 50f;
+        }
+
+        byte[] tile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, tile);
+
+        float[] qRot = new float[dim];
+        float[] scoresSimd = new float[T];
+        float[] scoresScalar = new float[T];
+
+        float worstRel = 0f;
+        for (int qi = 0; qi < 8; qi++)
+        {
+            float[] q = GaussianVector(dim, rng);
+            // Planted exact zeros exercise the qw == 0 skip path in both kernels.
+            q[3] = 0f;
+            if (dim > 17) q[17] = 0f;
+            c.RotateQuery(q, qRot);
+
+            c.KeyScores(tile, qRot, scoresSimd); // dispatch (AVX2 where supported)
+            RunForcedScalar(() => c.KeyScores(tile, qRot, scoresScalar));
+
+            float maxAbs = 0f, maxDiff = 0f;
+            for (int t = 0; t < T; t++)
+            {
+                maxAbs = MathF.Max(maxAbs, MathF.Abs(scoresScalar[t]));
+                maxDiff = MathF.Max(maxDiff, MathF.Abs(scoresSimd[t] - scoresScalar[t]));
+            }
+            float rel = maxDiff / MathF.Max(1f, maxAbs);
+            worstRel = MathF.Max(worstRel, rel);
+        }
+
+        output.WriteLine($"KeyScores D={dim} outliers={plantOutliers}: worst relative deviation {worstRel:E3}");
+        Assert.True(worstRel <= RelTolerance,
+            $"AVX2 KeyScores deviates from scalar by {worstRel:E3} (> {RelTolerance:E1}) at D={dim}");
+    }
+
+    [Fact]
+    public void KeyScores_AllChannelsConstant_BothPathsSkipEverything()
+    {
+        // Identical token rows → every rotated channel is constant across the
+        // tile → all chanStep == 0 → both kernels reduce to rowScale·bias.
+        const int dim = 128;
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(97);
+
+        float[] row = GaussianVector(dim, rng);
+        float[] keys = new float[T * dim];
+        for (int t = 0; t < T; t++)
+            row.CopyTo(keys, t * dim);
+
+        byte[] tile = new byte[c.KeyTileBytes];
+        c.CompressKeyTile(keys, tile);
+
+        float[] qRot = new float[dim];
+        c.RotateQuery(GaussianVector(dim, rng), qRot);
+
+        float[] scoresSimd = new float[T];
+        float[] scoresScalar = new float[T];
+        c.KeyScores(tile, qRot, scoresSimd);
+        RunForcedScalar(() => c.KeyScores(tile, qRot, scoresScalar));
+
+        float maxAbs = 0f, maxDiff = 0f;
+        for (int t = 0; t < T; t++)
+        {
+            maxAbs = MathF.Max(maxAbs, MathF.Abs(scoresScalar[t]));
+            maxDiff = MathF.Max(maxDiff, MathF.Abs(scoresSimd[t] - scoresScalar[t]));
+        }
+        output.WriteLine($"all-constant-channel tile: max |scalar| {maxAbs:E3}, max diff {maxDiff:E3}");
+        Assert.True(maxDiff <= RelTolerance * MathF.Max(1f, maxAbs));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // AggregateValues
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(64, false)]
+    [InlineData(128, false)]
+    [InlineData(128, true)]
+    [InlineData(256, false)] // two-group (G=2) path
+    [InlineData(512, false)] // four-group path, upper vectorized dims
+    public void AggregateValues_Avx2MatchesScalar(int dim, bool plantOutliers)
+    {
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(dim * 2000 + (plantOutliers ? 1 : 0));
+
+        float[] values = GaussianMatrix(T, dim, rng);
+        if (plantOutliers)
+        {
+            for (int ch = 0; ch < dim; ch++) values[13 * dim + ch] *= 100f;
+            for (int t = 0; t < T; t++) values[t * dim + 27] *= 50f;
+        }
+        // All-zero token row → tokStep == tokMin == 0 → the ws == 0 skip path.
+        Array.Clear(values, 77 * dim, dim);
+
+        byte[] tile = new byte[c.ValueTileBytes];
+        c.CompressValueTile(values, tile);
+
+        float worstRel = 0f;
+        for (int trial = 0; trial < 8; trial++)
+        {
+            float[] weights = SoftmaxWeights(T, rng);
+            // Exact-zero weights exercise the w == 0 skip path in both kernels.
+            weights[0] = 0f;
+            weights[63] = 0f;
+            weights[127] = 0f;
+
+            // Pre-seeded accumulators (same seed) so the += contract is compared too.
+            float[] seed = GaussianVector(dim, rng);
+            float[] accSimd = (float[])seed.Clone();
+            float[] accScalar = (float[])seed.Clone();
+
+            c.AggregateValues(tile, weights, accSimd);
+            RunForcedScalar(() => c.AggregateValues(tile, weights, accScalar));
+
+            float maxAbs = 0f, maxDiff = 0f;
+            for (int ch = 0; ch < dim; ch++)
+            {
+                maxAbs = MathF.Max(maxAbs, MathF.Abs(accScalar[ch]));
+                maxDiff = MathF.Max(maxDiff, MathF.Abs(accSimd[ch] - accScalar[ch]));
+            }
+            worstRel = MathF.Max(worstRel, maxDiff / MathF.Max(1f, maxAbs));
+        }
+
+        output.WriteLine($"AggregateValues D={dim} outliers={plantOutliers}: worst relative deviation {worstRel:E3}");
+        Assert.True(worstRel <= RelTolerance,
+            $"AVX2 AggregateValues deviates from scalar by {worstRel:E3} (> {RelTolerance:E1}) at D={dim}");
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(32)]
+    public void AggregateValues_SmallDims_DispatchFallsBackAndMatches(int dim)
+    {
+        // d < 64 always takes the scalar kernel (the AVX2 unpack needs 64-channel
+        // strides); this pins the dispatch producing identical results either way.
+        var c = new KVarNCompressor(dim);
+        var rng = new Random(dim);
+
+        float[] values = GaussianMatrix(T, dim, rng);
+        byte[] tile = new byte[c.ValueTileBytes];
+        c.CompressValueTile(values, tile);
+
+        float[] weights = SoftmaxWeights(T, rng);
+        float[] accDefault = new float[dim];
+        float[] accScalar = new float[dim];
+
+        c.AggregateValues(tile, weights, accDefault);
+        RunForcedScalar(() => c.AggregateValues(tile, weights, accScalar));
+
+        for (int ch = 0; ch < dim; ch++)
+            Assert.Equal(accScalar[ch], accDefault[ch]); // bit-identical: same kernel
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static void RunForcedScalar(Action action)
+    {
+        KVarNCompressor.ForceScalar = true;
+        try
+        {
+            action();
+        }
+        finally
+        {
+            KVarNCompressor.ForceScalar = false;
+        }
+    }
+
+    private static float[] GaussianMatrix(int rows, int cols, Random rng)
+    {
+        float[] m = new float[rows * cols];
+        for (int i = 0; i < m.Length; i++)
+            m[i] = NextGaussian(rng);
+        return m;
+    }
+
+    private static float[] GaussianVector(int dim, Random rng)
+    {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++)
+            v[i] = NextGaussian(rng);
+        return v;
+    }
+
+    private static float NextGaussian(Random rng)
+    {
+        double u1 = 1.0 - rng.NextDouble();
+        double u2 = rng.NextDouble();
+        return (float)(Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2));
+    }
+
+    private static float[] SoftmaxWeights(int count, Random rng)
+    {
+        float[] w = new float[count];
+        double sum = 0;
+        for (int i = 0; i < count; i++)
+        {
+            w[i] = MathF.Exp(NextGaussian(rng));
+            sum += w[i];
+        }
+        for (int i = 0; i < count; i++)
+            w[i] = (float)(w[i] / sum);
+        return w;
+    }
+}

--- a/tests/SharpInference.Tests.TurboQuant/SharpInference.Tests.TurboQuant.csproj
+++ b/tests/SharpInference.Tests.TurboQuant/SharpInference.Tests.TurboQuant.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\SharpInference.TurboQuant\SharpInference.TurboQuant.csproj" />
   </ItemGroup>
 

--- a/tests/SharpInference.Tests.TurboQuant/xunit.runner.json
+++ b/tests/SharpInference.Tests.TurboQuant/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Implements **KVarN** (arXiv:2606.03458) end-to-end per the phased plan in `docs/kvarn-feasibility-research.md` and #180: calibration-free 4-bit-key / 2-bit-value KV-cache quantization as a selectable quantizer inside the existing TurboQuant machinery, on the CPU (scalar + AVX2) and CUDA paths. Clean-room from the paper — no code from the reference vLLM fork.

## Commits (each implemented + adversarially reviewed before landing)

- `82efc4f` **Core quantizer** — Hadamard rotation (reuses `WalshHadamard`, K and V), log-space dual-axis Sinkhorn variance normalization, asymmetric RTN K4/V2 in 128-token tiles (channel-major K / token-major V packing), 2-bit `BitPacking`.
- `6040076` **Cache + attention integration** — `TqQuantizer` enum in `TurboQuantKvCache` (KVarN mode: the FP32 window is the staging; whole-tile promotion), `TqAttention` dispatch, CLI `--tq-mode <lloydmax|kvarn>`.
- `f95fb3e` **Accuracy gate** — new `perplexity` CLI command (teacher-forced NLL, position buckets) + `scripts/kvarn-gate/` (wikitext fetcher, 20-problem math eval). **P0 gate: strong pass.**
- `44a5e1a` **P1 AVX2** — fused KeyScores/AggregateValues (9.7×/8.4× per-kernel), scalar fallback + `ForceScalar` parity hook.
- `0d7cd28` **P2 CUDA correctness** — `llm_kvarn_rotate_query` / `llm_kvarn_compress_tile` / `llm_kvarn_attention`; packed codes byte-identical to the CPU compressor; `EstimateMaxContextKvarn`; `--tq-mode kvarn -g -1`; `perplexity -g -1`.
- `e43f3f0` **P2 CUDA decode perf** — CUDA-graph re-entry (two topologies, tracked params, promotion hoisted), warp-per-channel / flat-index attention walks.
- `99c3773` **Chunked batched prefill** — `llm_kvarn_prefill_attention` (single streaming softmax over compressed tiles + FP32 window, deferred inverse WHT), schedule-independent tiles (re-chunking is byte-exact).

## Measured (RTX 4070 Laptop 8 GB · Qwen3-0.6B-Q8_0 / Qwen3-8B-Q4_K_M · wikitext-2)

| Claim | Result |
|---|---|
| Accuracy at FP16 parity | PPL +1.26% (0.6B c=3072) / **+0.98%** (8B c=4096) vs fp32; math eval 18/20 = fp32; depth penalty flattens at ~+2.2% (no drift accumulation) |
| ~4× KV capacity | 8B auto-context **2376 → 18304 (7.7×)** in 8 GB |
| Throughput ≥ FP16 | CPU decode **1.57–2.20× faster** than fp32; CUDA 8B decode ≥ fp32 (+13% at 4k depth); prefill **7.7–13×** vs per-token (15.5k prompt + 300 tokens: **98 s**, was ~610 s) |

Gates that must keep holding: `perplexity` (0.6B c=3072 kvarn ≈ 15.60, 8B c=4096 ≈ 8.99), compress byte-exactness tests, graph-vs-direct decode parity (bit-identical over promotion boundaries).

## Scope notes

- KVarN CUDA: full offload of dense models, head_dim pow2 ≤ 256 (CPU up to 1024); SnapKV / narrowed-KV / batching / MoE combos rejected at config time (same exclusivity as Lloyd-Max TQ).
- Lloyd-Max path byte-for-byte unchanged (`--tq` alone). Related: the gate found Lloyd-Max 3-bit collapses on Qwen3 — #432.
- Follow-ups with calibrated baselines: #433 (int8-TC prefill GEMM, split-tile decode kernel, minors).

Closes #180 P0–P2 (P3 Vulkan optional, tracked in #433).

Tests: 32 KVarN (ForwardPass) + 7 graph + 78 TurboQuant + 80 CLI green; zero-warning Release build (TreatWarningsAsErrors, AOT/trim analyzers on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EWo1niax1g8A5E79RSALJ