### PR TITLE
perf(cpu): batched CPU-FFN/MoE prefill — hoist Q6_K input re-quant, default flags on (#416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ sharpi-cli -m models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf -g -1 \
 
 | Backend | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---|
-| **CUDA** `-g -1` (hybrid) | **29.4** | **28.0** | 29 GPU + 19 CPU layers; routed experts stream through `CudaExpertSlotManager` SLRU (#72/#77). Batched-trunk prefill (#123, bit-identical; `SHARPI_BATCHED_PREFILL=0` to bisect); `SHARPI_EXPERT_STATS=path` for hit rates |
+| **CUDA** `-g -1` (hybrid) | **102.6** | **28.0** | 48-layer trunk on GPU; routed experts auto-select to CPU mmap (expert cache too small for full SLRU offload — `SHARPI_CPU_MOE=0` forces GPU SLRU streaming). Prefill: batched CPU-MoE (#416/#440, bit-identical, default-on) — **3.5× over the per-token path** (29.4); the Q6_K down-projection no longer re-quantizes its input per weight row. `SHARPI_HYBRID_BATCHED_MOE=0` to bisect; `SHARPI_EXPERT_STATS=path` for hit rates |
 | CPU `--tq` | 19.6 | 22.6 | 3-bit KV; FastScan (#34) → 15.5 t/s decode @ 3.2K ctx |
 | CPU | 19.8 | 22.4 | 128 experts / 8 active |
 | Vulkan `-g -1` (hybrid) | 1.2 | 4.9 | 29 GPU + 19 CPU layers, SLRU expert cache + predictive prefetch (`--no-moe-predict-prefetch` to disable). PCIe/expert-stream bound; short-ctx values |
@@ -173,8 +173,8 @@ sharpi-cli -m models/Qwen3.6-27B-MTP-Q4_K_M.gguf -g -1 \
 
 | Backend | Size | Prefill t/s | Decode t/s | Notes |
 |---|---:|---:|---:|---|
-| **CUDA** `-g -1 --no-thinking` (hybrid) | 16 GB | **10.0** | **12.3** | GDN/attn KV resident on GPU, dense FFN on CPU mmap (the k=4 ring reclaims the VRAM the old k=2 default spent on 22 GPU FFN layers). 84% acceptance; 4-input CPU-FFN `MatVec4In` (#209) moves the verify optimum from k=2 → k=4 — **1.9× over MTP-off (6.5)**, +22% over the old k=2 default (10.1) |
-| **CUDA** `-g -1 --no-thinking` `Q5_K_M` (hybrid) | 19 GB | 6.2 | **5.5** | 13/64 FFN on GPU, 51/64 CPU mmap. 98% acceptance; batched trunk (#119) bit-identical |
+| **CUDA** `-g -1 --no-thinking` (hybrid) | 16 GB | **22.0** | **12.3** | GDN/attn KV resident on GPU, dense FFN on CPU mmap (20/64 FFN on GPU, 44 CPU; the k=4 ring reclaims the VRAM the old k=2 default spent on GPU FFN). Prefill: batched CPU dense-FFN (#416/#440, bit-identical, default-on) — **2.2× over the per-token path** (10.0) once the Q6_K down-projection stopped re-quantizing per weight row. Decode: 84% acceptance; 4-input CPU-FFN `MatVec4In` (#209) moves the verify optimum from k=2 → k=4 — **1.9× over MTP-off (6.5)** |
+| **CUDA** `-g -1 --no-thinking` `Q5_K_M` (hybrid) | 19 GB | 9.6 | **5.5** | 12/64 FFN on GPU, 52/64 CPU mmap. Prefill: batched CPU dense-FFN (#416/#440) — **1.5× over per-token** (6.2; smaller than Q4_K_M — only the Q6_K down-proj benefits, the Q5_K gate/up were already fused). 98% acceptance; batched trunk (#119) bit-identical |
 | Vulkan `-g -1 --no-thinking` (hybrid) | 16 GB | 7.6 | **3.9** | GDN/attn + MTP head on GPU, dense FFN CPU mmap. MTP self-spec runs on Vulkan (#357), greedy **byte-identical** to MTP-off — but currently a **slight loss** on throughput (3.9 @ 54% accept vs **4.9 MTP-off**; only wins at very high acceptance, ~5.8 @ 98%) because the dense CPU FFN isn't amortized in batched verify (#371) |
 | CPU `--no-thinking` | 16 GB | 3.0 | **3.6** | dense 27B GDN/attn + native MTP head; auto MTP self-spec (#25) at greedy + `--no-thinking`. 90% draft acceptance; folded k-token batched verify (#30/#207) — 1.2× over MTP-off (3.0) |
 | CPU `--no-thinking` `Q5_K_M` | 19 GB | 2.8 | **3.5** | ~10% slower than Q4_K_M; 100% acceptance |

--- a/src/SharpInference.Engine/CudaHybridForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridForwardPass.cs
@@ -217,9 +217,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     // reduce runs in top-k order) — but the Q8_KS int8 tier AUTO-ENABLES per expert
     // dtype (see _q3kQ8KEnabled et al.) and is argmax-stable, NOT byte-exact: pin
     // SHARPI_Q3K_Q8K=0 / SHARPI_Q8_0_Q8K=0 / SHARPI_Q4K_Q8K=0 for byte parity with
-    // the per-token oracle. Default OFF until validated (issue #410 constraint).
+    // the per-token oracle. Default ON after the desktop validation (issue #416):
+    // batched routed-MoE prefill is 3.65× over per-token on Coder-30B once the Q6_K
+    // down-projection stopped re-quantizing its input per weight row (the #416 fix
+    // hoists the Q8K prepack); byte-exact on AVX-512 (Q8_KS tier off), argmax-stable
+    // where the int8 tier auto-enables. Kill-switch: SHARPI_HYBRID_BATCHED_MOE=0.
     internal static bool BatchedCpuMoePrefillEnabled =
-        Environment.GetEnvironmentVariable("SHARPI_HYBRID_BATCHED_MOE") == "1";
+        CudaHybridGdnForwardPass.ResolveGate("SHARPI_HYBRID_BATCHED_MOE", true);
 
     // Test observable (issue #410): whether the last Prefill's FFN stage ran the batched
     // CPU-MoE path (vs the per-token loop). Non-vacuous parity assertions, same idea as
@@ -296,6 +300,13 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
     private byte* _bmNormAllQ8K;       // [N × _bmQ8KEmbStride] — prepacked norm rows
     private byte* _bmGateAllQ8K;       // [N × numActive × _bmQ8KExpStride] — prepacked silu'd gates
     private readonly int _bmQ8KEmbStride, _bmQ8KExpStride;
+    // Issue #410: Q6_K down projection — the single Q6_K dot always quantizes its input to
+    // Q8_K (no float Q6_K dot exists), so the batched down projection hoists that prepack out
+    // of the per-row loop whenever a routed down weight is Q6_K, independent of the SHARPI_*
+    // gates above (which drive the distinct Q8_KS scheme). Scratch is one Q8_K row per slot.
+    private readonly bool _hasQ6KDownExp;
+    private byte* _bmGateAllQ6KQ8K;    // [N × numActive × _bmQ6KExpStride] — Q8_K-packed silu'd gates
+    private readonly int _bmQ6KExpStride;
 
     // Non-transactional fault latch (mirror of CudaHybridGdnForwardPass._faulted):
     // set at batched-prefill entry, cleared only after the KV/position counters have
@@ -470,6 +481,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                     $"(Q3_K:{_q3kQ8KEnabled} Q8_0:{_q8_0Q8KEnabled} Q4_K:{_q4kQ8KEnabled}). " +
                     "Override with SHARPI_Q3K_Q8K=0 / SHARPI_Q8_0_Q8K=0 / SHARPI_Q4K_Q8K=0.");
             }
+            // Q6_K down experts always dot via Q8_K input; hoist the prepack unconditionally.
+            _hasQ6KDownExp = CudaHybridGdnForwardPass.HasRoutedDownExpertsOfDType(model, hp, DType.Q6_K);
+            if (_hasQ6KDownExp)
+                _bmQ6KExpStride = SimdKernels.Q8KScratchBytes(_expertDim);
         }
 
         string kvTag = _kvDType switch { DType.BFloat16 => " [KV bf16]", DType.Q8_0 => " [KV q8_0]", _ => "" };
@@ -1435,6 +1450,8 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 _bmNormAllQ8K = (byte*)NativeMemory.Alloc((nuint)((long)n * _bmQ8KEmbStride));
                 _bmGateAllQ8K = (byte*)NativeMemory.Alloc((nuint)(sel * _bmQ8KExpStride));
             }
+            if (_hasQ6KDownExp)
+                _bmGateAllQ6KQ8K = (byte*)NativeMemory.Alloc((nuint)(sel * _bmQ6KExpStride));
             _bmPinnedNorm   = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
             _bmPinnedRouted = _gpu.AllocatePinned(TensorShape.D1((long)n * _embDim));
             _bmCapN = n;
@@ -1452,6 +1469,7 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         if (_bmDownPartial != null) { NativeMemory.Free(_bmDownPartial); _bmDownPartial = null; }
         if (_bmNormAllQ8K  != null) { NativeMemory.Free(_bmNormAllQ8K);  _bmNormAllQ8K = null; }
         if (_bmGateAllQ8K  != null) { NativeMemory.Free(_bmGateAllQ8K);  _bmGateAllQ8K = null; }
+        if (_bmGateAllQ6KQ8K != null) { NativeMemory.Free(_bmGateAllQ6KQ8K); _bmGateAllQ6KQ8K = null; }
         if (_bmPinnedNorm is { } pn)   { _gpu.Free(pn); _bmPinnedNorm = null; }
         if (_bmPinnedRouted is { } pr) { _gpu.Free(pr); _bmPinnedRouted = null; }
         _bmCapN = 0;
@@ -1553,6 +1571,10 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
         bool useQ8KDown = (_q3kQ8KEnabled && downDt == DType.Q3_K) || (_q8_0Q8KEnabled && downDt == DType.Q8_0) || (_q4kQ8KEnabled && downDt == DType.Q4_K);
         byte* normAllQ8K = _bmNormAllQ8K; byte* gateAllQ8K = _bmGateAllQ8K;
         int q8kEmbStride = _bmQ8KEmbStride, q8kExpStride = _bmQ8KExpStride;
+        // Issue #410: Q6_K down projection hoists its Q8_K input prepack (see _bmGateAllQ6KQ8K).
+        // Engages whenever the down dtype is Q6_K, independent of the SHARPI_*_Q8K gates.
+        bool downQ6K = downDt == DType.Q6_K;
+        byte* gateAllQ6KQ8K = _bmGateAllQ6KQ8K; int q6kExpStride = _bmQ6KExpStride;
 
         // Bucket (token, slot) pairs by selected expert (CSR layout).
         int* expStart = _bmExpStart!; int* cursor = _bmExpCursor!; int* used = _bmUsedExperts!;
@@ -1690,6 +1712,12 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
             Parallel.For(0, (int)totalSel, s_moeParallelOpts, s =>
                 SimdKernels.QuantizeRowToQ8KS(gateAll + (long)s * expertDim, expertDim,
                     gateAllQ8K + (long)s * q8kExpStride));
+        // Q6_K (issue #410): prepack each silu'd gate slice to Q8_K ONCE, reused across the
+        // expert's down rows below (was re-quantized per down row inside DispatchDot→DotQ6K).
+        else if (downQ6K)
+            Parallel.For(0, (int)totalSel, s_moeParallelOpts, s =>
+                SimdKernels.QuantizeRowToQ8K(gateAll + (long)s * expertDim, expertDim,
+                    gateAllQ6KQ8K + (long)s * q6kExpStride));
 
         // Phase C: down. Parallelize over (used expert, emb-row BLOCK); same row-block
         // structure as Phase A — a quad's 4 silu'd-gate slices are reused across every
@@ -1725,6 +1753,20 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                         downPartial[s3 * embDimL + r] = d3;
                     }
                 }
+                else if (downQ6K)
+                {
+                    byte* q0 = gateAllQ6KQ8K + s0 * q6kExpStride, q1 = gateAllQ6KQ8K + s1 * q6kExpStride;
+                    byte* q2 = gateAllQ6KQ8K + s2 * q6kExpStride, q3 = gateAllQ6KQ8K + s3 * q6kExpStride;
+                    for (int r = rStart; r < rEnd; r++)
+                    {
+                        SimdKernels.DotQ6K_Q8K_4In(downBase + (long)r * bprD, q0, q1, q2, q3, expertDimL,
+                            out float d0, out float d1, out float d2, out float d3);
+                        downPartial[s0 * embDimL + r] = d0;
+                        downPartial[s1 * embDimL + r] = d1;
+                        downPartial[s2 * embDimL + r] = d2;
+                        downPartial[s3 * embDimL + r] = d3;
+                    }
+                }
                 else
                 {
                     float* g0 = gateAll + s0 * expertDimL, g1 = gateAll + s1 * expertDimL;
@@ -1750,6 +1792,9 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                     if (useQ8KDown)
                         DispatchDotQ8K2In(downBase + (long)r * bprD, gateAllQ8K + s0 * q8kExpStride,
                             gateAllQ8K + s1 * q8kExpStride, expertDimL, downDt, out d0, out d1);
+                    else if (downQ6K)
+                        SimdKernels.DotQ6K_Q8K_2In(downBase + (long)r * bprD, gateAllQ6KQ8K + s0 * q6kExpStride,
+                            gateAllQ6KQ8K + s1 * q6kExpStride, expertDimL, out d0, out d1);
                     else
                         DispatchDot2In(downBase + (long)r * bprD, gateAll + s0 * expertDimL,
                             gateAll + s1 * expertDimL, expertDimL, downDt, out d0, out d1);
@@ -1763,7 +1808,9 @@ public sealed unsafe class CudaHybridForwardPass : IForwardPass
                 for (int r = rStart; r < rEnd; r++)
                     downPartial[slot * embDimL + r] = useQ8KDown
                         ? DispatchDotQ8K(downBase + (long)r * bprD, gateAllQ8K + slot * q8kExpStride, expertDimL, downDt)
-                        : DispatchDot(downBase + (long)r * bprD, gateAll + slot * expertDimL, expertDimL, downDt);
+                        : downQ6K
+                            ? SimdKernels.DotQ6K_Q8K(downBase + (long)r * bprD, gateAllQ6KQ8K + slot * q6kExpStride, expertDimL)
+                            : DispatchDot(downBase + (long)r * bprD, gateAll + slot * expertDimL, expertDimL, downDt);
             }
         });
 

--- a/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
+++ b/src/SharpInference.Engine/CudaHybridGdnForwardPass.cs
@@ -287,6 +287,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private readonly bool _q3kQ8KEnabled;
     private readonly bool _q8_0Q8KEnabled;
     private readonly bool _q4kQ8KEnabled;
+    // Issue #410: true when any routed-expert DOWN weight is Q6_K. The single Q6_K dot
+    // always quantizes its input to Q8_K (there is no float Q6_K dot), so — independent of
+    // the SHARPI_*_Q8K gates above (which control the Q8_KS scheme for Q3_K/Q4_K/Q8_0) —
+    // the batched routed down projection hoists that quantization out of the per-row loop.
+    private readonly bool _hasQ6KDownExp;
 
     // ── CPU MoE state (only allocated/populated when _cpuMoe == true) ──
     // Packed MoE weight refs (mmap pointers; routed experts stay quantized on disk).
@@ -648,6 +653,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private byte*  _bGateAllQ8K;       // [bCap × numActive × q8ksExpBytes] — Q8_KS-packed silu'd gate slices
     private int    _bQ8KEmbStride;     // Q8_KS bytes for an embDim row
     private int    _bQ8KExpStride;     // Q8_KS bytes for an expertDim row
+    // Issue #410: Q6_K down projection — the silu'd-gate slices (Q8_K-quantized once per
+    // slot, reused across the down rows). Distinct from _bGateAllQ8K (Q8_KS scheme, gated by
+    // SHARPI_*_Q8K); Q6_K uses the plain Q8_K scheme its single dot uses. Allocated only when
+    // _hasQ6KDownExp — see EnsureBatchedScratch.
+    private byte*  _bGateAllQ6KQ8K;    // [bCap × numActive × q6kExpStride] — Q8_K-packed silu'd gate slices
+    private int    _bQ6KExpStride;     // Q8_K (DotQ6K_Q8K) bytes for an expertDim row
     private int*   _bSelected;         // [bCap × numActive] — per-token selected experts
     private float* _bWeights;          // [bCap × numActive] — per-token expert weights
     private float* _bShexpScale;       // [bCap] — per-token shared-expert sigmoid gate
@@ -889,11 +900,13 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     // quads (#114) / pairs (#112) / a single — N/tile DRAM passes over the FFN weights
     // per chunk instead of N — then ONE H2D of the new stream rows. Bit-identical to the
     // per-token path (the multi-input kernels mirror the single accumulation order).
-    // Default OFF until validated (issue #410 constraint) — and see the KNOWN LIMIT note
-    // on the _bd* scratch fields: without row-blocked kernels the activation cache
-    // traffic currently outweighs the weight-read win. Decode is untouched.
+    // Default ON after the desktop validation (issue #416): batched is 2.3× over per-token
+    // on 27B-MTP once the Q6_K down-projection stopped re-quantizing its input per weight
+    // row (the #416 fix hoists the Q8K prepack + routes Q6_K through DotQ6K_Q8K_4In, so the
+    // activation cache traffic no longer outweighs the weight-read win). Decode is untouched.
+    // Kill-switch: SHARPI_BATCHED_CPU_FFN=0.
     internal static bool BatchedCpuDenseFfnEnabled =
-        Environment.GetEnvironmentVariable("SHARPI_BATCHED_CPU_FFN") == "1";
+        ResolveGate("SHARPI_BATCHED_CPU_FFN", true);
 
     // Test observable (issue #410): how many layers of the last Prefill ran the batched
     // CPU dense-FFN stage (vs the per-token fallback loop). A count, not a bool, so the
@@ -922,6 +935,15 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
     private float* _bdGateAll;     // [tile × intermDim]  — gate projections → silu'd
     private float* _bdUpAll;       // [tile × intermDim]  — up projections
     private float* _bdHiddenAll;   // pinned [N × embDim] — FFN outputs, no residual (one H2D)
+    // Issue #410: Q6_K down projection — the single Q6_K dot (DotQ6K_Q8K) quantizes its
+    // input to Q8_K once per super-block, but DispatchDot re-does that PER WEIGHT ROW
+    // (embDim× redundant). This tile-sized scratch holds each of the _bdTile silu'd-gate
+    // rows prepacked to Q8_K ONCE (Phase C), so the quad/pair/single down loops call the
+    // fused DotQ6K_Q8K_4In/_2In/DotQ6K_Q8K kernels — bit-identical to the per-row single
+    // dot (they mirror its accumulation order), only the input quantization is hoisted.
+    // Only allocated when the layer's down weight is Q6_K; null otherwise.
+    private byte* _bdGateQ8K;      // [tile × Q8KScratchBytes(intermDim)] — prepacked silu'd gates
+    private int _bdQ8KStride;      // Q8KScratchBytes(intermDim), 0 when the scratch is absent
     private int _bdCapN;
     private int _bdTile;           // tokens per tile (~8 MB of gate slab, multiple of 4)
 
@@ -1245,6 +1267,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         // (Q3_K/Q8_0 int8 have no f32-AVX512 competitor, so they stay auto-on.)
         _q4kQ8KEnabled  = ResolveGate("SHARPI_Q4K_Q8K",
             hasQ4KRouted && !System.Runtime.Intrinsics.Vector512.IsHardwareAccelerated);
+        // Q6_K down experts always dot via Q8_K input; hoist the prepack unconditionally.
+        _hasQ6KDownExp = HasRoutedDownExpertsOfDType(model, hp, DType.Q6_K);
         if (_cpuMoe && (_q3kQ8KEnabled || _q8_0Q8KEnabled || _q4kQ8KEnabled))
         {
             var enabled = new List<string>(3);
@@ -1949,6 +1973,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             _bNormAllQ8K = (byte*)NativeMemory.Alloc((nuint)((long)N * _bQ8KEmbStride));
             _bGateAllQ8K = (byte*)NativeMemory.Alloc((nuint)(perTokSel * _bQ8KExpStride));
         }
+        if (_hasQ6KDownExp)
+        {
+            _bQ6KExpStride = SimdKernels.Q8KScratchBytes(_expertDim);
+            _bGateAllQ6KQ8K = (byte*)NativeMemory.Alloc((nuint)(perTokSel * _bQ6KExpStride));
+        }
 
         // Per-expert bucket bookkeeping (sized by numExperts, allocated once).
         if (_bExpStart == null)
@@ -2557,6 +2586,7 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         if (_bExpTokK    != null) { NativeMemory.Free(_bExpTokK);    _bExpTokK = null; }
         if (_bNormAllQ8K != null) { NativeMemory.Free(_bNormAllQ8K); _bNormAllQ8K = null; }
         if (_bGateAllQ8K != null) { NativeMemory.Free(_bGateAllQ8K); _bGateAllQ8K = null; }
+        if (_bGateAllQ6KQ8K != null) { NativeMemory.Free(_bGateAllQ6KQ8K); _bGateAllQ6KQ8K = null; }
         _bCap = 0;
     }
 
@@ -3015,6 +3045,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         _bdHiddenAll = AllocPinnedL(emb);
         _bdGateAll   = (float*)NativeMemory.Alloc(interm);
         _bdUpAll     = (float*)NativeMemory.Alloc(interm);
+        // Q6_K-down prepack scratch: one Q8_K row per tile token (tile-sized, not N-sized).
+        // Allocated unconditionally (tiny — ≤256 tiles × ~20 KB) so a mixed-quant model whose
+        // down dtype varies per layer always has it ready; the down loops use it only when
+        // downDt == Q6_K.
+        _bdQ8KStride = SimdKernels.Q8KScratchBytes(_intermDim);
+        _bdGateQ8K   = (byte*)NativeMemory.Alloc((nuint)((long)_bdTile * _bdQ8KStride));
         _bdCapN = n;
     }
 
@@ -3024,6 +3060,8 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         if (_bdHiddenAll != null) { CudaBackend.FreePinnedHost((nint)_bdHiddenAll); _bdHiddenAll = null; }
         if (_bdGateAll   != null) { NativeMemory.Free(_bdGateAll);   _bdGateAll = null; }
         if (_bdUpAll     != null) { NativeMemory.Free(_bdUpAll);     _bdUpAll = null; }
+        if (_bdGateQ8K   != null) { NativeMemory.Free(_bdGateQ8K);   _bdGateQ8K = null; }
+        _bdQ8KStride = 0;
         _bdCapN = 0;
     }
 
@@ -3155,21 +3193,44 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             // Phase B: SiLU(gate) * up over the tile's contiguous [T × intermDim] block.
             SimdKernels.SiLuMul(gateAll, upAll, (int)((long)T * intermDim));
 
+            // Q6_K down prepack (issue #410): the single Q6_K dot quantizes its input to
+            // Q8_K per super-block; done inside DispatchDot it re-quantizes each silu'd-gate
+            // row once PER down weight row (embDim× redundant). Hoist it: prepack the tile's
+            // T silu'd-gate rows to Q8_K ONCE here, then dot the fused DotQ6K_Q8K_* kernels
+            // below. Bit-identical to the per-row DotQ6K (same QuantizeRowToQ8K, same
+            // DotQ6K_Q8K accumulation order). Only for Q6_K — other dtypes stay on the float
+            // DispatchDot path unchanged.
+            bool downQ6K = downDt == DType.Q6_K;
+            if (downQ6K)
+            {
+                byte* q8k = _bdGateQ8K!; int stride = _bdQ8KStride; int id = intermDim;
+                Parallel.For(0, T, s_moeParallelOpts, i =>
+                    SimdKernels.QuantizeRowToQ8K(gateAll + (long)i * id, id, q8k + (long)i * stride));
+            }
+
             // Phase C: down over the tile, same row-block structure — the 4 silu'd gate
             // slices of a quad are reused across the block's down rows.
             int blocksC = (embDim + rbC - 1) / rbC;
             Parallel.For(0, blocksC, s_moeParallelOpts, b =>
             {
                 int rStart = b * rbC, rEnd = Math.Min(rStart + rbC, embDim);
+                byte* q8k = _bdGateQ8K!; int stride = _bdQ8KStride;
                 int i = 0;
                 for (; i + 3 < T; i += 4)
                 {
-                    float* g0 = gateAll + (long)i * intermDim,       g1 = gateAll + (long)(i + 1) * intermDim;
-                    float* g2 = gateAll + (long)(i + 2) * intermDim, g3 = gateAll + (long)(i + 3) * intermDim;
                     for (int r = rStart; r < rEnd; r++)
                     {
-                        DispatchDot4In(downP + (long)r * bprD, g0, g1, g2, g3, intermDim, downDt,
-                            out float d0, out float d1, out float d2, out float d3);
+                        float d0, d1, d2, d3;
+                        if (downQ6K)
+                            SimdKernels.DotQ6K_Q8K_4In(downP + (long)r * bprD,
+                                q8k + (long)i * stride, q8k + (long)(i + 1) * stride,
+                                q8k + (long)(i + 2) * stride, q8k + (long)(i + 3) * stride,
+                                intermDim, out d0, out d1, out d2, out d3);
+                        else
+                            DispatchDot4In(downP + (long)r * bprD,
+                                gateAll + (long)i * intermDim, gateAll + (long)(i + 1) * intermDim,
+                                gateAll + (long)(i + 2) * intermDim, gateAll + (long)(i + 3) * intermDim,
+                                intermDim, downDt, out d0, out d1, out d2, out d3);
                         hidT[(long)i * embDim + r]       = d0;
                         hidT[(long)(i + 1) * embDim + r] = d1;
                         hidT[(long)(i + 2) * embDim + r] = d2;
@@ -3178,21 +3239,27 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 }
                 for (; i + 1 < T; i += 2)
                 {
-                    float* g0 = gateAll + (long)i * intermDim, g1 = gateAll + (long)(i + 1) * intermDim;
                     for (int r = rStart; r < rEnd; r++)
                     {
-                        DispatchDot2In(downP + (long)r * bprD, g0, g1, intermDim, downDt,
-                            out float d0, out float d1);
+                        float d0, d1;
+                        if (downQ6K)
+                            SimdKernels.DotQ6K_Q8K_2In(downP + (long)r * bprD,
+                                q8k + (long)i * stride, q8k + (long)(i + 1) * stride,
+                                intermDim, out d0, out d1);
+                        else
+                            DispatchDot2In(downP + (long)r * bprD,
+                                gateAll + (long)i * intermDim, gateAll + (long)(i + 1) * intermDim,
+                                intermDim, downDt, out d0, out d1);
                         hidT[(long)i * embDim + r]       = d0;
                         hidT[(long)(i + 1) * embDim + r] = d1;
                     }
                 }
                 if (i < T) // odd remainder
                 {
-                    float* g0 = gateAll + (long)i * intermDim;
                     for (int r = rStart; r < rEnd; r++)
-                        hidT[(long)i * embDim + r] =
-                            DispatchDot(downP + (long)r * bprD, g0, intermDim, downDt);
+                        hidT[(long)i * embDim + r] = downQ6K
+                            ? SimdKernels.DotQ6K_Q8K(downP + (long)r * bprD, q8k + (long)i * stride, intermDim)
+                            : DispatchDot(downP + (long)r * bprD, gateAll + (long)i * intermDim, intermDim, downDt);
                 }
             });
         }
@@ -3244,6 +3311,11 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
         float* normAll = _bNormAll;
         byte* normAllQ8K = _bNormAllQ8K; byte* gateAllQ8K = _bGateAllQ8K;
         int q8kEmbStride = _bQ8KEmbStride, q8kExpStride = _bQ8KExpStride;
+        // Issue #410: Q6_K down projection hoists its Q8_K input prepack out of the per-row
+        // dot (see _bGateAllQ6KQ8K). Engages whenever the down dtype is Q6_K, independent of
+        // the SHARPI_*_Q8K gates (useQ8KDown, which is the distinct Q8_KS scheme).
+        bool downQ6K = downDt == DType.Q6_K;
+        byte* gateAllQ6KQ8K = _bGateAllQ6KQ8K; int q6kExpStride = _bQ6KExpStride;
 
         long sp1 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         if (_prefillProfile) _profMoeBucket += sp1 - sp0;
@@ -3349,6 +3421,12 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             Parallel.For(0, (int)totalSel, s_moeParallelOpts, s =>
                 SimdKernels.QuantizeRowToQ8KS(gateAll + (long)s * expertDim, expertDim,
                     gateAllQ8K + (long)s * q8kExpStride));
+        // Q6_K (issue #410): prepack each silu'd gate slice to Q8_K ONCE, reused across the
+        // expert's down rows below (was re-quantized per down row inside DispatchDot→DotQ6K).
+        else if (downQ6K)
+            Parallel.For(0, (int)totalSel, s_moeParallelOpts, s =>
+                SimdKernels.QuantizeRowToQ8K(gateAll + (long)s * expertDim, expertDim,
+                    gateAllQ6KQ8K + (long)s * q6kExpStride));
         long sp5 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         if (_prefillProfile) _profMoeGateQ += sp5 - sp4;
 
@@ -3376,6 +3454,10 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                     DispatchDotQ8K4In(downRow, gateAllQ8K + s0 * q8kExpStride,
                         gateAllQ8K + s1 * q8kExpStride, gateAllQ8K + s2 * q8kExpStride,
                         gateAllQ8K + s3 * q8kExpStride, expertDimL, downDt, out d0, out d1, out d2, out d3);
+                else if (downQ6K)
+                    SimdKernels.DotQ6K_Q8K_4In(downRow, gateAllQ6KQ8K + s0 * q6kExpStride,
+                        gateAllQ6KQ8K + s1 * q6kExpStride, gateAllQ6KQ8K + s2 * q6kExpStride,
+                        gateAllQ6KQ8K + s3 * q6kExpStride, expertDimL, out d0, out d1, out d2, out d3);
                 else
                     DispatchDot4In(downRow, gateAll + s0 * expertDimL, gateAll + s1 * expertDimL,
                         gateAll + s2 * expertDimL, gateAll + s3 * expertDimL, expertDimL, downDt,
@@ -3393,6 +3475,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 if (useQ8KDown)
                     DispatchDotQ8K2In(downRow, gateAllQ8K + s0 * q8kExpStride,
                         gateAllQ8K + s1 * q8kExpStride, expertDimL, downDt, out d0, out d1);
+                else if (downQ6K)
+                    SimdKernels.DotQ6K_Q8K_2In(downRow, gateAllQ6KQ8K + s0 * q6kExpStride,
+                        gateAllQ6KQ8K + s1 * q6kExpStride, expertDimL, out d0, out d1);
                 else
                     DispatchDot2In(downRow, gateAll + s0 * expertDimL,
                         gateAll + s1 * expertDimL, expertDimL, downDt, out d0, out d1);
@@ -3404,7 +3489,9 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
                 long slot = (long)expTokI[p] * naL + expTokK[p];
                 downPartial[slot * embDimL + r] = useQ8KDown
                     ? DispatchDotQ8K(downRow, gateAllQ8K + slot * q8kExpStride, expertDimL, downDt)
-                    : DispatchDot(downRow, gateAll + slot * expertDimL, expertDimL, downDt);
+                    : downQ6K
+                        ? SimdKernels.DotQ6K_Q8K(downRow, gateAllQ6KQ8K + slot * q6kExpStride, expertDimL)
+                        : DispatchDot(downRow, gateAll + slot * expertDimL, expertDimL, downDt);
             }
         });
         long sp6 = _prefillProfile ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
@@ -6869,6 +6956,18 @@ public sealed unsafe class CudaHybridGdnForwardPass : IForwardPass
             if (model.FindTensor($"blk.{i}.ffn_up_exps.weight")?.DType   == target) return true;
             if (model.FindTensor($"blk.{i}.ffn_down_exps.weight")?.DType == target) return true;
         }
+        return false;
+    }
+
+    // True if any routed-expert DOWN weight (trunk layers + MTP head) is encoded in
+    // `target`. Down-only sibling of HasRoutedExpertsOfDType — used to gate the Q6_K
+    // down-projection Q8_K prepack scratch, whose only consumer is the down phase.
+    internal static bool HasRoutedDownExpertsOfDType(GgufModel model, ModelHyperparams hp, DType target)
+    {
+        if (!hp.IsMoE) return false;
+        int L = hp.NumLayers;
+        for (int i = 0; i <= L; i++) // <= L so the MTP-head layer (index L) is included if present
+            if (model.FindTensor($"blk.{i}.ffn_down_exps.weight")?.DType == target) return true;
         return false;
     }
 


### PR DESCRIPTION
## Summary
Fixes the batched CPU-FFN prefill **regression** the #416 desktop validation surfaced (batched was *slower* than per-token — the opposite of its purpose) and flips the flags default-**ON**.

## Root cause
The FFN down-projection is **Q6_K** in Q4_K_M models (27B-MTP `ffn_down`, Coder-30B `ffn_down_exps` — the largest FFN matmul). `DispatchDot4In` only fast-paths Q4_K, so Q6_K fell back to per-input single `DotQ6K` calls — and `DotQ6K` re-quantizes its float input to Q8K (`QuantizeRowToQ8K`) **once per weight row** (embDim×/expertDim× redundant). The per-token reference (`MatVecQ6K`) quantizes **once**. That redundant re-quantization made the batched FFN stage run **3.7× slower**.

Diagnosis path: a synthetic Q4_K micro-benchmark (no model/GPU) showed the fused kernel is 2.4–4.8× *faster*, disproving a cache-thrashing theory and isolating the cause to the Q6_K dtype dispatch; `SHARPI_PREFILL_PROFILE` then confirmed the `ffn=` stage was where the time went.

## Fix
Hoist the Q8K input prepack out of the per-weight-row loop (quantize each tile / routed input once) and route Q6_K down through the fused `DotQ6K_Q8K_4In`/`_2In` kernels (already present + proven), amortizing the weight decode too. Applied to `BatchedCpuDenseFfn` Phase C (dense) and `BatchedRoutedExperts`/`BatchedRoutedExpertsCpu` Phase C (MoE), disjoint from the flag-gated Q8_KS tier.

**Bit-identical** — same `QuantizeRowToQ8K` prepack + `DotQ6K_Q8K` accumulation order. Decode untouched (prefill-only).

## Results (RTX 4070 Ti, warm, interleaved)
| Model | before (batched) | after (batched) | vs per-token |
|---|---|---|---|
| 27B-MTP all-FFN-CPU | timed out / 1.7 t/s | **15.2 t/s** | **2.3×** (FFN stage 178.5s→19.5s, 9.2×) |
| Coder-30B CPU-MoE | 20.6 t/s | **102.6 t/s** | **3.65×** |

Coder llama.cpp b9529 gap (pp2048 694 t/s) closes from **~23× → ~6.8×**.

## Defaults
Both flags now default **ON** via `ResolveGate` (kill-switches `SHARPI_BATCHED_CPU_FFN=0` / `SHARPI_HYBRID_BATCHED_MOE=0`), per #416's "batched wins → flip default-on" criterion. Validated on AVX-512 desktop with Q4_K_M models; bit-identical + prefill-only, so the risk on untested AVX2 is perf-only.

## Verification
- `dotnet build -c Release`: 0 warnings.
- Parity oracles pass **bitwise** (4/4): `BatchedCpuDenseFfn_BitwiseMatchesPerTokenCpuFfn_Dense27BMtp` + `CudaHybridBatchedCpuMoePrefillTests` (3).
- Default path (no env flag) confirmed engaging the batched path (102.0 t/s).

Closes #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)